### PR TITLE
Setup fix

### DIFF
--- a/nemo/setup.py
+++ b/nemo/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     ],
     install_requires=[
         'torch==1.2.0',
-        'torchvision',
+        'torchvision==0.4.0',
         'tensorboardX',
         'pandas',
         'wget'


### PR DESCRIPTION
- TorchVision explicit version set to 0.4.0 (compatible with PyTorch 1.2.0)