### PR TITLE
Fix export tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,13 +50,13 @@ def neural_factory(request):
 
 
 @pytest.fixture(autouse=True)
-def skip_by_device(request, device):
-    if request.node.get_closest_marker('skip_on_device'):
-        if request.node.get_closest_marker('skip_on_device').args[0] == device:
+def run_only_on_device_fixture(request, device):
+    if request.node.get_closest_marker('run_only_on'):
+        if request.node.get_closest_marker('run_only_on').args[0] != device:
             pytest.skip('skipped on this device: {}'.format(device))
 
 
 def pytest_configure(config):
     config.addinivalue_line(
-        "markers", "skip_on_device(device): skip test for the given device [CPU | GPU]",
+        "markers", "run_only_on(device): runs the test only on a given device [CPU | GPU]",
     )

--- a/tests/unclassified/test_unclassified_tts.py
+++ b/tests/unclassified/test_unclassified_tts.py
@@ -78,7 +78,7 @@ class TestTTSPytorch(TestCase):
             logging.info("speech data found in: {0}".format(data_folder + "asr"))
 
     @pytest.mark.unclassified
-    @pytest.mark.skip_on_device('CPU')
+    @pytest.mark.run_only_on('GPU')
     def test_tacotron2_training(self):
         data_layer = nemo_asr.AudioToTextDataLayer(
             manifest_filepath=self.manifest_filepath, labels=self.labels, batch_size=4,

--- a/tests/unit/core/test_deploy_export.py
+++ b/tests/unit/core/test_deploy_export.py
@@ -218,7 +218,7 @@ class TestDeployExport(TestCase):
         self.__test_export_route(module, out_name + '.ts', nemo.core.DeploymentFormat.TORCHSCRIPT, input_example)
 
     @pytest.mark.unit
-    # @pytest.mark.skip_on_device('CPU')
+    @pytest.mark.run_only_on('GPU')
     def test_simple_module_export(self):
         simplest_module = nemo.backends.pytorch.tutorials.TaylorNet(dim=4)
         self.__test_export_route_all(
@@ -226,7 +226,7 @@ class TestDeployExport(TestCase):
         )
 
     @pytest.mark.unit
-    # @pytest.mark.skip_on_device('CPU')
+    @pytest.mark.run_only_on('GPU')
     def test_TokenClassifier_module_export(self):
         t_class = nemo.collections.nlp.nm.trainables.common.token_classification_nm.TokenClassifier(
             hidden_size=512, num_classes=16, use_transformer_pretrained=False
@@ -236,7 +236,7 @@ class TestDeployExport(TestCase):
         )
 
     @pytest.mark.unit
-    # @pytest.mark.skip_on_device('CPU')
+    @pytest.mark.run_only_on('GPU')
     def test_jasper_decoder(self):
         j_decoder = nemo_asr.JasperDecoderForCTC(feat_in=1024, num_classes=33)
         self.__test_export_route_all(
@@ -244,7 +244,7 @@ class TestDeployExport(TestCase):
         )
 
     @pytest.mark.unit
-    # @pytest.mark.skip_on_device('CPU')
+    @pytest.mark.run_only_on('GPU')
     def test_hf_bert(self):
         bert = nemo.collections.nlp.nm.trainables.common.huggingface.BERT(pretrained_model_name="bert-base-uncased")
         input_example = (
@@ -255,7 +255,7 @@ class TestDeployExport(TestCase):
         self.__test_export_route_all(module=bert, out_name="bert", input_example=input_example)
 
     @pytest.mark.unit
-    # @pytest.mark.skip_on_device('CPU')
+    @pytest.mark.run_only_on('GPU')
     def test_jasper_encoder(self):
         with open("tests/data/jasper_smaller.yaml") as file:
             yaml = YAML(typ="safe")
@@ -274,7 +274,7 @@ class TestDeployExport(TestCase):
         )
 
     @pytest.mark.unit
-    # @pytest.mark.skip_on_device('CPU')
+    @pytest.mark.run_only_on('GPU')
     def test_quartz_encoder(self):
         with open("tests/data/quartznet_test.yaml") as file:
             yaml = YAML(typ="safe")

--- a/tests/unit/core/test_deploy_export.py
+++ b/tests/unit/core/test_deploy_export.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from unittest import TestCase
 
 import numpy as np
+
 # git clone git@github.com:microsoft/onnxruntime.git
 # cd onnxruntime
 #

--- a/tests/unit/core/test_deploy_export.py
+++ b/tests/unit/core/test_deploy_export.py
@@ -25,7 +25,6 @@ from pathlib import Path
 from unittest import TestCase
 
 import numpy as np
-
 # git clone git@github.com:microsoft/onnxruntime.git
 # cd onnxruntime
 #
@@ -35,17 +34,7 @@ import numpy as np
 #
 # pip install --upgrade ./build/Linux/RelWithDebInfo/dist/*.whl
 import onnxruntime as ort
-
-# Only initialize GPU after this runner is activated.
-import pycuda.autoinit
-
-# This import causes pycuda to automatically manage CUDA context creation and cleanup.
-import pycuda.driver as cuda
 import pytest
-
-sys.path.append(os.path.join(path.dirname(path.abspath(__file__)), 'trt_ONNX'))
-import tensorrt_loaders as loaders
-import tensorrt_runner as runner
 import torch
 from ruamel.yaml import YAML
 
@@ -54,6 +43,21 @@ import nemo.collections.asr as nemo_asr
 import nemo.collections.nlp as nemo_nlp
 import nemo.collections.nlp.nm.trainables.common.token_classification_nm
 from nemo import logging
+
+# Check if the required libraries and runtimes are installed.
+try:
+    # Only initialize GPU after this runner is activated.
+    import pycuda.autoinit
+
+    # This import causes pycuda to automatically manage CUDA context creation and cleanup.
+    import pycuda.driver as cuda
+
+    sys.path.append(os.path.join(path.dirname(path.abspath(__file__)), 'trt_ONNX'))
+    import tensorrt_loaders as loaders
+    import tensorrt_runner as runner
+except:
+    # Skip tests.
+    pytestmark = pytest.mark.skip
 
 
 @pytest.mark.usefixtures("neural_factory")

--- a/tests/unit/core/test_weight_share.py
+++ b/tests/unit/core/test_weight_share.py
@@ -287,7 +287,7 @@ class TestWeightSharing(TestCase):
         self.assertFalse(np.array_equal(embd.embedding.weight.detach().cpu().numpy(), weights.detach().cpu().numpy()))
 
     @pytest.mark.unit
-    @pytest.mark.skip_on_device('CPU')
+    @pytest.mark.run_only_on('GPU')
     def test_freeze_unfreeze_TrainableNM(self):
         path = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../data/jasper_smaller.yaml"))
         with open(path) as file:


### PR DESCRIPTION
Export tests from PR #409 won't work without installation of additional dependencies (pyCUDA, TensorRT, cuDNN) and other stuff required to test export.

Those dependencies are not (cannot be?) included in requirements/requirements_test.txt

This PR fixes this issue by skipping the tests when one import fails. As a result - once again - enables to run tests on CPUs.

Additionally, changes the marker name to `run_only_on(device)` as suggested by @drnikolaev 