### PR TITLE
Online augmentation for ASR Collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ To release a new version, please update the changelog as followed:
 ### Added
 - Added multi-dataset data-layer and dataset.
 ([PR #538](https://github.com/NVIDIA/NeMo/pull/538)) - @yzhang123
-- Online Data Augmentation for ASR Collection. ([PR #565](https://github.com/NVIDIA/NeMo/pull/565))
+- Online Data Augmentation for ASR Collection. ([PR #565](https://github.com/NVIDIA/NeMo/pull/565)) - @titu1994
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,7 @@ To release a new version, please update the changelog as followed:
 ### Added
 - Added multi-dataset data-layer and dataset.
 ([PR #538](https://github.com/NVIDIA/NeMo/pull/538)) - @yzhang123
+- Online Data Augmentation for ASR Collection. ([PR #565](https://github.com/NVIDIA/NeMo/pull/565))
 
 ### Changed
 

--- a/nemo/collections/asr/data_layer.py
+++ b/nemo/collections/asr/data_layer.py
@@ -16,7 +16,7 @@
 
 import copy
 from functools import partial
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 import torch
 
@@ -532,7 +532,7 @@ target_label_n, "offset": offset_in_sec_n}
         trim_silence: bool = False,
         drop_last: bool = False,
         load_audio: bool = True,
-        augmentor: Optional[Dict[str, Dict[str, Any]]] = None,
+        augmentor: Optional[Union[AudioAugmentor, Dict[str, Dict[str, Any]]]] = None,
     ):
         super(AudioToSpeechLabelDataLayer, self).__init__()
 
@@ -541,7 +541,12 @@ target_label_n, "offset": offset_in_sec_n}
         self._sample_rate = sample_rate
 
         if augmentor is not None:
-            augmentor = self._process_augmentations(augmentor)
+            if isinstance(augmentor, AudioAugmentor):
+                pass
+            elif isinstance(augmentor, dict):
+                augmentor = self._process_augmentations(augmentor)
+            else:
+                raise ValueError("Cannot parse augmentor provided !")
 
         self._featurizer = WaveformFeaturizer(sample_rate=sample_rate, int_values=int_values, augmentor=augmentor)
 

--- a/nemo/collections/asr/data_layer.py
+++ b/nemo/collections/asr/data_layer.py
@@ -455,10 +455,10 @@ class AudioToSpeechLabelDataLayer(DataLayerNM):
     and their target labels. JSON files should be of the following format::
 
         {"audio_filepath": path_to_wav_0, "duration": time_in_sec_0, "label": \
-target_label_0}
+target_label_0, "offset": offset_in_sec_0}
         ...
         {"audio_filepath": path_to_wav_n, "duration": time_in_sec_n, "label": \
-target_label_n}
+target_label_n, "offset": offset_in_sec_n}
 
     Args:
         manifest_filepath (str): Dataset parameter.

--- a/nemo/collections/asr/data_layer.py
+++ b/nemo/collections/asr/data_layer.py
@@ -14,6 +14,7 @@
 # =============================================================================
 """This package contains Neural Modules responsible for ASR data layers."""
 
+import copy
 from functools import partial
 from typing import Any, Dict, List, Optional
 
@@ -577,6 +578,7 @@ target_label_n}
 
     def _process_augmentations(self, augmentor) -> AudioAugmentor:
         augmentations = []
+        augmentor = copy.deepcopy(augmentor)
         for augment_name, augment_kwargs in augmentor.items():
             prob = augment_kwargs.get('prob', None)
 

--- a/nemo/collections/asr/data_layer.py
+++ b/nemo/collections/asr/data_layer.py
@@ -62,6 +62,9 @@ def _process_augmentations(augmenter) -> AudioAugmentor:
         else:
             _ = augment_kwargs.pop('prob')
 
+            if prob < 0.0 or prob > 1.0:
+                raise ValueError("`prob` must be a float value between 0 and 1.")
+
             try:
                 augmentation = perturbation_types[augment_name](**augment_kwargs)
                 augmentations.append([prob, augmentation])

--- a/nemo/collections/asr/parts/collections.py
+++ b/nemo/collections/asr/parts/collections.py
@@ -240,7 +240,7 @@ class ASRSpeechLabel(SpeechLabel):
             labels.append(item['label'])
             offsets.append(item['offset'])
 
-        super().__init__(audio_files, durations, labels, *args, **kwargs)
+        super().__init__(audio_files, durations, labels, offsets, *args, **kwargs)
 
     def __parse_item(self, line: str, manifest_file: str) -> Dict[str, Any]:
         item = json.loads(line)

--- a/nemo/collections/asr/parts/collections.py
+++ b/nemo/collections/asr/parts/collections.py
@@ -79,13 +79,16 @@ class FromFileText(Text):
 class AudioText(_Collection):
     """List of audio-transcript text correspondence with preprocessing."""
 
-    OUTPUT_TYPE = collections.namedtuple(typename='AudioTextEntity', field_names='audio_file duration text_tokens',)
+    OUTPUT_TYPE = collections.namedtuple(
+        typename='AudioTextEntity', field_names='audio_file duration text_tokens offset',
+    )
 
     def __init__(
         self,
         audio_files: List[str],
         durations: List[float],
         texts: List[str],
+        offsets: List[str],
         parser: parsers.CharParser,
         min_duration: Optional[float] = None,
         max_duration: Optional[float] = None,
@@ -98,6 +101,7 @@ class AudioText(_Collection):
             audio_files: List of audio files.
             durations: List of float durations.
             texts: List of raw text transcripts.
+            offsets: List of duration offsets or None.
             parser: Instance of `CharParser` to convert string to tokens.
             min_duration: Minimum duration to keep entry with (default: None).
             max_duration: Maximum duration to keep entry with (default: None).
@@ -107,7 +111,7 @@ class AudioText(_Collection):
 
         output_type = self.OUTPUT_TYPE
         data, duration_filtered, num_filtered, total_duration = [], 0.0, 0, 0.0
-        for audio_file, duration, text in zip(audio_files, durations, texts):
+        for audio_file, duration, text, offset in zip(audio_files, durations, texts, offsets):
             # Duration filters.
             if min_duration is not None and duration < min_duration:
                 duration_filtered += duration
@@ -126,7 +130,7 @@ class AudioText(_Collection):
                 continue
 
             total_duration += duration
-            data.append(output_type(audio_file, duration, text_tokens))
+            data.append(output_type(audio_file, duration, text_tokens, offset))
 
             # Max number of entities filter.
             if len(data) == max_number:
@@ -154,13 +158,14 @@ class ASRAudioText(AudioText):
             **kwargs: Kwargs to pass to `AudioText` constructor.
         """
 
-        audio_files, durations, texts = [], [], []
+        audio_files, durations, texts, offsets = [], [], [], []
         for item in manifest.item_iter(manifests_files):
             audio_files.append(item['audio_file'])
             durations.append(item['duration'])
             texts.append(item['text'])
+            offsets.append(item['offset'])
 
-        super().__init__(audio_files, durations, texts, *args, **kwargs)
+        super().__init__(audio_files, durations, texts, offsets, *args, **kwargs)
 
 
 class SpeechLabel(_Collection):

--- a/nemo/collections/asr/parts/collections.py
+++ b/nemo/collections/asr/parts/collections.py
@@ -166,13 +166,14 @@ class ASRAudioText(AudioText):
 class SpeechLabel(_Collection):
     """List of audio-label correspondence with preprocessing."""
 
-    OUTPUT_TYPE = collections.namedtuple(typename='SpeechLabelEntity', field_names='audio_file duration label',)
+    OUTPUT_TYPE = collections.namedtuple(typename='SpeechLabelEntity', field_names='audio_file duration label offset',)
 
     def __init__(
         self,
         audio_files: List[str],
         durations: List[float],
         labels: List[Union[int, str]],
+        offsets: List[Optional[float]],
         min_duration: Optional[float] = None,
         max_duration: Optional[float] = None,
         max_number: Optional[int] = None,
@@ -184,6 +185,7 @@ class SpeechLabel(_Collection):
             audio_files: List of audio files.
             durations: List of float durations.
             labels: List of labels.
+            offsets: List of offsets or None.
             min_duration: Minimum duration to keep entry with (default: None).
             max_duration: Maximum duration to keep entry with (default: None).
             max_number: Maximum number of samples to collect.
@@ -192,7 +194,7 @@ class SpeechLabel(_Collection):
 
         output_type = self.OUTPUT_TYPE
         data, duration_filtered = [], 0.0
-        for audio_file, duration, command in zip(audio_files, durations, labels):
+        for audio_file, duration, command, offset in zip(audio_files, durations, labels, offsets):
             # Duration filters.
             if min_duration is not None and duration < min_duration:
                 duration_filtered += duration
@@ -202,7 +204,7 @@ class SpeechLabel(_Collection):
                 duration_filtered += duration
                 continue
 
-            data.append(output_type(audio_file, duration, command))
+            data.append(output_type(audio_file, duration, command, offset))
 
             # Max number of entities filter.
             if len(data) == max_number:
@@ -230,12 +232,13 @@ class ASRSpeechLabel(SpeechLabel):
             *args: Args to pass to `SpeechLabel` constructor.
             **kwargs: Kwargs to pass to `SpeechLabel` constructor.
         """
-        audio_files, durations, labels = [], [], []
+        audio_files, durations, labels, offsets = [], [], [], []
 
         for item in manifest.item_iter(manifests_files, parse_func=self.__parse_item):
             audio_files.append(item['audio_file'])
             durations.append(item['duration'])
             labels.append(item['label'])
+            offsets.append(item['offset'])
 
         super().__init__(audio_files, durations, labels, *args, **kwargs)
 

--- a/nemo/collections/asr/parts/dataset.py
+++ b/nemo/collections/asr/parts/dataset.py
@@ -380,7 +380,11 @@ class AudioLabelDataset(Dataset):
     def __getitem__(self, index):
         sample = self.collection[index]
         if self.load_audio:
-            features = self.featurizer.process(sample.audio_file, offset=0, duration=sample.duration, trim=self.trim)
+            offset = sample.offset
+            if offset is None:
+                offset = 0
+
+            features = self.featurizer.process(sample.audio_file, offset=offset, duration=sample.duration, trim=self.trim)
             f, fl = features, torch.tensor(features.shape[0]).long()
         else:
             f, fl = None, None

--- a/nemo/collections/asr/parts/dataset.py
+++ b/nemo/collections/asr/parts/dataset.py
@@ -381,10 +381,13 @@ class AudioLabelDataset(Dataset):
         sample = self.collection[index]
         if self.load_audio:
             offset = sample.offset
+
             if offset is None:
                 offset = 0
 
-            features = self.featurizer.process(sample.audio_file, offset=offset, duration=sample.duration, trim=self.trim)
+            features = self.featurizer.process(
+                sample.audio_file, offset=offset, duration=sample.duration, trim=self.trim
+            )
             f, fl = features, torch.tensor(features.shape[0]).long()
         else:
             f, fl = None, None

--- a/nemo/collections/asr/parts/dataset.py
+++ b/nemo/collections/asr/parts/dataset.py
@@ -96,7 +96,7 @@ class AudioDataset(Dataset):
     "/path/to/audio.txt", "duration": 23.147}
     ...
     {"audio_filepath": "/path/to/audio.wav", "text": "the
-    transcription", offset": 301.75, "duration": 0.82, "utt":
+    transcription", "offset": 301.75, "duration": 0.82, "utt":
     "utterance_id", "ctm_utt": "en_4156", "side": "A"}
 
     Args:
@@ -153,7 +153,14 @@ class AudioDataset(Dataset):
     def __getitem__(self, index):
         sample = self.collection[index]
         if self.load_audio:
-            features = self.featurizer.process(sample.audio_file, offset=0, duration=sample.duration, trim=self.trim,)
+            offset = sample.offset
+
+            if offset is None:
+                offset = 0
+
+            features = self.featurizer.process(
+                sample.audio_file, offset=offset, duration=sample.duration, trim=self.trim,
+            )
             f, fl = features, torch.tensor(features.shape[0]).long()
         else:
             f, fl = None, None

--- a/nemo/collections/asr/parts/perturb.py
+++ b/nemo/collections/asr/parts/perturb.py
@@ -119,13 +119,39 @@ class WhiteNoisePerturbation(Perturbation):
         data._samples += noise_signal
 
 
+class EchoPerturbation(Perturbation):
+    def __init__(self, min_delay=0.1, max_delay=1.0, max_dampen=0.5, rng=None):
+        self.min_delay = min_delay
+        self.max_delay = max_delay
+        self.max_dampen = max_dampen
+        self._rng = np.random.RandomState() if rng is None else rng
+
+    def perturb(self, data: AudioSegment):
+        min_delay = self._rng.uniform(0., self.min_delay)
+        max_delay = self._rng.uniform(min_delay, self.max_delay)
+        max_dampen = self._rng.uniform(0., self.max_dampen)
+
+        echo_start = min_delay * data._samples.shape[0]
+        echo_end = max_delay * data._samples.shape[0]
+        echo_duration = echo_end - echo_start
+
+        data._samples[echo_start:echo_end] += data._samples[0:echo_duration] * max_dampen
+
+        max_amplitude = np.max(np.abs(data._samples))
+        if max_amplitude > 1.0:
+            data._samples /= max_amplitude
+
+        return data
+
+
 perturbation_types = {
     "speed": SpeedPerturbation,
     "gain": GainPerturbation,
     "impulse": ImpulsePerturbation,
     "shift": ShiftPerturbation,
     "noise": NoisePerturbation,
-    'white_noise': WhiteNoisePerturbation,
+    "white_noise": WhiteNoisePerturbation,
+    "echo": EchoPerturbation,
 }
 
 

--- a/nemo/collections/asr/parts/perturb.py
+++ b/nemo/collections/asr/parts/perturb.py
@@ -108,7 +108,7 @@ class NoisePerturbation(Perturbation):
 
         if noise._samples.shape[0] < data._samples.shape[0]:
             noise_idx = self._rng.randint(0, data._samples.shape[0] - noise._samples.shape[0])
-            data._samples[noise_idx: noise_idx + noise._samples.shape[0]] += noise._samples
+            data._samples[noise_idx : noise_idx + noise._samples.shape[0]] += noise._samples
 
         else:
             data._samples += noise._samples
@@ -132,7 +132,7 @@ perturbation_types = {
     "impulse": ImpulsePerturbation,
     "shift": ShiftPerturbation,
     "noise": NoisePerturbation,
-    "white_noise": WhiteNoisePerturbation
+    "white_noise": WhiteNoisePerturbation,
 }
 
 

--- a/nemo/collections/asr/parts/perturb.py
+++ b/nemo/collections/asr/parts/perturb.py
@@ -120,26 +120,29 @@ class WhiteNoisePerturbation(Perturbation):
 
 
 class EchoPerturbation(Perturbation):
-    def __init__(self, min_delay=0.1, max_delay=1.0, max_dampen=0.5, rng=None):
+    def __init__(self, min_delay=0.1, max_duration=1.0, max_dampen=0.5, normalize=False, rng=None):
         self.min_delay = min_delay
-        self.max_delay = max_delay
+        self.max_duration = max_duration
         self.max_dampen = max_dampen
+        self.normalize = normalize
         self._rng = np.random.RandomState() if rng is None else rng
 
     def perturb(self, data: AudioSegment):
         min_delay = self._rng.uniform(0., self.min_delay)
-        max_delay = self._rng.uniform(min_delay, self.max_delay)
+        max_delay = self._rng.uniform(min_delay, self.max_duration)
         max_dampen = self._rng.uniform(0., self.max_dampen)
 
         echo_start = min_delay * data._samples.shape[0]
         echo_end = max_delay * data._samples.shape[0]
         echo_duration = echo_end - echo_start
+        echo_dampen = np.linspace(max_dampen, 0., num=echo_duration, dtype=np.float32)
 
-        data._samples[echo_start:echo_end] += data._samples[0:echo_duration] * max_dampen
+        data._samples[echo_start:echo_end] += (data._samples[0:echo_duration] * echo_dampen)
 
-        max_amplitude = np.max(np.abs(data._samples))
-        if max_amplitude > 1.0:
-            data._samples /= max_amplitude
+        if self.normalize:
+            max_amplitude = np.max(np.abs(data._samples))
+            if max_amplitude > 1.0:
+                data._samples /= max_amplitude
 
         return data
 

--- a/nemo/collections/asr/parts/perturb.py
+++ b/nemo/collections/asr/parts/perturb.py
@@ -55,7 +55,7 @@ class ImpulsePerturbation(Perturbation):
 
     def perturb(self, data):
         impulse_record = self._rng.sample(self._manifest.data, 1)[0]
-        impulse = AudioSegment.from_file(impulse_record['audio_filepath'], target_sr=data.sample_rate)
+        impulse = AudioSegment.from_file(impulse_record.audio_file, target_sr=data.sample_rate)
         # logging.debug("impulse: %s", impulse_record['audio_filepath'])
         data._samples = signal.fftconvolve(data.samples, impulse.samples, "full")
 
@@ -134,6 +134,14 @@ perturbation_types = {
     "noise": NoisePerturbation,
     "white_noise": WhiteNoisePerturbation,
 }
+
+
+def register_perturbation(name: str, perturbation: Perturbation):
+    if name in perturbation_types.keys():
+        raise KeyError(f"Perturbation with the name {name} exists. "
+                       f"Type of perturbation : {perturbation_types[name]}.")
+
+    perturbation_types[name] = perturbation
 
 
 class AudioAugmentor(object):

--- a/nemo/collections/asr/parts/perturb.py
+++ b/nemo/collections/asr/parts/perturb.py
@@ -56,7 +56,7 @@ class ImpulsePerturbation(Perturbation):
     def perturb(self, data):
         impulse_record = self._rng.sample(self._manifest.data, 1)[0]
         impulse = AudioSegment.from_file(impulse_record['audio_filepath'], target_sr=data.sample_rate)
-        logging.debug("impulse: %s", impulse_record['audio_filepath'])
+        # logging.debug("impulse: %s", impulse_record['audio_filepath'])
         data._samples = signal.fftconvolve(data.samples, impulse.samples, "full")
 
 

--- a/nemo/collections/asr/parts/perturb.py
+++ b/nemo/collections/asr/parts/perturb.py
@@ -138,8 +138,9 @@ perturbation_types = {
 
 def register_perturbation(name: str, perturbation: Perturbation):
     if name in perturbation_types.keys():
-        raise KeyError(f"Perturbation with the name {name} exists. "
-                       f"Type of perturbation : {perturbation_types[name]}.")
+        raise KeyError(
+            f"Perturbation with the name {name} exists. " f"Type of perturbation : {perturbation_types[name]}."
+        )
 
     perturbation_types[name] = perturbation
 


### PR DESCRIPTION
Enables usage of online augmentation of audio samples during training by utilizing the `AudioAugmentor` component in `WaveformFeaturizer`.

# Changelog
## Additions
- Add `_process_augmentations(augmentor)` which accepts either an AudioAugmentor object or a dictionary which maps `augmentation_name` -> dict(augmentation_kwarg, val). 
  - Note, it is mandatory to have a keyword called `prob` in each of the augmentation with some floating point probability in the range [0, 1], otherwise the augmentation is ignored
- Add `augmentor` kwarg to `AudioToTextDataLayer` and `AudioToSpeechLabelDataLayer`.

## Modifications
- `AudioText` and `SpeechLabel` collections now support "offset" as a parameter - to allow per audio sample offset
- `AudioDataset` and `AudioLabelDataset` now support per audio file offset.
- `NoiseAugmentation` now correctly supports the new offset parameter
- Commented out debug mode logging for augmentations as it slows down training significantly. 

## Major change
- `NoiseAugmentation` will no longer assume noise sample duration is longer than original sample length. 
- Noise segment will be randomly sub-segment to match the length of the original sample (if original duration is shorter than the noise duration)
- Full noise segment will be randomly added to a sub-segment of the original sample (if original duration is longer than the noise duration)
