### PR TITLE
Added Cython module from pip as its required by youtokentome

### DIFF
--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -5,6 +5,7 @@ sentencepiece
 torchtext
 transformers
 unidecode
+cython
 youtokentome
 numpy
 tqdm


### PR DESCRIPTION
Cython module is required otherwise installation will fail when installing youtokentome from pip, it should be downloaded and installed before youtokentome and it's available on pip, a better place to install it would be as part of the requirements.txt for the NeMo core.