### PR TITLE
Change Attention Mask typing to float

### DIFF
--- a/collections/nemo_nlp/nemo_nlp/transformer/utils.py
+++ b/collections/nemo_nlp/nemo_nlp/transformer/utils.py
@@ -35,7 +35,7 @@ def form_attention_mask(input_mask, diagonal=None):
         future_mask = torch.tril(
             torch.ones(attn_shape).byte().to(input_mask.device), diagonal)
         attn_mask = attn_mask & future_mask
-    attention_mask = (1 - attn_mask.to(input_mask.dtype)) * NEG_INF
+    attention_mask = (1 - attn_mask.to(torch.float)) * NEG_INF
     return attention_mask.unsqueeze(1)
 
 


### PR DESCRIPTION
If input_mask is an int type, transformer training would fail silently.