### PR TITLE
restore from checkpoint dir if it exists

### DIFF
--- a/nemo/utils/exp_logging.py
+++ b/nemo/utils/exp_logging.py
@@ -123,12 +123,15 @@ class ExpManager:
         # Create work_dir if specified
         if work_dir:
             self.work_dir = work_dir
-            if add_time:
+            self.ckpt_dir = f'{self.work_dir}/checkpoints'
+            # only create tm_sur dir if checkpoints dir is not present in the work_dir
+            if add_time and not os.path.exists(self.ckpt_dir):
                 self.work_dir = os.path.join(work_dir, tm_suf)
+                self.ckpt_dir = f'{self.work_dir}/checkpoints'
             self.make_dir(self.work_dir, exist_ok)
             if use_tb:
                 self.get_tb_writer(exist_ok=exist_ok)
-            self.ckpt_dir = f'{self.work_dir}/checkpoints'
+
             if files_to_copy and self.global_rank == 0:
                 for file in files_to_copy:
                     basename = os.path.basename(file)


### PR DESCRIPTION
In most nlp examples we're using add_time_to_log_dir=True, when initializing the nf; but then we have to manually set this flag to false if we need to restore from a work_dir with an existing checkpoint dir.
Updating the ExpManager so it first checks if the ckpt dir exists before adding a time_dir to the path.

Signed-off-by: Evelina Bakhturina <ebakhturina@nvidia.com>