### PR TITLE
Add Speed augmentation on CPU, Time Stretch augmentation on CPU+GPU

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,7 @@ To release a new version, please update the changelog as followed:
 - Added multi-dataset data-layer and dataset.
 ([PR #538](https://github.com/NVIDIA/NeMo/pull/538)) - @yzhang123
 - Online Data Augmentation for ASR Collection. ([PR #565](https://github.com/NVIDIA/NeMo/pull/565)) - @titu1994
+- Speed augmentation on CPU, TimeStretch augmentation on CPU+GPU ([PR #594](https://github.com/NVIDIA/NeMo/pull/565)) - @titu1994
 
 ### Changed
 

--- a/nemo/collections/asr/audio_preprocessing.py
+++ b/nemo/collections/asr/audio_preprocessing.py
@@ -773,7 +773,7 @@ class TimeStretchAugmentation(NonTrainableNM):
                 will be sampled uniformly.
                 Note: If a positive integer is provided and the resultant discretized
                 range of rates contains the value '1.0', then those samples with rate=1.0,
-                will not be augmented at all and simply skipped. This is to unnecessary
+                will not be augmented at all and simply skipped. This is to avoid unnecessary
                 augmentation and increase computation time. Effective augmentation chance
                 in such a case is = `prob * (num_rates - 1 / num_rates) * 100`% chance
                 where `prob` is the global probability of a sample being augmented.

--- a/nemo/collections/asr/audio_preprocessing.py
+++ b/nemo/collections/asr/audio_preprocessing.py
@@ -24,12 +24,14 @@ __all__ = [
     'CropOrPadSpectrogramAugmentation',
     'MultiplyBatch',
     'SpectrogramAugmentation',
+    'TimeStretchAugmentation',
 ]
 
 import math
 import warnings
 from abc import abstractmethod
 
+import numpy as np
 import torch
 
 from .parts.features import FilterbankFeatures
@@ -41,6 +43,8 @@ from nemo.utils.decorators import add_port_docs
 
 try:
     import torchaudio
+    import torchaudio.transforms
+    import torchaudio.functional
 
     HAVE_TORCHAUDIO = True
 except ModuleNotFoundError:
@@ -734,6 +738,163 @@ class CropOrPadSpectrogramAugmentation(NonTrainableNM):
             # ),
             # "processed_length": NeuralType({0: AxisType(BatchTag)}),
             "processed_signal": NeuralType(('B', 'D', 'T'), SpectrogramType()),
+            "processed_length": NeuralType(tuple('B'), LengthsType()),
+        }
+
+
+class TimeStretchAugmentation(NonTrainableNM):
+    def __init__(
+        self,
+        sample_rate: int,
+        probability: float,
+        min_speed_rate: float = 0.9,
+        max_speed_rate: float = 1.1,
+        num_rates: int = 5,
+        n_fft: int = 512,
+    ):
+        """
+        Time-stretch an audio series by a fixed rate while preserving pitch.
+
+        Note:
+        This is a simplified implementation, intended primarily for reference and pedagogical purposes.
+        It makes no attempt to handle transients, and is likely to produce audible artifacts.
+
+        Args:
+            sample_rate: Sampling rate.
+            probability: Float value declaring chance of the input being augmented.
+                Must be a float value in the range [0, 1].
+            min_speed_rate: Minimum sampling rate modifier.
+            max_speed_rate: Maximum sampling rate modifier.
+            num_rates: Number of discrete rates to allow. Can be a positive or negative
+                integer.
+                If a positive integer greater than 0 is provided, the range of
+                speed rates will be discretized into `num_rates` values.
+                If a negative integer or 0 is provided, the full range of speed rates
+                will be sampled uniformly.
+                Note: If a positive integer is provided and the resultant discretized
+                range of rates contains the value '1.0', then those samples with rate=1.0,
+                will not be augmented at all and simply skipped. This is to unnecessary
+                augmentation and increase computation time. Effective augmentation chance
+                in such a case is = `prob * (num_rates - 1 / num_rates) * 100`% chance
+                where `prob` is the global probability of a sample being augmented.
+            n_fft: Number of fft filters to be computed.
+        """
+        super(TimeStretchAugmentation, self).__init__()
+
+        if probability > 1.0 or probability < 0.0:
+            raise ValueError("`probability` must be between 0 and 1")
+
+        if not HAVE_TORCHAUDIO:
+            raise ModuleNotFoundError(
+                "torchaudio is not installed but is necessary for "
+                "TimeStretchAugmentation. We recommend you try "
+                "installing it from conda for the PyTorch version you have."
+            )
+
+        self._sample_rate = sample_rate
+        self.probability = float(probability)
+        self.min_rate = float(min_speed_rate)
+        self.max_rate = float(max_speed_rate)
+        self.num_rates = num_rates
+        if num_rates > 0:
+            self._rates = np.linspace(min_speed_rate, max_speed_rate, num_rates)
+        self._rng = np.random.RandomState()
+
+        self._n_fft = n_fft
+        self._hop_length = n_fft // 2
+        self._stft_window = torch.hann_window(self._n_fft, periodic=True, device=self._device)
+        self._phi_advance = torch.linspace(0, np.pi * self._hop_length, self._hop_length + 1, device=self._device)
+        self._phi_advance = self._phi_advance.view(-1, 1)
+
+    @torch.no_grad()
+    def forward(self, input_signal, length):
+        proba = self._rng.uniform(0.0, 1.0)
+
+        if proba > self.probability:
+            return input_signal, length
+
+        # Select speed rate either from choice or random sample
+        if self.num_rates < 0:
+            speed_rate = self._rng.uniform(self.min_rate, self.max_rate)
+        else:
+            speed_rate = np.random.choice(self._rates)
+
+        # Skip perturbation in case of identity speed rate
+        if speed_rate == 1.0:
+            return input_signal, length
+
+        if speed_rate <= 0:
+            raise ValueError("speed_rate should be greater than zero.")
+
+        features = self._stft(input_signal, self._n_fft, self._hop_length)
+        features = self._phase_vocoder(features, speed_rate)
+
+        # Predict the length of y_stretch
+        len_stretch = int(round(input_signal.shape[1] / speed_rate))
+
+        audio = self._istft(features, len_stretch)
+
+        length = (length * speed_rate).type(torch.long)
+
+        return audio, length
+
+    def _stft(self, data: torch.Tensor, n_fft: int, hop_length: int):
+        win_length = n_fft
+        window = self._stft_window
+
+        stft = torch.stft(
+            data,
+            n_fft=n_fft,
+            hop_length=hop_length,
+            win_length=win_length,
+            window=window,
+            center=True,
+            pad_mode='reflect',
+            normalized=False,
+        )
+        return stft
+
+    def _phase_vocoder(self, data: torch.Tensor, rate: float):
+        data_stretch = torchaudio.functional.phase_vocoder(data, rate, self._phi_advance)
+        return data_stretch
+
+    def _istft(self, data: torch.Tensor, len_stretch: int):
+        n_fft = 2 * (data.shape[1] - 1)
+        hop_length = self._hop_length
+        win_length = n_fft
+        window = self._stft_window
+
+        audio = torchaudio.functional.istft(
+            data,
+            n_fft,
+            hop_length,
+            win_length,
+            window=window,
+            center=True,
+            pad_mode='reflect',
+            normalized=False,
+            length=len_stretch,
+        )
+
+        return audio
+
+    @property
+    @add_port_docs()
+    def input_ports(self):
+        """Returns definitions of module input ports.
+        """
+        return {
+            "input_signal": NeuralType(('B', 'T'), AudioSignal(freq=self._sample_rate)),
+            "length": NeuralType(tuple('B'), LengthsType()),
+        }
+
+    @property
+    @add_port_docs()
+    def output_ports(self):
+        """Returns definitions of module output ports.
+        """
+        return {
+            "processed_signal": NeuralType(('B', 'T'), AudioSignal(freq=self._sample_rate)),
             "processed_length": NeuralType(tuple('B'), LengthsType()),
         }
 

--- a/nemo/collections/asr/audio_preprocessing.py
+++ b/nemo/collections/asr/audio_preprocessing.py
@@ -813,6 +813,10 @@ class TimeStretchAugmentation(NonTrainableNM):
                 str(TORCHAUDIO_VERSION_MIN),
             )
 
+        min_rate = min(min_speed_rate, max_speed_rate)
+        if min_rate < 0.0:
+            raise ValueError("Minimum sampling rate modifier must be > 0.")
+
         self._sample_rate = sample_rate
         self.probability = float(probability)
         self.min_rate = float(min_speed_rate)
@@ -844,9 +848,6 @@ class TimeStretchAugmentation(NonTrainableNM):
         # Skip perturbation in case of identity speed rate
         if speed_rate == 1.0:
             return input_signal, length
-
-        if speed_rate <= 0:
-            raise ValueError("speed_rate should be greater than zero.")
 
         features = self._stft(input_signal, self._n_fft, self._hop_length)
         features = self._phase_vocoder(features, speed_rate)

--- a/nemo/collections/asr/helpers.py
+++ b/nemo/collections/asr/helpers.py
@@ -257,12 +257,12 @@ def process_classification_evaluation_epoch(global_vars: dict, eval_metric=None,
 
     eloss = torch.mean(torch.stack(global_vars['EvalLoss'])).item()
     batch_sizes = global_vars['batchsize']
-    total_num_samples = torch.tensor(batch_sizes).sum().float()
+    total_num_samples = torch.tensor(batch_sizes).sum().double()
 
     topk_accs = []
     for k in top_k:
         correct_counts = torch.tensor(global_vars[f'CorrectCount@{k}'])
-        topk_acc = correct_counts.sum() / total_num_samples
+        topk_acc = correct_counts.sum().double() / total_num_samples
         topk_accs.append(topk_acc)
 
     if tag is None:

--- a/nemo/collections/asr/parts/numba_utils.py
+++ b/nemo/collections/asr/parts/numba_utils.py
@@ -1,3 +1,16 @@
+# Copyright 2020 NVIDIA. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import numpy as np
 from numba import jit
 

--- a/nemo/collections/asr/parts/numba_utils.py
+++ b/nemo/collections/asr/parts/numba_utils.py
@@ -1,0 +1,80 @@
+import numpy as np
+from numba import jit
+
+
+def phase_vocoder(D: np.ndarray, rate: float, phi_advance: np.ndarray, scale_buffer: np.ndarray):
+    """
+    Optimized implementation of phase vocoder from Librosa.
+
+    Reference implementation:
+        - https://librosa.github.io/librosa/generated/librosa.core.phase_vocoder.html
+
+    Args:
+        D: Complex spectograms of shape [d, t, complex=2].
+        rate: Speed rate, must be float greater than 0.
+        phi_advance: Precomputed phase advance buffer array of length [n_fft + 1]
+        scale_buffer: Precomputed numpy buffer array of length [n_fft + 1]
+
+    Returns:
+        Complex64 ndarray of shape [d, t / rate, complex=2]
+    """
+    time_steps = np.arange(0, D.shape[1], rate, dtype=np.float)
+
+    # Create an empty output array
+    d_stretch = np.zeros((D.shape[0], len(time_steps)), D.dtype, order='F')
+
+    # Phase accumulator; initialize to the first sample
+    phase_acc = np.angle(D[:, 0])
+
+    # Pad 0 columns to simplify boundary logic
+    D = np.pad(D, [(0, 0), (0, 2)], mode='constant')
+
+    d_stretch = _phase_vocoder_kernel(D, time_steps, phi_advance, d_stretch, phase_acc, scale_buffer)
+
+    return d_stretch
+
+
+@jit(nopython=True, nogil=True)
+def _phase_vocoder_kernel(D, time_steps, phi_advance, d_stretch, phase_acc, scale_buffer):
+    """
+    Numba optimized kernel to compute the phase vocoder step.
+
+    Args:
+        D: Complex spectograms of shape [d, t, complex=2].
+        rate: Speed rate, must be float greater than 0.
+        time_steps: Numpy ndarray of linearly spaced time steps, shape = [t]
+        phi_advance: Precomputed phase advance buffer array of length [n_fft + 1]
+        d_stretch: Output complex matrix of shape [d, t / rate, complex=2]
+        phase_acc: Phase accumulator initialized to first sample of shape [d, complex=2]
+        scale_buffer: Precomputed numpy buffer array of length [n_fft + 1]
+
+    Returns:
+        Complex64 ndarray of shape [d, t / rate, complex=2]
+    """
+    two_pi = 2.0 * np.pi
+
+    for (t, step) in enumerate(time_steps):
+        columns = D[:, int(step) : int(step + 2)]
+        columns_0 = columns[:, 0]
+        columns_1 = columns[:, 1]
+
+        # Weighting for linear magnitude interpolation
+        alpha = np.mod(step, 1.0)
+        mag = (1.0 - alpha) * np.abs(columns_0) + alpha * np.abs(columns_1)
+
+        # Store to output array
+        d_stretch[:, t] = mag * np.exp(1.0j * phase_acc)
+
+        # Compute phase advance
+        dphase = np.angle(columns_1) - np.angle(columns_0) - phi_advance
+
+        # Wrap to -pi:pi range
+        scale = dphase / two_pi
+        np.round(scale, 0, scale_buffer)
+
+        dphase = dphase - two_pi * scale_buffer
+
+        # Accumulate phase
+        phase_acc += phi_advance + dphase
+
+    return d_stretch

--- a/nemo/collections/asr/parts/perturb.py
+++ b/nemo/collections/asr/parts/perturb.py
@@ -108,7 +108,7 @@ class TimeStretchPerturbation(Perturbation):
                 will be sampled uniformly.
                 Note: If a positive integer is provided and the resultant discretized
                 range of rates contains the value '1.0', then those samples with rate=1.0,
-                will not be augmented at all and simply skipped. This is to unnecessary
+                will not be augmented at all and simply skipped. This is to avoid unnecessary
                 augmentation and increase computation time. Effective augmentation chance
                 in such a case is = `prob * (num_rates - 1 / num_rates) * 100`% chance
                 where `prob` is the global probability of a sample being augmented.

--- a/nemo/collections/asr/parts/perturb.py
+++ b/nemo/collections/asr/parts/perturb.py
@@ -10,6 +10,13 @@ from nemo import logging
 from nemo.collections.asr.parts import collections, parsers
 from nemo.collections.asr.parts.segment import AudioSegment
 
+try:
+    from nemo.collections.asr.parts import numba_utils
+
+    HAVE_NUMBA = True
+except (ImportError, ModuleNotFoundError):
+    HAVE_NUMBA = False
+
 
 class Perturbation(object):
     def max_augmentation_length(self, length):
@@ -20,20 +27,164 @@ class Perturbation(object):
 
 
 class SpeedPerturbation(Perturbation):
-    def __init__(self, min_speed_rate=0.85, max_speed_rate=1.15, rng=None):
+    def __init__(self, sr, min_speed_rate=0.9, max_speed_rate=1.1, num_rates=5, rng=None):
+        """
+        Performs Speed Augmentation by re-sampling the data to a different sampling rate,
+        which does not preserve pitch.
+
+        Note: This is a very slow operation for online augmentation. If space allows,
+        it is preferable to pre-compute and save the files to augment the dataset.
+
+        Args:
+            sr: Original sampling rate.
+            min_speed_rate: Minimum sampling rate modifier.
+            max_speed_rate: Maximum sampling rate modifier.
+            num_rates: Number of discrete rates to allow. Can be a positive or negative
+                integer.
+                If a positive integer greater than 0 is provided, the range of
+                speed rates will be discretized into `num_rates` values.
+                If a negative integer or 0 is provided, the full range of speed rates
+                will be sampled uniformly.
+                Note: If a positive integer is provided and the resultant discretized
+                range of rates contains the value '1.0', then those samples with rate=1.0,
+                will not be augmented at all and simply skipped. This is to unnecessary
+                augmentation and increase computation time. Effective augmentation chance
+                in such a case is = `prob * (num_rates - 1 / num_rates) * 100`% chance
+                where `prob` is the global probability of a sample being augmented.
+            rng: Random seed number.
+        """
+        self._sr = sr
         self._min_rate = min_speed_rate
         self._max_rate = max_speed_rate
+        self._num_rates = num_rates
+        if num_rates > 0:
+            self._rates = np.linspace(self._min_rate, self._max_rate, self._num_rates, endpoint=True)
         self._rng = random.Random() if rng is None else rng
 
     def max_augmentation_length(self, length):
         return length * self._max_rate
 
     def perturb(self, data):
-        speed_rate = self._rng.uniform(self._min_rate, self._max_rate)
+        # Select speed rate either from choice or random sample
+        if self._num_rates < 0:
+            speed_rate = self._rng.uniform(self._min_rate, self._max_rate)
+        else:
+            speed_rate = self._rng.choice(self._rates)
+
+        # Skip perturbation in case of identity speed rate
+        if speed_rate == 1.0:
+            return
+
         if speed_rate <= 0:
             raise ValueError("speed_rate should be greater than zero.")
-        # logging.debug("speed: %f", speed_rate)
-        data._samples = librosa.effects.time_stretch(data._samples, speed_rate)
+
+        new_sr = int(self._sr * speed_rate)
+        data._samples = librosa.core.resample(data._samples, self._sr, new_sr, res_type='kaiser_fast')
+
+
+class TimeStretchPerturbation(Perturbation):
+    def __init__(self, min_speed_rate=0.9, max_speed_rate=1.1, num_rates=5, n_fft=512, rng=None):
+        """
+        Time-stretch an audio series by a fixed rate while preserving pitch, based on [1, 2].
+
+        Note:
+        This is a simplified implementation, intended primarily for reference and pedagogical purposes.
+        It makes no attempt to handle transients, and is likely to produce audible artifacts.
+
+        Reference
+        [1] [Ellis, D. P. W. “A phase vocoder in Matlab.” Columbia University, 2002.]
+        (http://www.ee.columbia.edu/~dpwe/resources/matlab/pvoc/)
+        [2] [librosa.effects.time_stretch]
+        (https://librosa.github.io/librosa/generated/librosa.effects.time_stretch.html)
+
+        Args:
+            min_speed_rate: Minimum sampling rate modifier.
+            max_speed_rate: Maximum sampling rate modifier.
+            num_rates: Number of discrete rates to allow. Can be a positive or negative
+                integer.
+                If a positive integer greater than 0 is provided, the range of
+                speed rates will be discretized into `num_rates` values.
+                If a negative integer or 0 is provided, the full range of speed rates
+                will be sampled uniformly.
+                Note: If a positive integer is provided and the resultant discretized
+                range of rates contains the value '1.0', then those samples with rate=1.0,
+                will not be augmented at all and simply skipped. This is to unnecessary
+                augmentation and increase computation time. Effective augmentation chance
+                in such a case is = `prob * (num_rates - 1 / num_rates) * 100`% chance
+                where `prob` is the global probability of a sample being augmented.
+            n_fft: Number of fft filters to be computed.
+            rng: Random seed number.
+        """
+        self._min_rate = min_speed_rate
+        self._max_rate = max_speed_rate
+        self._num_rates = num_rates
+        if num_rates > 0:
+            self._rates = np.linspace(self._min_rate, self._max_rate, self._num_rates, endpoint=True)
+        self._rng = random.Random() if rng is None else rng
+
+        # Pre-compute constants
+        self._n_fft = int(n_fft)
+        self._hop_length = int(n_fft // 2)
+
+        # Pre-allocate buffers
+        self._phi_advance_fast = np.linspace(0, np.pi * self._hop_length, self._hop_length + 1)
+        self._scale_buffer_fast = np.empty(self._hop_length + 1, dtype=np.float32)
+
+        self._phi_advance_slow = np.linspace(0, np.pi * self._n_fft, self._n_fft + 1)
+        self._scale_buffer_slow = np.empty(self._n_fft + 1, dtype=np.float32)
+
+    def max_augmentation_length(self, length):
+        return length * self._max_rate
+
+    def perturb(self, data):
+        # Select speed rate either from choice or random sample
+        if self._num_rates < 0:
+            speed_rate = self._rng.uniform(self._min_rate, self._max_rate)
+        else:
+            speed_rate = self._rng.choice(self._rates)
+
+        # Skip perturbation in case of identity speed rate
+        if speed_rate == 1.0:
+            return
+
+        if speed_rate <= 0:
+            raise ValueError("speed_rate should be greater than zero.")
+
+        # Increase `n_fft` based on task (speed up or slow down audio)
+        # This greatly reduces upper bound of maximum time taken
+        # to compute slowed down audio segments.
+        if speed_rate >= 1.0:  # Speed up audio
+            fft_multiplier = 1
+            phi_advance = self._phi_advance_fast
+            scale_buffer = self._scale_buffer_fast
+
+        else:  # Slow down audio
+            fft_multiplier = 2
+            phi_advance = self._phi_advance_slow
+            scale_buffer = self._scale_buffer_slow
+
+        n_fft = int(self._n_fft * fft_multiplier)
+        hop_length = int(self._hop_length * fft_multiplier)
+
+        # Perform short-term Fourier transform (STFT)
+        stft = librosa.core.stft(data._samples, n_fft=n_fft, hop_length=hop_length)
+
+        # Stretch by phase vocoding
+        if HAVE_NUMBA:
+            stft_stretch = numba_utils.phase_vocoder(stft, speed_rate, phi_advance, scale_buffer)
+
+        else:
+            stft_stretch = librosa.core.phase_vocoder(stft, speed_rate, hop_length)
+
+        # Predict the length of y_stretch
+        len_stretch = int(round(len(data._samples) / speed_rate))
+
+        # Invert the STFT
+        y_stretch = librosa.core.istft(
+            stft_stretch, dtype=data._samples.dtype, hop_length=hop_length, length=len_stretch
+        )
+
+        data._samples = y_stretch
 
 
 class GainPerturbation(Perturbation):
@@ -129,6 +280,7 @@ class WhiteNoisePerturbation(Perturbation):
 
 perturbation_types = {
     "speed": SpeedPerturbation,
+    "time_stretch": TimeStretchPerturbation,
     "gain": GainPerturbation,
     "impulse": ImpulsePerturbation,
     "shift": ShiftPerturbation,

--- a/nemo/collections/asr/parts/perturb.py
+++ b/nemo/collections/asr/parts/perturb.py
@@ -27,7 +27,7 @@ class Perturbation(object):
 
 
 class SpeedPerturbation(Perturbation):
-    def __init__(self, sr, min_speed_rate=0.9, max_speed_rate=1.1, num_rates=5, rng=None):
+    def __init__(self, sr, resample_type, min_speed_rate=0.9, max_speed_rate=1.1, num_rates=5, rng=None):
         """
         Performs Speed Augmentation by re-sampling the data to a different sampling rate,
         which does not preserve pitch.
@@ -37,6 +37,10 @@ class SpeedPerturbation(Perturbation):
 
         Args:
             sr: Original sampling rate.
+            resample_type: Type of resampling operation that will be performed.
+                For better speed using `resampy`'s fast resampling method, use `resample_type='kaiser_fast'`.
+                For high-quality resampling, set `resample_type='kaiser_best'`.
+                To use `scipy.signal.resample`, set `resample_type='fft'` or `resample_type='scipy'`
             min_speed_rate: Minimum sampling rate modifier.
             max_speed_rate: Maximum sampling rate modifier.
             num_rates: Number of discrete rates to allow. Can be a positive or negative
@@ -53,12 +57,20 @@ class SpeedPerturbation(Perturbation):
                 where `prob` is the global probability of a sample being augmented.
             rng: Random seed number.
         """
+        min_rate = min(min_speed_rate, max_speed_rate)
+        if min_rate < 0.0:
+            raise ValueError("Minimum sampling rate modifier must be > 0.")
+
+        if resample_type not in ('kaiser_best', 'kaiser_fast', 'fft', 'scipy'):
+            raise ValueError("Supported `resample_type` values are ('kaiser_best', 'kaiser_fast', 'fft', 'scipy')")
+
         self._sr = sr
         self._min_rate = min_speed_rate
         self._max_rate = max_speed_rate
         self._num_rates = num_rates
         if num_rates > 0:
             self._rates = np.linspace(self._min_rate, self._max_rate, self._num_rates, endpoint=True)
+        self._res_type = resample_type
         self._rng = random.Random() if rng is None else rng
 
     def max_augmentation_length(self, length):
@@ -75,11 +87,8 @@ class SpeedPerturbation(Perturbation):
         if speed_rate == 1.0:
             return
 
-        if speed_rate <= 0:
-            raise ValueError("speed_rate should be greater than zero.")
-
         new_sr = int(self._sr * speed_rate)
-        data._samples = librosa.core.resample(data._samples, self._sr, new_sr, res_type='kaiser_fast')
+        data._samples = librosa.core.resample(data._samples, self._sr, new_sr, res_type=self._res_type)
 
 
 class TimeStretchPerturbation(Perturbation):
@@ -115,6 +124,10 @@ class TimeStretchPerturbation(Perturbation):
             n_fft: Number of fft filters to be computed.
             rng: Random seed number.
         """
+        min_rate = min(min_speed_rate, max_speed_rate)
+        if min_rate < 0.0:
+            raise ValueError("Minimum sampling rate modifier must be > 0.")
+
         self._min_rate = min_speed_rate
         self._max_rate = max_speed_rate
         self._num_rates = num_rates
@@ -146,9 +159,6 @@ class TimeStretchPerturbation(Perturbation):
         # Skip perturbation in case of identity speed rate
         if speed_rate == 1.0:
             return
-
-        if speed_rate <= 0:
-            raise ValueError("speed_rate should be greater than zero.")
 
         # Increase `n_fft` based on task (speed up or slow down audio)
         # This greatly reduces upper bound of maximum time taken

--- a/requirements/requirements_asr.txt
+++ b/requirements/requirements_asr.txt
@@ -9,3 +9,4 @@ soundfile
 sox
 torch-stft
 unidecode
+packaging

--- a/tests/unit/test_unit_speech_commands.py
+++ b/tests/unit/test_unit_speech_commands.py
@@ -117,8 +117,8 @@ class TestSpeechCommandsPytorch(TestCase):
             xp_min = rng.randn(xp.shape[0]) * min_range
 
             # Compute z statistic
-            z_max = (xp.mean() - xp_max.mean()) / np.sqrt(np.square(xp.std()) - np.square(xp_max.std()))
-            z_min = (xp.mean() - xp_min.mean()) / np.sqrt(np.square(xp.std()) - np.square(xp_min.std()))
+            z_max = (xp.mean() - xp_max.mean()) / np.sqrt(np.square(xp.std()) + np.square(xp_max.std()))
+            z_min = (xp.mean() - xp_min.mean()) / np.sqrt(np.square(xp.std()) + np.square(xp_min.std()))
             self.assertTrue(z_max < 0.01)
             self.assertTrue(z_min < 0.01)
 

--- a/tests/unit/test_unit_speech_commands.py
+++ b/tests/unit/test_unit_speech_commands.py
@@ -21,6 +21,7 @@ import tarfile
 import unittest
 from unittest import TestCase
 
+import numpy as np
 import pytest
 from ruamel.yaml import YAML
 
@@ -83,31 +84,78 @@ class TestSpeechCommandsPytorch(TestCase):
 
     @pytest.mark.unit
     def test_pytorch_audio_dataset_with_perturbation(self):
-        perturbations = [
-            perturb.WhiteNoisePerturbation(min_level=-90, max_level=-46),
-            perturb.ShiftPerturbation(min_shift_ms=-5.0, max_shift_ms=5.0),
-            perturb.TimeStretchPerturbation(min_speed_rate=0.9, max_speed_rate=1.1),
-            perturb.SpeedPerturbation(
-                sr=self.featurizer_config['sample_rate'], min_speed_rate=0.9, max_speed_rate=1.1
-            ),
-        ]
+        def construct_perturbed_dataset(perturbation):
+            if perturbation is not None:
+                # Execute perturbations with 100% probability
+                prob_perturb = [(1.0, perturbation)]
+                audio_augmentor = perturb.AudioAugmentor(prob_perturb)
+            else:
+                audio_augmentor = None
 
-        # Execute perturbations with 100% probability
-        prob_perturb = [(1.0, p) for p in perturbations]
+            featurizer = WaveformFeaturizer(
+                sample_rate=self.featurizer_config['sample_rate'],
+                int_values=self.featurizer_config['int_values'],
+                augmentor=audio_augmentor,
+            )
 
-        audio_augmentor = perturb.AudioAugmentor(prob_perturb)
+            ds = AudioLabelDataset(manifest_filepath=self.manifest_filepath, labels=self.labels, featurizer=featurizer)
+            return ds
 
-        featurizer = WaveformFeaturizer(
-            sample_rate=self.featurizer_config['sample_rate'],
-            int_values=self.featurizer_config['int_values'],
-            augmentor=audio_augmentor,
+        baseline_ds = construct_perturbed_dataset(perturbation=None)
+        num_samples = len(baseline_ds)
+
+        # test white noise perturbation
+        white_noise_perturbation = perturb.WhiteNoisePerturbation(min_level=-90, max_level=-46)
+        white_noise_ds = construct_perturbed_dataset(white_noise_perturbation)
+        max_range = 10.0 ** (-46 / 20.0)
+        min_range = 10.0 ** (-90 / 20.0)
+        rng = np.random.RandomState(0)
+
+        for i in range(num_samples):
+            xp = white_noise_ds[i][0]
+            xp_max = rng.randn(xp.shape[0]) * max_range
+            xp_min = rng.randn(xp.shape[0]) * min_range
+
+            # Compute z statistic
+            z_max = (xp.mean() - xp_max.mean()) / np.sqrt(np.square(xp.std()) - np.square(xp_max.std()))
+            z_min = (xp.mean() - xp_min.mean()) / np.sqrt(np.square(xp.std()) - np.square(xp_min.std()))
+            self.assertTrue(z_max < 0.01)
+            self.assertTrue(z_min < 0.01)
+
+        # test shift perturbation
+        shift_perturbation = perturb.ShiftPerturbation(min_shift_ms=-5.0, max_shift_ms=5.0)
+        shift_ds = construct_perturbed_dataset(shift_perturbation)
+
+        for i in range(num_samples):
+            x = baseline_ds[i][0]
+            xp = shift_ds[i][0]
+            delta = np.abs(x - xp)
+            count_zeros = np.count_nonzero(delta == 0.0)
+            self.assertTrue(count_zeros >= 0)
+
+        # test time stretch perturbation
+        ts_perturbation = perturb.TimeStretchPerturbation(min_speed_rate=0.9, max_speed_rate=1.1, num_rates=4)
+        timestretch_ds = construct_perturbed_dataset(ts_perturbation)
+
+        for i in range(num_samples):
+            x = baseline_ds[i][0]
+            xp = timestretch_ds[i][0]
+            self.assertTrue((x.shape[0] > xp.shape[0]) or (x.shape[0] < xp.shape[0]))
+
+        # test speed perturbation
+        speed_perturbation = perturb.SpeedPerturbation(
+            sr=self.featurizer_config['sample_rate'],
+            resample_type='kaiser_fast',
+            min_speed_rate=0.9,
+            max_speed_rate=1.1,
+            num_rates=4,
         )
-        ds = AudioLabelDataset(manifest_filepath=self.manifest_filepath, labels=self.labels, featurizer=featurizer,)
+        speed_ds = construct_perturbed_dataset(speed_perturbation)
 
-        for i in range(len(ds)):
-            logging.info(ds[i])
-            # logging.info(ds[i][0].shape)
-            # self.assertEqual(freq, ds[i][0].shape[0])
+        for i in range(num_samples):
+            x = baseline_ds[i][0]
+            xp = speed_ds[i][0]
+            self.assertTrue((x.shape[0] > xp.shape[0]) or (x.shape[0] < xp.shape[0]))
 
     @pytest.mark.unit
     def test_dataloader(self):
@@ -187,7 +235,7 @@ class TestSpeechCommandsPytorch(TestCase):
             to_spectrogram = nemo_asr.AudioToSpectrogramPreprocessor(n_fft=400, window=None)
             to_mfcc = nemo_asr.AudioToMFCCPreprocessor(n_mfcc=15)
             time_stretch_augment = nemo_asr.TimeStretchAugmentation(
-                self.featurizer_config['sample_rate'], probability=1.0
+                self.featurizer_config['sample_rate'], probability=1.0, min_speed_rate=0.9, max_speed_rate=1.1
             )
 
         to_melspec = nemo_asr.AudioToMelSpectrogramPreprocessor(features=50)
@@ -212,5 +260,5 @@ class TestSpeechCommandsPytorch(TestCase):
                 self.assertTrue(mfcc[0].shape[1] == 15)
 
                 timesteps = ts_input_signals[0].shape[1]
-                self.assertTrue(timesteps <= int(1.1 * self.featurizer_config['sample_rate']))
-                self.assertTrue(timesteps >= int(0.9 * self.featurizer_config['sample_rate']))
+                self.assertTrue(timesteps <= int(1.15 * self.featurizer_config['sample_rate']))
+                self.assertTrue(timesteps >= int(0.85 * self.featurizer_config['sample_rate']))

--- a/tests/unit/test_unit_speech_commands.py
+++ b/tests/unit/test_unit_speech_commands.py
@@ -86,6 +86,9 @@ class TestSpeechCommandsPytorch(TestCase):
         perturbations = [
             perturb.WhiteNoisePerturbation(min_level=-90, max_level=-46),
             perturb.ShiftPerturbation(min_shift_ms=-5.0, max_shift_ms=5.0),
+            perturb.TimeStretchPerturbation(min_speed_rate=0.9, max_speed_rate=1.1),
+            perturb.SpeedPerturbation(sr=self.featurizer_config['sample_rate'],
+                                      min_speed_rate=0.9, max_speed_rate=1.1)
         ]
 
         # Execute perturbations with 100% probability

--- a/tests/unit/test_unit_speech_commands.py
+++ b/tests/unit/test_unit_speech_commands.py
@@ -87,8 +87,9 @@ class TestSpeechCommandsPytorch(TestCase):
             perturb.WhiteNoisePerturbation(min_level=-90, max_level=-46),
             perturb.ShiftPerturbation(min_shift_ms=-5.0, max_shift_ms=5.0),
             perturb.TimeStretchPerturbation(min_speed_rate=0.9, max_speed_rate=1.1),
-            perturb.SpeedPerturbation(sr=self.featurizer_config['sample_rate'],
-                                      min_speed_rate=0.9, max_speed_rate=1.1)
+            perturb.SpeedPerturbation(
+                sr=self.featurizer_config['sample_rate'], min_speed_rate=0.9, max_speed_rate=1.1
+            ),
         ]
 
         # Execute perturbations with 100% probability
@@ -185,8 +186,9 @@ class TestSpeechCommandsPytorch(TestCase):
         if installed_torchaudio:
             to_spectrogram = nemo_asr.AudioToSpectrogramPreprocessor(n_fft=400, window=None)
             to_mfcc = nemo_asr.AudioToMFCCPreprocessor(n_mfcc=15)
-            time_stretch_augment = nemo_asr.TimeStretchAugmentation(self.featurizer_config['sample_rate'],
-                                                                    probability=1.0)
+            time_stretch_augment = nemo_asr.TimeStretchAugmentation(
+                self.featurizer_config['sample_rate'], probability=1.0
+            )
 
         to_melspec = nemo_asr.AudioToMelSpectrogramPreprocessor(features=50)
 


### PR DESCRIPTION
# Changelog
## Additions
- SpeedPerturbation + TimeStretchPerturbation for sample level augmentation on the CPU
- TimeStretchAugmentation neural module for batch level augmentation on the GPU.

## Fixes
- Use double type to compute accuracy to correct bug on PyTorch 1.5

## Issues
- **GPU TimeStretchAugmentation can cause deadlock on Pytorch 1.4 and torchaudio 0.4**. This issue seems to be resolved in Pytorch 1.5 and torchaudio 0.5.
Should we check library version and inform user of possible deadlock?
