### PR TITLE
Fixed LossAggregatorNM (was not differentiable)

### DIFF
--- a/collections/nemo_nlp/nemo_nlp/modules/losses.py
+++ b/collections/nemo_nlp/nemo_nlp/modules/losses.py
@@ -79,7 +79,7 @@ class LossAggregatorNM(LossNM):
         values = [kwargs[x] for x in sorted(kwargs.keys())]
         loss = values[0]
         for loss_i in values[1:]:
-            loss = loss.add(loss_i.item())
+            loss = loss.add(loss_i)
         return loss
 
 


### PR DESCRIPTION
Signed-off-by: Yang Zhang <yangzhang@nvidia.com>

Wrong implementation of LossAggregator. Prevented bert pretraining among others.
@chiphuyen 