### PR TITLE
Add support for W&B

### DIFF
--- a/nemo/backends/pytorch/actions.py
+++ b/nemo/backends/pytorch/actions.py
@@ -629,7 +629,7 @@ class PtActions(Actions):
                 if vals_to_log is not None:
                     if hasattr(callback, 'swriter') and callback.swriter is not None:
                         if hasattr(callback, 'tb_writer_func') and callback.tb_writer_func is not None:
-                            callback.tb_writer_func(callback.swriter, vals_to_log, step) 
+                            callback.tb_writer_func(callback.swriter, vals_to_log, step)
                         else:
                             for key, val in vals_to_log.items():
                                 callback.swriter.add_scalar(key, val, step)

--- a/nemo/backends/pytorch/actions.py
+++ b/nemo/backends/pytorch/actions.py
@@ -625,13 +625,16 @@ class PtActions(Actions):
             # should happend only on one worker
             if callback.user_done_callback and (self.global_rank is None or self.global_rank == 0):
                 vals_to_log = callback.user_done_callback(callback._global_var_dict)
-                # log results to Tensorboard
-                if vals_to_log is not None and callback.swriter is not None:
-                    if callback.tb_writer_func is not None:
-                        callback.tb_writer_func(callback.swriter, vals_to_log, step)
-                    else:
-                        for key, val in vals_to_log.items():
-                            callback.swriter.add_scalar(key, val, step)
+                # log results to Tensorboard or Weights & Biases
+                if vals_to_log is not None:
+                    if hasattr(callback, 'swriter') and callback.swriter is not None:
+                        if hasattr(callback, 'tb_writer_func') and callback.tb_writer_func is not None:
+                            callback.tb_writer_func(callback.swriter, vals_to_log, step) 
+                        else:
+                            for key, val in vals_to_log.items():
+                                callback.swriter.add_scalar(key, val, step)
+                    if hasattr(callback, 'wandb_log'):
+                        callback.wandb_log(vals_to_log)
 
     def _infer(
         self, tensors_to_return, verbose=False, cache=False, use_cache=False, offload_to_cpu=True,

--- a/nemo/core/callbacks.py
+++ b/nemo/core/callbacks.py
@@ -571,8 +571,15 @@ class WandbCallback(ActionCallback):
     Log metrics to [Weights & Biases](https://docs.wandb.com/)
     """
 
-    def __init__(self, train_tensors=[], eval_tensors=[], name=None, project=None,
-                 user_iter_callback=None, user_epochs_done_callback=None):
+    def __init__(
+        self,
+        train_tensors=[],
+        eval_tensors=[],
+        name=None,
+        project=None,
+        user_iter_callback=None,
+        user_epochs_done_callback=None,
+    ):
         super().__init__()
         try:
             import wandb
@@ -589,17 +596,18 @@ class WandbCallback(ActionCallback):
             # Callbacks
             self.user_iter_callback = user_iter_callback
             self.user_done_callback = user_epochs_done_callback
-        
+
     def on_action_start(self):
         # initialize W&B run
         if self.global_rank is None or self.global_rank == 0:
             import wandb
+
             wandb.init(name=self._name, project=self._project)
 
     def on_iteration_end(self):
         # log training metrics
         if self.global_rank is None or self.global_rank == 0:
-            tensors_logged = {t.name:self.registered_tensors[t.unique_name] for t in self._train_tensors}
+            tensors_logged = {t.name: self.registered_tensors[t.unique_name] for t in self._train_tensors}
             self.wandb_log(tensors_logged)
 
     def on_epoch_end(self):
@@ -609,8 +617,8 @@ class WandbCallback(ActionCallback):
 
     def wandb_log(self, tensors_logged):
         import wandb
+
         wandb.log(tensors_logged, step=self.step)
 
     def clear_global_var_dict(self):
         self._global_var_dict = {}
-        


### PR DESCRIPTION
Add basic support for logging to [Weights & Biases](https://docs.wandb.com/).

Training metrics are logged at each batch and evaluation/validation metrics at the end of each epoch.

**Example:**

On `machine_translation_tutorial.py`, I added:

```python
wandb_callback = nemo.core.WandbCallback(
    train_tensors=[train_loss],
    eval_tensors=eval_tensors,
    user_iter_callback=lambda x, y: eval_iter_callback(x, y, tgt_tokenizer),
    user_epochs_done_callback=lambda x: eval_epochs_done_callback(x, validation_dataset=eval_dataset_tgt),
)
```

Here is [logged run](https://app.wandb.ai/borisd13/NeMo-examples_nlp_neural_machine_translation/runs/tid84r83?workspace=user-borisd13).

Let me know if you require any change and I'll add documentation.