### PR TITLE
Remove replacement of \xa0 by ' '

### DIFF
--- a/collections/nemo_nlp/nemo_nlp/data/datasets/bert_pretraining.py
+++ b/collections/nemo_nlp/nemo_nlp/data/datasets/bert_pretraining.py
@@ -67,8 +67,7 @@ class BertPretrainingDataset(Dataset):
                         new_start = contents.index(b"\n", start)
                         line = contents[start:new_start] \
                             .replace(b"\xc2\x99", b" ") \
-                            .replace(b"\xc2\xa0", b" ") \
-                            .replace(b"\xa0", b" ")
+                            .replace(b"\xc2\xa0", b" ")
                         num_tokens = len(line.split())
 
                         # Ensure the line has at least max_seq_length tokens


### PR DESCRIPTION
`\xa0` may be a part of a Chinese character utf-8 encoding. Thus replacing it by space causes errors for a Chinese dataset.