### PR TITLE
Fix of documentation after package reorganization

### DIFF
--- a/docs/docs_zh/sources/source/collections/nemo_asr.rst
+++ b/docs/docs_zh/sources/source/collections/nemo_asr.rst
@@ -1,4 +1,4 @@
-nemo.collections.ASR collection
+NeMo ASR collection
 ===================
 
 语音数据处理模块

--- a/docs/docs_zh/sources/source/collections/nemo_asr.rst
+++ b/docs/docs_zh/sources/source/collections/nemo_asr.rst
@@ -1,9 +1,9 @@
-NeMo_ASR collection
+nemo.collections.ASR collection
 ===================
 
 语音数据处理模块
 ------------------------------
-.. automodule:: nemo_asr.data_layer
+.. automodule:: nemo.collections.asr.data_layer
     :members:
     :undoc-members:
     :show-inheritance:
@@ -11,7 +11,7 @@ NeMo_ASR collection
 
 语音识别模块
 ------------------------------------
-.. automodule:: nemo_asr.jasper
+.. automodule:: nemo.collections.asr.jasper
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/docs_zh/sources/source/collections/nemo_nlp.rst
+++ b/docs/docs_zh/sources/source/collections/nemo_nlp.rst
@@ -3,11 +3,10 @@ NeMo NLP collection
 
 NLP 数据处理模块
 ---------------------------
-.. automodule:: nemo.collections.nlp.nm.data_layers
+.. automodule:: nemo.collections.nlp.data.datasets
     :members:
     :undoc-members:
     :show-inheritance:
-    :exclude-members: forward
 
 NLP 分词器
 --------------
@@ -27,7 +26,7 @@ NLP 分词器
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo.collections.nlp.data.tokenizers.spc_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.sentencepiece_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
@@ -42,7 +41,7 @@ NLP 分词器
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo.collections.nlp.data.tokenizers.yttm_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.youtokentome_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
@@ -50,7 +49,8 @@ NLP 分词器
 NLP 神经模块
 ------------------
 
-.. automodule:: nemo.collections.nlp.modules.classifiers
+
+.. automodule:: nemo.collections.nlp.nm.data_layers
    :members:
    :undoc-members:
    :show-inheritance:
@@ -64,7 +64,19 @@ NLP 神经模块
    :exclude-members: forward
 
 
-.. automodule:: nemo.collections.nlp.modules.pytorch_utils
+.. automodule:: nemo.collections.nlp.nm.trainables.common.sequence_classification_nm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: forward
+
+.. automodule:: nemo.collections.nlp.nm.trainables.common.sequence_regression_nm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: forward
+
+.. automodule:: nemo.collections.nlp.nm.trainables.common.token_classification_nm
    :members:
    :undoc-members:
    :show-inheritance:
@@ -76,10 +88,22 @@ NLP 神经模块
    :show-inheritance:
    :exclude-members: forward
 
+.. automodule:: nemo.collections.nlp.nm.trainables.dialogue_state_tracking.state_tracking_trade_nm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: forward
+
+.. automodule:: nemo.collections.nlp.nm.trainables.joint_intent_slot.joint_intent_slot_nm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: forward
+
 NLP Hugging Face 神经模块
 -------------------------------
 
-.. automodule:: nemo.collections.nlp.nm.trainables.common.huggingface
+.. automodule:: nemo.collections.nlp.nm.trainables.common.huggingface.bert_nm
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/docs_zh/sources/source/collections/nemo_nlp.rst
+++ b/docs/docs_zh/sources/source/collections/nemo_nlp.rst
@@ -1,4 +1,4 @@
-nemo.collections.NLP collection
+NeMo NLP collection
 ===================
 
 NLP 数据处理模块
@@ -57,7 +57,7 @@ NLP 神经模块
    :exclude-members: forward
 
 
-.. automodule:: nemo.collections.nlp.modules.losses
+.. automodule:: nemo.collections.nlp.nm.losses
    :members:
    :undoc-members:
    :show-inheritance:
@@ -70,7 +70,7 @@ NLP 神经模块
    :show-inheritance:
    :exclude-members: forward
 
-.. automodule:: nemo.collections.nlp.modules.transformer_nm
+.. automodule:: nemo.collections.nlp.nm.trainables.common.transformer.transformer_nm
    :members:
    :undoc-members:
    :show-inheritance:
@@ -79,7 +79,7 @@ NLP 神经模块
 NLP Hugging Face 神经模块
 -------------------------------
 
-.. automodule:: nemo.collections.nlp.huggingface.bert
+.. automodule:: nemo.collections.nlp.nm.trainables.common.huggingface
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/docs_zh/sources/source/collections/nemo_nlp.rst
+++ b/docs/docs_zh/sources/source/collections/nemo_nlp.rst
@@ -1,9 +1,9 @@
-NeMo_NLP collection
+nemo.collections.NLP collection
 ===================
 
 NLP 数据处理模块
 ---------------------------
-.. automodule:: nemo_nlp.data_layers
+.. automodule:: nemo.collections.nlp.nm.data_layers
     :members:
     :undoc-members:
     :show-inheritance:
@@ -12,37 +12,37 @@ NLP 数据处理模块
 NLP 分词器
 --------------
 
-.. automodule:: nemo_nlp.data.tokenizers.bert_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.bert_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo_nlp.data.tokenizers.char_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.char_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo_nlp.data.tokenizers.gpt2_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.gpt2_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo_nlp.data.tokenizers.spc_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.spc_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo_nlp.data.tokenizers.tokenizer_spec
+.. automodule:: nemo.collections.nlp.data.tokenizers.tokenizer_spec
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo_nlp.data.tokenizers.word_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.word_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo_nlp.data.tokenizers.yttm_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.yttm_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
@@ -50,27 +50,27 @@ NLP 分词器
 NLP 神经模块
 ------------------
 
-.. automodule:: nemo_nlp.modules.classifiers
+.. automodule:: nemo.collections.nlp.modules.classifiers
    :members:
    :undoc-members:
    :show-inheritance:
    :exclude-members: forward
 
 
-.. automodule:: nemo_nlp.modules.losses
+.. automodule:: nemo.collections.nlp.modules.losses
    :members:
    :undoc-members:
    :show-inheritance:
    :exclude-members: forward
 
 
-.. automodule:: nemo_nlp.modules.pytorch_utils
+.. automodule:: nemo.collections.nlp.modules.pytorch_utils
    :members:
    :undoc-members:
    :show-inheritance:
    :exclude-members: forward
 
-.. automodule:: nemo_nlp.modules.transformer_nm
+.. automodule:: nemo.collections.nlp.modules.transformer_nm
    :members:
    :undoc-members:
    :show-inheritance:
@@ -79,7 +79,7 @@ NLP 神经模块
 NLP Hugging Face 神经模块
 -------------------------------
 
-.. automodule:: nemo_nlp.huggingface.bert
+.. automodule:: nemo.collections.nlp.huggingface.bert
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/docs_zh/sources/source/collections/nemo_tts.rst
+++ b/docs/docs_zh/sources/source/collections/nemo_tts.rst
@@ -1,4 +1,4 @@
-nemo.collections.TTS collection
+NeMo TTS collection
 ===================
 
 语音数据处理模块

--- a/docs/docs_zh/sources/source/collections/nemo_tts.rst
+++ b/docs/docs_zh/sources/source/collections/nemo_tts.rst
@@ -1,9 +1,9 @@
-NeMo_TTS collection
+nemo.collections.TTS collection
 ===================
 
 语音数据处理模块
 ------------------------------
-.. automodule:: nemo_tts.data_layers
+.. automodule:: nemo.collections.tts.data_layers
     :members:
     :undoc-members:
     :show-inheritance:
@@ -11,7 +11,7 @@ NeMo_TTS collection
 
 Tacotron 2 模块
 ------------------
-.. automodule:: nemo_tts.tacotron2_modules
+.. automodule:: nemo.collections.tts.tacotron2_modules
     :members:
     :undoc-members:
     :show-inheritance:
@@ -19,7 +19,7 @@ Tacotron 2 模块
 
 Waveglow 模块
 ------------------
-.. automodule:: nemo_tts.waveglow_modules
+.. automodule:: nemo.collections.tts.waveglow_modules
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/docs_zh/sources/source/conf.py
+++ b/docs/docs_zh/sources/source/conf.py
@@ -25,11 +25,6 @@ import nemo
 
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("../../../"))
-# sys.path.insert(0, os.path.abspath("../../../nemo/nemo"))
-# sys.path.insert(0, os.path.abspath("../../../collections"))
-# sys.path.insert(0, os.path.abspath("../../../collections/nemo_asr"))
-# sys.path.insert(0, os.path.abspath("../../../collections/nemo_nlp"))
-# sys.path.insert(0, os.path.abspath("../../../collections/nemo_lpr"))
 
 # ---- Mocking up the classes. -----
 MOCK_CLASSES = {'Dataset': 'torch.utils.data', 'Module': 'torch.nn'}

--- a/docs/docs_zh/sources/source/conf.py
+++ b/docs/docs_zh/sources/source/conf.py
@@ -25,10 +25,10 @@ import nemo
 
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("../../../"))
-sys.path.insert(0, os.path.abspath("../../../nemo/nemo"))
-sys.path.insert(0, os.path.abspath("../../../collections"))
-sys.path.insert(0, os.path.abspath("../../../collections/nemo_asr"))
-sys.path.insert(0, os.path.abspath("../../../collections/nemo_nlp"))
+# sys.path.insert(0, os.path.abspath("../../../nemo/nemo"))
+# sys.path.insert(0, os.path.abspath("../../../collections"))
+# sys.path.insert(0, os.path.abspath("../../../collections/nemo_asr"))
+# sys.path.insert(0, os.path.abspath("../../../collections/nemo_nlp"))
 # sys.path.insert(0, os.path.abspath("../../../collections/nemo_lpr"))
 
 # ---- Mocking up the classes. -----
@@ -63,6 +63,7 @@ MOCK_MODULES = [
     'h5py',
     'kaldi_io',
     'transformers',
+    'transformers.tokenization_bert',
 ]
 
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/docs/sources/source/collections/nemo_asr.rst
+++ b/docs/sources/source/collections/nemo_asr.rst
@@ -1,4 +1,4 @@
-NeMo_ASR collection
+NeMo ASR collection
 ===================
 
 Speech data processing modules

--- a/docs/sources/source/collections/nemo_asr.rst
+++ b/docs/sources/source/collections/nemo_asr.rst
@@ -3,7 +3,7 @@ NeMo_ASR collection
 
 Speech data processing modules
 ------------------------------
-.. automodule:: nemo_asr.data_layer
+.. automodule:: nemo.collections.asr.data_layer
     :members:
     :undoc-members:
     :show-inheritance:
@@ -11,7 +11,7 @@ Speech data processing modules
 
 Automatic Speech Recognition modules
 ------------------------------------
-.. automodule:: nemo_asr.jasper
+.. automodule:: nemo.collections.asr.jasper
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/sources/source/collections/nemo_nlp.rst
+++ b/docs/sources/source/collections/nemo_nlp.rst
@@ -1,9 +1,9 @@
-NeMo_NLP collection
+nemo.collections.nlp collection
 ===================
 
 NLP data processing modules
 ---------------------------
-.. automodule:: nemo_nlp.data_layers
+.. automodule:: nemo.collections.nlp.data_layers
     :members:
     :undoc-members:
     :show-inheritance:
@@ -12,37 +12,37 @@ NLP data processing modules
 NLP Tokenizers
 --------------
 
-.. automodule:: nemo_nlp.data.tokenizers.bert_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.bert_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo_nlp.data.tokenizers.char_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.char_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo_nlp.data.tokenizers.gpt2_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.gpt2_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo_nlp.data.tokenizers.spc_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.spc_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo_nlp.data.tokenizers.tokenizer_spec
+.. automodule:: nemo.collections.nlp.data.tokenizers.tokenizer_spec
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo_nlp.data.tokenizers.word_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.word_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo_nlp.data.tokenizers.yttm_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.yttm_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
@@ -50,27 +50,27 @@ NLP Tokenizers
 NLP Neural Modules
 ------------------
 
-.. automodule:: nemo_nlp.modules.classifiers
+.. automodule:: nemo.collections.nlp.modules.classifiers
    :members:
    :undoc-members:
    :show-inheritance:
    :exclude-members: forward
 
 
-.. automodule:: nemo_nlp.modules.losses
+.. automodule:: nemo.collections.nlp.modules.losses
    :members:
    :undoc-members:
    :show-inheritance:
    :exclude-members: forward
 
 
-.. automodule:: nemo_nlp.modules.pytorch_utils
+.. automodule:: nemo.collections.nlp.modules.pytorch_utils
    :members:
    :undoc-members:
    :show-inheritance:
    :exclude-members: forward
 
-.. automodule:: nemo_nlp.modules.transformer_nm
+.. automodule:: nemo.collections.nlp.modules.transformer_nm
    :members:
    :undoc-members:
    :show-inheritance:
@@ -79,7 +79,7 @@ NLP Neural Modules
 NLP Hugging Face Neural Modules
 -------------------------------
 
-.. automodule:: nemo_nlp.huggingface.bert
+.. automodule:: nemo.collections.nlp.huggingface.bert
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/sources/source/collections/nemo_nlp.rst
+++ b/docs/sources/source/collections/nemo_nlp.rst
@@ -3,11 +3,10 @@ NeMo NLP collection
 
 NLP data processing modules
 ---------------------------
-.. automodule:: nemo.collections.nlp.data_layers
+.. automodule:: nemo.collections.nlp.data.datasets
     :members:
     :undoc-members:
     :show-inheritance:
-    :exclude-members: forward
 
 NLP Tokenizers
 --------------
@@ -27,7 +26,7 @@ NLP Tokenizers
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo.collections.nlp.data.tokenizers.spc_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.sentencepiece_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
@@ -42,7 +41,7 @@ NLP Tokenizers
    :undoc-members:
    :show-inheritance:
 
-.. automodule:: nemo.collections.nlp.data.tokenizers.yttm_tokenizer
+.. automodule:: nemo.collections.nlp.data.tokenizers.youtokentome_tokenizer
    :members:
    :undoc-members:
    :show-inheritance:
@@ -50,21 +49,33 @@ NLP Tokenizers
 NLP Neural Modules
 ------------------
 
-.. automodule:: nemo.collections.nlp.modules.classifiers
+.. automodule:: nemo.collections.nlp.nm.data_layers
    :members:
    :undoc-members:
    :show-inheritance:
    :exclude-members: forward
 
 
-.. automodule:: nemo.collections.nlp.modules.losses
+.. automodule:: nemo.collections.nlp.nm.losses
    :members:
    :undoc-members:
    :show-inheritance:
    :exclude-members: forward
 
 
-.. automodule:: nemo.collections.nlp.modules.pytorch_utils
+.. automodule:: nemo.collections.nlp.nm.trainables.common.sequence_classification_nm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: forward
+
+.. automodule:: nemo.collections.nlp.nm.trainables.common.sequence_regression_nm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: forward
+
+.. automodule:: nemo.collections.nlp.nm.trainables.common.token_classification_nm
    :members:
    :undoc-members:
    :show-inheritance:
@@ -76,10 +87,22 @@ NLP Neural Modules
    :show-inheritance:
    :exclude-members: forward
 
+.. automodule:: nemo.collections.nlp.nm.trainables.dialogue_state_tracking.state_tracking_trade_nm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: forward
+
+.. automodule:: nemo.collections.nlp.nm.trainables.joint_intent_slot.joint_intent_slot_nm
+   :members:
+   :undoc-members:
+   :show-inheritance:
+   :exclude-members: forward
+
 NLP Hugging Face Neural Modules
 -------------------------------
 
-.. automodule:: nemo.collections.nlp.nm.trainables.common.huggingface
+.. automodule:: nemo.collections.nlp.nm.trainables.common.huggingface.bert_nm
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/sources/source/collections/nemo_nlp.rst
+++ b/docs/sources/source/collections/nemo_nlp.rst
@@ -1,4 +1,4 @@
-nemo.collections.nlp collection
+NeMo NLP collection
 ===================
 
 NLP data processing modules
@@ -70,7 +70,7 @@ NLP Neural Modules
    :show-inheritance:
    :exclude-members: forward
 
-.. automodule:: nemo.collections.nlp.modules.transformer_nm
+.. automodule:: nemo.collections.nlp.nm.trainables.common.transformer.transformer_nm
    :members:
    :undoc-members:
    :show-inheritance:
@@ -79,7 +79,7 @@ NLP Neural Modules
 NLP Hugging Face Neural Modules
 -------------------------------
 
-.. automodule:: nemo.collections.nlp.huggingface.bert
+.. automodule:: nemo.collections.nlp.nm.trainables.common.huggingface
    :members:
    :undoc-members:
    :show-inheritance:

--- a/docs/sources/source/collections/nemo_tts.rst
+++ b/docs/sources/source/collections/nemo_tts.rst
@@ -1,4 +1,4 @@
-nemo.collections.TTS collection
+NeMo TTS collection
 ===================
 
 Speech data processing modules

--- a/docs/sources/source/collections/nemo_tts.rst
+++ b/docs/sources/source/collections/nemo_tts.rst
@@ -1,9 +1,9 @@
-NeMo_TTS collection
+nemo.collections.TTS collection
 ===================
 
 Speech data processing modules
 ------------------------------
-.. automodule:: nemo_tts.data_layers
+.. automodule:: nemo.collections.tts.data_layers
     :members:
     :undoc-members:
     :show-inheritance:
@@ -11,7 +11,7 @@ Speech data processing modules
 
 Tacotron 2 modules
 ------------------
-.. automodule:: nemo_tts.tacotron2_modules
+.. automodule:: nemo.collections.tts.tacotron2_modules
     :members:
     :undoc-members:
     :show-inheritance:
@@ -19,7 +19,7 @@ Tacotron 2 modules
 
 Waveglow modules
 ------------------
-.. automodule:: nemo_tts.waveglow_modules
+.. automodule:: nemo.collections.tts.waveglow_modules
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/sources/source/conf.py
+++ b/docs/sources/source/conf.py
@@ -25,12 +25,7 @@ import nemo
 
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("../../../"))
-sys.path.insert(0, os.path.abspath("../../../nemo/nemo"))
-sys.path.insert(0, os.path.abspath("../../../collections"))
-sys.path.insert(0, os.path.abspath("../../../collections/nemo_asr"))
-sys.path.insert(0, os.path.abspath("../../../collections/nemo_nlp"))
-sys.path.insert(0, os.path.abspath("../../../collections/nemo_tts"))
-# sys.path.insert(0, os.path.abspath("../../../collections/nemo_lpr"))
+sys.path.insert(0, os.path.abspath("../../../nemo/"))
 
 # ---- Mocking up the classes. -----
 MOCK_CLASSES = {'Dataset': 'torch.utils.data', 'Module': 'torch.nn'}
@@ -66,6 +61,7 @@ MOCK_MODULES = [
     'h5py',
     'kaldi_io',
     'transformers',
+    'transformers.tokenization_bert',
 ]
 
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)

--- a/docs/sources/source/conf.py
+++ b/docs/sources/source/conf.py
@@ -25,7 +25,6 @@ import nemo
 
 sys.path.insert(0, os.path.abspath("."))
 sys.path.insert(0, os.path.abspath("../../../"))
-sys.path.insert(0, os.path.abspath("../../../nemo/"))
 
 # ---- Mocking up the classes. -----
 MOCK_CLASSES = {'Dataset': 'torch.utils.data', 'Module': 'torch.nn'}

--- a/examples/image/gan.py
+++ b/examples/image/gan.py
@@ -44,7 +44,7 @@ mnist_data = nemo_simple_gan.MnistGanDataLayer(
     batch_size=batch_size, shuffle=True, train=True, root=args.train_dataset
 )
 
-generator = nemo_simple_gan.SimpleGenerator()
+generator = nemo_simple_gan.SimpleGenerator(batch_size)
 discriminator = nemo_simple_gan.SimpleDiscriminator()
 neg_disc_loss = nemo_simple_gan.DiscriminatorLoss(neg=True)
 disc_loss = nemo_simple_gan.DiscriminatorLoss()

--- a/examples/image/resnet50.py
+++ b/examples/image/resnet50.py
@@ -54,41 +54,37 @@ neural_factory = nemo.core.NeuralModuleFactory(
     optimization_level=nemo.core.Optimization.mxprO0,
 )
 
-resnet = neural_factory.get_module(
-    name="resnet50", params={"placement": device}, collection="torchvision", pretrained=False,
-)
+resnet = neural_factory.get_module(name="resnet50", params={}, collection="torchvision", pretrained=False)
 
 dl_train = neural_factory.get_module(
     name="ImageFolderDataLayer",
     collection="torchvision",
     params={
         "batch_size": batch_size,
-        "input_size": resnet.inputs["x"].axis2type[2].dim,
+        "input_size": resnet.input_ports["x"].axis2type[2].dim,
         "shuffle": True,
         "path": args.data_root + "train",
         # "path": "/mnt/D1/Data/ImageNet/ImageFolder/train",
-        "placement": device,
     },
 )
 
-L_train = neural_factory.get_module(name="CrossEntropyLoss", collection="toys", params={"placement": device})
+L_train = neural_factory.get_module(name="CrossEntropyLoss", collection="toys", params={})
 
 dl_eval = neural_factory.get_module(
     name="ImageFolderDataLayer",
     collection="torchvision",
     params={
         "batch_size": batch_size,
-        "input_size": resnet.inputs["x"].axis2type[2].dim,
+        "input_size": resnet.input_ports["x"].axis2type[2].dim,
         "shuffle": False,
         "is_eval": True,
         "path": args.data_root + "val",
         # "path": "/mnt/D1/Data/ImageNet/ImageFolder/val",
         # "path": "/raid/okuchaiev/Data/ImageNet/ImageFolder/val",
-        "placement": device,
     },
 )
 
-L_eval = neural_factory.get_module(name="CrossEntropyLoss", collection="toys", params={"placement": device})
+L_eval = neural_factory.get_module(name="CrossEntropyLoss", collection="toys", params={})
 
 step_per_epoch = int(len(dl_train) / (batch_size * num_gpus))
 

--- a/examples/nlp/language_modeling/bert_pretraining.py
+++ b/examples/nlp/language_modeling/bert_pretraining.py
@@ -84,6 +84,8 @@ from nemo import logging
 from nemo.collections.nlp.data.datasets.lm_bert_dataset import BERTPretrainingDataDesc
 from nemo.utils.lr_policies import get_lr_policy
 
+print("nemo_nlp path", nemo_nlp.__file__)
+
 parser = argparse.ArgumentParser(description='BERT pretraining')
 parser.add_argument("--local_rank", default=None, type=int)
 parser.add_argument("--num_gpus", default=1, type=int)

--- a/examples/nlp/language_modeling/bert_pretraining.py
+++ b/examples/nlp/language_modeling/bert_pretraining.py
@@ -84,8 +84,6 @@ from nemo import logging
 from nemo.collections.nlp.data.datasets.lm_bert_dataset import BERTPretrainingDataDesc
 from nemo.utils.lr_policies import get_lr_policy
 
-print("nemo_nlp path", nemo_nlp.__file__)
-
 parser = argparse.ArgumentParser(description='BERT pretraining')
 parser.add_argument("--local_rank", default=None, type=int)
 parser.add_argument("--num_gpus", default=1, type=int)

--- a/nemo/collections/simple_gan/gan.py
+++ b/nemo/collections/simple_gan/gan.py
@@ -123,8 +123,10 @@ class SimpleGenerator(TrainableNM):
             )
         }
 
-    def __init__(self):
+    def __init__(self, batch_size):
         super().__init__()
+        self._batch_size = batch_size
+
         self.layers = torch.nn.Sequential(
             torch.nn.ConvTranspose2d(64, 128, 3, stride=2),
             torch.nn.ReLU(),


### PR DESCRIPTION
Fixed several Sphinx-related issues that probably resulted from the reorganizations of a) the packages in general and  b) of NLP collection in particular.

DONE:
- [x] Cleaned up paths (EN/CN conf.py)
- [x] Added 'transformers.tokenization_bert' to mocked up modules (EN/CN conf.py)
- [x] Added 'transformers.tokenization_bert' to mocked up modules (EN/CN conf.py)
- [x] Fixed several references to whole modules (EN/CN)
- [x] Fixed several references to particular classes (EN/CN)

For example, .. automodule:: nemo.collections.nlp.huggingface.bert ->
.. automodule:: nemo.collections.nlp.nm.trainables.common.huggingface.bert

