### PR TITLE
Issue 357

### DIFF
--- a/examples/asr/jasper_eval.py
+++ b/examples/asr/jasper_eval.py
@@ -16,43 +16,46 @@ from nemo.collections.asr.helpers import post_process_predictions, post_process_
 
 def main():
     parser = argparse.ArgumentParser(description='Jasper')
-    parser.add_argument("--local_rank", default=None, type=int)
-    parser.add_argument("--batch_size", default=64, type=int)
+    # model params
     parser.add_argument("--model_config", type=str, required=True)
     parser.add_argument("--eval_datasets", type=str, required=True)
     parser.add_argument("--load_dir", type=str, required=True)
+    # run params
+    parser.add_argument("--local_rank", default=None, type=int)
+    parser.add_argument("--batch_size", default=64, type=int)
+    parser.add_argument("--amp_opt_level", default="O0", type=str) # new
+    # store results
     parser.add_argument("--save_logprob", default=None, type=str)
+
+    # lm inference parameters
     parser.add_argument("--lm_path", default=None, type=str)
     parser.add_argument(
-        '--alpha', default=2.0, type=float, help='value of LM weight', required=False,
-    )
+        '--alpha', default=2., type=float,
+        help='value of LM weight',
+        required=False)
     parser.add_argument(
-        '--alpha_max',
-        type=float,
+        '--alpha_max', type=float,
         help='maximum value of LM weight (for a grid search in \'eval\' mode)',
-        required=False,
-    )
+        required=False)
     parser.add_argument(
-        '--alpha_step', type=float, help='step for LM weight\'s tuning in \'eval\' mode', required=False, default=0.1,
-    )
+        '--alpha_step', type=float,
+        help='step for LM weight\'s tuning in \'eval\' mode',
+        required=False, default=0.1)
     parser.add_argument(
-        '--beta', default=1.5, type=float, help='value of word count weight', required=False,
-    )
+        '--beta', default=1.5, type=float,
+        help='value of word count weight',
+        required=False)
     parser.add_argument(
-        '--beta_max',
-        type=float,
+        '--beta_max', type=float,
         help='maximum value of word count weight (for a grid search in \
           \'eval\' mode',
-        required=False,
-    )
+        required=False)
     parser.add_argument(
-        '--beta_step',
-        type=float,
+        '--beta_step', type=float,
         help='step for word count weight\'s tuning in \'eval\' mode',
-        required=False,
-        default=0.1,
-    )
-    parser.add_argument("--beam_width", default=128, type=int)
+        required=False, default=0.1)
+    parser.add_argument(
+        "--beam_width", default=128, type=int)
 
     args = parser.parse_args()
     batch_size = args.batch_size
@@ -61,8 +64,8 @@ def main():
     if args.local_rank is not None:
         if args.lm_path:
             raise NotImplementedError(
-                "Beam search decoder with LM does not currently support " "evaluation on multi-gpu."
-            )
+                "Beam search decoder with LM does not currently support "
+                 "evaluation on multi-gpu.")
         device = nemo.core.DeviceType.AllGpu
     else:
         device = nemo.core.DeviceType.GPU
@@ -71,7 +74,7 @@ def main():
     neural_factory = nemo.core.NeuralModuleFactory(
         backend=nemo.core.Backend.PyTorch,
         local_rank=args.local_rank,
-        optimization_level=nemo.core.Optimization.mxprO1,
+        optimization_level=args.amp_opt_level,
         placement=device,
     )
 
@@ -102,45 +105,55 @@ def main():
     nemo.logging.info('Evaluating {0} examples'.format(N))
 
     data_preprocessor = nemo_asr.AudioToMelSpectrogramPreprocessor(
-        sample_rate=sample_rate, **jasper_params["AudioToMelSpectrogramPreprocessor"],
-    )
+        sample_rate=sample_rate,
+        **jasper_params["AudioToMelSpectrogramPreprocessor"])
     jasper_encoder = nemo_asr.JasperEncoder(
-        feat_in=jasper_params["AudioToMelSpectrogramPreprocessor"]["features"], **jasper_params["JasperEncoder"],
-    )
+        feat_in=jasper_params["AudioToMelSpectrogramPreprocessor"]["features"],
+        **jasper_params["JasperEncoder"])
     jasper_decoder = nemo_asr.JasperDecoderForCTC(
-        feat_in=jasper_params["JasperEncoder"]["jasper"][-1]["filters"], num_classes=len(vocab),
-    )
+        feat_in=jasper_params["JasperEncoder"]["jasper"][-1]["filters"],
+        num_classes=len(vocab))
     greedy_decoder = nemo_asr.GreedyCTCDecoder()
 
     nemo.logging.info('================================')
-    nemo.logging.info(f"Number of parameters in encoder: {jasper_encoder.num_weights}")
-    nemo.logging.info(f"Number of parameters in decoder: {jasper_decoder.num_weights}")
     nemo.logging.info(
-        f"Total number of parameters in model: " f"{jasper_decoder.num_weights + jasper_encoder.num_weights}"
-    )
+        f"Number of parameters in encoder: {jasper_encoder.num_weights}")
+    nemo.logging.info(
+        f"Number of parameters in decoder: {jasper_decoder.num_weights}")
+    nemo.logging.info(
+        f"Total number of parameters in model: "
+        f"{jasper_decoder.num_weights + jasper_encoder.num_weights}")
     nemo.logging.info('================================')
 
-    (audio_signal_e1, a_sig_length_e1, transcript_e1, transcript_len_e1,) = data_layer()
-    processed_signal_e1, p_length_e1 = data_preprocessor(input_signal=audio_signal_e1, length=a_sig_length_e1)
-    encoded_e1, encoded_len_e1 = jasper_encoder(audio_signal=processed_signal_e1, length=p_length_e1)
+    # Define inference DAG
+    audio_signal_e1, a_sig_length_e1, transcript_e1, transcript_len_e1 =\
+        data_layer()
+    processed_signal_e1, p_length_e1 = data_preprocessor(
+        input_signal=audio_signal_e1,
+        length=a_sig_length_e1)
+    encoded_e1, encoded_len_e1 = jasper_encoder(
+        audio_signal=processed_signal_e1,
+        length=p_length_e1)
     log_probs_e1 = jasper_decoder(encoder_output=encoded_e1)
     predictions_e1 = greedy_decoder(log_probs=log_probs_e1)
 
-    eval_tensors = [
-        log_probs_e1,
-        predictions_e1,
-        transcript_e1,
-        transcript_len_e1,
-        encoded_len_e1,
-    ]
+    eval_tensors = [log_probs_e1, predictions_e1,
+                    transcript_e1, transcript_len_e1, encoded_len_e1]
 
-    evaluated_tensors = neural_factory.infer(tensors=eval_tensors, checkpoint_dir=load_dir, cache=True)
+    # inference
+    evaluated_tensors = neural_factory.infer(
+        tensors=eval_tensors,
+        checkpoint_dir=load_dir,
+        cache=False)
 
     greedy_hypotheses = post_process_predictions(evaluated_tensors[1], vocab)
-    references = post_process_transcripts(evaluated_tensors[2], evaluated_tensors[3], vocab)
+    references = post_process_transcripts(
+        evaluated_tensors[2], evaluated_tensors[3], vocab)
+
     wer = word_error_rate(hypotheses=greedy_hypotheses, references=references)
     nemo.logging.info("Greedy WER {:.2f}%".format(wer * 100))
 
+    # language model
     if args.lm_path:
         if args.alpha_max is None:
             args.alpha_max = args.alpha
@@ -164,11 +177,15 @@ def main():
                     alpha=alpha,
                     beta=beta,
                     lm_path=args.lm_path,
-                    num_cpus=max(os.cpu_count(), 1),
-                )
-                beam_predictions_e1 = beam_search_with_lm(log_probs=log_probs_e1, log_probs_length=encoded_len_e1)
+                    num_cpus=max(os.cpu_count(), 1))
+                beam_predictions_e1 = beam_search_with_lm(
+                    log_probs=log_probs_e1, log_probs_length=encoded_len_e1)
 
-                evaluated_tensors = neural_factory.infer(tensors=[beam_predictions_e1], use_cache=True, verbose=False,)
+                evaluated_tensors = neural_factory.infer(
+                    tensors=[beam_predictions_e1],
+                    use_cache=False,
+                    verbose=False
+                )
 
                 beam_hypotheses = []
                 # Over mini-batch
@@ -176,17 +193,19 @@ def main():
                     # Over samples
                     for j in i:
                         beam_hypotheses.append(j[0][1])
-
-                wer = word_error_rate(hypotheses=beam_hypotheses, references=references)
-                nemo.logging.info("Beam WER {:.2f}%".format(wer * 100))
-                beam_wers.append(((alpha, beta), wer * 100))
+                lm_wer = word_error_rate(
+                    hypotheses=beam_hypotheses, references=references)
+                nemo.logging.info("Beam WER {:.2f}%".format(lm_wer*100))
+                beam_wers.append(((alpha, beta), lm_wer*100))
 
         nemo.logging.info('Beam WER for (alpha, beta)')
         nemo.logging.info('================================')
         nemo.logging.info('\n' + '\n'.join([str(e) for e in beam_wers]))
         nemo.logging.info('================================')
         best_beam_wer = min(beam_wers, key=lambda x: x[1])
-        nemo.logging.info('Best (alpha, beta): ' f'{best_beam_wer[0]}, ' f'WER: {best_beam_wer[1]:.2f}%')
+        nemo.logging.info('Best (alpha, beta): '
+                    f'{best_beam_wer[0]}, '
+                    f'WER: {best_beam_wer[1]:.2f}%')
 
     if args.save_logprob:
         # Convert logits to list of numpy arrays

--- a/scripts/export_jasper_to_onnx.py
+++ b/scripts/export_jasper_to_onnx.py
@@ -7,6 +7,8 @@ from ruamel.yaml import YAML
 import nemo
 import nemo.collections.asr as nemo_asr
 
+logging = nemo.logging
+
 
 def get_parser():
     parser = argparse.ArgumentParser(description="Convert Jasper NeMo checkpoint to ONNX")
@@ -43,12 +45,11 @@ def main(
 ):
     yaml = YAML(typ="safe")
 
-    nemo.logging.info("Loading config file...")
+    logging.info("Loading config file...")
     with open(config_file) as f:
         jasper_model_definition = yaml.load(f)
 
-    print(jasper_model_definition)
-    nemo.logging.info("Determining model shape...")
+    logging.info("Determining model shape...")
     if 'AudioPreprocessing' in jasper_model_definition:
         num_encoder_input_features = jasper_model_definition['AudioPreprocessing']['features']
     elif 'AudioToMelSpectrogramPreprocessor' in jasper_model_definition:
@@ -56,12 +57,12 @@ def main(
     else:
         num_encoder_input_features = 64
     num_decoder_input_features = jasper_model_definition['JasperEncoder']['jasper'][-1]['filters']
-    nemo.logging.info("  Num encoder input features: {}".format(num_encoder_input_features))
-    nemo.logging.info("  Num decoder input features: {}".format(num_decoder_input_features))
+    logging.info("  Num encoder input features: {}".format(num_encoder_input_features))
+    logging.info("  Num decoder input features: {}".format(num_decoder_input_features))
 
     nf = nemo.core.NeuralModuleFactory(create_tb_writer=False)
 
-    nemo.logging.info("Initializing models...")
+    logging.info("Initializing models...")
     jasper_encoder = nemo_asr.JasperEncoder(
         feat_in=num_encoder_input_features, **jasper_model_definition['JasperEncoder']
     )
@@ -72,9 +73,9 @@ def main(
 
     # This is necessary if you are using checkpoints trained with NeMo
     # version before 0.9
-    nemo.logging.info("Loading checkpoints...")
+    logging.info("Loading checkpoints...")
     if pre_v09_model:
-        nemo.logging.info("  Converting pre v0.9 checkpoint...")
+        logging.info("  Converting pre v0.9 checkpoint...")
         ckpt = torch.load(nn_encoder)
         new_ckpt = {}
         for k, v in ckpt.items():
@@ -87,22 +88,22 @@ def main(
         jasper_encoder.restore_from(nn_encoder)
     jasper_decoder.restore_from(nn_decoder)
 
-
-    nemo.logging.info("Exporting encoder...")
+    logging.info("Exporting encoder...")
     nf.deployment_export(
         jasper_encoder,
         nn_onnx_encoder,
         nemo.core.neural_factory.DeploymentFormat.ONNX,
         torch.zeros(batch_size, num_encoder_input_features, time_steps, dtype=torch.float, device="cuda:0",),
     )
-    nemo.logging.info("Exporting decoder...")
+    logging.info("Exporting decoder...")
     nf.deployment_export(
         jasper_decoder,
         nn_onnx_decoder,
         nemo.core.neural_factory.DeploymentFormat.ONNX,
         (torch.zeros(batch_size, num_decoder_input_features, time_steps // 2, dtype=torch.float, device="cuda:0",)),
     )
-    nemo.logging.info("Export completed successfully.")
+    logging.info("Export completed successfully.")
+
 
 if __name__ == "__main__":
     args = get_parser().parse_args()


### PR DESCRIPTION
Changes to two files:

1. Bug fixes to` scripts/export_jasper_to_onnx.py` factory was not being created before encoder/decoder initialization and logger was out of date.

2. Changes to `jasper_eval.py`:
- Set cache=False because batch size is severely reduced to be able to perform inference with cache=True.
- Added amp_opt_level arg to be able to set amp level for inference
- Fixed formatting to fit the 80 characters standard