### PR TITLE
Checking out fixed commit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update && apt-get install -y libsndfile1 sox \
 ENV PATH=$PATH:/usr/src/tensorrt/bin
 WORKDIR /tmp/onnx-trt
 COPY scripts/docker/onnx-trt.patch .
-RUN git clone https://github.com/onnx/onnx-tensorrt.git && cd onnx-tensorrt && git submodule update --init --recursive && patch -f < ../onnx-trt.patch && \
+RUN git clone -n https://github.com/onnx/onnx-tensorrt.git && cd onnx-tensorrt && git checkout 8716c9b && git submodule update --init --recursive && patch -f < ../onnx-trt.patch && \
     mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DGPU_ARCHS="60 70 75" && make -j16 && make install && mv -f /usr/lib/libnvonnx* /usr/lib/x86_64-linux-gnu/ && ldconfig
 
 WORKDIR /workspace/nemo


### PR DESCRIPTION
Latest CMakelists.txt made our patch fail. Also, onnx-tensorrt master now is based on TRT7 - so preferred fix is to use the latest TRT6-based commit.