### PR TITLE
Reorder master setup.py to earlier format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,19 +28,6 @@ from itertools import chain
 
 import setuptools
 
-from nemo.package_info import (
-    __contact_emails__,
-    __contact_names__,
-    __description__,
-    __download_url__,
-    __homepage__,
-    __keywords__,
-    __license__,
-    __package_name__,
-    __repository_url__,
-    __version__,
-)
-
 
 def is_build_action():
     if len(sys.argv) <= 1:
@@ -57,6 +44,18 @@ def is_build_action():
 if is_build_action():
     os.environ['NEMO_PACKAGE_BUILDING'] = 'True'
 
+from nemo.package_info import (
+    __contact_emails__,
+    __contact_names__,
+    __description__,
+    __download_url__,
+    __homepage__,
+    __keywords__,
+    __license__,
+    __package_name__,
+    __repository_url__,
+    __version__,
+)
 
 if os.path.exists('README.rst'):
     # codec is used for consistent encoding


### PR DESCRIPTION
# Changelog
## Bugfix
- Revert order of imports to earlier level, due to isort misconfiguration.

Signed-off-by: smajumdar <titu1994@gmail.com>