### PR TITLE
deprecated test case (NeuralFactory) + important bugfix! (v3)

### DIFF
--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -17,11 +17,10 @@ from typing import List, Optional
 import numpy as np
 
 import nemo
-from nemo.utils.decorators import deprecated
-
 from ..utils import ExpManager
 from .callbacks import ActionCallback, EvaluatorCallback
 from .neural_types import *
+from nemo.utils.decorators import deprecated
 
 
 class DeploymentFormat(Enum):

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -10,7 +10,6 @@ __all__ = [
 ]
 
 import random
-import warnings
 from abc import ABC, abstractmethod
 from enum import Enum
 from typing import List, Optional

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -18,6 +18,8 @@ from typing import List, Optional
 import numpy as np
 
 import nemo
+from nemo.utils.decorators import deprecated
+
 from ..utils import ExpManager
 from .callbacks import ActionCallback, EvaluatorCallback
 from .neural_types import *
@@ -417,6 +419,7 @@ class NeuralModuleFactory(object):
             mod = getattr(mod, comp)
         return mod
 
+    @deprecated(version=0.11)
     def __get_pytorch_module(self, name, params, collection, pretrained):
         params["factory"] = self
         if collection == "toys" or collection == "tutorials" or collection == "other":
@@ -493,6 +496,7 @@ class NeuralModuleFactory(object):
         instance = constructor(**params)
         return instance
 
+    @deprecated(version=0.11)
     def get_module(self, name, params, collection, pretrained=False):
         """
         Creates NeuralModule instance
@@ -665,6 +669,7 @@ class NeuralModuleFactory(object):
         """Helper function to clean inference cache."""
         self._trainer.clear_cache()
 
+    @deprecated(version="future")
     def _get_trainer(self, tb_writer=None):
         if self._backend == Backend.PyTorch:
             constructor = NeuralModuleFactory.__name_import("nemo.backends.pytorch.PtActions")
@@ -678,14 +683,12 @@ class NeuralModuleFactory(object):
         else:
             raise ValueError("Only PyTorch backend is currently supported.")
 
+    @deprecated(
+        version="future",
+        explanation="Please use .train(...), .eval(...), .infer(...) and "
+        f".create_optimizer(...) of the NeuralModuleFactory instance directly.",
+    )
     def get_trainer(self, tb_writer=None):
-        nemo.logging.warning(
-            f"This function is deprecated and will be removed"
-            f"in future versions of NeMo."
-            f"Please use .train(...), .eval(...), .infer(...) and "
-            f".create_optimizer(...) directly methods from "
-            f"NeuralModuleFactory instance."
-        )
         if self._trainer:
             nemo.logging.warning(
                 "The trainer instance was created during initialization of "
@@ -742,9 +745,9 @@ class NeuralModuleFactory(object):
     def optim_level(self):
         return self._optim_level
 
+    @deprecated(version=0.11, explanation="Please use ``nemo.logging instead``")
     @property
     def logger(self):
-        warnings.warn("This will be deprecated in future releases. Please use " "nemo.logging instead")
         return nemo.logging
 
     @property

--- a/nemo/utils/decorators/__init__.py
+++ b/nemo/utils/decorators/__init__.py
@@ -13,8 +13,3 @@
 # limitations under the License.
 
 from .deprecated import deprecated
-
-
-__all__ = [
-    'deprecated',
-]

--- a/nemo/utils/decorators/__init__.py
+++ b/nemo/utils/decorators/__init__.py
@@ -1,0 +1,20 @@
+# Copyright (C) NVIDIA. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from .deprecated import deprecated
+
+
+__all__ = [
+    'deprecated',
+]

--- a/nemo/utils/decorators/deprecated.py
+++ b/nemo/utils/decorators/deprecated.py
@@ -17,10 +17,8 @@ import nemo
 
 
 class deprecated(object):
-    """ Decorator class used for indicating that a function is
-    deprecated and going to be removed.
-    Tracks down which functions printed the warning and
-    will print it only once per function.
+    """ Decorator class used for indicating that a function is deprecated and going to be removed.
+    Tracks down which functions printed the warning and will print it only once per function.
     """
 
     # Static variable - list of names of functions that we already printed
@@ -33,8 +31,7 @@ class deprecated(object):
 
         Args:
           version: Version in which the function will be removed (optional)
-          explanation: Additional explanation (optional), e.g. use method
-          ``blabla instead``.
+          explanation: Additional explanation (optional), e.g. use method ``blabla instead``.
 
         """
         self.version = version
@@ -61,7 +58,8 @@ class deprecated(object):
 
                 # Optionally, add version and alternative.
                 if self.version is not None:
-                    msg = msg + " It is going to be removed in version {}.".format(self.version)
+                    msg = msg + " It is going to be removed in "
+                    msg = msg + "the {} version.".format(self.version)
 
                 if self.explanation is not None:
                     msg = msg + " " + self.explanation
@@ -70,6 +68,6 @@ class deprecated(object):
                 nemo.logging.warning(msg)
 
             # Call the function.
-            func(*args, **kwargs)
+            return func(*args, **kwargs)
 
         return wrapper

--- a/nemo/utils/decorators/deprecated.py
+++ b/nemo/utils/decorators/deprecated.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+__all__ = [
+    'deprecated',
+]
 
 import nemo
 

--- a/tests/test_deprecated.py
+++ b/tests/test_deprecated.py
@@ -17,7 +17,7 @@ from io import StringIO
 from unittest.mock import patch
 
 from .common_setup import NeMoUnitTest
-from nemo.utils.decorators.deprecated import deprecated
+from nemo.utils.decorators import deprecated
 
 
 class DeprecatedTestCase(NeMoUnitTest):
@@ -89,8 +89,7 @@ class DeprecatedTestCase(NeMoUnitTest):
         # Check error output.
         self.assertEqual(
             std_err.getvalue().strip(),
-            'Function ``say_whoopie`` is deprecated. It is going \
-to be removed in version 0.1.',
+            "Function ``say_whoopie`` is deprecated. It is going to be removed in the 0.1 version.",
         )
 
     def test_say_kowabunga_deprecated_explanation(self):
@@ -111,7 +110,5 @@ to be removed in version 0.1.',
 
         # Check error output.
         self.assertEqual(
-            std_err.getvalue().strip(),
-            'Function ``say_kowabunga`` is deprecated. Please \
-use ``print_ihaa`` instead.',
+            std_err.getvalue().strip(), 'Function ``say_kowabunga`` is deprecated. Please use ``print_ihaa`` instead.'
         )


### PR DESCRIPTION
* bugfix: decodator now also returns the result of the function (!)
* several NeuralFactory methods indicated as deprecated
* added init to decorators