### PR TITLE
adding badge for code coverage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,10 @@
 	:target: https://github.com/NVIDIA/NeMo/blob/master/LICENSE
 	:alt: NeMo core license and license for collections in this repo
 
+.. image:: https://coveralls.io/repos/github/NVIDIA/NeMo/badge.svg?branch=master
+    :target: https://coveralls.io/github/NVIDIA/NeMo?branch=master
+	:alt: NeMo code test coverage
+
 
 NVIDIA Neural Modules: NeMo
 ===========================


### PR DESCRIPTION
Following the subject that we have discussed yesterday during the "Retrospection" meeting I am adding the badge that enables automatic monitoring of code coverage with (unit) tests