### PR TITLE
Fix Dockerfile to include checked out version

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+__pycache__
+*.pyc
+*.pyo
+*.pyd
+.Python
+env
+pip-log.txt
+pip-delete-this-directory.txt
+.tox
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+*.log
+.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:experimental
+
 # Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG FROM_IMAGE_NAME=nvcr.io/nvidia/pytorch:19.11-py3
+ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:20.01-py3
 
-FROM ${FROM_IMAGE_NAME}
+# build an image that includes only the nemo dependencies, ensures that dependencies
+# are included first for optimal caching, and useful for building a development
+# image (by specifying build target as `nemo-deps`)
+FROM ${BASE_IMAGE} as nemo-deps
 
 # Ensure apt-get won't prompt for selecting options
 ENV DEBIAN_FRONTEND=noninteractive
@@ -25,27 +30,42 @@ RUN apt-get update && \
     python-dev && \
     rm -rf /var/lib/apt/lists/*
 
+# install onnx trt open source plugins
 ENV PATH=$PATH:/usr/src/tensorrt/bin
 WORKDIR /tmp/onnx-trt
 COPY scripts/docker/onnx-trt.patch .
-RUN git clone -n https://github.com/onnx/onnx-tensorrt.git && cd onnx-tensorrt && git checkout 8716c9b && git submodule update --init --recursive && patch -f < ../onnx-trt.patch && \
-    mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DGPU_ARCHS="60 70 75" && make -j16 && make install && mv -f /usr/lib/libnvonnx* /usr/lib/x86_64-linux-gnu/ && ldconfig
+RUN git clone -n https://github.com/onnx/onnx-tensorrt.git && cd onnx-tensorrt && \
+    git checkout 8716c9b && git submodule update --init --recursive && patch -f < ../onnx-trt.patch && \
+    mkdir build && cd build && cmake .. -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr -DGPU_ARCHS="60 70 75" && \
+    make -j16 && make install && mv -f /usr/lib/libnvonnx* /usr/lib/x86_64-linux-gnu/ && ldconfig && rm -rf /tmp/onnx-tensorrt
 
-WORKDIR /workspace/nemo
-ARG NEMO_GIT_BRANCH="master"
-
+# install nemo dependencies
+WORKDIR /tmp/nemo
 COPY requirements/requirements_docker.txt requirements.txt
-RUN pip install \
-    --disable-pip-version-check --no-cache-dir\
-    --upgrade -r requirements.txt && \
-    pip install --no-cache-dir \
-    git+git://github.com/NVIDIA/NeMo.git@${NEMO_GIT_BRANCH}#egg=project[all]
+RUN pip install --disable-pip-version-check --no-cache-dir -r requirements.txt
+
+# copy nemo source into a scratch image
+FROM scratch as nemo-src
+COPY . .
+
+# start building the final container
+FROM nemo-deps as nemo
+ARG NEMO_VERSION
+ARG BASE_IMAGE
+# Check that NEMO_VERSION is set. Build will fail without this. Expose NEMO and base container
+# version information as runtime environment variable for introspection purposes
+RUN /usr/bin/test -n "$NEMO_VERSION" && \
+    /bin/echo "export NEMO_VERSION=${NEMO_VERSION}" >> /root/.bashrc && \
+    /bin/echo "export BASE_IMAGE=${BASE_IMAGE}" >> /root/.bashrc
+RUN --mount=from=nemo-src,target=/tmp/nemo cd /tmp/nemo && pip install ".[all]"
+
+# copy scripts/examples/tests into container for end user
+WORKDIR /workspace/nemo
+COPY scripts /workspace/nemo/scripts
+COPY examples /workspace/nemo/examples
+COPY tests /workspace/nemo/tests
+COPY README.rst LICENSE /workspace/nemo/
 
 RUN printf "#!/bin/bash\njupyter lab --no-browser --allow-root --ip=0.0.0.0" >> start-jupyter.sh && \
     chmod +x start-jupyter.sh
-
-
-
-
-
 

--- a/requirements/requirements_docker.txt
+++ b/requirements/requirements_docker.txt
@@ -21,7 +21,6 @@ ruamel.yaml
 sentencepiece
 six
 sox
-torch
 tqdm
 unidecode
 wget


### PR DESCRIPTION
The recent change included in the PR to fix unit tests introduces a regression/bug in the Dockerfile. With the Dockerfile you should be able to build the currently checked out version (and any local changes).

The current Dockerfile doesn't support this -- basically mandates that a Docker image may only be made from a branch of the main repository.

Signed-off-by: Ryan Leary <rleary@nvidia.com>