### PR TITLE
Small Checkpoint Loading Fix

### DIFF
--- a/nemo/nemo/utils/helpers.py
+++ b/nemo/nemo/utils/helpers.py
@@ -54,7 +54,9 @@ def get_checkpoint_from_dir(module_names, cpkt_dir, ckpt_pattern=''):
             step_str = checkpoint_name.split('-')[-1].split('.')[0]
             return int(step_str)
 
-        module_ckpt = max(module_ckpts, key=step_from_checkpoint)
+        module_ckpt = module_ckpts[0]
+        if len(module_ckpts) > 1:
+            module_ckpt = max(module_ckpts, key=step_from_checkpoint)
         ckpts.append(module_ckpt)
 
     return ckpts


### PR DESCRIPTION
Simple check for when there is only 1 checkpoint that matches a neural modules in the checkpoint loading directory.