### PR TITLE
allow for labels with length > 1

### DIFF
--- a/collections/nemo_asr/nemo_asr/parts/manifest.py
+++ b/collections/nemo_asr/nemo_asr/parts/manifest.py
@@ -139,10 +139,21 @@ class Manifest(object):
         return transcript
 
     def parse_transcript(self, transcript):
-        chars = [self.labels_map.get(x, self.blank_index)
-                 for x in list(transcript)]
-        transcript = list(filter(lambda x: x != self.blank_index, chars))
-        return transcript
+        # allow for special labels such as "<NOISE>"
+        special_labels = set([label for label in self.labels_map.keys() if len(label) > 1])
+        tokens = []
+        # split by word to find special tokens
+        for i, word in enumerate(transcript.split(" ")):
+            if i > 0:
+                tokens.append(self.labels_map.get(" ", self.blank_index))
+            if word in special_labels:
+                tokens.append(self.labels_map.get(word))
+                continue
+            # split by character to get the rest of the tokens
+            for char in word:
+                tokens.append(self.labels_map.get(char, self.blank_index))
+        tokens = [x for x in tokens if x != self.blank_index]
+        return tokens
 
     def __getitem__(self, item):
         return self._data[item]

--- a/collections/nemo_asr/nemo_asr/parts/manifest.py
+++ b/collections/nemo_asr/nemo_asr/parts/manifest.py
@@ -140,7 +140,7 @@ class Manifest(object):
 
     def parse_transcript(self, transcript):
         # allow for special labels such as "<NOISE>"
-        special_labels = set([label for label in self.labels_map.keys() if len(label) > 1])
+        special_labels = set([l for l in self.labels_map.keys() if len(l) > 1])
         tokens = []
         # split by word to find special tokens
         for i, word in enumerate(transcript.split(" ")):


### PR DESCRIPTION
Currently, the audio dataset splits the transcript by character, which doesn't allow for labels which are greater than one character.  This makes it impossible to add labels such as `<NOISE>` or other special labels that one might want in the audio without some preprocessing hack such as replacing these labels with OOV single characters.  Nothing should change for normal label sets without special labels, but now special labels will get properly replaced with the appropriate token id.

Also, I refactored the naming a bit because I found it unintuitive that the input is a transcript of words and the output is a list of ints, but you were using the variable name `transcript` for both.

In the long run, a better solution would be to allow for a set of special tokens in the dataset; rather than adding them to the labels.  Currently, I also had to turn off the normalization so my tokens wouldn't get mangled because they contain punctuation.

Signed-off-by: David Pollack <david@i2x.ai>