### PR TITLE
Epoch Restoring

### DIFF
--- a/nemo/nemo/backends/pytorch/actions.py
+++ b/nemo/nemo/backends/pytorch/actions.py
@@ -1380,7 +1380,6 @@ class PtActions(Actions):
 
         # MAIN TRAINING LOOP
         # iteration over epochs
-        self.epoch_num = 0
         while num_epochs is None or self.epoch_num < num_epochs:
             if train_sampler is not None:
                 train_sampler.set_epoch(self.epoch_num)


### PR DESCRIPTION
Fixes issue where epoch always gets set to zero even if restoring.

Forking this PR from #174 so it can be addressed separately.