### PR TITLE
deprecated test case (NeuralFactory) + important bugfix!

### DIFF
--- a/nemo/nemo/core/neural_factory.py
+++ b/nemo/nemo/core/neural_factory.py
@@ -742,8 +742,8 @@ class NeuralModuleFactory(object):
     @deprecated(version="future",
                 explanation="Please use "
                 f".train(...), .eval(...), .infer(...) and "
-                f".create_optimizer(...) methods directly from "
-                f"NeuralModuleFactory instance.")
+                f".create_optimizer(...) of "
+                f"the NeuralModuleFactory instance directly.")
     def get_trainer(self, tb_writer=None):
         if self._trainer:
             nemo.logging.warning(

--- a/nemo/nemo/core/neural_factory.py
+++ b/nemo/nemo/core/neural_factory.py
@@ -10,12 +10,13 @@ __all__ = ['Backend',
 from abc import ABC, abstractmethod
 import random
 from typing import List, Optional
-import warnings
 
 from enum import Enum
 import numpy as np
 
 import nemo
+from nemo.utils.decorators import deprecated
+
 from .callbacks import ActionCallback, EvaluatorCallback
 from .neural_types import *
 from ..utils import ExpManager
@@ -434,6 +435,7 @@ class NeuralModuleFactory(object):
             mod = getattr(mod, comp)
         return mod
 
+    @deprecated(version=0.11)
     def __get_pytorch_module(self, name, params, collection, pretrained):
         params["factory"] = self
         if collection == "toys" or collection == "tutorials" or collection \
@@ -537,6 +539,7 @@ class NeuralModuleFactory(object):
         instance = constructor(**params)
         return instance
 
+    @deprecated(version=0.11)
     def get_module(self, name, params, collection, pretrained=False):
         """
         Creates NeuralModule instance
@@ -736,13 +739,12 @@ class NeuralModuleFactory(object):
         else:
             raise ValueError("Only PyTorch backend is currently supported.")
 
+    @deprecated(version="future",
+                explanation="Please use "
+                f".train(...), .eval(...), .infer(...) and "
+                f".create_optimizer(...) methods directly from "
+                f"NeuralModuleFactory instance.")
     def get_trainer(self, tb_writer=None):
-        nemo.logging.warning(
-            f"This function is deprecated and will be removed"
-            f"in future versions of NeMo."
-            f"Please use .train(...), .eval(...), .infer(...) and "
-            f".create_optimizer(...) directly methods from "
-            f"NeuralModuleFactory instance.")
         if self._trainer:
             nemo.logging.warning(
                 "The trainer instance was created during initialization of "
@@ -798,10 +800,10 @@ class NeuralModuleFactory(object):
     def optim_level(self):
         return self._optim_level
 
+    @deprecated(version=0.11,
+                explanation="Please use ``nemo.logging instead``")
     @property
     def logger(self):
-        warnings.warn("This will be deprecated in future releases. Please use "
-                      "nemo.logging instead")
         return nemo.logging
 
     @property

--- a/nemo/nemo/utils/decorators/__init__.py
+++ b/nemo/nemo/utils/decorators/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (C) NVIDIA. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .deprecated import deprecated
+
+
+__all__ = [
+    'deprecated',
+]

--- a/nemo/nemo/utils/decorators/deprecated.py
+++ b/nemo/nemo/utils/decorators/deprecated.py
@@ -60,9 +60,8 @@ class deprecated(object):
 
                 # Optionally, add version and alternative.
                 if self.version is not None:
-                    msg = msg + \
-                        " It is going to be removed in version {}.".format(
-                            self.version)
+                    msg = msg + " It is going to be removed in "
+                    msg = msg + "the {} version.".format(self.version)
 
                 if self.explanation is not None:
                     msg = msg + " " + self.explanation

--- a/nemo/nemo/utils/decorators/deprecated.py
+++ b/nemo/nemo/utils/decorators/deprecated.py
@@ -70,6 +70,6 @@ class deprecated(object):
                 nemo.logging.warning(msg)
 
             # Call the function.
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
 
         return wrapper

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -98,7 +98,7 @@ class DeprecatedTestCase(NeMoUnitTest):
         # Check error output.
         self.assertEqual(std_err.getvalue().strip(),
                          "Function ``say_whoopie`` is deprecated. It is going "
-                         f"to be removed in version 0.1.")
+                         f"to be removed in the 0.1 version.")
 
     def test_say_kowabunga_deprecated_explanation(self):
         """ Tests whether both std and err streams return the right values

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -18,7 +18,7 @@ from io import StringIO
 from unittest.mock import patch
 
 from .common_setup import NeMoUnitTest
-from nemo.utils.decorators.deprecated import deprecated
+from nemo.utils.decorators import deprecated
 
 
 class DeprecatedTestCase(NeMoUnitTest):
@@ -97,8 +97,8 @@ class DeprecatedTestCase(NeMoUnitTest):
 
         # Check error output.
         self.assertEqual(std_err.getvalue().strip(),
-                         'Function ``say_whoopie`` is deprecated. It is going \
-to be removed in version 0.1.')
+                         "Function ``say_whoopie`` is deprecated. It is going "
+                         f"to be removed in version 0.1.")
 
     def test_say_kowabunga_deprecated_explanation(self):
         """ Tests whether both std and err streams return the right values
@@ -119,5 +119,5 @@ to be removed in version 0.1.')
 
         # Check error output.
         self.assertEqual(std_err.getvalue().strip(),
-                         'Function ``say_kowabunga`` is deprecated. Please \
-use ``print_ihaa`` instead.')
+                         "Function ``say_kowabunga`` is deprecated. Please "
+                         f"use ``print_ihaa`` instead.")


### PR DESCRIPTION
 * several NeuralFactory methods indicated as deprecated
 * added __init__ to decorators
 * bugfix: decodator now also returns the result of the function (!)