### PR TITLE
Fixed an issue with loading a checkpoint

### DIFF
--- a/nemo/nemo/utils/helpers.py
+++ b/nemo/nemo/utils/helpers.py
@@ -47,8 +47,8 @@ def get_checkpoint_from_dir(module_names, cpkt_dir, ckpt_pattern=''):
             step_str = checkpoint_name.split('-STEP-')[1].split('.')[0]
             return int(step_str)
 
-        module_ckpts = sorted(module_ckpts, key=step_from_checkpoint)
-        ckpts.append(module_ckpts[-1])
+        module_ckpt = max(module_ckpts, key=step_from_checkpoint)
+        ckpts.append(module_ckpt)
 
     return ckpts
 

--- a/nemo/nemo/utils/helpers.py
+++ b/nemo/nemo/utils/helpers.py
@@ -42,7 +42,12 @@ def get_checkpoint_from_dir(module_names, cpkt_dir, ckpt_pattern=''):
             raise ValueError(f'No file matches {ckpt_pattern} in {cpkt_dir}')
 
         # if multiple checkpoints match a pattern, take the latest one
-        module_ckpts = sorted(module_ckpts, key=os.path.getmtime)
+        def step_from_checkpoint(checkpoint_name):
+            # return step number given a checkpoint filename
+            step_str = checkpoint_name.split('-STEP-')[1].split('.')[0]
+            return int(step_str)
+
+        module_ckpts = sorted(module_ckpts, key=step_from_checkpoint)
         ckpts.append(module_ckpts[-1])
 
     return ckpts


### PR DESCRIPTION
PR fixes the issue when a checkpoint with the latest step doesn't have the most recent timestamp.
For example, it may occur if checkpoints were archived / extracted / moved.

Signed-off-by: Vitaly Lavrukhin <vlavrukhin@nvidia.com>