### PR TITLE
Update pytest instructions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -120,7 +120,7 @@ This command runs unittests:
 .. code-block:: bash
 
     ./reinstall.sh
-    python pytest tests
+    python -m pytest tests
 
 
 Citation


### PR DESCRIPTION
Likely it was meant to call pytest with the "-m" argument passed to python.
https://docs.pytest.org/en/latest/usage.html#calling-pytest-through-python-m-pytest