### PR TITLE
Add TTS Example notebook for Tacotron2 + WaveGlow

### DIFF
--- a/examples/tts/notebooks/1_Tacotron_inference.ipynb
+++ b/examples/tts/notebooks/1_Tacotron_inference.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,10 +30,16 @@
     "import argparse\n",
     "import math\n",
     "import os\n",
+    "import copy\n",
+    "import shutil\n",
+    "import librosa\n",
+    "import matplotlib.pyplot as plt\n",
     "from functools import partial\n",
+    "from scipy.io.wavfile import write\n",
     "\n",
     "from ruamel.yaml import YAML\n",
     "\n",
+    "import torch\n",
     "import nemo\n",
     "import nemo.collections.asr as nemo_asr\n",
     "import nemo.collections.tts as nemo_tts\n",
@@ -50,48 +56,271 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
     "# Download config files\n",
     "config_path = '../configs/tacotron2.yaml'\n",
-    "\n",
+    "waveglow_config_path = '../configs/waveglow.yaml'\n",
     "\n",
     "yaml = YAML(typ=\"safe\")\n",
     "with open(config_path) as file:\n",
     "    tacotron2_config = yaml.load(file)\n",
-    "    labels = tacotron2_config[\"labels\"]"
+    "    labels = tacotron2_config[\"labels\"]\n",
+    "    \n",
+    "with open(waveglow_config_path) as file:\n",
+    "    waveglow_config = yaml.load(file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Download pre-trained checkpoints\n",
+    "\n",
+    "Note: The checkpoint for WaveGlow is very large (>1GB), so please ensure you have sufficient storage space."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def create_NMs(tacotron2_config, labels, decoder_infer=False, decoder_force=False):\n",
+    "base_checkpoint_path = './checkpoints/'\n",
+    "WAVEGLOW = os.path.join(base_checkpoint_path, 'WaveGlowNM.pt')\n",
+    "TACOTRON_ENCODER = os.path.join(base_checkpoint_path, 'Tacotron2Encoder.pt')\n",
+    "TACOTRON_DECODER = os.path.join(base_checkpoint_path, 'Tacotron2Decoder.pt')\n",
+    "TACOTRON_POSTNET = os.path.join(base_checkpoint_path, 'Tacotron2Postnet.pt')\n",
+    "TEXT_EMBEDDING = os.path.join(base_checkpoint_path, 'TextEmbedding.pt')\n",
+    "\n",
+    "if not os.path.exists(base_checkpoint_path):\n",
+    "    os.makedirs(base_checkpoint_path)\n",
+    "    \n",
+    "if not os.path.exists(WAVEGLOW):\n",
+    "    !wget wget https://api.ngc.nvidia.com/v2/models/nvidia/waveglow_ljspeech/versions/2/files/WaveGlowNM.pt -P {base_checkpoint_path};\n",
+    "\n",
+    "if not os.path.exists(TACOTRON_ENCODER):\n",
+    "    !wget https://api.ngc.nvidia.com/v2/models/nvidia/tacotron2_ljspeech/versions/2/files/Tacotron2Encoder.pt -P {base_checkpoint_path};\n",
+    "        \n",
+    "if not os.path.exists(TACOTRON_DECODER):\n",
+    "    !wget https://api.ngc.nvidia.com/v2/models/nvidia/tacotron2_ljspeech/versions/2/files/Tacotron2Decoder.pt -P {base_checkpoint_path};\n",
+    "\n",
+    "if not os.path.exists(TACOTRON_POSTNET):\n",
+    "    !wget https://api.ngc.nvidia.com/v2/models/nvidia/tacotron2_ljspeech/versions/2/files/Tacotron2Postnet.pt -P {base_checkpoint_path};\n",
+    "\n",
+    "if not os.path.exists(TEXT_EMBEDDING):\n",
+    "    !wget https://api.ngc.nvidia.com/v2/models/nvidia/tacotron2_ljspeech/versions/2/files/TextEmbedding.pt -P {base_checkpoint_path};\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prepare the Neural Factory\n",
+    "neural_factory = nemo.core.NeuralModuleFactory(\n",
+    "        optimization_level=\"O0\", backend=nemo.core.Backend.PyTorch\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Text Line Data Layer\n",
+    "\n",
+    "Construct a simple datalayer to load a single line of text (accepted from the user) and pass it to the model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from nemo.backends.pytorch import DataLayerNM\n",
+    "from nemo.core.neural_types import *\n",
+    "from nemo.utils.misc import pad_to\n",
+    "from nemo.collections.asr.parts.dataset import TranscriptDataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class SentenceDataLayer(DataLayerNM):\n",
+    "    \"\"\"A simple Neural Module for loading textual transcript data.\n",
+    "    The path, labels, and eos_id arguments are dataset parameters.\n",
+    "\n",
+    "    Args:\n",
+    "        pad_id (int): Label position of padding symbol\n",
+    "        batch_size (int): Size of batches to generate in data loader\n",
+    "        drop_last (bool): Whether we drop last (possibly) incomplete batch.\n",
+    "            Defaults to False.\n",
+    "        num_workers (int): Number of processes to work on data loading (0 for\n",
+    "            just main process).\n",
+    "            Defaults to 0.\n",
+    "    \"\"\"\n",
+    "\n",
+    "    @property\n",
+    "    def output_ports(self):\n",
+    "        \"\"\"Returns definitions of module output ports.\n",
+    "\n",
+    "        texts:\n",
+    "            0: AxisType(BatchTag)\n",
+    "\n",
+    "            1: AxisType(TimeTag)\n",
+    "\n",
+    "        texts_length:\n",
+    "            0: AxisType(BatchTag)\n",
+    "\n",
+    "        \"\"\"\n",
+    "        return {\n",
+    "            # 'texts': NeuralType({0: AxisType(BatchTag), 1: AxisType(TimeTag)}),\n",
+    "            # 'texts_length': NeuralType({0: AxisType(BatchTag)}),\n",
+    "            'texts': NeuralType(('B', 'T'), LabelsType()),\n",
+    "            'texts_length': NeuralType(tuple('B'), LengthsType()),\n",
+    "        }\n",
+    "\n",
+    "    def __init__(\n",
+    "        self,\n",
+    "        path,\n",
+    "        labels,\n",
+    "        batch_size,\n",
+    "        bos_id=None,\n",
+    "        eos_id=None,\n",
+    "        pad_id=None,\n",
+    "        drop_last=False,\n",
+    "        num_workers=0,\n",
+    "        shuffle=True,\n",
+    "    ):\n",
+    "        super().__init__()\n",
+    "\n",
+    "        # Set up dataset\n",
+    "        self.dataset_params = {\n",
+    "            'path': path,\n",
+    "            'labels': labels,\n",
+    "            'bos_id': bos_id,\n",
+    "            'eos_id': eos_id,\n",
+    "        }\n",
+    "\n",
+    "        self._dataset = TranscriptDataset(**self.dataset_params)\n",
+    "\n",
+    "        # Set up data loader\n",
+    "        sampler = None\n",
+    "        pad_id = 0 if pad_id is None else pad_id\n",
+    "\n",
+    "#         # noinspection PyTypeChecker\n",
+    "#         self._dataloader = torch.utils.data.DataLoader(\n",
+    "#             dataset=self._dataset,\n",
+    "#             batch_size=1,\n",
+    "#             collate_fn=partial(self._collate_fn, pad_id=pad_id, pad8=True),\n",
+    "#             drop_last=drop_last,\n",
+    "#             shuffle=shuffle if sampler is None else False,\n",
+    "#             sampler=sampler,\n",
+    "#             num_workers=num_workers,\n",
+    "#         )\n",
+    "        \n",
+    "    def update_dataset(self):\n",
+    "        self._dataset = TranscriptDataset(**self.dataset_params)\n",
+    "        logging.info('Dataset updated.')\n",
+    "\n",
+    "    @staticmethod\n",
+    "    def _collate_fn(batch, pad_id, pad8=False):\n",
+    "        texts_list, texts_len = zip(*batch)\n",
+    "        max_len = max(texts_len)\n",
+    "        if pad8:\n",
+    "            max_len = pad_to(max_len, 8)\n",
+    "\n",
+    "        texts = torch.empty(len(texts_list), max_len, dtype=torch.long)\n",
+    "        texts.fill_(pad_id)\n",
+    "\n",
+    "        for i, s in enumerate(texts_list):\n",
+    "            texts[i].narrow(0, 0, s.size(0)).copy_(s)\n",
+    "\n",
+    "        if len(texts.shape) != 2:\n",
+    "            raise ValueError(f\"Texts in collate function have shape {texts.shape},\" f\" should have 2 dimensions.\")\n",
+    "\n",
+    "        return texts, torch.stack(texts_len)\n",
+    "\n",
+    "    def __len__(self):\n",
+    "        return len(self._dataset)\n",
+    "\n",
+    "    @property\n",
+    "    def dataset(self):\n",
+    "        return self._dataset\n",
+    "\n",
+    "    @property\n",
+    "    def data_iterator(self):\n",
+    "        return None  # self._dataloader\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create the Tacotron 2 + WaveGlow Neural Modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_NMs(tacotron2_config, waveglow_config, labels, decoder_infer=False, waveglow_sigma=0.6):\n",
     "    data_preprocessor = nemo_asr.AudioToMelSpectrogramPreprocessor(\n",
-    "        **tacotron2_config['AudioToMelSpectrogramPreprocessor']['init_params']\n",
+    "        **tacotron2_config[\"AudioToMelSpectrogramPreprocessor\"][\"init_params\"]\n",
     "    )\n",
-    "    text_embedding = nemo_tts.TextEmbedding.import_from_config(\n",
-    "        tacotron2_config_file, \"TextEmbedding\", overwrite_params={\"n_symbols\": len(labels) + 3}\n",
-    "    )\n",
-    "    t2_enc = nemo_tts.Tacotron2Encoder.import_from_config(tacotron2_config_file, \"Tacotron2Encoder\")\n",
-    "    if decoder_infer:\n",
-    "        t2_dec = nemo_tts.Tacotron2DecoderInfer.import_from_config(tacotron2_config_file, \"Tacotron2DecoderInfer\")\n",
-    "    else:\n",
-    "        t2_dec = nemo_tts.Tacotron2Decoder.import_from_config(\n",
-    "            tacotron2_config_file, \"Tacotron2Decoder\", overwrite_params={\"force\": decoder_force}\n",
-    "        )\n",
-    "    t2_postnet = nemo_tts.Tacotron2Postnet.import_from_config(tacotron2_config_file, \"Tacotron2Postnet\")\n",
-    "    t2_loss = nemo_tts.Tacotron2Loss.import_from_config(tacotron2_config_file, \"Tacotron2Loss\")\n",
+    "    \n",
+    "    text_embedding_params = copy.deepcopy(tacotron2_config[\"TextEmbedding\"][\"init_params\"])\n",
+    "    text_embedding_params['n_symbols'] = len(labels) + 3\n",
+    "    \n",
+    "    # Load checkpoint for text embedding\n",
+    "    text_embedding = nemo_tts.TextEmbedding(**text_embedding_params)\n",
+    "    text_embedding.restore_from(TEXT_EMBEDDING)\n",
+    "    \n",
+    "    # Load checkpoint for encoder\n",
+    "    t2_enc = nemo_tts.Tacotron2Encoder(**tacotron2_config[\"Tacotron2Encoder\"][\"init_params\"])\n",
+    "    t2_enc.restore_from(TACOTRON_ENCODER)\n",
+    "    \n",
+    "    # Load checkpoint for decoder\n",
+    "    decoder_params = copy.deepcopy(tacotron2_config[\"Tacotron2Decoder\"][\"init_params\"])\n",
+    "    \n",
+    "    t2_dec = nemo_tts.Tacotron2DecoderInfer(**decoder_params)    \n",
+    "    t2_dec.restore_from(TACOTRON_DECODER)\n",
+    "        \n",
+    "    # Load checkpoint for PortNet\n",
+    "    t2_postnet = nemo_tts.Tacotron2Postnet(**tacotron2_config[\"Tacotron2Postnet\"][\"init_params\"])\n",
+    "    t2_postnet.restore_from(TACOTRON_POSTNET)\n",
+    "    \n",
+    "    t2_loss = nemo_tts.Tacotron2Loss(**tacotron2_config[\"Tacotron2Loss\"][\"init_params\"])\n",
+    "    \n",
     "    makegatetarget = nemo_tts.MakeGate()\n",
     "\n",
     "    total_weights = text_embedding.num_weights + t2_enc.num_weights + t2_dec.num_weights + t2_postnet.num_weights\n",
     "\n",
     "    logging.info('================================')\n",
-    "    logging.info(f\"Total number of parameters: {total_weights}\")\n",
+    "    logging.info(f\"Total number of parameters (Tacotron 2): {total_weights}\")\n",
+    "    logging.info('================================')\n",
+    "    \n",
+    "    \n",
+    "    # Load WaveGlow model\n",
+    "    waveglow_args = copy.deepcopy(waveglow_config[\"WaveGlowNM\"][\"init_params\"])\n",
+    "    waveglow_args['sigma'] = waveglow_sigma\n",
+    "    \n",
+    "    waveglow = nemo_tts.WaveGlowInferNM(**waveglow_args)\n",
+    "    waveglow.restore_from(WAVEGLOW)\n",
+    "    \n",
+    "    total_weights = waveglow.num_weights\n",
+    "    \n",
+    "    logging.info('================================')\n",
+    "    logging.info(f\"Total number of parameters (WaveGlow 2): {total_weights}\")\n",
     "    logging.info('================================')\n",
     "\n",
     "    return (\n",
@@ -102,33 +331,110 @@
     "        t2_postnet,\n",
     "        t2_loss,\n",
     "        makegatetarget,\n",
-    "    )"
+    "    ), waveglow"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
-     "ename": "AttributeError",
-     "evalue": "'NoneType' object has no attribute 'placement'",
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[NeMo I 2020-05-08 11:16:27 features:144] PADDING: 16\n",
+      "[NeMo I 2020-05-08 11:16:27 features:152] STFT using conv\n"
+     ]
+    },
+    {
+     "ename": "AssertionError",
+     "evalue": "",
      "output_type": "error",
      "traceback": [
       "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-20-c97829da6961>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mneural_modules\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcreate_NMs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtacotron2_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlabels\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecoder_infer\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m;\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m<ipython-input-19-8f4693d3296a>\u001b[0m in \u001b[0;36mcreate_NMs\u001b[0;34m(tacotron2_config, labels, decoder_infer, decoder_force)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0mcreate_NMs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtacotron2_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlabels\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecoder_infer\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecoder_force\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m     data_preprocessor = nemo_asr.AudioToMelSpectrogramPreprocessor(\n\u001b[0;32m----> 3\u001b[0;31m         \u001b[0;34m**\u001b[0m\u001b[0mtacotron2_config\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'AudioToMelSpectrogramPreprocessor'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'init_params'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m     )\n\u001b[1;32m      5\u001b[0m     text_embedding = nemo_tts.TextEmbedding.import_from_config(\n",
-      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/collections/asr/audio_preprocessing.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, sample_rate, window_size, window_stride, n_window_size, n_window_stride, window, normalize, n_fft, preemph, features, lowfreq, highfreq, log, log_zero_guard_type, log_zero_guard_value, dither, pad_to, frame_splicing, stft_conv, pad_value, mag_power)\u001b[0m\n\u001b[1;32m    360\u001b[0m             \u001b[0mn_window_stride\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mwindow_stride\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_sample_rate\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    361\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 362\u001b[0;31m         \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn_window_size\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mn_window_stride\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    363\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    364\u001b[0m         self.featurizer = FilterbankFeatures(\n",
-      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/collections/asr/audio_preprocessing.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, win_length, hop_length)\u001b[0m\n\u001b[1;32m     72\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     73\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwin_length\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mhop_length\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 74\u001b[0;31m         \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     75\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     76\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwin_length\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mwin_length\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/backends/pytorch/nm.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, name)\u001b[0m\n\u001b[1;32m    131\u001b[0m \u001b[0;32mclass\u001b[0m \u001b[0mNonTrainableNM\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mNeuralModule\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    132\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 133\u001b[0;31m         \u001b[0mNeuralModule\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m)\u001b[0m  \u001b[0;31m# For NeuralModule API\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    134\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_device\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_cuda_device\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mplacement\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    135\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/core/neural_modules.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, name)\u001b[0m\n\u001b[1;32m     77\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     78\u001b[0m         \u001b[0;31m# Set module properties from factory else use defaults\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 79\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_placement\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_factory\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mplacement\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     80\u001b[0m         \u001b[0;31m# If one needs to change that should override it manually.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     81\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAttributeError\u001b[0m: 'NoneType' object has no attribute 'placement'"
+      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-15-a9fe1510fa6c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mneural_modules\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwaveglow\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcreate_NMs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtacotron2_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwaveglow_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlabels\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecoder_infer\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m;\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m<ipython-input-14-c48e19123d49>\u001b[0m in \u001b[0;36mcreate_NMs\u001b[0;34m(tacotron2_config, waveglow_config, labels, decoder_infer, waveglow_sigma)\u001b[0m\n\u001b[1;32m     18\u001b[0m     \u001b[0mdecoder_params\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcopy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdeepcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtacotron2_config\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"Tacotron2Decoder\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"init_params\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     19\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 20\u001b[0;31m     \u001b[0mt2_dec\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnemo_tts\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTacotron2DecoderInfer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0mdecoder_params\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     21\u001b[0m     \u001b[0mt2_dec\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrestore_from\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mTACOTRON_DECODER\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     22\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/collections/tts/tacotron2_modules.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, n_mel_channels, n_frames_per_step, encoder_embedding_dim, gate_threshold, prenet_dim, max_decoder_steps, decoder_rnn_dim, p_decoder_dropout, p_attention_dropout, attention_rnn_dim, attention_dim, attention_location_n_filters, attention_location_kernel_size, prenet_p_dropout, force)\u001b[0m\n\u001b[1;32m    211\u001b[0m         \u001b[0mforce\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mbool\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    212\u001b[0m     ):\n\u001b[0;32m--> 213\u001b[0;31m         \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    214\u001b[0m         self.decoder = Decoder(\n\u001b[1;32m    215\u001b[0m             \u001b[0mn_mel_channels\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mn_mel_channels\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/backends/pytorch/nm.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, pretrained_model_name, name)\u001b[0m\n\u001b[1;32m     36\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     37\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpretrained_model_name\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 38\u001b[0;31m         \u001b[0mNeuralModule\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m)\u001b[0m  \u001b[0;31m# For NeuralModule API\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     39\u001b[0m         \u001b[0mnn\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mModule\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m  \u001b[0;31m# For PyTorch API\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/core/neural_modules.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, name)\u001b[0m\n\u001b[1;32m     62\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     63\u001b[0m         \u001b[0;31m# Retrieve dictionary of parameters (keys, values) passed to init.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 64\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_init_params\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__extract_init_params\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     65\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     66\u001b[0m         \u001b[0;31m# Get object UUID.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/core/neural_modules.py\u001b[0m in \u001b[0;36m__extract_init_params\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    133\u001b[0m                     \u001b[0mno_of_unset\u001b[0m \u001b[0;34m-=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    134\u001b[0m             \u001b[0;31m# That should set all the init_params!\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 135\u001b[0;31m             \u001b[0;32massert\u001b[0m \u001b[0mno_of_unset\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    136\u001b[0m             \u001b[0;31m# Ok, we can terminate.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    137\u001b[0m             \u001b[0;32mbreak\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAssertionError\u001b[0m: "
      ]
     }
    ],
    "source": [
-    "neural_modules = create_NMs(tacotron2_config, labels, decoder_infer=True);"
+    "neural_modules, waveglow = create_NMs(tacotron2_config, waveglow_config, labels, decoder_infer=True);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Utility functions"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def update_text(text):\n",
+    "    if not os.path.exists('cache/'):\n",
+    "        os.makedirs('cache/')\n",
+    "        \n",
+    "    fp = os.path.join('cache', 'input.txt')\n",
+    "    with open(fp, 'w', encoding='utf8') as f:\n",
+    "        f.write('{}\\n'.format(text))\n",
+    "        f.flush()\n",
+    "    \n",
+    "    logging.info(\"Updated input file with value : %s\", text)\n",
+    "    return fp\n",
+    "        \n",
+    "def cleanup_cachedir():\n",
+    "    if os.path.exists('cache/'):\n",
+    "        shutil.rmtree('cache/')\n",
+    "    logging.info(\"Cleaned up cache directory !\")\n",
+    "    \n",
+    "def plot_and_save_spec(spectrogram, i, save_dir=None):\n",
+    "    fig, ax = plt.subplots(figsize=(12, 3))\n",
+    "    im = ax.imshow(spectrogram, aspect=\"auto\", origin=\"lower\", interpolation='none')\n",
+    "    plt.colorbar(im, ax=ax)\n",
+    "    plt.xlabel(\"Frames\")\n",
+    "    plt.ylabel(\"Channels\")\n",
+    "    plt.tight_layout()\n",
+    "    save_file = f\"spec_{i}.png\"\n",
+    "    if save_dir:\n",
+    "        save_file = os.path.join(save_dir, save_file)\n",
+    "    plt.savefig(save_file)\n",
+    "    plt.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Accept User Input"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text = input('Please enter some initial text here :')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filepath = update_text(text)"
    ]
   },
   {
@@ -140,83 +446,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "\u001b[0;31mInit signature:\u001b[0m\n",
-       "\u001b[0mnemo_tts\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTacotron2Decoder\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mn_mel_channels\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mn_frames_per_step\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mencoder_embedding_dim\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m512\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mgate_threshold\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mfloat\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.5\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mprenet_dim\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m256\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mmax_decoder_steps\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1000\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mdecoder_rnn_dim\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1024\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mp_decoder_dropout\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mfloat\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mp_attention_dropout\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mfloat\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mattention_rnn_dim\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1024\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mattention_dim\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m128\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mattention_location_n_filters\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m32\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mattention_location_kernel_size\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m31\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mprenet_p_dropout\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mfloat\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.5\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m    \u001b[0mforce\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mbool\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
-       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-       "\u001b[0;31mDocstring:\u001b[0m     \n",
-       "Tacotron2Decoder implements the attention, decoder, and prenet parts of\n",
-       "Tacotron 2. It takes the encoded text and produces mel spectrograms. The\n",
-       "decoder contains two rnns, one is called the decoder rnn and the other is\n",
-       "called the attention rnn.\n",
-       "\n",
-       "Args:\n",
-       "    n_mel_channels (int): The size or dimensionality of the mel spectrogram\n",
-       "    n_frames_per_step (int): The number of frames we predict at each\n",
-       "        decoder time step. Defaults to 1\n",
-       "    encoder_embedding_dim (int): The size of the encoded text.\n",
-       "        Defaults to 512.\n",
-       "    gate_threshold (float): A number in [0, 1). When teacher forcing is\n",
-       "        not used, the model predict a stopping value at each model time\n",
-       "        step. The model will stop if the value is greater than\n",
-       "        gate_threshold. Defaults to 0.5.\n",
-       "    prenet_dim (int): The hidden dimension of the prenet. Defaults to 256.\n",
-       "    max_decoder_steps (int): When not teacher forcing, the maximum number\n",
-       "        of frames to predict. Defaults to 1000.\n",
-       "    decoder_rnn_dim (int): The hidden dimension of the decoder rnn.\n",
-       "        Defaults to 1024.\n",
-       "    p_decoder_dropout (float): Dropout probability for the decoder rnn.\n",
-       "        Defaults to 0.1.\n",
-       "    p_attention_dropout (float): Dropout probability for the attention rnn.\n",
-       "        Defaults to 0.1.\n",
-       "    attention_rnn_dim (int): The hidden dimension of the attention rnn.\n",
-       "        Defaults to 1024.\n",
-       "    attention_dim (int): The hidden dimension of the attention mechanism.\n",
-       "        Defaults to 128.\n",
-       "    attention_location_n_filters (int): The number of convolution filters\n",
-       "        for the location part of the attention mechanism.\n",
-       "        Defaults to 32.\n",
-       "    attention_location_kernel_size (int): The kernel size of the\n",
-       "        convolution for the location part of the attention mechanism.\n",
-       "        Defaults to 31.\n",
-       "\u001b[0;31mInit docstring:\u001b[0m Constructor. Creates a \"shortcut\" to the application state.\n",
-       "\u001b[0;31mFile:\u001b[0m           ~/PycharmProjects/NeMo-som/nemo/collections/tts/tacotron2_modules.py\n",
-       "\u001b[0;31mType:\u001b[0m           ABCMeta\n",
-       "\u001b[0;31mSubclasses:\u001b[0m     Tacotron2DecoderInfer\n"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
+    "# Tacotron 2 DAG\n",
     "(_, text_embedding, t2_enc, t2_dec, t2_postnet, _, _) = neural_modules\n",
     "\n",
-    "data_layer = nemo_asr.TranscriptDataLayer(\n",
-    "    path=infer_dataset,\n",
+    "data_layer = SentenceDataLayer(\n",
+    "    path=filepath,\n",
     "    labels=labels,\n",
-    "    batch_size=infer_batch_size,\n",
-    "    num_workers=cpu_per_dl,\n",
+    "    batch_size=1,\n",
+    "    num_workers=0,\n",
     "    # load_audio=False,\n",
     "    bos_id=len(labels),\n",
     "    eos_id=len(labels) + 1,\n",
@@ -233,7 +474,135 @@
     "    char_phone_encoded=transcript_encoded, encoded_length=transcript_len,\n",
     ")\n",
     "\n",
-    "mel_postnet = t2_postnet(mel_input=mel_decoder)"
+    "mel_postnet = t2_postnet(mel_input=mel_decoder)\n",
+    "\n",
+    "# WaveGlow DAG\n",
+    "audio_pred = waveglow(mel_spectrogram=mel_postnet)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Setup inference tensors\n",
+    "infer_tensors = [mel_postnet, gate, alignments, mel_len]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compute Tacotron 2 forward pass"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def run_tacotron2():\n",
+    "    logging.info(\"Running Tacotron 2\")\n",
+    "    # Run tacotron 2\n",
+    "    evaluated_tensors = neural_factory.infer(\n",
+    "        tensors=infer_tensors, offload_to_cpu=False\n",
+    "    )\n",
+    "    logging.info(\"Done Running Tacotron 2\")\n",
+    "    \n",
+    "    mel_len = evaluated_tensors[-1]\n",
+    "    filterbank = librosa.filters.mel(\n",
+    "        sr=tacotron2_config[\"sample_rate\"],\n",
+    "        n_fft=tacotron2_config[\"n_fft\"],\n",
+    "        n_mels=tacotron2_config[\"n_mels\"],\n",
+    "        fmax=tacotron2_config[\"fmax\"],\n",
+    "    )\n",
+    "    \n",
+    "    return evaluated_tensors, filterbank\n",
+    "\n",
+    "def run_waveglow(save_dir, waveglow_denoiser_strength=0.0):\n",
+    "    logging.info(\"Running Waveglow\")\n",
+    "    evaluated_tensors = neural_factory.infer(\n",
+    "        tensors=[audio_pred],\n",
+    "    )\n",
+    "    logging.info(\"Done Running Waveglow\")\n",
+    "    \n",
+    "    if waveglow_denoiser_strength > 0:\n",
+    "        logging.info(\"Setup WaveGlow denoiser\")\n",
+    "        waveglow.setup_denoiser()\n",
+    "    \n",
+    "    logging.info(\"Saving results to disk\")\n",
+    "    for i, batch in enumerate(evaluated_tensors[0]):\n",
+    "        audio = batch.cpu().numpy()\n",
+    "        for j, sample in enumerate(audio):\n",
+    "            sample_len = mel_len[i][j] * tacotron2_config[\"n_stride\"]\n",
+    "            sample = sample[:sample_len]\n",
+    "            save_file = f\"sample_{i * 32 + j}.wav\"\n",
+    "            if args.save_dir:\n",
+    "                save_file = os.path.join(save_dir, save_file)\n",
+    "            if waveglow_denoiser_strength > 0:\n",
+    "                sample, spec = waveglow.denoise(sample, strength=waveglow_denoiser_strength)\n",
+    "            else:\n",
+    "                spec, _ = librosa.core.magphase(librosa.core.stft(sample, n_fft=waveglow_config[\"n_fft\"]))\n",
+    "            write(save_file, waveglow_params[\"sample_rate\"], sample)\n",
+    "            spec = np.dot(filterbank, spec)\n",
+    "            spec = np.log(np.clip(spec, a_min=1e-5, a_max=None))\n",
+    "            plot_and_save_spec(spec, i * 32 + j, save_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Run Tacotron 2 + WaveGlow on input text"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "text = input('Please enter some initial text here :')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filepath = update_text(text)\n",
+    "data_layer.update_dataset()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Prepare directories to save results"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "savedir = 'results/'\n",
+    "\n",
+    "if not os.path.exists(savedir):\n",
+    "    os.makedirs(savedir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "run_waveglow(savedir, waveglow_denoiser_strength=0.6)"
    ]
   },
   {

--- a/examples/tts/notebooks/1_Tacotron_inference.ipynb
+++ b/examples/tts/notebooks/1_Tacotron_inference.ipynb
@@ -23,7 +23,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,6 +36,8 @@
     "import matplotlib.pyplot as plt\n",
     "from functools import partial\n",
     "from scipy.io.wavfile import write\n",
+    "import numpy as np\n",
+    "import IPython.display as ipd\n",
     "\n",
     "from ruamel.yaml import YAML\n",
     "\n",
@@ -44,19 +46,13 @@
     "import nemo.collections.asr as nemo_asr\n",
     "import nemo.collections.tts as nemo_tts\n",
     "import nemo.utils.argparse as nm_argparse\n",
-    "from nemo.collections.tts import (\n",
-    "    tacotron2_eval_log_to_tb_func,\n",
-    "    tacotron2_log_to_tb_func,\n",
-    "    tacotron2_process_eval_batch,\n",
-    "    tacotron2_process_final_eval,\n",
-    ")\n",
     "\n",
     "logging = nemo.logging"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +80,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +112,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +133,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +145,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,8 +177,6 @@
     "\n",
     "        \"\"\"\n",
     "        return {\n",
-    "            # 'texts': NeuralType({0: AxisType(BatchTag), 1: AxisType(TimeTag)}),\n",
-    "            # 'texts_length': NeuralType({0: AxisType(BatchTag)}),\n",
     "            'texts': NeuralType(('B', 'T'), LabelsType()),\n",
     "            'texts_length': NeuralType(tuple('B'), LengthsType()),\n",
     "        }\n",
@@ -214,39 +208,10 @@
     "        # Set up data loader\n",
     "        sampler = None\n",
     "        pad_id = 0 if pad_id is None else pad_id\n",
-    "\n",
-    "#         # noinspection PyTypeChecker\n",
-    "#         self._dataloader = torch.utils.data.DataLoader(\n",
-    "#             dataset=self._dataset,\n",
-    "#             batch_size=1,\n",
-    "#             collate_fn=partial(self._collate_fn, pad_id=pad_id, pad8=True),\n",
-    "#             drop_last=drop_last,\n",
-    "#             shuffle=shuffle if sampler is None else False,\n",
-    "#             sampler=sampler,\n",
-    "#             num_workers=num_workers,\n",
-    "#         )\n",
     "        \n",
     "    def update_dataset(self):\n",
     "        self._dataset = TranscriptDataset(**self.dataset_params)\n",
     "        logging.info('Dataset updated.')\n",
-    "\n",
-    "    @staticmethod\n",
-    "    def _collate_fn(batch, pad_id, pad8=False):\n",
-    "        texts_list, texts_len = zip(*batch)\n",
-    "        max_len = max(texts_len)\n",
-    "        if pad8:\n",
-    "            max_len = pad_to(max_len, 8)\n",
-    "\n",
-    "        texts = torch.empty(len(texts_list), max_len, dtype=torch.long)\n",
-    "        texts.fill_(pad_id)\n",
-    "\n",
-    "        for i, s in enumerate(texts_list):\n",
-    "            texts[i].narrow(0, 0, s.size(0)).copy_(s)\n",
-    "\n",
-    "        if len(texts.shape) != 2:\n",
-    "            raise ValueError(f\"Texts in collate function have shape {texts.shape},\" f\" should have 2 dimensions.\")\n",
-    "\n",
-    "        return texts, torch.stack(texts_len)\n",
     "\n",
     "    def __len__(self):\n",
     "        return len(self._dataset)\n",
@@ -257,7 +222,7 @@
     "\n",
     "    @property\n",
     "    def data_iterator(self):\n",
-    "        return None  # self._dataloader\n"
+    "        return None\n"
    ]
   },
   {
@@ -269,7 +234,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -320,7 +285,7 @@
     "    total_weights = waveglow.num_weights\n",
     "    \n",
     "    logging.info('================================')\n",
-    "    logging.info(f\"Total number of parameters (WaveGlow 2): {total_weights}\")\n",
+    "    logging.info(f\"Total number of parameters (WaveGlow): {total_weights}\")\n",
     "    logging.info('================================')\n",
     "\n",
     "    return (\n",
@@ -336,36 +301,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[NeMo I 2020-05-08 11:16:27 features:144] PADDING: 16\n",
-      "[NeMo I 2020-05-08 11:16:27 features:152] STFT using conv\n"
-     ]
-    },
-    {
-     "ename": "AssertionError",
-     "evalue": "",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
-      "\u001b[0;31mAssertionError\u001b[0m                            Traceback (most recent call last)",
-      "\u001b[0;32m<ipython-input-15-a9fe1510fa6c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mneural_modules\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwaveglow\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcreate_NMs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtacotron2_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwaveglow_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlabels\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecoder_infer\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m;\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
-      "\u001b[0;32m<ipython-input-14-c48e19123d49>\u001b[0m in \u001b[0;36mcreate_NMs\u001b[0;34m(tacotron2_config, waveglow_config, labels, decoder_infer, waveglow_sigma)\u001b[0m\n\u001b[1;32m     18\u001b[0m     \u001b[0mdecoder_params\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcopy\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdeepcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtacotron2_config\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"Tacotron2Decoder\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"init_params\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     19\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 20\u001b[0;31m     \u001b[0mt2_dec\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mnemo_tts\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTacotron2DecoderInfer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m**\u001b[0m\u001b[0mdecoder_params\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     21\u001b[0m     \u001b[0mt2_dec\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrestore_from\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mTACOTRON_DECODER\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     22\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/collections/tts/tacotron2_modules.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, n_mel_channels, n_frames_per_step, encoder_embedding_dim, gate_threshold, prenet_dim, max_decoder_steps, decoder_rnn_dim, p_decoder_dropout, p_attention_dropout, attention_rnn_dim, attention_dim, attention_location_n_filters, attention_location_kernel_size, prenet_p_dropout, force)\u001b[0m\n\u001b[1;32m    211\u001b[0m         \u001b[0mforce\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mbool\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    212\u001b[0m     ):\n\u001b[0;32m--> 213\u001b[0;31m         \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    214\u001b[0m         self.decoder = Decoder(\n\u001b[1;32m    215\u001b[0m             \u001b[0mn_mel_channels\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mn_mel_channels\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/backends/pytorch/nm.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, pretrained_model_name, name)\u001b[0m\n\u001b[1;32m     36\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     37\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpretrained_model_name\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 38\u001b[0;31m         \u001b[0mNeuralModule\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m)\u001b[0m  \u001b[0;31m# For NeuralModule API\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     39\u001b[0m         \u001b[0mnn\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mModule\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m  \u001b[0;31m# For PyTorch API\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/core/neural_modules.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, name)\u001b[0m\n\u001b[1;32m     62\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     63\u001b[0m         \u001b[0;31m# Retrieve dictionary of parameters (keys, values) passed to init.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 64\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_init_params\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__extract_init_params\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     65\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     66\u001b[0m         \u001b[0;31m# Get object UUID.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/core/neural_modules.py\u001b[0m in \u001b[0;36m__extract_init_params\u001b[0;34m(self)\u001b[0m\n\u001b[1;32m    133\u001b[0m                     \u001b[0mno_of_unset\u001b[0m \u001b[0;34m-=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    134\u001b[0m             \u001b[0;31m# That should set all the init_params!\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 135\u001b[0;31m             \u001b[0;32massert\u001b[0m \u001b[0mno_of_unset\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;36m0\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    136\u001b[0m             \u001b[0;31m# Ok, we can terminate.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    137\u001b[0m             \u001b[0;32mbreak\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
-      "\u001b[0;31mAssertionError\u001b[0m: "
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "neural_modules, waveglow = create_NMs(tacotron2_config, waveglow_config, labels, decoder_infer=True);"
+    "neural_modules, waveglow = create_NMs(tacotron2_config, waveglow_config, labels, decoder_infer=True, waveglow_sigma=0.6);"
    ]
   },
   {
@@ -416,7 +356,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Accept User Input"
+    "# Initializing the inference DAG\n",
+    "\n",
+    "To initialize the graph, we accept some text from the user. Later, we will accept the actual text that we want to convert to speech !"
    ]
   },
   {
@@ -441,7 +383,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Create inference dags"
+    "## Create inference DAG"
    ]
   },
   {
@@ -458,7 +400,6 @@
     "    labels=labels,\n",
     "    batch_size=1,\n",
     "    num_workers=0,\n",
-    "    # load_audio=False,\n",
     "    bos_id=len(labels),\n",
     "    eos_id=len(labels) + 1,\n",
     "    pad_id=len(labels) + 2,\n",
@@ -494,7 +435,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Compute Tacotron 2 forward pass"
+    "## Run inference DAG"
    ]
   },
   {
@@ -511,7 +452,8 @@
     "    )\n",
     "    logging.info(\"Done Running Tacotron 2\")\n",
     "    \n",
-    "    mel_len = evaluated_tensors[-1]\n",
+    "    mel_len_val = evaluated_tensors[-1]\n",
+    "    \n",
     "    filterbank = librosa.filters.mel(\n",
     "        sr=tacotron2_config[\"sample_rate\"],\n",
     "        n_fft=tacotron2_config[\"n_fft\"],\n",
@@ -519,9 +461,12 @@
     "        fmax=tacotron2_config[\"fmax\"],\n",
     "    )\n",
     "    \n",
-    "    return evaluated_tensors, filterbank\n",
+    "    return evaluated_tensors, filterbank, mel_len_val\n",
     "\n",
     "def run_waveglow(save_dir, waveglow_denoiser_strength=0.0):\n",
+    "    # Run Tacotron 2 and WaveGlow\n",
+    "    evaluated_tensors, filterbank, mel_len_val = run_tacotron2()\n",
+    "    \n",
     "    logging.info(\"Running Waveglow\")\n",
     "    evaluated_tensors = neural_factory.infer(\n",
     "        tensors=[audio_pred],\n",
@@ -536,16 +481,16 @@
     "    for i, batch in enumerate(evaluated_tensors[0]):\n",
     "        audio = batch.cpu().numpy()\n",
     "        for j, sample in enumerate(audio):\n",
-    "            sample_len = mel_len[i][j] * tacotron2_config[\"n_stride\"]\n",
+    "            sample_len = mel_len_val[i][j] * tacotron2_config[\"n_stride\"]\n",
     "            sample = sample[:sample_len]\n",
     "            save_file = f\"sample_{i * 32 + j}.wav\"\n",
-    "            if args.save_dir:\n",
+    "            if save_dir:\n",
     "                save_file = os.path.join(save_dir, save_file)\n",
     "            if waveglow_denoiser_strength > 0:\n",
     "                sample, spec = waveglow.denoise(sample, strength=waveglow_denoiser_strength)\n",
     "            else:\n",
     "                spec, _ = librosa.core.magphase(librosa.core.stft(sample, n_fft=waveglow_config[\"n_fft\"]))\n",
-    "            write(save_file, waveglow_params[\"sample_rate\"], sample)\n",
+    "            write(save_file, waveglow_config[\"sample_rate\"], sample)\n",
     "            spec = np.dot(filterbank, spec)\n",
     "            spec = np.log(np.clip(spec, a_min=1e-5, a_max=None))\n",
     "            plot_and_save_spec(spec, i * 32 + j, save_dir)"
@@ -581,7 +526,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Prepare directories to save results"
+    "## Prepare directories to save results"
    ]
   },
   {
@@ -591,9 +536,20 @@
    "outputs": [],
    "source": [
     "savedir = 'results/'\n",
+    "saved_audio = os.path.join(savedir, 'sample_0.wav')\n",
+    "saved_spectogram = os.path.join(savedir, 'spec_0.png')\n",
     "\n",
     "if not os.path.exists(savedir):\n",
     "    os.makedirs(savedir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate the audio\n",
+    "\n",
+    "Lets run the Tacotron 2 model and send the results to WaveGlow to generate the audio!"
    ]
   },
   {
@@ -602,7 +558,48 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "run_waveglow(savedir, waveglow_denoiser_strength=0.6)"
+    "run_waveglow(savedir, waveglow_denoiser_strength=0.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Lets hear the generated audio !"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ipd.Audio(saved_audio, rate=16000)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ipd.Image(saved_spectogram)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Cleanup cachedir"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cleanup_cachedir()"
    ]
   },
   {

--- a/examples/tts/notebooks/1_Tacotron_inference.ipynb
+++ b/examples/tts/notebooks/1_Tacotron_inference.ipynb
@@ -1,0 +1,268 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Copyright 2020 NVIDIA. All Rights Reserved.\n",
+    "#\n",
+    "# Licensed under the Apache License, Version 2.0 (the \"License\");\n",
+    "# you may not use this file except in compliance with the License.\n",
+    "# You may obtain a copy of the License at\n",
+    "#\n",
+    "#     http://www.apache.org/licenses/LICENSE-2.0\n",
+    "#\n",
+    "# Unless required by applicable law or agreed to in writing, software\n",
+    "# distributed under the License is distributed on an \"AS IS\" BASIS,\n",
+    "# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n",
+    "# See the License for the specific language governing permissions and\n",
+    "# limitations under the License."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import argparse\n",
+    "import math\n",
+    "import os\n",
+    "from functools import partial\n",
+    "\n",
+    "from ruamel.yaml import YAML\n",
+    "\n",
+    "import nemo\n",
+    "import nemo.collections.asr as nemo_asr\n",
+    "import nemo.collections.tts as nemo_tts\n",
+    "import nemo.utils.argparse as nm_argparse\n",
+    "from nemo.collections.tts import (\n",
+    "    tacotron2_eval_log_to_tb_func,\n",
+    "    tacotron2_log_to_tb_func,\n",
+    "    tacotron2_process_eval_batch,\n",
+    "    tacotron2_process_final_eval,\n",
+    ")\n",
+    "\n",
+    "logging = nemo.logging"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download config files\n",
+    "config_path = '../configs/tacotron2.yaml'\n",
+    "\n",
+    "\n",
+    "yaml = YAML(typ=\"safe\")\n",
+    "with open(config_path) as file:\n",
+    "    tacotron2_config = yaml.load(file)\n",
+    "    labels = tacotron2_config[\"labels\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def create_NMs(tacotron2_config, labels, decoder_infer=False, decoder_force=False):\n",
+    "    data_preprocessor = nemo_asr.AudioToMelSpectrogramPreprocessor(\n",
+    "        **tacotron2_config['AudioToMelSpectrogramPreprocessor']['init_params']\n",
+    "    )\n",
+    "    text_embedding = nemo_tts.TextEmbedding.import_from_config(\n",
+    "        tacotron2_config_file, \"TextEmbedding\", overwrite_params={\"n_symbols\": len(labels) + 3}\n",
+    "    )\n",
+    "    t2_enc = nemo_tts.Tacotron2Encoder.import_from_config(tacotron2_config_file, \"Tacotron2Encoder\")\n",
+    "    if decoder_infer:\n",
+    "        t2_dec = nemo_tts.Tacotron2DecoderInfer.import_from_config(tacotron2_config_file, \"Tacotron2DecoderInfer\")\n",
+    "    else:\n",
+    "        t2_dec = nemo_tts.Tacotron2Decoder.import_from_config(\n",
+    "            tacotron2_config_file, \"Tacotron2Decoder\", overwrite_params={\"force\": decoder_force}\n",
+    "        )\n",
+    "    t2_postnet = nemo_tts.Tacotron2Postnet.import_from_config(tacotron2_config_file, \"Tacotron2Postnet\")\n",
+    "    t2_loss = nemo_tts.Tacotron2Loss.import_from_config(tacotron2_config_file, \"Tacotron2Loss\")\n",
+    "    makegatetarget = nemo_tts.MakeGate()\n",
+    "\n",
+    "    total_weights = text_embedding.num_weights + t2_enc.num_weights + t2_dec.num_weights + t2_postnet.num_weights\n",
+    "\n",
+    "    logging.info('================================')\n",
+    "    logging.info(f\"Total number of parameters: {total_weights}\")\n",
+    "    logging.info('================================')\n",
+    "\n",
+    "    return (\n",
+    "        data_preprocessor,\n",
+    "        text_embedding,\n",
+    "        t2_enc,\n",
+    "        t2_dec,\n",
+    "        t2_postnet,\n",
+    "        t2_loss,\n",
+    "        makegatetarget,\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "AttributeError",
+     "evalue": "'NoneType' object has no attribute 'placement'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAttributeError\u001b[0m                            Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-20-c97829da6961>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[0;32m----> 1\u001b[0;31m \u001b[0mneural_modules\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcreate_NMs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtacotron2_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlabels\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecoder_infer\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m;\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m<ipython-input-19-8f4693d3296a>\u001b[0m in \u001b[0;36mcreate_NMs\u001b[0;34m(tacotron2_config, labels, decoder_infer, decoder_force)\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;32mdef\u001b[0m \u001b[0mcreate_NMs\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtacotron2_config\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mlabels\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecoder_infer\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdecoder_force\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mFalse\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m     data_preprocessor = nemo_asr.AudioToMelSpectrogramPreprocessor(\n\u001b[0;32m----> 3\u001b[0;31m         \u001b[0;34m**\u001b[0m\u001b[0mtacotron2_config\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'AudioToMelSpectrogramPreprocessor'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'init_params'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m     )\n\u001b[1;32m      5\u001b[0m     text_embedding = nemo_tts.TextEmbedding.import_from_config(\n",
+      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/collections/asr/audio_preprocessing.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, sample_rate, window_size, window_stride, n_window_size, n_window_stride, window, normalize, n_fft, preemph, features, lowfreq, highfreq, log, log_zero_guard_type, log_zero_guard_value, dither, pad_to, frame_splicing, stft_conv, pad_value, mag_power)\u001b[0m\n\u001b[1;32m    360\u001b[0m             \u001b[0mn_window_stride\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mwindow_stride\u001b[0m \u001b[0;34m*\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_sample_rate\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    361\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 362\u001b[0;31m         \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mn_window_size\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mn_window_stride\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    363\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    364\u001b[0m         self.featurizer = FilterbankFeatures(\n",
+      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/collections/asr/audio_preprocessing.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, win_length, hop_length)\u001b[0m\n\u001b[1;32m     72\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     73\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwin_length\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mhop_length\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 74\u001b[0;31m         \u001b[0msuper\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     75\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     76\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwin_length\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mwin_length\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/backends/pytorch/nm.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, name)\u001b[0m\n\u001b[1;32m    131\u001b[0m \u001b[0;32mclass\u001b[0m \u001b[0mNonTrainableNM\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mNeuralModule\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    132\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 133\u001b[0;31m         \u001b[0mNeuralModule\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__init__\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mname\u001b[0m\u001b[0;34m)\u001b[0m  \u001b[0;31m# For NeuralModule API\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    134\u001b[0m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_device\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mget_cuda_device\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mplacement\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    135\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/PycharmProjects/NeMo-som/nemo/core/neural_modules.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, name)\u001b[0m\n\u001b[1;32m     77\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     78\u001b[0m         \u001b[0;31m# Set module properties from factory else use defaults\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 79\u001b[0;31m         \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_placement\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_factory\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mplacement\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     80\u001b[0m         \u001b[0;31m# If one needs to change that should override it manually.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     81\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mAttributeError\u001b[0m: 'NoneType' object has no attribute 'placement'"
+     ]
+    }
+   ],
+   "source": [
+    "neural_modules = create_NMs(tacotron2_config, labels, decoder_infer=True);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Create inference dags"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "\u001b[0;31mInit signature:\u001b[0m\n",
+       "\u001b[0mnemo_tts\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mTacotron2Decoder\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mn_mel_channels\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mn_frames_per_step\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mencoder_embedding_dim\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m512\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mgate_threshold\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mfloat\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.5\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mprenet_dim\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m256\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mmax_decoder_steps\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1000\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mdecoder_rnn_dim\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1024\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mp_decoder_dropout\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mfloat\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mp_attention_dropout\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mfloat\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.1\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mattention_rnn_dim\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1024\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mattention_dim\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m128\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mattention_location_n_filters\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m32\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mattention_location_kernel_size\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mint\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m31\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mprenet_p_dropout\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mfloat\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m0.5\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m    \u001b[0mforce\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mbool\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mFalse\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\n",
+       "\u001b[0;34m\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+       "\u001b[0;31mDocstring:\u001b[0m     \n",
+       "Tacotron2Decoder implements the attention, decoder, and prenet parts of\n",
+       "Tacotron 2. It takes the encoded text and produces mel spectrograms. The\n",
+       "decoder contains two rnns, one is called the decoder rnn and the other is\n",
+       "called the attention rnn.\n",
+       "\n",
+       "Args:\n",
+       "    n_mel_channels (int): The size or dimensionality of the mel spectrogram\n",
+       "    n_frames_per_step (int): The number of frames we predict at each\n",
+       "        decoder time step. Defaults to 1\n",
+       "    encoder_embedding_dim (int): The size of the encoded text.\n",
+       "        Defaults to 512.\n",
+       "    gate_threshold (float): A number in [0, 1). When teacher forcing is\n",
+       "        not used, the model predict a stopping value at each model time\n",
+       "        step. The model will stop if the value is greater than\n",
+       "        gate_threshold. Defaults to 0.5.\n",
+       "    prenet_dim (int): The hidden dimension of the prenet. Defaults to 256.\n",
+       "    max_decoder_steps (int): When not teacher forcing, the maximum number\n",
+       "        of frames to predict. Defaults to 1000.\n",
+       "    decoder_rnn_dim (int): The hidden dimension of the decoder rnn.\n",
+       "        Defaults to 1024.\n",
+       "    p_decoder_dropout (float): Dropout probability for the decoder rnn.\n",
+       "        Defaults to 0.1.\n",
+       "    p_attention_dropout (float): Dropout probability for the attention rnn.\n",
+       "        Defaults to 0.1.\n",
+       "    attention_rnn_dim (int): The hidden dimension of the attention rnn.\n",
+       "        Defaults to 1024.\n",
+       "    attention_dim (int): The hidden dimension of the attention mechanism.\n",
+       "        Defaults to 128.\n",
+       "    attention_location_n_filters (int): The number of convolution filters\n",
+       "        for the location part of the attention mechanism.\n",
+       "        Defaults to 32.\n",
+       "    attention_location_kernel_size (int): The kernel size of the\n",
+       "        convolution for the location part of the attention mechanism.\n",
+       "        Defaults to 31.\n",
+       "\u001b[0;31mInit docstring:\u001b[0m Constructor. Creates a \"shortcut\" to the application state.\n",
+       "\u001b[0;31mFile:\u001b[0m           ~/PycharmProjects/NeMo-som/nemo/collections/tts/tacotron2_modules.py\n",
+       "\u001b[0;31mType:\u001b[0m           ABCMeta\n",
+       "\u001b[0;31mSubclasses:\u001b[0m     Tacotron2DecoderInfer\n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "(_, text_embedding, t2_enc, t2_dec, t2_postnet, _, _) = neural_modules\n",
+    "\n",
+    "data_layer = nemo_asr.TranscriptDataLayer(\n",
+    "    path=infer_dataset,\n",
+    "    labels=labels,\n",
+    "    batch_size=infer_batch_size,\n",
+    "    num_workers=cpu_per_dl,\n",
+    "    # load_audio=False,\n",
+    "    bos_id=len(labels),\n",
+    "    eos_id=len(labels) + 1,\n",
+    "    pad_id=len(labels) + 2,\n",
+    "    shuffle=False,\n",
+    ")\n",
+    "transcript, transcript_len = data_layer()\n",
+    "\n",
+    "transcript_embedded = text_embedding(char_phone=transcript)\n",
+    "\n",
+    "transcript_encoded = t2_enc(char_phone_embeddings=transcript_embedded, embedding_length=transcript_len,)\n",
+    "\n",
+    "mel_decoder, gate, alignments, mel_len = t2_dec(\n",
+    "    char_phone_encoded=transcript_encoded, encoded_length=transcript_len,\n",
+    ")\n",
+    "\n",
+    "mel_postnet = t2_postnet(mel_input=mel_decoder)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.7.6 64-bit ('NeMo': conda)",
+   "language": "python",
+   "name": "python37664bitnemoconda43f94a748a2e4953b0129556ecdf4f62"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/examples/tts/notebooks/1_Tacotron_inference.ipynb
+++ b/examples/tts/notebooks/1_Tacotron_inference.ipynb
@@ -582,7 +582,9 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "ipd.Image(saved_spectrogram)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -599,13 +601,6 @@
    "source": [
     "cleanup_cachedir()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/examples/tts/notebooks/1_Tacotron_inference.ipynb
+++ b/examples/tts/notebooks/1_Tacotron_inference.ipynb
@@ -537,7 +537,7 @@
    "source": [
     "savedir = 'results/'\n",
     "saved_audio = os.path.join(savedir, 'sample_0.wav')\n",
-    "saved_spectogram = os.path.join(savedir, 'spec_0.png')\n",
+    "saved_spectrogram = os.path.join(savedir, 'spec_0.png')\n",
     "\n",
     "if not os.path.exists(savedir):\n",
     "    os.makedirs(savedir)"
@@ -582,9 +582,7 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": [
-    "ipd.Image(saved_spectogram)"
-   ]
+   "source": []
   },
   {
    "cell_type": "markdown",

--- a/nemo/collections/tts/tacotron2_modules.py
+++ b/nemo/collections/tts/tacotron2_modules.py
@@ -279,6 +279,42 @@ class Tacotron2DecoderInfer(Tacotron2Decoder):
             Defaults to 31.
     """
 
+    def __init__(
+            self,
+            n_mel_channels: int,
+            n_frames_per_step: int = 1,
+            encoder_embedding_dim: int = 512,
+            gate_threshold: float = 0.5,
+            prenet_dim: int = 256,
+            max_decoder_steps: int = 1000,
+            decoder_rnn_dim: int = 1024,
+            p_decoder_dropout: float = 0.1,
+            p_attention_dropout: float = 0.1,
+            attention_rnn_dim: int = 1024,
+            attention_dim: int = 128,
+            attention_location_n_filters: int = 32,
+            attention_location_kernel_size: int = 31,
+            prenet_p_dropout: float = 0.5,
+            force: bool = False,
+        ):
+        super().__init__(
+            n_mel_channels=n_mel_channels,
+            n_frames_per_step=n_frames_per_step,
+            encoder_embedding_dim=encoder_embedding_dim,
+            gate_threshold=gate_threshold,
+            prenet_dim=prenet_dim,
+            max_decoder_steps=max_decoder_steps,
+            decoder_rnn_dim=decoder_rnn_dim,
+            p_decoder_dropout=p_decoder_dropout,
+            p_attention_dropout=p_attention_dropout,
+            attention_rnn_dim=attention_rnn_dim,
+            attention_dim=attention_dim,
+            attention_location_n_filters=attention_location_n_filters,
+            attention_location_kernel_size=attention_location_kernel_size,
+            prenet_p_dropout=prenet_p_dropout,
+            force=force
+        )
+
     @property
     @add_port_docs()
     def input_ports(self):
@@ -482,6 +518,9 @@ class Tacotron2Loss(LossNM):
 class MakeGate(NonTrainableNM):
     """MakeGate is a helper Neural Module that makes the target stop value.
     """
+
+    def __init__(self):
+        super().__init__()
 
     @property
     @add_port_docs()

--- a/nemo/collections/tts/tacotron2_modules.py
+++ b/nemo/collections/tts/tacotron2_modules.py
@@ -280,23 +280,23 @@ class Tacotron2DecoderInfer(Tacotron2Decoder):
     """
 
     def __init__(
-            self,
-            n_mel_channels: int,
-            n_frames_per_step: int = 1,
-            encoder_embedding_dim: int = 512,
-            gate_threshold: float = 0.5,
-            prenet_dim: int = 256,
-            max_decoder_steps: int = 1000,
-            decoder_rnn_dim: int = 1024,
-            p_decoder_dropout: float = 0.1,
-            p_attention_dropout: float = 0.1,
-            attention_rnn_dim: int = 1024,
-            attention_dim: int = 128,
-            attention_location_n_filters: int = 32,
-            attention_location_kernel_size: int = 31,
-            prenet_p_dropout: float = 0.5,
-            force: bool = False,
-        ):
+        self,
+        n_mel_channels: int,
+        n_frames_per_step: int = 1,
+        encoder_embedding_dim: int = 512,
+        gate_threshold: float = 0.5,
+        prenet_dim: int = 256,
+        max_decoder_steps: int = 1000,
+        decoder_rnn_dim: int = 1024,
+        p_decoder_dropout: float = 0.1,
+        p_attention_dropout: float = 0.1,
+        attention_rnn_dim: int = 1024,
+        attention_dim: int = 128,
+        attention_location_n_filters: int = 32,
+        attention_location_kernel_size: int = 31,
+        prenet_p_dropout: float = 0.5,
+        force: bool = False,
+    ):
         super().__init__(
             n_mel_channels=n_mel_channels,
             n_frames_per_step=n_frames_per_step,
@@ -312,7 +312,7 @@ class Tacotron2DecoderInfer(Tacotron2Decoder):
             attention_location_n_filters=attention_location_n_filters,
             attention_location_kernel_size=attention_location_kernel_size,
             prenet_p_dropout=prenet_p_dropout,
-            force=force
+            force=force,
         )
 
     @property


### PR DESCRIPTION
# Changelog
- Adds Jupyter notebook to download NGC checkpoints for Tacotron 2 and WaveGlow models, initializes a custom data loader that reads a single text sentence from the user, initializes the models with weights and then runs them to generate spectrogram and wav files
- Updates Tacotron  2 Infer class to override `__init__`