### PR TITLE
Allow to run in CPU-only mode

### DIFF
--- a/collections/nemo_asr/nemo_asr/data_layer.py
+++ b/collections/nemo_asr/nemo_asr/data_layer.py
@@ -4,8 +4,11 @@ This package contains Neural Modules responsible for ASR-related data
 processing
 """
 import torch
-from apex import amp
-
+try:
+    from apex import amp
+except AttributeError:
+    print("Unable to import APEX. Mixed precision and distributed training "
+          "will not work.")
 from nemo.backends.pytorch.nm import DataLayerNM, TrainableNM, NonTrainableNM
 from nemo.core import Optimization, DeviceType
 from nemo.core.neural_types import *

--- a/collections/nemo_nlp/nemo_nlp/transformer/modules.py
+++ b/collections/nemo_nlp/nemo_nlp/transformer/modules.py
@@ -30,8 +30,14 @@ __all__ = ['FixedPositionalEncoding',
            'PositionWiseFF']
 
 import math
+try:
+    from apex.normalization import FusedLayerNorm
+except AttributeError:
+    # this is lie - it isn't fused in this case
+    print("Unable to import APEX. Mixed precision, distributed training and "
+          "FusedLayerNorm are not available.")
+    from torch.nn import LayerNorm as FusedLayerNorm
 
-from apex.normalization import FusedLayerNorm
 import torch
 from torch import nn
 

--- a/examples/asr/ASR_made_simple.ipynb
+++ b/examples/asr/ASR_made_simple.ipynb
@@ -25,8 +25,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "train_manifest = \"an4data/an4_train.json\"\n",
-    "val_manifest = \"an4data/an4_val.json\""
+    "train_manifest = \"an4_dataset/an4_train.json\"\n",
+    "val_manifest = \"an4_dataset/an4_val.json\""
    ]
   },
   {
@@ -54,6 +54,20 @@
    "metadata": {},
    "source": [
     "### Instantiate necessary Neural Modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First step is to instantiate a NeuralModuleFactory\n",
+    "# If torch is installed without CUDA and Apex CPU will be used\n",
+    "# and training is impractically slow even for this dataset\n",
+    "from nemo.core import DeviceType\n",
+    "import torch\n",
+    "nf = nemo.core.NeuralModuleFactory(placement=DeviceType.GPU if torch.cuda.is_available() else DeviceType.CPU)"
    ]
   },
   {
@@ -192,44 +206,12 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# instantiate Neural Factory with supported backend\n",
-    "neural_factory = nemo.core.NeuralModuleFactory(backend=nemo.core.Backend.PyTorch)\n",
-    "# \n",
-    "# neural_factory = nemo.core.NeuralModuleFactory(\n",
-    "#      backend=nemo.core.Backend.PyTorch,\n",
-    "#      local_rank=args.local_rank,\n",
-    "#      optimization_level=nemo.core.Optimization.mxprO1,\n",
-    "#      placement=device)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "neural_factory.train(tensors_to_optimize=[loss],\n",
+    "nf.train(tensors_to_optimize=[loss],\n",
     "                callbacks=[train_callback],\n",
     "                optimizer=\"novograd\",\n",
     "                optimization_params={\"num_epochs\": 30, \"lr\": 1e-2,\n",
     "                                    \"weight_decay\": 1e-3})"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "jasper_encoder.save_to('jasper_encoder.pt')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -248,7 +230,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/examples/asr/InferenceWithBeamSearch.ipynb
+++ b/examples/asr/InferenceWithBeamSearch.ipynb
@@ -36,6 +36,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# First step is to instantiate a NeuralModuleFactory\n",
+    "# If torch is installed without CUDA and Apex CPU will be used\n",
+    "# and training is impractically slow even for this dataset\n",
+    "from nemo.core import DeviceType\n",
+    "import torch\n",
+    "nf = nemo.core.NeuralModuleFactory(placement=DeviceType.GPU if torch.cuda.is_available() else DeviceType.CPU)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Instantiate necessary neural modules\n",
     "data_layer = nemo_asr.AudioToTextDataLayer(\n",
     "    shuffle=False,\n",
@@ -66,7 +80,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Download checkpoint from here: https://drive.google.com/drive/folders/1b-TQYY7o8_CQgZsVEe-8_2kHWU0lYJ-z?usp=sharing\n",
+    "# Download checkpoint from here: https://ngc.nvidia.com/catalog/models/nvidia:quartznet15x5\n",
     "import os\n",
     "# Instantiate BeamSearch NM\n",
     "beam_search_with_lm = nemo_asr.BeamSearchDecoderWithLM(\n",
@@ -88,7 +102,6 @@
    "source": [
     "from nemo_asr.helpers import post_process_predictions, \\\n",
     "                             post_process_transcripts, word_error_rate\n",
-    "neural_factory = nemo.core.NeuralModuleFactory(backend=nemo.core.Backend.PyTorch)\n",
     "\n",
     "evaluated_tensors = neural_factory.infer(\n",
     "    tensors=eval_tensors,\n",
@@ -138,7 +151,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/examples/start_here/chatbot_example.py
+++ b/examples/start_here/chatbot_example.py
@@ -1,5 +1,4 @@
 import os
-import sys
 import gzip
 import shutil
 import nemo
@@ -32,7 +31,8 @@ config = {
 }
 
 # instantiate neural factory
-nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
+#nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
+nf = nemo.core.NeuralModuleFactory()
 
 # instantiate neural modules
 dl = nemo.tutorials.DialogDataLayer(**config)

--- a/examples/start_here/chatbot_example.py
+++ b/examples/start_here/chatbot_example.py
@@ -31,7 +31,7 @@ config = {
 }
 
 # instantiate neural factory
-#nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
+# nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
 nf = nemo.core.NeuralModuleFactory()
 
 # instantiate neural modules

--- a/examples/start_here/chatbot_example.py
+++ b/examples/start_here/chatbot_example.py
@@ -2,7 +2,6 @@ import os
 import gzip
 import shutil
 import nemo
-from nemo.core import DeviceType
 
 # Get Data
 data_file = "movie_data.txt"
@@ -31,8 +30,10 @@ config = {
 }
 
 # instantiate neural factory
-# nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
 nf = nemo.core.NeuralModuleFactory()
+# To use CPU-only do:
+# from nemo.core import DeviceType
+# nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
 
 # instantiate neural modules
 dl = nemo.tutorials.DialogDataLayer(**config)

--- a/examples/start_here/chatbot_example.py
+++ b/examples/start_here/chatbot_example.py
@@ -3,6 +3,7 @@ import sys
 import gzip
 import shutil
 import nemo
+from nemo.core import DeviceType
 
 # Get Data
 data_file = "movie_data.txt"
@@ -31,7 +32,7 @@ config = {
 }
 
 # instantiate neural factory
-nf = nemo.core.NeuralModuleFactory()
+nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
 
 # instantiate neural modules
 dl = nemo.tutorials.DialogDataLayer(**config)

--- a/examples/start_here/simplest_example.py
+++ b/examples/start_here/simplest_example.py
@@ -2,7 +2,8 @@
 import nemo
 from nemo.core import DeviceType
 # instantiate Neural Factory with supported backend
-nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
+#nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
+nf = nemo.core.NeuralModuleFactory()
 
 # instantiate necessary neural modules
 # RealFunctionDataLayer defaults to f=torch.sin, sampling from x=[-4, 4]

--- a/examples/start_here/simplest_example.py
+++ b/examples/start_here/simplest_example.py
@@ -1,8 +1,8 @@
 # Copyright (c) 2019 NVIDIA Corporation
 import nemo
-
+from nemo.core import DeviceType
 # instantiate Neural Factory with supported backend
-nf = nemo.core.NeuralModuleFactory()
+nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
 
 # instantiate necessary neural modules
 # RealFunctionDataLayer defaults to f=torch.sin, sampling from x=[-4, 4]

--- a/examples/start_here/simplest_example.py
+++ b/examples/start_here/simplest_example.py
@@ -2,7 +2,7 @@
 import nemo
 from nemo.core import DeviceType
 # instantiate Neural Factory with supported backend
-#nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
+# nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
 nf = nemo.core.NeuralModuleFactory()
 
 # instantiate necessary neural modules

--- a/examples/start_here/simplest_example.py
+++ b/examples/start_here/simplest_example.py
@@ -1,9 +1,9 @@
 # Copyright (c) 2019 NVIDIA Corporation
 import nemo
-from nemo.core import DeviceType
-# instantiate Neural Factory with supported backend
-# nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
 nf = nemo.core.NeuralModuleFactory()
+# To use CPU-only do:
+# from nemo.core import DeviceType
+# nf = nemo.core.NeuralModuleFactory(placement=DeviceType.CPU)
 
 # instantiate necessary neural modules
 # RealFunctionDataLayer defaults to f=torch.sin, sampling from x=[-4, 4]

--- a/nemo/nemo/backends/pytorch/actions.py
+++ b/nemo/nemo/backends/pytorch/actions.py
@@ -1203,10 +1203,13 @@ class PtActions(Actions):
                             continue
                         scaled_loss.backward(
                             bps_scale.to(scaled_loss.get_device()))
+                # no AMP optimizations needed
                 else:
+                    # multi-GPU, float32
                     if self._local_rank is not None:
                         final_loss.backward(
                             bps_scale.to(final_loss.get_device()))
+                    # single device (CPU or GPU)
                     else:
                         final_loss.backward()
 

--- a/nemo/nemo/backends/pytorch/actions.py
+++ b/nemo/nemo/backends/pytorch/actions.py
@@ -1263,7 +1263,8 @@ class PtActions(Actions):
                 mod.restore_from(checkpoint, self._local_rank)
 
             # Init Amp
-            if self._optim_level in AmpOptimizations:
+            if self._optim_level in AmpOptimizations and \
+                    self._optim_level != Optimization.mxprO0:
                 pt_modules = []
                 for i in range(len(call_chain)):
                     if isinstance(call_chain[i][0], nn.Module):

--- a/nemo/nemo/backends/pytorch/actions.py
+++ b/nemo/nemo/backends/pytorch/actions.py
@@ -1,4 +1,5 @@
 # Copyright (c) 2019 NVIDIA Corporation
+import importlib
 import itertools
 import logging
 import os
@@ -45,24 +46,24 @@ class PtActions(Actions):
                     optimization_level != Optimization.mxprO0
         if need_apex:
             try:
+                apex = importlib.import_module('apex')
                 if optimization_level != Optimization.mxprO0:
                     global amp
-                    amp = __import__('amp', fromlist=['apex'])
+                    amp = importlib.import_module('apex.amp')
                 if local_rank is not None:
                     global DDP
-                    DDP = __import__('DistributedDataParallel',
-                                     fromlist=['apex.parallel'])
-                    # from apex.parallel import DistributedDataParallel as DDP
                     global LARC
-                    LARC = __import__('LARC',
-                                      fromlist=['apex.parallel'])
-                    # from apex.parallel.LARC import LARC
+                    parallel = importlib.import_module('apex.parallel')
+                    DDP = parallel.DistributedDataParallel
+                    LARC = parallel.LARC
+
             except ImportError:
                 raise ImportError(
                     "NVIDIA Apex is necessary for distributed training and"
                     "mixed precision training. It only works on GPUs."
                     "Please install Apex from "
                     "https://www.github.com/nvidia/apex")
+
         super(PtActions, self).__init__(
             local_rank=local_rank,
             optimization_level=optimization_level)

--- a/nemo/nemo/backends/pytorch/actions.py
+++ b/nemo/nemo/backends/pytorch/actions.py
@@ -21,6 +21,11 @@ from ...core.callbacks import (ActionCallback,
 from ...core.neural_factory import Actions, ModelMode, Optimization
 from ...utils.helpers import get_checkpoint_from_dir
 
+# these imports will happen on as-needed basis
+amp = None
+DDP = None
+LARC = None
+
 AmpOptimizations = {
     Optimization.mxprO0: "O0",
     Optimization.mxprO1: "O1",

--- a/nemo/nemo/backends/pytorch/actions.py
+++ b/nemo/nemo/backends/pytorch/actions.py
@@ -371,11 +371,12 @@ class PtActions(Actions):
             m_id = call_chain[ind][0].unique_instance_id
             pmodule = self.module_reference_table[m_id][1]
 
-            if isinstance(pmodule, DDP):
-                if disable_allreduce:
-                    pmodule.disable_allreduce()
-                else:
-                    pmodule.enable_allreduce()
+            if self._local_rank is not None:
+                if isinstance(pmodule, DDP):
+                    if disable_allreduce:
+                        pmodule.disable_allreduce()
+                    else:
+                        pmodule.enable_allreduce()
 
             if mode == ModelMode.train:
                 # if module.is_trainable():
@@ -1164,7 +1165,8 @@ class PtActions(Actions):
                     final_loss += registered_tensors[tensor.unique_name]
                 if nan:
                     continue
-                if self._optim_level in AmpOptimizations:
+                if self._optim_level in AmpOptimizations \
+                        and self._optim_level != Optimization.mxprO0:
                     with amp.scale_loss(
                             final_loss,
                             curr_optimizer,

--- a/nemo/nemo/backends/pytorch/actions.py
+++ b/nemo/nemo/backends/pytorch/actions.py
@@ -40,13 +40,14 @@ class PtActions(Actions):
                     optimization_level != Optimization.mxprO0
         if need_apex:
             try:
-                import apex
+                apex = __import__('apex')
                 if optimization_level != Optimization.mxprO0:
-                    from apex import amp
-                    print('AAAAAAAAAAAAAAAAAAAAAAA')
+                    amp = __import__('apex.amp')
                 if local_rank is not None:
-                    from apex.parallel import DistributedDataParallel as DDP
-                    from apex.parallel.LARC import LARC
+                    DDP = __import__(apex.parallel.DistributedDataParallel)
+                    # from apex.parallel import DistributedDataParallel as DDP
+                    LARC = __import__(apex.parallel.LARC)
+                    # from apex.parallel.LARC import LARC
             except ImportError:
                 raise ImportError(
                     "NVIDIA Apex is necessary for distributed training and"

--- a/nemo/nemo/backends/pytorch/actions.py
+++ b/nemo/nemo/backends/pytorch/actions.py
@@ -47,10 +47,13 @@ class PtActions(Actions):
             try:
                 apex = __import__('apex')
                 if optimization_level != Optimization.mxprO0:
+                    global amp
                     amp = __import__('apex.amp')
                 if local_rank is not None:
+                    global DDP
                     DDP = __import__(apex.parallel.DistributedDataParallel)
                     # from apex.parallel import DistributedDataParallel as DDP
+                    global LARC
                     LARC = __import__(apex.parallel.LARC)
                     # from apex.parallel.LARC import LARC
             except ImportError:

--- a/nemo/nemo/backends/pytorch/actions.py
+++ b/nemo/nemo/backends/pytorch/actions.py
@@ -45,16 +45,17 @@ class PtActions(Actions):
                     optimization_level != Optimization.mxprO0
         if need_apex:
             try:
-                apex = __import__('apex')
                 if optimization_level != Optimization.mxprO0:
                     global amp
-                    amp = __import__('apex.amp')
+                    amp = __import__('amp', fromlist=['apex'])
                 if local_rank is not None:
                     global DDP
-                    DDP = __import__(apex.parallel.DistributedDataParallel)
+                    DDP = __import__('DistributedDataParallel',
+                                     fromlist=['apex.parallel'])
                     # from apex.parallel import DistributedDataParallel as DDP
                     global LARC
-                    LARC = __import__(apex.parallel.LARC)
+                    LARC = __import__('LARC',
+                                      fromlist=['apex.parallel'])
                     # from apex.parallel.LARC import LARC
             except ImportError:
                 raise ImportError(

--- a/nemo/nemo/backends/pytorch/actions.py
+++ b/nemo/nemo/backends/pytorch/actions.py
@@ -1204,9 +1204,11 @@ class PtActions(Actions):
                         scaled_loss.backward(
                             bps_scale.to(scaled_loss.get_device()))
                 else:
-                    final_loss.backward(
-                        bps_scale.to(
-                            final_loss.get_device()))
+                    if self._local_rank is not None:
+                        final_loss.backward(
+                            bps_scale.to(final_loss.get_device()))
+                    else:
+                        final_loss.backward()
 
                 batch_counter += 1
 

--- a/nemo/nemo/backends/pytorch/actions.py
+++ b/nemo/nemo/backends/pytorch/actions.py
@@ -21,15 +21,6 @@ from ...core.callbacks import (ActionCallback,
 from ...core.neural_factory import Actions, ModelMode, Optimization
 from ...utils.helpers import get_checkpoint_from_dir
 
-try:
-    import apex
-    from apex.parallel import DistributedDataParallel as DDP
-    from apex.parallel.LARC import LARC
-    from apex import amp
-except ImportError:
-    raise ImportError(
-        "Please install apex from https://www.github.com/nvidia/apex")
-
 AmpOptimizations = {
     Optimization.mxprO0: "O0",
     Optimization.mxprO1: "O1",
@@ -339,6 +330,15 @@ class PtActions(Actions):
     def __initialize_amp(
             self, optimizer, optim_level, amp_min_loss_scale=1.0
     ):
+        try:
+            import apex
+            from apex.parallel import DistributedDataParallel as DDP
+            from apex.parallel.LARC import LARC
+            from apex import amp
+        except ImportError:
+            raise ImportError(
+                "Please install apex from https://www.github.com/nvidia/apex")
+
         if optim_level not in AmpOptimizations:
             raise ValueError("__initialize_amp() was called but optim_level "
                              "was set to float32.")

--- a/nemo/nemo/core/neural_factory.py
+++ b/nemo/nemo/core/neural_factory.py
@@ -292,6 +292,16 @@ class NeuralModuleFactory(object):
         if backend == Backend.PyTorch:
             # TODO: Move all framework specific code from this file
             import torch
+            if self._placement != DeviceType.CPU:
+                if not torch.cuda.is_available():
+                    raise ValueError("You requested to use GPUs but CUDA is "
+                                     "not installed. You can try running using"
+                                     " CPU-only. To do this, instantiate your"
+                                     " factory with placement=DeviceType.CPU"
+                                     "\n"
+                                     "Note that this is slow and is not "
+                                     "well supported.")
+
             torch.backends.cudnn.benchmark = cudnn_benchmark
             if random_seed is not None and cudnn_benchmark:
                 raise ValueError("cudnn_benchmark can not be set to True"

--- a/scripts/install_decoders_MacOS.sh
+++ b/scripts/install_decoders_MacOS.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Make sure swig is installed first. On Anaconda do:
+# conda install swig
+set -xe
+brew update
+brew install wget
+brew install boost
+brew install cmake
+export CFLAGS="-stdlib=libc++"
+export MACOSX_DEPLOYMENT_TARGET=10.14
+git clone https://github.com/PaddlePaddle/DeepSpeech
+cd DeepSpeech
+git checkout a76fc69
+cd ..
+mv DeepSpeech/decoders/swig_wrapper.py DeepSpeech/decoders/swig/ctc_decoders.py
+mv DeepSpeech/decoders/swig ./decoders
+rm -rf DeepSpeech
+cd decoders
+sed -i'.original' -e "s/\.decode('utf-8')//g" ctc_decoders.py
+sed -i'.original' -e 's/\.decode("utf-8")//g' ctc_decoders.py
+sed -i'.original' -e "s/name='swig_decoders'/name='ctc_decoders'/g" setup.py
+sed -i'.original' -e "s/-space_prefixes\[i\]->approx_ctc/space_prefixes\[i\]->score/g" decoder_utils.cpp
+sed -i'.original' -e "s/py_modules=\['swig_decoders'\]/py_modules=\['ctc_decoders', 'swig_decoders'\]/g" setup.py
+chmod +x setup.sh
+./setup.sh
+echo 'Installing kenlm'
+cd kenlm
+mkdir build
+cd build
+cmake ..
+make -j
+cd ..
+cd ..


### PR DESCRIPTION
For getting started, toy examples and, perhaps, some inference scenarios it might be beneficial to allow running on CPU only (and not requiring APEX install and pytorch cuda).
The scenario I use as a test case is running some examples on MacBook pro (without proper GPU).