### PR TITLE
Graph save/restore actions

### DIFF
--- a/docs/sources/source/api-docs/nemo.rst
+++ b/docs/sources/source/api-docs/nemo.rst
@@ -18,6 +18,14 @@ neural_modules
     :undoc-members:
     :show-inheritance:
 
+neural_graph
+--------------
+
+.. automodule:: nemo.core.neural_graph
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 neural_factory
 --------------
 

--- a/nemo/backends/load_backend.py
+++ b/nemo/backends/load_backend.py
@@ -20,7 +20,7 @@ _BACKEND = 'pytorch'
 
 def backend() -> str:
     """
-        Returns:
-            Name of the currently used backend.
+    Returns:
+        Name of the currently used backend.
     """
     return _BACKEND

--- a/nemo/backends/load_backend.py
+++ b/nemo/backends/load_backend.py
@@ -14,9 +14,13 @@
 # limitations under the License.
 # =============================================================================
 
-from .load_backend import backend
+# Set the default backend to PyTorch.
+_BACKEND = 'pytorch'
 
-# Load backend specific classes, functions etc.
-if backend() == 'pytorch':
-    from .torch_backend import save, load, get_state_dict, set_state_dict
-    from . import pytorch
+
+def backend() -> str:
+    """
+        Returns:
+            Name of the currently used backend.
+    """
+    return _BACKEND

--- a/nemo/backends/torch_backend.py
+++ b/nemo/backends/torch_backend.py
@@ -22,11 +22,11 @@ import torch
 
 def save(checkpoint: Dict[str, Any], filename: str) -> None:
     """
-        A proxy function that saves the checkpoint to a given file.
+    A proxy function that saves the checkpoint to a given file.
 
-        Args:
-            checkpoint: Checkpoint to be stored.
-            filename: Name of the file containing checkpoint.
+    Args:
+        checkpoint: Checkpoint to be stored.
+        filename: Name of the file containing checkpoint.
     """
     # Get the absolute path and save.
     abs_filename = expanduser(filename)
@@ -35,12 +35,12 @@ def save(checkpoint: Dict[str, Any], filename: str) -> None:
 
 def load(filename: str) -> Dict[str, Any]:
     """
-        A proxy function that loads checkpoint from a given file.
+    A proxy function that loads checkpoint from a given file.
 
-        Args:
-            filename: Name of the file containing checkpoint.
-        Returns:
-            Loaded checkpoint.
+    Args:
+        filename: Name of the file containing checkpoint.
+    Returns:
+        Loaded checkpoint.
     """
     # Get the absolute path and save.
     abs_filename = expanduser(filename)
@@ -50,22 +50,22 @@ def load(filename: str) -> Dict[str, Any]:
 
 def get_state_dict(model: torch.nn.Module) -> Dict[str, Any]:
     """
-        A proxy function that gets the state dictionary.
+    A proxy function that gets the state dictionary.
 
-        Args:
-            model: Torch model.
-        Returns:
-            State dictionary containing model weights.
+    Args:
+        model: Torch model.
+    Returns:
+        State dictionary containing model weights.
     """
     return model.state_dict()
 
 
 def set_state_dict(model: torch.nn.Module, state_dict: Dict[str, Any]) -> None:
     """
-        A proxy function that sets the state dictionary.
+    A proxy function that sets the state dictionary.
 
-        Args:
-            model: Torch model.
-            state_dict: State dictionary containing model weights.
+    Args:
+        model: Torch model.
+        state_dict: State dictionary containing model weights.
     """
     model.load_state_dict(state_dict)

--- a/nemo/backends/torch_backend.py
+++ b/nemo/backends/torch_backend.py
@@ -1,0 +1,71 @@
+# =============================================================================
+# Copyright (c) 2020 NVIDIA. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+from os.path import expanduser
+from typing import Any, Dict
+
+import torch
+
+
+def save(checkpoint: Dict[str, Any], filename: str) -> None:
+    """
+        A proxy function that saves the checkpoint to a given file.
+
+        Args:
+            checkpoint: Checkpoint to be stored.
+            filename: Name of the file containing checkpoint.
+    """
+    # Get the absolute path and save.
+    abs_filename = expanduser(filename)
+    torch.save(checkpoint, abs_filename)
+
+
+def load(filename: str) -> Dict[str, Any]:
+    """
+        A proxy function that loads checkpoint from a given file.
+
+        Args:
+            filename: Name of the file containing checkpoint.
+        Returns:
+            Loaded checkpoint.
+    """
+    # Get the absolute path and save.
+    abs_filename = expanduser(filename)
+    # Use map location to be able to load CUDA-trained modules on CPU.
+    return torch.load(abs_filename, map_location=lambda storage, loc: storage)
+
+
+def get_state_dict(model: torch.nn.Module) -> Dict[str, Any]:
+    """
+        A proxy function that gets the state dictionary.
+
+        Args:
+            model: Torch model.
+        Returns:
+            State dictionary containing model weights.
+    """
+    return model.state_dict()
+
+
+def set_state_dict(model: torch.nn.Module, state_dict: Dict[str, Any]) -> None:
+    """
+        A proxy function that sets the state dictionary.
+
+        Args:
+            model: Torch model.
+            state_dict: State dictionary containing model weights.
+    """
+    model.load_state_dict(state_dict)

--- a/nemo/core/neural_graph.py
+++ b/nemo/core/neural_graph.py
@@ -47,12 +47,12 @@ class NeuralGraph(NeuralInterface):
 
     def __init__(self, operation_mode: OperationMode = OperationMode.both, name: Optional[str] = None):
         """
-            Constructor. Initializes graph variables.
+        Constructor. Initializes graph variables.
 
-            Args:
-                operation_mode: Graph operation mode, that will be propagated along modules during graph creation.
-                [training | eval | both] (DEFAULT: both)
-                name: Name of the graph (optional)
+        Args:
+            operation_mode: Graph operation mode, that will be propagated along modules during graph creation.
+            [training | eval | both] (DEFAULT: both)
+            name: Name of the graph (optional)
         """
         # Initialize the inferface.
         super().__init__()
@@ -85,12 +85,11 @@ class NeuralGraph(NeuralInterface):
 
     def __call__(self, **kwargs):
         """
-            This method "nests" one existing neural graph into another one.
-            Also checks if all inputs were provided and properly connects them.
+        This method "nests" one existing neural graph into another one.
+        Also checks if all inputs were provided and properly connects them.
 
-            Args:
-                kwargs: keyword arguments containing dictionary of (input_port_name, port_content).
-
+        Args:
+            kwargs: keyword arguments containing dictionary of (input_port_name, port_content).
         """
         # Test operation modes of the nested graphs.
         outer_mode = self._app_state.active_graph.operation_mode
@@ -122,11 +121,11 @@ class NeuralGraph(NeuralInterface):
 
     def __nest(self, inner_graph: 'NeuralGraph', inner_graph_args):
         """
-            Method nests (copies) a graph: modules, steps, topology (tensors).
+        Method nests (copies) a graph: modules, steps, topology (tensors).
 
-            Args:
-                inner_graph: Graph to be copied (will be "nested" in this (self) graph).
-                inner_graph_args: inputs passed to the graph call.
+        Args:
+            inner_graph: Graph to be copied (will be "nested" in this (self) graph).
+            inner_graph_args: inputs passed to the graph call.
         """
         # Remember the number of "already present steps".
         step_bump = len(self.steps)
@@ -249,13 +248,13 @@ class NeuralGraph(NeuralInterface):
 
     def record_step(self, module: NeuralModule):
         """
-            Records the operation (module plus passed inputs) on a list.
+        Records the operation (the module to be executed) on a list.
 
-            Args:
-                module: Neural modules added to a given graph.
+        Args:
+            module: Neural modules added to a given graph.
 
-            Returns:
-                Step number.
+        Returns:
+            Step number.
         """
         # The solution allows loops in the graph.
         # This also means that module with that name can already be present in the graph.
@@ -278,17 +277,17 @@ class NeuralGraph(NeuralInterface):
     @property
     def step_number(self) -> int:
         """
-            Returns:
-                The current step number.
+        Returns:
+            The current step number.
         """
         return len(self._steps) - 1
 
     def bind_outputs(self, tensors_list: Union[NmTensor, List[NmTensor]]):
         """
-            Binds the output tensors.
+        Binds the output tensors.
 
-            Args:
-                tensors_list: A single tensor OR a List of tensors to be bound.
+        Args:
+            tensors_list: A single tensor OR a List of tensors to be bound.
         """
         # Handle both single port and lists of ports to be bound.
         if type(tensors_list) is not list:
@@ -312,48 +311,46 @@ class NeuralGraph(NeuralInterface):
     @property
     def inputs(self) -> GraphInputs:
         """
-            Returns graph inputs.
-
         Returns:
-            A graph input.
+            Graph input.
         """
         return self._inputs
 
     @property
     def input_ports(self) -> Dict[str, NeuralType]:
         """
-            Returns definitions of graph input ports (dict of Neural Types).
+        Returns definitions of graph input ports (dict of Neural Types).
 
         .. note::
             This method actually returns an immutable  dictionary with port types (like Neural Modules).
             In order to get access to actual graph inputs please call the inputs() method.
 
         Returns:
-            A graph input ports definitions.
+            Graph input ports definitions.
         """
         return self._inputs.definitions
 
     @property
     def outputs(self) -> GraphOutputs:
         """
-            Returns graph outputs.
+        Returns graph outputs.
 
         Returns:
-            A graph outputs.
+            Graph outputs.
         """
         return self._outputs
 
     @property
     def output_ports(self) -> Dict[str, NeuralType]:
         """
-            Returns definitions of module output ports (dict of Neural Types).
+        Returns definitions of module output ports (dict of Neural Types).
 
         .. note::
             This method actually returns an immutable dictionary with port types (like Neural Modules).
             In order to get access to actual graph outpus please call the outputs() method.
 
         Returns:
-            A graph output ports definitions.
+            Graph output ports definitions.
             
         """
         return self._outputs.definitions
@@ -361,10 +358,8 @@ class NeuralGraph(NeuralInterface):
     @property
     def output_tensors(self) -> Dict[str, NmTensor]:
         """
-            Returns graph output tensors.
-
         Returns:
-            A graph output tensors.
+            Fraph output tensors.
         """
         return self._outputs.tensors
 
@@ -388,35 +383,36 @@ class NeuralGraph(NeuralInterface):
 
     def __len__(self) -> int:
         """
-            Returns:
-                The number of modules (vertices) in a given graph.
+        Returns:
+            The number of modules (vertices) in a given graph.
         """
         return len(self._modules)
 
     @property
     def steps(self) -> Dict[int, str]:
-        """ Returns steps. """
+        """
+        Returns:
+            Dictionary [steps_number, module_name]
+        """
         return self._steps
 
     @property
     def tensors(self):
         """
-            Property returning a (double) dictionary of all output tensors.
+        Property returning a (double) dictionary of all output tensors.
 
-            Returns:
-                Dictionary of tensors in the format [module_name][output_port_name].
-        
+        Returns:
+            Dictionary of tensors in the format [module_name][output_port_name].
          """
         return self._all_tensors
 
     @property
     def tensor_list(self) -> List[NmTensor]:
         """
-            Property returning output tensors by extracting them on the fly from the bound outputs.
-            
-            Returns:
-                List of tensors.
-
+        Property returning output tensors by extracting them on the fly from the bound outputs.
+        
+        Returns:
+            List of tensors.
         """
         tensor_list = []
         # Get tensors by acessing the producer-ports.
@@ -430,45 +426,45 @@ class NeuralGraph(NeuralInterface):
     @property
     def operation_mode(self) -> OperationMode:
         """
-            Returns:
-                Operation mode.
+        Returns:
+            Operation mode.
         """
         return self._operation_mode
 
     def __enter__(self) -> 'NeuralGraph':
         """ 
-            Activates this graph.
-        
-            Returns:
-                The graph object.
+        Activates this graph.
+    
+        Returns:
+            The graph object.
         """
         self._app_state.active_graph = self
         return self
 
     def __exit__(self, exc_type, exc_value, exc_traceback):
         """
-            Deactivates the current graph.
+        Deactivates the current graph.
         """
         self._app_state.active_graph = None
 
     def activate(self):
         """ 
-            Activates this graph.
+        Activates this graph.
         """
         self._app_state.active_graph = self
 
     def deactivate(self):
         """
-            Deactivates the current graph.
+        Deactivates the current graph.
         """
         self._app_state.active_graph = None
 
     def export_to_config(self, config_file: str):
         """
-            Exports the neural graph to a file.
-        
-            Args:
-                config_file: Name (and path) of the config file (YML) to be written to.
+        Exports the neural graph to a file.
+    
+        Args:
+            config_file: Name (and path) of the config file (YML) to be written to.
         """
         # Greate an absolute path.
         abs_path_file = path.expanduser(config_file)
@@ -485,10 +481,11 @@ class NeuralGraph(NeuralInterface):
         )
 
     def serialize(self) -> Dict[str, Any]:
-        """ Method serializes the whole graph.
+        """
+        Method serializes the whole graph.
 
-            Returns:
-                Dictionary containing description of the whole graph.
+        Returns:
+            Dictionary containing description of the whole graph.
         """
         # Create a dictionary representing the serialized object.
         serialized_graph = {}
@@ -515,10 +512,11 @@ class NeuralGraph(NeuralInterface):
         return serialized_graph
 
     def __serialize_header(self) -> Dict[str, Any]:
-        """ Private method responsible for serializing the graph header.
+        """
+        Private method responsible for serializing the graph header.
 
-            Returns:
-                Dictionary containing description of the whole graph.        
+        Returns:
+            Dictionary containing description of the whole graph.        
         """
         # Generate full_spec of the class.
         full_spec = str(self.__module__) + "." + str(self.__class__.__qualname__)
@@ -534,10 +532,11 @@ class NeuralGraph(NeuralInterface):
         return header
 
     def __serialize_modules(self) -> Dict[str, Any]:
-        """ Private method responsible for serializing the modules present in the graph.
+        """
+        Private method responsible for serializing the modules present in the graph.
 
-            Returns:
-                Dictionary containing description of all graph modules.
+        Returns:
+            Dictionary containing description of all graph modules.
         """
         serialized_modules = {}
         for name, module in self._modules.items():
@@ -545,10 +544,11 @@ class NeuralGraph(NeuralInterface):
         return serialized_modules
 
     def __serialize_steps(self):
-        """ Private method responsible for serializing the steps (order of module executions).
+        """
+        Private method responsible for serializing the steps (order of module executions).
 
-            Returns:
-                Dictionary containing description of the steps.
+        Returns:
+            Dictionary containing description of the steps.
         """
         serialized_steps = {}
         for no, module_name in self._steps.items():
@@ -556,10 +556,11 @@ class NeuralGraph(NeuralInterface):
         return serialized_steps
 
     def __serialize_connections(self) -> Dict[str, Any]:
-        """ Private method responsible for serializing the connections in the graph.
+        """
+        Private method responsible for serializing the connections in the graph.
 
-            Returns:
-                List containing "connections" between modules.
+        Returns:
+            List containing "connections" between modules.
         """
         serialized_connections = []
         # Iterate through "tensor modules".
@@ -584,22 +585,18 @@ class NeuralGraph(NeuralInterface):
         name: Optional[str] = None,
     ) -> 'NeuralGraph':
         """
-            Class method importing the neural graph from the configuration file.
-            Raises an ImportError exception when config file is invalid.
+        Class method importing the neural graph from the configuration file.
+        Raises an ImportError exception when config file is invalid.
 
-            Args:
-                config_file: path (absolute or relative) and name of the config file (YML)
-
-                reuse_existing_modules: If the modules with (name, type, init_params) are already created, import will
-                connect to them instead of creating new instances.
-
-                overwrite_params: Dictionary containing parameters that will be added to or overwrite (!) the default
-                parameters loaded from the configuration file
-
-                name: Name of the new graph (optional, DEFAULT: NONE)
-
-            Returns:
-                Instance of the created NeuralGraph object.
+        Args:
+            config_file: path (absolute or relative) and name of the config file (YML)
+            reuse_existing_modules: If the modules with (name, type, init_params) are already created, import will
+            connect to them instead of creating new instances.
+            overwrite_params: Dictionary containing parameters that will be added to or overwrite (!) the default
+            parameters loaded from the configuration file
+            name: Name of the new graph (optional, DEFAULT: NONE)
+        Returns:
+            Instance of the created NeuralGraph object.
         """
         logging.info("Loading configuration of a new Neural Graph from the `{}` file".format(config_file))
 
@@ -616,15 +613,14 @@ class NeuralGraph(NeuralInterface):
     @classmethod
     def __validate_config_file(cls, config_file: str):
         """
-            Class method validating whether the config file has a proper content (sections, specification etc.).
-            Raises an ImportError exception when config file is invalid or
-            incompatible (when called from a particular class).
+        Class method validating whether the config file has a proper content (sections, specification etc.).
+        Raises an ImportError exception when config file is invalid or
+        incompatible (when called from a particular class).
 
-            Args:
-                config_file: path (absolute or relative) and name of the config file (YML)
-
-            Returns:
-                A loaded configuration file (dictionary).
+        Args:
+            config_file: path (absolute or relative) and name of the config file (YML)
+        Returns:
+            A loaded configuration file (dictionary).
         """
         # Greate an absolute path.
         abs_path_file = path.expanduser(config_file)
@@ -659,16 +655,14 @@ class NeuralGraph(NeuralInterface):
         cls, configuration: Dict[str, Any], reuse_existing_modules: bool = False, name: Optional[str] = None
     ) -> 'NeuralGraph':
         """
-            Class method creating a graph instance by deserializing the provided configuratino.
+        Class method creating a graph instance by deserializing the provided configuratino.
 
-            Args:
-                configuration: Dictionary containing serialized graph.
-
-                reuse_existing_modules: If the modules with (name, type, init_params) are already created, import will
-                connect to them instead of creating new instances.
-
-            Returns:
-                Instance of the created NeuralGraph object.
+        Args:
+            configuration: Dictionary containing serialized graph.
+            reuse_existing_modules: If the modules with (name, type, init_params) are already created, import will
+            connect to them instead of creating new instances.
+        Returns:
+            Instance of the created NeuralGraph object.
         """
         # Deserialize header and get object class.
         operation_mode = cls.__deserialize_header(configuration["header"])
@@ -703,13 +697,13 @@ class NeuralGraph(NeuralInterface):
 
     @classmethod
     def __deserialize_header(cls, serialized_header: Dict[str, Any]):
-        """ Private class method deserializing the header and extracts the general information.
-            
-            Args:
-                serialized_header: Dictionary containing graph header.
-
-            Returns:
-                Operation mode.
+        """
+        Private class method deserializing the header and extracts the general information.
+        
+        Args:
+            serialized_header: Dictionary containing graph header.
+        Returns:
+            Operation mode.
         """
         # Parse the "full specification" - do not need that now.
         # spec_list = serialized_header["full_spec"].split(".")
@@ -726,17 +720,18 @@ class NeuralGraph(NeuralInterface):
         return operation_mode
 
     def __deserialize_modules(self, serialized_modules: Dict[str, Any], reuse_existing_modules: bool):
-        """ Private method deserializing the modules present in the graph.
+        """
+        Private method deserializing the modules present in the graph.
 
-            Args:
-                serialized_modules: Dictionary containing graph modules.
-                reuse_existing_modules: If True, won create a new module when a module with a given name exists.
+        Args:
+            serialized_modules: Dictionary containing graph modules.
+            reuse_existing_modules: If True, won create a new module when a module with a given name exists.
 
-            Returns:
-                Dictionary of modules.
+        Returns:
+            Dictionary of modules.
 
-            Raises:
-                KeyError: A module with name already exists (if reuse_existing_modules is set to False).
+        Raises:
+            KeyError: A module with name already exists (if reuse_existing_modules is set to False).
         """
         modules = {}
         for name, module_params in serialized_modules.items():
@@ -754,13 +749,13 @@ class NeuralGraph(NeuralInterface):
         return modules
 
     def __deserialize_steps(self, serialized_steps: Dict[str, Any]):
-        """ Private method deserializing the steps (order of module executions).
+        """
+        Private method deserializing the steps (order of module executions).
 
-            Args:
-                serialized_steps: Dictionary containing serialized steps.
-
-            Returns:
-                Odered dict with steps.
+        Args:
+            serialized_steps: Dictionary containing serialized steps.
+        Returns:
+            Odered dict with steps.
         """
         steps = OrderedDict()
         for i in range(len(serialized_steps)):
@@ -769,14 +764,14 @@ class NeuralGraph(NeuralInterface):
         return steps
 
     def __deserialize_connections(self, serialized_connections: Dict[str, Any], modules: Dict[str, NeuralModule]):
-        """ Private method deserializing the connections in the graph.
+        """
+        Private method deserializing the connections in the graph.
 
-            Args:
-                serialized_steps: Dictionary containing serialized connections.
-                modules: List of modules.
-
-            Returns:
-                List of connections, in a format enabling graph traversing.
+        Args:
+            serialized_steps: Dictionary containing serialized connections.
+            modules: List of modules.
+        Returns:
+            List of connections, in a format enabling graph traversing.
         """
         connections = []
         # Deserialize connections one by one.
@@ -799,15 +794,15 @@ class NeuralGraph(NeuralInterface):
         return connections
 
     def __execute_and_create_tensors(self, steps, modules, connections, inputs):
-        """ Method creates (internal) tensors of the graph by executing it following the order and using 
-            the provided connections and inputs.
+        """
+        Method creates (internal) tensors of the graph by executing it following the order and using 
+        the provided connections and inputs.
 
-            Args:
-                steps: List of steps to be executed.
-                modules: List of modules.
-                connections: List of connections.
-                inputs: List of "bound inputs"
-        
+        Args:
+            steps: List of steps to be executed.
+            modules: List of modules.
+            connections: List of connections.
+            inputs: List of "bound inputs"
         """
         # Activate this graph, so all the tensors will be added to this !
         self.activate()
@@ -875,8 +870,8 @@ class NeuralGraph(NeuralInterface):
 
     def summary(self) -> str:
         """ 
-            Returns:
-                A nice, full graph summary.
+        Returns:
+            A nice, full graph summary.
         """
         # Line "decorator".
         desc = "\n" + 120 * '=' + "\n"
@@ -924,11 +919,12 @@ class NeuralGraph(NeuralInterface):
 
     def freeze(self, module_names: Optional[List[str]] = None):
         """
-            A method that freezes the weights of the trainable modules in a graph.
-            Args:
-                module_names: List of modules to be frozen (Optional). If passed, all modules will be unfrozen.
-            Raises:
-                KeyError: If name of the module won't be recognized.
+        A method that freezes the weights of the trainable modules in a graph.
+
+        Args:
+            module_names: List of modules to be frozen (Optional). If passed, all modules will be unfrozen.
+        Raises:
+            KeyError: If name of the module won't be recognized.
         """
         # Work on all modules.
         if module_names is None:
@@ -948,11 +944,12 @@ class NeuralGraph(NeuralInterface):
 
     def unfreeze(self, module_names: Optional[List[str]] = None):
         """
-            Unfreezes weights of the trainable modules in a graph.
-            Args:
-                module_names: List of modules to be unfrozen (Optional). If not passed, all modules will be unfrozen.
-            Raises:
-                KeyError: If name of the module won't be recognized.
+        Unfreezes weights of the trainable modules in a graph.
+
+        Args:
+            module_names: List of modules to be unfrozen (Optional). If not passed, all modules will be unfrozen.
+        Raises:
+            KeyError: If name of the module won't be recognized.
         """
         # Work on all modules.
         if module_names is None:
@@ -972,12 +969,13 @@ class NeuralGraph(NeuralInterface):
 
     def save_to(self, filename: str, module_names: Optional[List[str]] = None):
         """
-            Saves the state of trainable modules in the graph to a checkpoint file.
-            Args:
-                filename (string): Name of the file where the checkpoint will be saved.
-                module_names: List of modules to be frozen (Optional). If passed, all modules will be saved.
-            Raises:
-                KeyError: If name of the module won't be recognized.
+        Saves the state of trainable modules in the graph to a checkpoint file.
+
+        Args:
+            filename (string): Name of the file where the checkpoint will be saved.
+            module_names: List of modules to be frozen (Optional). If passed, all modules will be saved.
+        Raises:
+            KeyError: If name of the module won't be recognized.
         """
         # Work on all modules.
         if module_names is None:
@@ -1007,12 +1005,13 @@ class NeuralGraph(NeuralInterface):
 
     def restore_from(self, filename: str, module_names: Optional[List[str]] = None):
         """
-            Restores the state of trainable modules in the graph from a checkpoint file.
-            Args:
-                filename (string): Name of the checkpoint to be restored from.
-                module_names: List of modules to be frozen (Optional). If passed, all modules will be restored.
-            Raises:
-                KeyError: If name of the module won't be recognized.
+        Restores the state of trainable modules in the graph from a checkpoint file.
+        
+        Args:
+            filename (string): Name of the checkpoint to be restored from.
+            module_names: List of modules to be frozen (Optional). If passed, all modules will be restored.
+        Raises:
+            KeyError: If name of the module won't be recognized.
         """
         # Work on all modules.
         if module_names is None:

--- a/nemo/core/neural_graph.py
+++ b/nemo/core/neural_graph.py
@@ -26,6 +26,7 @@ from typing import Any, Dict, List, Optional, Union
 
 from ruamel.yaml import YAML
 
+from nemo.backends import get_state_dict, load, save, set_state_dict
 from nemo.core import OperationMode
 from nemo.core.neural_interface import NeuralInterface
 from nemo.core.neural_modules import ModuleType, NeuralModule
@@ -929,9 +930,10 @@ class NeuralGraph(NeuralInterface):
             Raises:
                 KeyError: If name of the module won't be recognized.
         """
+        # Work on all modules.
         if module_names is None:
-            # Work on all modules.
             module_names = self._modules.keys()
+
         # Iterate through modules one by one.
         for name in module_names:
             if name not in self._modules.keys():
@@ -939,8 +941,10 @@ class NeuralGraph(NeuralInterface):
             # Check module type.
             module = self._modules[name]
             if module.type == ModuleType.trainable:
-                # Freeze weights of the module
+                # Freeze weights of the module.
                 module.freeze()
+            else:
+                logging.debug("Module `{}` is not trainable so cannot be frozen".format(name))
 
     def unfreeze(self, module_names: Optional[List[str]] = None):
         """
@@ -950,9 +954,10 @@ class NeuralGraph(NeuralInterface):
             Raises:
                 KeyError: If name of the module won't be recognized.
         """
+        # Work on all modules.
         if module_names is None:
-            # Work on all modules.
             module_names = self._modules.keys()
+
         # Iterate through modules one by one.
         for name in module_names:
             if name not in self._modules.keys():
@@ -962,3 +967,79 @@ class NeuralGraph(NeuralInterface):
             if module.type == ModuleType.trainable:
                 # Unfreeze weights of the module.
                 module.unfreeze()
+            else:
+                logging.debug("Module `{}` is not trainable so cannot be unfrozen".format(name))
+
+    def save_to(self, filename: str, module_names: Optional[List[str]] = None):
+        """
+            Saves the state of trainable modules in the graph to a checkpoint file.
+            Args:
+                filename (string): Name of the file where the checkpoint will be saved.
+                module_names: List of modules to be frozen (Optional). If passed, all modules will be saved.
+            Raises:
+                KeyError: If name of the module won't be recognized.
+        """
+        # Work on all modules.
+        if module_names is None:
+            module_names = self._modules.keys()
+
+        # Prepare the "graph checkpoint".
+        chkpt = {"header": {"nemo_core_version": nemo_version, "name": self.name}, "modules": {}}
+
+        log_str = ''
+        # Iterate through the modules one by one.
+        for name in module_names:
+            if name not in self._modules.keys():
+                raise KeyError("Module `{}` not present in the `{}` graph".format(name, self.name))
+            # Check module type.
+            module = self._modules[name]
+            if module.type == ModuleType.trainable:
+                # Get module state_dict().
+                chkpt["modules"][name] = get_state_dict(module)
+                log_str += "  * Module '{}' ({}) params saved \n".format(module.name, type(module).__name__)
+            else:
+                logging.debug("Module `{}` is not trainable so cannot be saved".format(name))
+
+        # Save checkpoint.
+        save(chkpt, filename)
+        log_str = "Saved  the '{}' graph to a checkpoint `{}`:\n".format(self.name, filename) + log_str
+        logging.info(log_str)
+
+    def restore_from(self, filename: str, module_names: Optional[List[str]] = None):
+        """
+            Restores the state of trainable modules in the graph from a checkpoint file.
+            Args:
+                filename (string): Name of the checkpoint to be restored from.
+                module_names: List of modules to be frozen (Optional). If passed, all modules will be restored.
+            Raises:
+                KeyError: If name of the module won't be recognized.
+        """
+        # Work on all modules.
+        if module_names is None:
+            module_names = self._modules.keys()
+
+        # Load the checkpoint.
+        chkpt = load(filename)
+
+        log_str = "Loading modules constituting the '{}' graph from the `{}` checkpoint :\n".format(
+            chkpt["header"]["name"], filename
+        )
+
+        warning = False
+        # Iterate through the modules one by one.
+        for name in module_names:
+            try:
+                # Get module.
+                module = self._modules[name]
+                # Restore module weights
+                set_state_dict(module, chkpt["modules"][name])
+                log_str += "  * Module '{}' ({}) params loaded\n".format(module.name, type(module).__name__)
+            except KeyError:
+                log_str += "  ! Module '{}' params not found in checkpoint\n".format(name)
+                warning = True
+
+        # Log results.
+        if warning:
+            logging.warning(log_str)
+        else:
+            logging.info(log_str)

--- a/nemo/core/neural_modules.py
+++ b/nemo/core/neural_modules.py
@@ -62,7 +62,7 @@ PretrainedModelInfo = namedtuple(
 
 class NeuralModule(NeuralInterface):
     """
-        Abstract class that every Neural Module must inherit from.
+    Abstract class that every Neural Module must inherit from.
     """
 
     def __init__(self, name=None):
@@ -97,20 +97,20 @@ class NeuralModule(NeuralInterface):
     @property
     def init_params(self) -> Dict[str, Any]:
         """
-            Property returning parameters used to instantiate the module.
+        Property returning parameters used to instantiate the module.
 
-            Returns:
-                Dictionary containing parameters used to instantiate the module.
+        Returns:
+            Dictionary containing parameters used to instantiate the module.
         """
         return self._init_params
 
     def __extract_init_params(self) -> Dict[str, Any]:
         """
-            Retrieves the dictionary of of parameters (keys, values) passed to constructor of a class derived
-            (also indirectly) from the Neural Module class.
+        Retrieves the dictionary of of parameters (keys, values) passed to constructor of a class derived
+        (also indirectly) from the Neural Module class.
 
-            Returns:
-                Dictionary containing parameters passed to init().
+        Returns:
+            Dictionary containing parameters passed to init().
         """
         # Get names of arguments of the original module init method.
         init_keys = getfullargspec(type(self).__init__).args
@@ -153,14 +153,13 @@ class NeuralModule(NeuralInterface):
 
     def __validate_params(self, params: Dict[str, Any]) -> bool:
         """
-            Checks whether dictionary contains parameters being primitive types (string, int, float etc.)
-            or (lists of)+ primitive types.
+        Checks whether dictionary contains parameters being primitive types (string, int, float etc.)
+        or (lists of)+ primitive types.
 
-            Args:
-                params: dictionary of parameters.
-
-            Returns:
-                True if all parameters were ok, False otherwise.
+        Args:
+            params: dictionary of parameters.
+        Returns:
+            True if all parameters were ok, False otherwise.
         """
         ok = True
 
@@ -179,13 +178,12 @@ class NeuralModule(NeuralInterface):
 
     def __is_of_allowed_type(self, var) -> bool:
         """
-            A recursive function that checks if a given variable is of allowed type.
+        A recursive function that checks if a given variable is of allowed type.
 
-            Args:
-                pretrained_model_name (str): name of pretrained model to use in order.
-
-            Returns:
-                True if all parameters were ok, False otherwise.
+        Args:
+            pretrained_model_name (str): name of pretrained model to use in order.
+        Returns:
+            True if all parameters were ok, False otherwise.
         """
         # Special case: None is also allowed.
         if var is None:
@@ -213,13 +211,12 @@ class NeuralModule(NeuralInterface):
 
     def export_to_config(self, config_file: str):
         """
-            A function that exports module "configuration" (i.e. init parameters) to a YAML file.
+        A function that exports module "configuration" (i.e. init parameters) to a YAML file.
 
-            Args:
-                config_file: path (absolute or relative) and name of the config file (YML)
-
-            Raises:
-                ValueError: An error occurred and  parameters coudn't be exported.
+        Args:
+            config_file: path (absolute or relative) and name of the config file (YML)
+        Raises:
+            ValueError: An error occurred and  parameters coudn't be exported.
         """
         # Greate an absolute path.
         abs_path_file = path.expanduser(config_file)
@@ -236,10 +233,11 @@ class NeuralModule(NeuralInterface):
         )
 
     def serialize(self) -> Dict[str, Any]:
-        """ A method serializing the whole Neural module (into a dictionary).
-            
-            Returns:
-                Dictionary containing a "serialized" module.
+        """
+        A method serializing the whole Neural module (into a dictionary).
+
+        Returns:
+            Dictionary containing a "serialized" module.
         """
         # Create a dictionary representing the serialized object.
         serialized_module = {}
@@ -254,10 +252,11 @@ class NeuralModule(NeuralInterface):
         return serialized_module
 
     def __serialize_header(self) -> Dict[str, Any]:
-        """ A protected method that creates a header stored later in the configuration file.
+        """
+        A protected method that creates a header stored later in the configuration file.
             
-            Returns:
-                Dictionary containing a header with module specification.
+        Returns:
+            Dictionary containing a header with module specification.
         """
 
         # Get module "full specification".
@@ -302,14 +301,15 @@ class NeuralModule(NeuralInterface):
 
     def _serialize_configuration(self) -> Dict[str, Any]:
         """
-            A function that serializes the module "configuration (i.e. init parameters) to a dictionary.
-            Raises a ValueError exception in case then parameters coudn't be exported.
+        A function that serializes the module "configuration (i.e. init parameters) to a dictionary.
 
-            ..note:
-                Thus functions should be overloaded when writing a custom module import/export.
+        ..note:
+            Thus functions should be overloaded when writing a custom module import/export.
 
-            Returns:
-                A "serialized" dictionary with module configuration.
+        Returns:
+            A "serialized" dictionary with module configuration.
+        Raises:
+            A ValueError exception in case then parameters coudn't be exported.
         """
         # Check if generic export will work.
         if not self.__validate_params(self._init_params):
@@ -326,22 +326,18 @@ class NeuralModule(NeuralInterface):
         cls, config_file: str, section_name: str = None, name: str = None, overwrite_params: Dict = {}
     ) -> 'NeuralModule':
         """
-            Class method importing the configuration file.
-            Raises an ImportError exception when config file is invalid or
-            incompatible (when called from a particular class).
+        Class method importing the configuration file.
+        Raises an ImportError exception when config file is invalid or
+        incompatible (when called from a particular class).
 
-            Args:
-                config_file: path (absolute or relative) and name of the config file (YML)
-
-                section_name: section in the configuration file storing module configuration (optional, DEFAULT: None)
-
-                name: name of the module that will overwrite the name in the `init_params` (optional, DEFAULT: None)
-
-                overwrite_params: Dictionary containing parameters that will be added to or overwrite (!)
-                the default init parameters loaded from the configuration file (the module "init_params" section).
-
-            Returns:
-                Instance of the created NeuralModule object.
+        Args:
+            config_file: path (absolute or relative) and name of the config file (YML)
+            section_name: section in the configuration file storing module configuration (optional, DEFAULT: None)
+            name: name of the module that will overwrite the name in the `init_params` (optional, DEFAULT: None)
+            overwrite_params: Dictionary containing parameters that will be added to or overwrite (!)
+            the default init parameters loaded from the configuration file (the module "init_params" section).
+        Returns:
+            Instance of the created NeuralModule object.
         """
         logging.info("Loading configuration of a new Neural Module from the `{}` file".format(config_file))
 
@@ -357,17 +353,15 @@ class NeuralModule(NeuralInterface):
     @classmethod
     def __validate_config_file(cls, config_file: str, section_name: str = None) -> Dict[str, Any]:
         """
-            Class method validating whether the config file has a proper content (sections, specification etc.).
-            Raises an ImportError exception when config file is invalid or
-            incompatible (when called from a particular class).
+        Class method validating whether the config file has a proper content (sections, specification etc.).
+        Raises an ImportError exception when config file is invalid or
+        incompatible (when called from a particular class).
 
-            Args:
-                config_file: path (absolute or relative) and name of the config file (YML)
-
-                section_name: section in the configuration file storing module configuration (optional, DEFAULT: None)
-
-            Returns:
-                A loaded configuration file (dictionary).
+        Args:
+            config_file: path (absolute or relative) and name of the config file (YML)
+            section_name: section in the configuration file storing module configuration (optional, DEFAULT: None)
+        Returns:
+            A loaded configuration file (dictionary).
         """
         # Greate an absolute path.
         abs_path_file = path.expanduser(config_file)
@@ -410,21 +404,21 @@ class NeuralModule(NeuralInterface):
 
     @classmethod
     def deserialize(
-        cls, configuration: str, name: str = None, overwrite_params: Dict[str, Any] = {}
+        cls, configuration: Dict[str, Any], name: str = None, overwrite_params: Dict[str, Any] = {}
     ) -> 'NeuralModule':
         """
-            Class method instantianting the neural module object based on the configuration (dictionary).
+        Class method instantianting the neural module object based on the configuration (dictionary).
 
-            Args:
-                configuration: Dictionary containing proper "header" and "init_params" sections.
+        Args:
+            configuration: Dictionary containing proper "header" and "init_params" sections.
 
-                name: name of the module that will overwrite the name in the `init_params` (optional, DEFAULT: None)
+            name: name of the module that will overwrite the name in the `init_params` (optional, DEFAULT: None)
 
-                overwrite_params: Dictionary containing parameters that will be added to or overwrite (!)
-                the default init parameters loaded from the configuration file (the module "init_params" section).
+            overwrite_params: Dictionary containing parameters that will be added to or overwrite (!)
+            the default init parameters loaded from the configuration file (the module "init_params" section).
 
-            Returns:
-                Instance of the created NeuralModule object.
+        Returns:
+            Instance of the created NeuralModule object.
         """
         # Deserialize header - get object class.
         module_class = cls.__deserialize_header(configuration["header"])
@@ -454,13 +448,13 @@ class NeuralModule(NeuralInterface):
 
     @classmethod
     def __deserialize_header(cls, serialized_header: Dict[str, Any]):
-        """ Method deserializes the header and extracts the module class.
-            
-            Args:
-                serialized_header: Dictionary containing module header.
+        """
+        Method deserializes the header and extracts the module class.
 
-            Returns:
-                Class of the module to be created.
+        Args:
+            serialized_header: Dictionary containing module header.
+        Returns:
+            Class of the module to be created.
         """
         # Parse the "full specification".
         spec_list = serialized_header["full_spec"].split(".")
@@ -476,16 +470,15 @@ class NeuralModule(NeuralInterface):
     @classmethod
     def _deserialize_configuration(cls, serialized_init_params: Dict[str, Any]):
         """
-            A function that deserializes the module "configuration (i.e. init parameters).
+        A function that deserializes the module "configuration (i.e. init parameters).
 
-            ..note:
-                Thus functions should be overloaded when writing a custom module import/export.
+        ..note:
+            Thus functions should be overloaded when writing a custom module import/export.
 
-            Args:
-                serialized_init_params: List of init parameters loaded from the file.
-
-            Returns:
-                A "deserialized" list with init parameters.
+        Args:
+            serialized_init_params: List of init parameters loaded from the file.
+        Returns:
+            A "deserialized" list with init parameters.
         """
         # In this case configuration = init parameters.
         return serialized_init_params
@@ -493,19 +486,21 @@ class NeuralModule(NeuralInterface):
     @property
     @abstractmethod
     def input_ports(self) -> Dict[str, NeuralType]:
-        """Returns definitions of module input ports
+        """
+        Returns definitions of module input ports
 
         Returns:
-          A (dict) of module's input ports names to NeuralTypes mapping
+          A dictionary containing module's input ports (names, NeuralTypes) mapping.
         """
 
     @property
     @abstractmethod
     def output_ports(self) -> Dict[str, NeuralType]:
-        """Returns definitions of module output ports
+        """
+        Returns definitions of module output ports
 
         Returns:
-          A (dict) of module's output ports names to NeuralTypes mapping
+          A dictionary containing module's output ports (names, NeuralTypes) mapping.
         """
 
     @property
@@ -528,7 +523,6 @@ class NeuralModule(NeuralInterface):
 
     def _prepare_for_deployment(self) -> None:
         """Patch the module if required to prepare for deployment
-
         """
         return
 

--- a/tests/unit/test_torch_backend.py
+++ b/tests/unit/test_torch_backend.py
@@ -1,0 +1,71 @@
+# ! /usr/bin/python
+# -*- coding: utf-8 -*-
+
+# =============================================================================
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+import pytest
+from numpy import array_equal
+
+from nemo.backends import get_state_dict, load, save, set_state_dict
+from nemo.backends.pytorch.tutorials import TaylorNet
+
+
+@pytest.mark.usefixtures("neural_factory")
+class TestTorchBackend:
+    @pytest.mark.unit
+    def test_state_dict(self):
+        """
+            Tests whether the get/set_state_dict proxy functions work properly.
+        """
+        # Module.
+        fx = TaylorNet(dim=4)
+
+        # Get state dict.
+        state_dict1 = get_state_dict(fx)
+
+        # Set state dict.
+        set_state_dict(fx, state_dict1)
+
+        # Compare state dicts.
+        state_dict2 = get_state_dict(fx)
+        for key in state_dict1.keys():
+            assert array_equal(state_dict1[key].cpu().numpy(), state_dict2[key].cpu().numpy())
+
+    @pytest.mark.unit
+    def test_save_load(self, tmpdir):
+        """
+            Tests whether the save and load proxy functions work properly.
+
+            Args:
+                tmpdir: Fixture which will provide a temporary directory.
+        """
+        # Module.
+        fx = TaylorNet(dim=4)
+
+        # Generate filename in the temporary directory.
+        tmp_file_name = str(tmpdir.join("tsl_taylornet.chkpt"))
+
+        # Save.
+        weights = get_state_dict(fx)
+        save(weights, tmp_file_name)
+
+        # Load.
+        loaded_weights = load(tmp_file_name)
+
+        # Compare state dicts.
+        for key in weights:
+            assert array_equal(weights[key].cpu().numpy(), loaded_weights[key].cpu().numpy())


### PR DESCRIPTION
This PR introduces new graph actions:
 - [x] save_to() - saves all trainable modules in a given graph to checkpoint
 - [x] restore_from() - restores all trainable modules from a checkpoint

Additionally, as Neural Graphs are supposed to be "backend-dependent", it polishes a bit the way we inject the "backend dependencies", by:
 - [x] introducing the "import_backend" solution based on the Keras approach
 - [x] introducing backend proxies for: save, load, get_state_dict, set_state_dict