### PR TITLE
allow jointintentslot data to take in generic data format

### DIFF
--- a/collections/nemo_nlp/nemo_nlp/data/datasets/utils.py
+++ b/collections/nemo_nlp/nemo_nlp/data/datasets/utils.py
@@ -545,7 +545,7 @@ def merge(data_dir, subdirs, dataset_name, modes=['train', 'test']):
 
 
 class JointIntentSlotDataDesc:
-    """ Convert the raw data to the standard format supported by 
+    """ Convert the raw data to the standard format supported by
     JointIntentSlotDataset.
 
     By default, the None label for slots is 'O'.

--- a/collections/nemo_nlp/nemo_nlp/utils/nlp_utils.py
+++ b/collections/nemo_nlp/nemo_nlp/utils/nlp_utils.py
@@ -45,7 +45,8 @@ def read_intent_slot_outputs(queries,
 
 def get_vocab(file):
     lines = open(file, 'r').readlines()
-    labels = {i: lines[i].strip() for i in range(len(lines))}
+    lines = [line.strip() for line in lines if line.strip()]
+    labels = {i: lines[i] for i in range(len(lines))}
     return labels
 
 
@@ -59,6 +60,11 @@ def write_vocab(items, outfile):
             idx += 1
     return vocab
 
+def label2idx(file):
+    lines = open(file, 'r').readlines()
+    lines = [line.strip() for line in lines if line.strip()]
+    labels = {lines[i]: i for i in range(len(lines))}
+    return labels
 
 def write_vocab_in_order(vocab, outfile):
     with open(outfile, 'w') as f:

--- a/collections/nemo_nlp/nemo_nlp/utils/nlp_utils.py
+++ b/collections/nemo_nlp/nemo_nlp/utils/nlp_utils.py
@@ -60,11 +60,13 @@ def write_vocab(items, outfile):
             idx += 1
     return vocab
 
+
 def label2idx(file):
     lines = open(file, 'r').readlines()
     lines = [line.strip() for line in lines if line.strip()]
     labels = {lines[i]: i for i in range(len(lines))}
     return labels
+
 
 def write_vocab_in_order(vocab, outfile):
     with open(outfile, 'w') as f:

--- a/examples/nlp/joint_intent_slot_infer.py
+++ b/examples/nlp/joint_intent_slot_infer.py
@@ -19,12 +19,11 @@ parser.add_argument("--pretrained_bert_model",
                     default="bert-base-uncased",
                     type=str)
 parser.add_argument("--dataset_name", default='snips-all', type=str)
-parser.add_argument("--data_dir",
-                    default='data/nlu/snips',
-                    type=str)
+parser.add_argument("--data_dir", default='data/nlu/snips', type=str)
 parser.add_argument("--work_dir",
-                    default='outputs/SNIPS-ALL/20191010-164934/checkpoints',
+                    default='outputs/SNIPS-ALL/20191014-104316/checkpoints',
                     type=str)
+parser.add_argument("--eval_file_prefix", default='test', type=str)
 parser.add_argument("--amp_opt_level", default="O0",
                     type=str, choices=["O0", "O1", "O2"])
 parser.add_argument("--do_lower_case", action='store_false')
@@ -49,14 +48,15 @@ hidden_size = pretrained_bert_model.local_parameters["hidden_size"]
 tokenizer = BertTokenizer.from_pretrained(args.pretrained_bert_model)
 
 
-data_desc = JointIntentSlotDataDesc(
-    args.dataset_name, args.data_dir, args.do_lower_case)
+data_desc = JointIntentSlotDataDesc(args.data_dir,
+                                    args.do_lower_case,
+                                    args.dataset_name)
 
 # Evaluation pipeline
 nf.logger.info("Loading eval data...")
 data_layer = nemo_nlp.BertJointIntentSlotDataLayer(
-    input_file=data_desc.eval_file,
-    slot_file=data_desc.eval_slot_file,
+    input_file=f'{data_desc.data_dir}/{args.eval_file_prefix}.tsv',
+    slot_file=f'{data_desc.data_dir}/{args.eval_file_prefix}_slots.tsv',
     pad_label=data_desc.pad_label,
     tokenizer=tokenizer,
     max_seq_length=args.max_seq_length,

--- a/examples/nlp/joint_intent_slot_infer_b1.py
+++ b/examples/nlp/joint_intent_slot_infer_b1.py
@@ -44,8 +44,9 @@ pretrained_bert_model = nemo_nlp.huggingface.BERT(
 tokenizer = BertTokenizer.from_pretrained(args.pretrained_bert_model)
 hidden_size = pretrained_bert_model.local_parameters["hidden_size"]
 
-data_desc = JointIntentSlotDataDesc(
-    args.dataset_name, args.data_dir, args.do_lower_case)
+data_desc = JointIntentSlotDataDesc(args.data_dir,
+                                    args.do_lower_case,
+                                    args.dataset_name)
 
 query = args.query
 if args.do_lower_case:


### PR DESCRIPTION
Changes in JointIntentSlotDataDesc:
- reorder the arguments
- added extra arguments none_slot_label and pad_label (which can be passed in as arguments in  the driver script)
Signed-off-by: Chip Nguyen <huyenntkvn@gmail.com>