### PR TITLE
Fix for creation of synced batchnorm groups

### DIFF
--- a/nemo/backends/pytorch/actions.py
+++ b/nemo/backends/pytorch/actions.py
@@ -1244,8 +1244,9 @@ class PtActions(Actions):
                                 # Find ranks of other nodes in the same batchnorm group
                                 rank = torch.distributed.get_rank()
                                 group = rank // synced_batchnorm_groupsize
-                                group_rank_ids = range(group * synced_batchnorm_groupsize,
-                                                       (group + 1) * synced_batchnorm_groupsize)
+                                group_rank_ids = range(
+                                    group * synced_batchnorm_groupsize, (group + 1) * synced_batchnorm_groupsize
+                                )
                                 sync_batchnorm_group = torch.distributed.new_group(group_rank_ids)
 
                             pmodule = nn.SyncBatchNorm.convert_sync_batchnorm(


### PR DESCRIPTION
torch.distributed.new_group() takes in a list of rank IDs rather than groupsize.