### PR TITLE
correction of dir path in installation instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ instead of
 
 .. code-block:: bash
 
-	cd NeMo
+	cd nemo
 	pip install .
 
 3) Install the collection you want.


### PR DESCRIPTION
correction of dir path in the installation instructions. The sub-directory should be nemo intead of NeMo (NeMo is the parent directory).

Signed-off-by: Hariankar H <harisankar.h@airtel.com>