### PR TITLE
Apex/Megatron dependencies fix

### DIFF
--- a/docs/docs_zh/sources/source/speech_command/tutorial.rst
+++ b/docs/docs_zh/sources/source/speech_command/tutorial.rst
@@ -90,7 +90,7 @@ QuartzNet 模型使用一种固定的模型定义模式： QuartzNet-[BxR], 其�
         process_classification_evaluation_epoch,
     )
 
-    logging = nemo.logging
+    from nemo.utils import logging
 
     # Lets define some hyper parameters
     lr = 0.05
@@ -420,7 +420,7 @@ QuartzNet 模型使用一种固定的模型定义模式： QuartzNet-[BxR], 其�
     import nemo
     import nemo.collections.asr as nemo_asr
 
-    logging = nemo.logging
+    from nemo.utils import logging
 
     # We add some
     data_dir = '<path to the data directory>'

--- a/docs/sources/source/conf.py
+++ b/docs/sources/source/conf.py
@@ -48,6 +48,7 @@ autodoc_mock_imports = [
     'soundfile',
     'sentencepiece',
     'youtokentome',
+    'megatron-lm',
 ]
 
 # -- General configuration ------------------------------------------------

--- a/docs/sources/source/speech_command/tutorial.rst
+++ b/docs/sources/source/speech_command/tutorial.rst
@@ -111,7 +111,7 @@ The script below does both training and evaluation (on V1 dataset) on single GPU
         process_classification_evaluation_epoch,
     )
 
-    logging = nemo.logging
+    from nemo.utils import logging
 
     # Lets define some hyper parameters
     lr = 0.05
@@ -447,7 +447,7 @@ but they can similarly be used for v2 dataset.
     import nemo
     import nemo.collections.asr as nemo_asr
 
-    logging = nemo.logging
+    from nemo.utils import logging
 
     # We add some
     data_dir = '<path to the data directory>'

--- a/examples/applications/asr_service/app/__init__.py
+++ b/examples/applications/asr_service/app/__init__.py
@@ -8,7 +8,7 @@ from ruamel.yaml import YAML
 import nemo
 import nemo.collections.asr as nemo_asr
 
-logging = nemo.logging
+from nemo.utils import logging
 
 app = Flask(__name__)
 # make sure WORK_DIR exists before calling your service

--- a/examples/applications/asr_service/app/__init__.py
+++ b/examples/applications/asr_service/app/__init__.py
@@ -7,7 +7,6 @@ from ruamel.yaml import YAML
 
 import nemo
 import nemo.collections.asr as nemo_asr
-
 from nemo.utils import logging
 
 app = Flask(__name__)

--- a/examples/applications/asr_service/app/routes.py
+++ b/examples/applications/asr_service/app/routes.py
@@ -17,7 +17,6 @@ from app import (
 from flask import request
 from werkzeug.utils import secure_filename
 
-import nemo
 import nemo.collections.asr as nemo_asr
 from nemo.utils import logging
 

--- a/examples/applications/asr_service/app/routes.py
+++ b/examples/applications/asr_service/app/routes.py
@@ -19,7 +19,6 @@ from werkzeug.utils import secure_filename
 
 import nemo
 import nemo.collections.asr as nemo_asr
-
 from nemo.utils import logging
 
 try:

--- a/examples/applications/asr_service/app/routes.py
+++ b/examples/applications/asr_service/app/routes.py
@@ -20,7 +20,7 @@ from werkzeug.utils import secure_filename
 import nemo
 import nemo.collections.asr as nemo_asr
 
-logging = nemo.logging
+from nemo.utils import logging
 
 try:
     from app import beam_search_with_lm

--- a/examples/asr/contextnet.py
+++ b/examples/asr/contextnet.py
@@ -25,7 +25,7 @@ import nemo.utils.argparse as nm_argparse
 from nemo.collections.asr.helpers import monitor_asr_train_progress, process_evaluation_batch, process_evaluation_epoch
 from nemo.utils.lr_policies import CosineAnnealing
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/asr/contextnet.py
+++ b/examples/asr/contextnet.py
@@ -23,9 +23,8 @@ import nemo
 import nemo.collections.asr as nemo_asr
 import nemo.utils.argparse as nm_argparse
 from nemo.collections.asr.helpers import monitor_asr_train_progress, process_evaluation_batch, process_evaluation_epoch
-from nemo.utils.lr_policies import CosineAnnealing
-
 from nemo.utils import logging
+from nemo.utils.lr_policies import CosineAnnealing
 
 
 def parse_args():

--- a/examples/asr/jasper.py
+++ b/examples/asr/jasper.py
@@ -13,7 +13,7 @@ import nemo.utils.argparse as nm_argparse
 from nemo.collections.asr.helpers import monitor_asr_train_progress, process_evaluation_batch, process_evaluation_epoch
 from nemo.utils.lr_policies import CosineAnnealing
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/asr/jasper.py
+++ b/examples/asr/jasper.py
@@ -11,9 +11,8 @@ import nemo
 import nemo.collections.asr as nemo_asr
 import nemo.utils.argparse as nm_argparse
 from nemo.collections.asr.helpers import monitor_asr_train_progress, process_evaluation_batch, process_evaluation_epoch
-from nemo.utils.lr_policies import CosineAnnealing
-
 from nemo.utils import logging
+from nemo.utils.lr_policies import CosineAnnealing
 
 
 def parse_args():

--- a/examples/asr/jasper_aishell.py
+++ b/examples/asr/jasper_aishell.py
@@ -12,7 +12,7 @@ import nemo.utils.argparse as nm_argparse
 from nemo.collections.asr.helpers import monitor_asr_train_progress, process_evaluation_batch, process_evaluation_epoch
 from nemo.utils.lr_policies import SquareAnnealing
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/asr/jasper_aishell.py
+++ b/examples/asr/jasper_aishell.py
@@ -10,9 +10,8 @@ import nemo
 import nemo.collections.asr as nemo_asr
 import nemo.utils.argparse as nm_argparse
 from nemo.collections.asr.helpers import monitor_asr_train_progress, process_evaluation_batch, process_evaluation_epoch
-from nemo.utils.lr_policies import SquareAnnealing
-
 from nemo.utils import logging
+from nemo.utils.lr_policies import SquareAnnealing
 
 
 def parse_args():

--- a/examples/asr/jasper_aishell_infer.py
+++ b/examples/asr/jasper_aishell_infer.py
@@ -10,7 +10,7 @@ import nemo
 import nemo.collections.asr as nemo_asr
 from nemo.collections.asr.helpers import post_process_predictions, post_process_transcripts, word_error_rate
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def load_vocab(vocab_file):

--- a/examples/asr/jasper_aishell_infer.py
+++ b/examples/asr/jasper_aishell_infer.py
@@ -9,7 +9,6 @@ from ruamel.yaml import YAML
 import nemo
 import nemo.collections.asr as nemo_asr
 from nemo.collections.asr.helpers import post_process_predictions, post_process_transcripts, word_error_rate
-
 from nemo.utils import logging
 
 

--- a/examples/asr/jasper_an4.py
+++ b/examples/asr/jasper_an4.py
@@ -17,9 +17,8 @@ from nemo.collections.asr.helpers import (
     process_evaluation_epoch,
     word_error_rate,
 )
-from nemo.utils.lr_policies import CosineAnnealing
-
 from nemo.utils import logging
+from nemo.utils.lr_policies import CosineAnnealing
 
 
 def create_dags(model_config_file, vocab, args, nf):

--- a/examples/asr/jasper_an4.py
+++ b/examples/asr/jasper_an4.py
@@ -19,7 +19,7 @@ from nemo.collections.asr.helpers import (
 )
 from nemo.utils.lr_policies import CosineAnnealing
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def create_dags(model_config_file, vocab, args, nf):

--- a/examples/asr/jasper_eval.py
+++ b/examples/asr/jasper_eval.py
@@ -23,7 +23,6 @@ from ruamel.yaml import YAML
 import nemo
 import nemo.collections.asr as nemo_asr
 from nemo.collections.asr.helpers import post_process_predictions, post_process_transcripts, word_error_rate
-
 from nemo.utils import logging
 
 

--- a/examples/asr/jasper_eval.py
+++ b/examples/asr/jasper_eval.py
@@ -24,7 +24,7 @@ import nemo
 import nemo.collections.asr as nemo_asr
 from nemo.collections.asr.helpers import post_process_predictions, post_process_transcripts, word_error_rate
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def main():

--- a/examples/asr/notebooks/3_Speech_Commands_using_NeMo.ipynb
+++ b/examples/asr/notebooks/3_Speech_Commands_using_NeMo.ipynb
@@ -254,7 +254,7 @@
     ")\n",
     "from nemo.collections.asr.metrics import classification_accuracy\n",
     "\n",
-    "logging = nemo.logging"
+    "from nemo.utils import logging"
    ]
   },
   {

--- a/examples/asr/notebooks/4_Online_Data_Augmentation.ipynb
+++ b/examples/asr/notebooks/4_Online_Data_Augmentation.ipynb
@@ -836,7 +836,7 @@
     ")\n",
     "from nemo.collections.asr.metrics import classification_accuracy\n",
     "\n",
-    "logging = nemo.logging"
+    "from nemo.utils import logging"
    ]
   },
   {

--- a/examples/asr/quartznet.py
+++ b/examples/asr/quartznet.py
@@ -10,9 +10,8 @@ import nemo
 import nemo.collections.asr as nemo_asr
 import nemo.utils.argparse as nm_argparse
 from nemo.collections.asr.helpers import monitor_asr_train_progress, process_evaluation_batch, process_evaluation_epoch
-from nemo.utils.lr_policies import CosineAnnealing
-
 from nemo.utils import logging
+from nemo.utils.lr_policies import CosineAnnealing
 
 
 def parse_args():

--- a/examples/asr/quartznet.py
+++ b/examples/asr/quartznet.py
@@ -12,7 +12,7 @@ import nemo.utils.argparse as nm_argparse
 from nemo.collections.asr.helpers import monitor_asr_train_progress, process_evaluation_batch, process_evaluation_epoch
 from nemo.utils.lr_policies import CosineAnnealing
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/asr/quartznet_speech_commands.py
+++ b/examples/asr/quartznet_speech_commands.py
@@ -19,7 +19,7 @@ from nemo.collections.asr.helpers import (
 )
 from nemo.utils.lr_policies import CosineAnnealing, PolynomialDecayAnnealing, PolynomialHoldDecayAnnealing
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/asr/quartznet_speech_commands.py
+++ b/examples/asr/quartznet_speech_commands.py
@@ -17,9 +17,8 @@ from nemo.collections.asr.helpers import (
     process_classification_evaluation_batch,
     process_classification_evaluation_epoch,
 )
-from nemo.utils.lr_policies import CosineAnnealing, PolynomialDecayAnnealing, PolynomialHoldDecayAnnealing
-
 from nemo.utils import logging
+from nemo.utils.lr_policies import CosineAnnealing, PolynomialDecayAnnealing, PolynomialHoldDecayAnnealing
 
 
 def parse_args():

--- a/examples/image/gan.py
+++ b/examples/image/gan.py
@@ -9,9 +9,7 @@ from tensorboardX import SummaryWriter
 import nemo
 import nemo.collections.simple_gan as nemo_simple_gan
 from nemo.backends.pytorch.torchvision.helpers import compute_accuracy, eval_epochs_done_callback, eval_iter_callback
-
 from nemo.utils import logging
-
 
 parser = argparse.ArgumentParser(description='MNIST')
 parser.add_argument("--local_rank", default=None, type=int)

--- a/examples/image/gan.py
+++ b/examples/image/gan.py
@@ -10,7 +10,7 @@ import nemo
 import nemo.collections.simple_gan as nemo_simple_gan
 from nemo.backends.pytorch.torchvision.helpers import compute_accuracy, eval_epochs_done_callback, eval_iter_callback
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 parser = argparse.ArgumentParser(description='MNIST')

--- a/examples/image/transfer_learning.py
+++ b/examples/image/transfer_learning.py
@@ -9,7 +9,7 @@ from tensorboardX import SummaryWriter
 import nemo
 from nemo.backends.pytorch.torchvision.helpers import compute_accuracy, eval_epochs_done_callback, eval_iter_callback
 
-logging = nemo.logging
+from nemo.utils import logging
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))
 

--- a/examples/image/transfer_learning.py
+++ b/examples/image/transfer_learning.py
@@ -8,7 +8,6 @@ from tensorboardX import SummaryWriter
 
 import nemo
 from nemo.backends.pytorch.torchvision.helpers import compute_accuracy, eval_epochs_done_callback, eval_iter_callback
-
 from nemo.utils import logging
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../..')))

--- a/examples/speaker_recognition/notebooks/Speaker_Recognition_an4.ipynb
+++ b/examples/speaker_recognition/notebooks/Speaker_Recognition_an4.ipynb
@@ -310,7 +310,7 @@
    },
    "outputs": [],
    "source": [
-    "logging = nemo.logging\n",
+    "from nemo.utils import logging\n",
     "yaml = YAML(typ=\"safe\")\n",
     "with open('../configs/quartznet_spkr_3x1x512_xvector.yaml') as f:\n",
     "    spkr_params = yaml.load(f)\n",

--- a/examples/speaker_recognition/notebooks/Speaker_Recognition_hi-mia.ipynb
+++ b/examples/speaker_recognition/notebooks/Speaker_Recognition_hi-mia.ipynb
@@ -198,7 +198,7 @@
    },
    "outputs": [],
    "source": [
-    "logging = nemo.logging\n",
+    "from nemo.utils import logging\n",
     "yaml = YAML(typ=\"safe\")\n",
     "with open('examples/speaker_recognition/configs/quartznet_spkr_3x2x512_xvector.yaml') as f:\n",
     "    spkr_params = yaml.load(f)\n",

--- a/examples/speaker_recognition/speaker_reco.py
+++ b/examples/speaker_recognition/speaker_reco.py
@@ -29,7 +29,7 @@ from nemo.collections.asr.helpers import (
 )
 from nemo.utils.lr_policies import CosineAnnealing
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/speaker_recognition/speaker_reco.py
+++ b/examples/speaker_recognition/speaker_reco.py
@@ -27,9 +27,8 @@ from nemo.collections.asr.helpers import (
     process_classification_evaluation_batch,
     process_classification_evaluation_epoch,
 )
-from nemo.utils.lr_policies import CosineAnnealing
-
 from nemo.utils import logging
+from nemo.utils.lr_policies import CosineAnnealing
 
 
 def parse_args():

--- a/examples/speaker_recognition/spkr_get_emb.py
+++ b/examples/speaker_recognition/spkr_get_emb.py
@@ -24,7 +24,7 @@ import nemo
 import nemo.collections.asr as nemo_asr
 import nemo.utils.argparse as nm_argparse
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/speaker_recognition/spkr_get_emb.py
+++ b/examples/speaker_recognition/spkr_get_emb.py
@@ -23,7 +23,6 @@ from ruamel.yaml import YAML
 import nemo
 import nemo.collections.asr as nemo_asr
 import nemo.utils.argparse as nm_argparse
-
 from nemo.utils import logging
 
 

--- a/examples/start_here/chatbot_example.py
+++ b/examples/start_here/chatbot_example.py
@@ -3,7 +3,6 @@ import os
 import shutil
 
 import nemo
-
 from nemo.utils import logging
 
 data_file = "movie_data.txt"

--- a/examples/start_here/chatbot_example.py
+++ b/examples/start_here/chatbot_example.py
@@ -4,7 +4,7 @@ import shutil
 
 import nemo
 
-logging = nemo.logging
+from nemo.utils import logging
 
 data_file = "movie_data.txt"
 

--- a/examples/start_here/simplest_example.py
+++ b/examples/start_here/simplest_example.py
@@ -1,6 +1,5 @@
 # Copyright (c) 2019 NVIDIA Corporation
 import nemo
-
 from nemo.utils import logging
 
 nf = nemo.core.NeuralModuleFactory()

--- a/examples/start_here/simplest_example.py
+++ b/examples/start_here/simplest_example.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2019 NVIDIA Corporation
 import nemo
 
-logging = nemo.logging
+from nemo.utils import logging
 
 nf = nemo.core.NeuralModuleFactory()
 # To use CPU-only do:

--- a/examples/tts/fastspeech.py
+++ b/examples/tts/fastspeech.py
@@ -23,9 +23,7 @@ import nemo
 from nemo.collections import asr as nemo_asr
 from nemo.collections import tts as nemo_tts
 from nemo.utils import argparse as nm_argparse
-from nemo.utils import lr_policies
-
-from nemo.utils import logging
+from nemo.utils import logging, lr_policies
 
 
 def parse_args():

--- a/examples/tts/fastspeech.py
+++ b/examples/tts/fastspeech.py
@@ -25,7 +25,7 @@ from nemo.collections import tts as nemo_tts
 from nemo.utils import argparse as nm_argparse
 from nemo.utils import lr_policies
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/tts/fastspeech_durations.py
+++ b/examples/tts/fastspeech_durations.py
@@ -22,7 +22,6 @@ from tacotron2 import create_NMs
 import nemo
 import nemo.collections.asr as nemo_asr
 import nemo.collections.tts as nemo_tts
-
 from nemo.utils import logging
 
 

--- a/examples/tts/fastspeech_durations.py
+++ b/examples/tts/fastspeech_durations.py
@@ -23,7 +23,7 @@ import nemo
 import nemo.collections.asr as nemo_asr
 import nemo.collections.tts as nemo_tts
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/tts/tacotron2.py
+++ b/examples/tts/tacotron2.py
@@ -28,9 +28,8 @@ from nemo.collections.tts import (
     tacotron2_process_eval_batch,
     tacotron2_process_final_eval,
 )
-from nemo.utils.lr_policies import CosineAnnealing
-
 from nemo.utils import logging
+from nemo.utils.lr_policies import CosineAnnealing
 
 
 def parse_args():

--- a/examples/tts/tacotron2.py
+++ b/examples/tts/tacotron2.py
@@ -30,7 +30,7 @@ from nemo.collections.tts import (
 )
 from nemo.utils.lr_policies import CosineAnnealing
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/tts/tacotron2_v0p9.py
+++ b/examples/tts/tacotron2_v0p9.py
@@ -33,9 +33,8 @@ from nemo.collections.tts import (
     tacotron2_process_eval_batch,
     tacotron2_process_final_eval,
 )
-from nemo.utils.lr_policies import CosineAnnealing
-
 from nemo.utils import logging
+from nemo.utils.lr_policies import CosineAnnealing
 
 
 def parse_args():

--- a/examples/tts/tacotron2_v0p9.py
+++ b/examples/tts/tacotron2_v0p9.py
@@ -35,7 +35,7 @@ from nemo.collections.tts import (
 )
 from nemo.utils.lr_policies import CosineAnnealing
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/tts/tts_infer.py
+++ b/examples/tts/tts_infer.py
@@ -24,7 +24,6 @@ from tacotron2 import create_NMs
 import nemo
 import nemo.collections.asr as nemo_asr
 import nemo.collections.tts as nemo_tts
-
 from nemo.utils import logging
 
 

--- a/examples/tts/tts_infer.py
+++ b/examples/tts/tts_infer.py
@@ -25,7 +25,7 @@ import nemo
 import nemo.collections.asr as nemo_asr
 import nemo.collections.tts as nemo_tts
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/tts/waveglow.py
+++ b/examples/tts/waveglow.py
@@ -20,7 +20,6 @@ import nemo.collections.asr as nemo_asr
 import nemo.collections.tts as nemo_tts
 import nemo.utils.argparse as nm_argparse
 from nemo.collections.tts import waveglow_eval_log_to_tb_func, waveglow_log_to_tb_func, waveglow_process_eval_batch
-
 from nemo.utils import logging
 
 

--- a/examples/tts/waveglow.py
+++ b/examples/tts/waveglow.py
@@ -21,7 +21,7 @@ import nemo.collections.tts as nemo_tts
 import nemo.utils.argparse as nm_argparse
 from nemo.collections.tts import waveglow_eval_log_to_tb_func, waveglow_log_to_tb_func, waveglow_process_eval_batch
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/examples/tts/waveglow_v0p9.py
+++ b/examples/tts/waveglow_v0p9.py
@@ -27,7 +27,6 @@ import nemo.collections.asr as nemo_asr
 import nemo.collections.tts as nemo_tts
 import nemo.utils.argparse as nm_argparse
 from nemo.collections.tts import waveglow_eval_log_to_tb_func, waveglow_log_to_tb_func, waveglow_process_eval_batch
-
 from nemo.utils import logging
 
 

--- a/examples/tts/waveglow_v0p9.py
+++ b/examples/tts/waveglow_v0p9.py
@@ -28,7 +28,7 @@ import nemo.collections.tts as nemo_tts
 import nemo.utils.argparse as nm_argparse
 from nemo.collections.tts import waveglow_eval_log_to_tb_func, waveglow_log_to_tb_func, waveglow_process_eval_batch
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def parse_args():

--- a/nemo/collections/asr/audio_preprocessing.py
+++ b/nemo/collections/asr/audio_preprocessing.py
@@ -61,7 +61,7 @@ except (AttributeError, ModuleNotFoundError) as e:
     warnings.warn("Unable to import APEX. Mixed precision and distributed training will not work.")
 
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 class AudioPreprocessor(NonTrainableNM):

--- a/nemo/collections/asr/audio_preprocessing.py
+++ b/nemo/collections/asr/audio_preprocessing.py
@@ -28,7 +28,6 @@ __all__ = [
 ]
 
 import math
-import warnings
 from abc import abstractmethod
 
 import numpy as np
@@ -54,11 +53,12 @@ try:
     HAVE_TORCHAUDIO = True
 except ModuleNotFoundError:
     HAVE_TORCHAUDIO = False
-    warnings.warn('Could not import torchaudio. Some features might not work.')
+    logging.warning('Could not import torchaudio. Some features might not work.')
+
 try:
     from apex import amp
 except (AttributeError, ModuleNotFoundError) as e:
-    warnings.warn("Unable to import APEX. Mixed precision and distributed training will not work.")
+    logging.warning("Unable to import APEX. Mixed precision and distributed training will not work.")
 
 
 class AudioPreprocessor(NonTrainableNM):

--- a/nemo/collections/asr/audio_preprocessing.py
+++ b/nemo/collections/asr/audio_preprocessing.py
@@ -41,6 +41,7 @@ from .parts.spectr_augment import SpecAugment, SpecCutout
 from nemo.backends.pytorch import NonTrainableNM
 from nemo.core import Optimization
 from nemo.core.neural_types import *
+from nemo.utils import logging
 from nemo.utils.decorators import add_port_docs
 
 try:
@@ -59,9 +60,6 @@ try:
     from apex import amp
 except (AttributeError, ModuleNotFoundError) as e:
     warnings.warn("Unable to import APEX. Mixed precision and distributed training will not work.")
-
-
-from nemo.utils import logging
 
 
 class AudioPreprocessor(NonTrainableNM):

--- a/nemo/collections/asr/audio_preprocessing.py
+++ b/nemo/collections/asr/audio_preprocessing.py
@@ -35,7 +35,6 @@ import numpy as np
 import torch
 from packaging import version
 
-import nemo
 from .parts.features import FilterbankFeatures
 from .parts.spectr_augment import SpecAugment, SpecCutout
 from nemo.backends.pytorch import NonTrainableNM

--- a/nemo/collections/asr/contextnet.py
+++ b/nemo/collections/asr/contextnet.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-import nemo
 from .jasper import JasperEncoder
 from .parts.jasper import init_weights
 from nemo.backends.pytorch.nm import TrainableNM

--- a/nemo/collections/asr/contextnet.py
+++ b/nemo/collections/asr/contextnet.py
@@ -10,9 +10,8 @@ from .jasper import JasperEncoder
 from .parts.jasper import init_weights
 from nemo.backends.pytorch.nm import TrainableNM
 from nemo.core.neural_types import *
-from nemo.utils.decorators import add_port_docs
-
 from nemo.utils import logging
+from nemo.utils.decorators import add_port_docs
 
 
 class ContextNetEncoder(JasperEncoder):

--- a/nemo/collections/asr/contextnet.py
+++ b/nemo/collections/asr/contextnet.py
@@ -12,7 +12,7 @@ from nemo.backends.pytorch.nm import TrainableNM
 from nemo.core.neural_types import *
 from nemo.utils.decorators import add_port_docs
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 class ContextNetEncoder(JasperEncoder):

--- a/nemo/collections/asr/data_layer.py
+++ b/nemo/collections/asr/data_layer.py
@@ -51,7 +51,7 @@ __all__ = [
     'AudioToSpeechLabelDataLayer',
 ]
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def _process_augmentations(augmenter) -> AudioAugmentor:

--- a/nemo/collections/asr/data_layer.py
+++ b/nemo/collections/asr/data_layer.py
@@ -24,7 +24,6 @@ import braceexpand
 import torch
 import webdataset as wd
 
-import nemo
 from .parts.collections import ASRAudioText
 from .parts.dataset import (
     AudioDataset,

--- a/nemo/collections/asr/data_layer.py
+++ b/nemo/collections/asr/data_layer.py
@@ -40,6 +40,7 @@ from .parts.perturb import AudioAugmentor, perturbation_types
 from nemo.backends.pytorch import DataLayerNM
 from nemo.core import DeviceType
 from nemo.core.neural_types import *
+from nemo.utils import logging
 from nemo.utils.decorators import add_port_docs
 from nemo.utils.misc import pad_to
 
@@ -50,8 +51,6 @@ __all__ = [
     'TranscriptDataLayer',
     'AudioToSpeechLabelDataLayer',
 ]
-
-from nemo.utils import logging
 
 
 def _process_augmentations(augmenter) -> AudioAugmentor:

--- a/nemo/collections/asr/helpers.py
+++ b/nemo/collections/asr/helpers.py
@@ -2,7 +2,6 @@
 
 import torch
 
-import nemo
 from .metrics import classification_accuracy, word_error_rate
 from nemo.utils import logging
 

--- a/nemo/collections/asr/helpers.py
+++ b/nemo/collections/asr/helpers.py
@@ -5,7 +5,7 @@ import torch
 import nemo
 from .metrics import classification_accuracy, word_error_rate
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def __ctc_decoder_predictions_tensor(tensor, labels):

--- a/nemo/collections/asr/helpers.py
+++ b/nemo/collections/asr/helpers.py
@@ -4,7 +4,6 @@ import torch
 
 import nemo
 from .metrics import classification_accuracy, word_error_rate
-
 from nemo.utils import logging
 
 

--- a/nemo/collections/asr/jasper.py
+++ b/nemo/collections/asr/jasper.py
@@ -9,9 +9,8 @@ import nemo
 from .parts.jasper import JasperBlock, StatsPoolLayer, init_weights, jasper_activations
 from nemo.backends.pytorch.nm import TrainableNM
 from nemo.core.neural_types import *
-from nemo.utils.decorators import add_port_docs
-
 from nemo.utils import logging
+from nemo.utils.decorators import add_port_docs
 
 
 class JasperEncoder(TrainableNM):

--- a/nemo/collections/asr/jasper.py
+++ b/nemo/collections/asr/jasper.py
@@ -5,7 +5,6 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
-import nemo
 from .parts.jasper import JasperBlock, StatsPoolLayer, init_weights, jasper_activations
 from nemo.backends.pytorch.nm import TrainableNM
 from nemo.core.neural_types import *

--- a/nemo/collections/asr/jasper.py
+++ b/nemo/collections/asr/jasper.py
@@ -11,7 +11,7 @@ from nemo.backends.pytorch.nm import TrainableNM
 from nemo.core.neural_types import *
 from nemo.utils.decorators import add_port_docs
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 class JasperEncoder(TrainableNM):

--- a/nemo/collections/asr/las/helpers.py
+++ b/nemo/collections/asr/las/helpers.py
@@ -3,7 +3,6 @@ from pprint import pformat
 
 import torch
 
-import nemo
 from nemo.backends.pytorch.common.metrics import char_lm_metrics
 from nemo.collections.asr.metrics import word_error_rate
 from nemo.utils import logging

--- a/nemo/collections/asr/las/helpers.py
+++ b/nemo/collections/asr/las/helpers.py
@@ -7,7 +7,8 @@ import nemo
 from nemo.backends.pytorch.common.metrics import char_lm_metrics
 from nemo.collections.asr.metrics import word_error_rate
 
-logging = nemo.logging
+from nemo.utils import logging
+
 ENG_MWN = 5.3
 
 

--- a/nemo/collections/asr/las/helpers.py
+++ b/nemo/collections/asr/las/helpers.py
@@ -6,7 +6,6 @@ import torch
 import nemo
 from nemo.backends.pytorch.common.metrics import char_lm_metrics
 from nemo.collections.asr.metrics import word_error_rate
-
 from nemo.utils import logging
 
 ENG_MWN = 5.3

--- a/nemo/collections/asr/parts/collections.py
+++ b/nemo/collections/asr/parts/collections.py
@@ -9,7 +9,7 @@ import pandas as pd
 import nemo
 from nemo.collections.asr.parts import manifest, parsers
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 class _Collection(collections.UserList):

--- a/nemo/collections/asr/parts/collections.py
+++ b/nemo/collections/asr/parts/collections.py
@@ -8,7 +8,6 @@ import pandas as pd
 
 import nemo
 from nemo.collections.asr.parts import manifest, parsers
-
 from nemo.utils import logging
 
 

--- a/nemo/collections/asr/parts/collections.py
+++ b/nemo/collections/asr/parts/collections.py
@@ -6,7 +6,6 @@ from typing import Any, Dict, List, Optional, Union
 
 import pandas as pd
 
-import nemo
 from nemo.collections.asr.parts import manifest, parsers
 from nemo.utils import logging
 

--- a/nemo/collections/nlp/data/tokenizers/tokenizer_utils.py
+++ b/nemo/collections/nlp/data/tokenizers/tokenizer_utils.py
@@ -18,14 +18,21 @@ import os
 from transformers import AlbertTokenizer, BertTokenizer, RobertaTokenizer
 
 import nemo
-from nemo.collections.nlp.nm.trainables.common.megatron.megatron_utils import (
-    get_megatron_vocab_file,
-    is_lower_cased_megatron,
-)
+from nemo.utils import logging
+
+try:
+    __megatron_utils_satisfied = True
+    from nemo.collections.nlp.nm.trainables.common.megatron.megatron_utils import (
+        get_megatron_vocab_file,
+        is_lower_cased_megatron,
+    )
+
+except Exception as e:
+    logging.error('Failed to import Megatron utils: `{}` ({})'.format(str(e), type(e)))
+    __megatron_utils_satisfied = True
+
 
 __all__ = ['MODEL_SPECIAL_TOKENS', 'TOKENIZERS', 'get_tokenizer', 'get_bert_special_tokens']
-
-logging = nemo.logging
 
 MODEL_SPECIAL_TOKENS = {
     'bert': {
@@ -84,12 +91,14 @@ def get_tokenizer(
     vocab_file (str): path to vocab file
     do_lower_case (bool): (whether to apply lower cased) - only applicable when tokenizer is build with vocab file
     '''
-    if 'megatron' in pretrained_model_name:
-        do_lower_case = is_lower_cased_megatron(pretrained_model_name)
-        vocab_file = get_megatron_vocab_file(pretrained_model_name)
-        return nemo.collections.nlp.data.tokenizers.NemoBertTokenizer(
-            vocab_file=vocab_file, do_lower_case=do_lower_case
-        )
+    # Check if we can use Megatron utils.
+    if __megatron_utils_satisfied:
+        if 'megatron' in pretrained_model_name:
+            do_lower_case = is_lower_cased_megatron(pretrained_model_name)
+            vocab_file = get_megatron_vocab_file(pretrained_model_name)
+            return nemo.collections.nlp.data.tokenizers.NemoBertTokenizer(
+                vocab_file=vocab_file, do_lower_case=do_lower_case
+            )
 
     if tokenizer_name == 'nemobert':
         tokenizer = nemo.collections.nlp.data.tokenizers.NemoBertTokenizer(

--- a/nemo/collections/nlp/data/tokenizers/tokenizer_utils.py
+++ b/nemo/collections/nlp/data/tokenizers/tokenizer_utils.py
@@ -29,7 +29,7 @@ try:
 
 except Exception as e:
     logging.error('Failed to import Megatron utils: `{}` ({})'.format(str(e), type(e)))
-    __megatron_utils_satisfied = True
+    __megatron_utils_satisfied = False
 
 
 __all__ = ['MODEL_SPECIAL_TOKENS', 'TOKENIZERS', 'get_tokenizer', 'get_bert_special_tokens']

--- a/nemo/collections/nlp/nm/trainables/common/__init__.py
+++ b/nemo/collections/nlp/nm/trainables/common/__init__.py
@@ -14,10 +14,16 @@
 # limitations under the License.
 # =============================================================================
 
+from nemo.utils import logging
 from nemo.collections.nlp.nm.trainables.common.common_utils import *
 from nemo.collections.nlp.nm.trainables.common.huggingface import *
-from nemo.collections.nlp.nm.trainables.common.megatron import *
 from nemo.collections.nlp.nm.trainables.common.sequence_classification_nm import *
 from nemo.collections.nlp.nm.trainables.common.sequence_regression_nm import *
 from nemo.collections.nlp.nm.trainables.common.token_classification_nm import *
 from nemo.collections.nlp.nm.trainables.common.transformer import *
+
+try:
+    from nemo.collections.nlp.nm.trainables.common.megatron.megatron_utils import *
+
+except Exception as e:
+    logging.error('Failed to import Megatron utils: `{}` ({})'.format(str(e), type(e)))

--- a/nemo/collections/nlp/nm/trainables/common/__init__.py
+++ b/nemo/collections/nlp/nm/trainables/common/__init__.py
@@ -14,13 +14,13 @@
 # limitations under the License.
 # =============================================================================
 
-from nemo.utils import logging
 from nemo.collections.nlp.nm.trainables.common.common_utils import *
 from nemo.collections.nlp.nm.trainables.common.huggingface import *
 from nemo.collections.nlp.nm.trainables.common.sequence_classification_nm import *
 from nemo.collections.nlp.nm.trainables.common.sequence_regression_nm import *
 from nemo.collections.nlp.nm.trainables.common.token_classification_nm import *
 from nemo.collections.nlp.nm.trainables.common.transformer import *
+from nemo.utils import logging
 
 try:
     from nemo.collections.nlp.nm.trainables.common.megatron.megatron_utils import *

--- a/nemo/collections/nlp/nm/trainables/common/common_utils.py
+++ b/nemo/collections/nlp/nm/trainables/common/common_utils.py
@@ -18,8 +18,16 @@ import json
 
 from nemo import logging
 from nemo.collections.nlp.nm.trainables.common.huggingface.huggingface_utils import *
-from nemo.collections.nlp.nm.trainables.common.megatron.megatron_bert_nm import MegatronBERT
-from nemo.collections.nlp.nm.trainables.common.megatron.megatron_utils import *
+
+try:
+    __megatron_satisfied = True
+    from nemo.collections.nlp.nm.trainables.common.megatron.megatron_bert_nm import MegatronBERT
+    from nemo.collections.nlp.nm.trainables.common.megatron.megatron_utils import *
+
+except Exception as e:
+    logging.error('Failed to import Megatron Neural Module and utils: `{}` ({})'.format(str(e), type(e)))
+    __megatron_utils_satisfied = True
+
 
 __all__ = ['get_pretrained_lm_models_list', 'get_pretrained_lm_model']
 
@@ -28,7 +36,10 @@ def get_pretrained_lm_models_list():
     '''
     Returns the list of support pretrained models
     '''
-    return get_megatron_lm_models_list() + get_huggingface_lm_models_list()
+    if __megatron_utils_satisfied:
+        return get_megatron_lm_models_list() + get_huggingface_lm_models_list()
+    else:
+        return get_huggingface_lm_models_list()
 
 
 def get_pretrained_lm_model(pretrained_model_name, config=None, vocab=None, checkpoint=None):
@@ -45,7 +56,7 @@ def get_pretrained_lm_model(pretrained_model_name, config=None, vocab=None, chec
     '''
     if pretrained_model_name in get_huggingface_lm_models_list():
         model = get_huggingface_lm_model(bert_config=config, pretrained_model_name=pretrained_model_name)
-    elif pretrained_model_name in get_megatron_lm_models_list():
+    elif __megatron_utils_satisfied and pretrained_model_name in get_megatron_lm_models_list():
         if pretrained_model_name == 'megatron-bert-cased' or pretrained_model_name == 'megatron-bert-uncased':
             if not (config and checkpoint):
                 raise ValueError(f'Config file and pretrained checkpoint required for {pretrained_model_name}')

--- a/nemo/collections/nlp/nm/trainables/common/common_utils.py
+++ b/nemo/collections/nlp/nm/trainables/common/common_utils.py
@@ -20,13 +20,13 @@ from nemo import logging
 from nemo.collections.nlp.nm.trainables.common.huggingface.huggingface_utils import *
 
 try:
-    __megatron_satisfied = True
+    __megatron_utils_satisfied = True
     from nemo.collections.nlp.nm.trainables.common.megatron.megatron_bert_nm import MegatronBERT
     from nemo.collections.nlp.nm.trainables.common.megatron.megatron_utils import *
 
 except Exception as e:
     logging.error('Failed to import Megatron Neural Module and utils: `{}` ({})'.format(str(e), type(e)))
-    __megatron_utils_satisfied = True
+    __megatron_utils_satisfied = False
 
 
 __all__ = ['get_pretrained_lm_models_list', 'get_pretrained_lm_model']

--- a/nemo/collections/nlp/nm/trainables/common/megatron/__init__.py
+++ b/nemo/collections/nlp/nm/trainables/common/megatron/__init__.py
@@ -14,4 +14,11 @@
 # limitations under the License.
 # =============================================================================
 
-from nemo.collections.nlp.nm.trainables.common.megatron.megatron_bert_nm import *
+from nemo.utils import logging
+
+try:
+    # from megatron import mpu
+    from nemo.collections.nlp.nm.trainables.common.megatron.megatron_bert_nm import *
+
+except Exception as e:
+    logging.error('Failed to import Megatron NM: `{}` ({})'.format(str(e), type(e)))

--- a/nemo/collections/nlp/nm/trainables/common/megatron/megatron_utils.py
+++ b/nemo/collections/nlp/nm/trainables/common/megatron/megatron_utils.py
@@ -30,7 +30,7 @@ __all__ = [
     'get_megatron_checkpoint',
 ]
 
-MEGATRON_CACHE = os.path.join(os.path.dirname(TRANSFORMERS_CACHE), 'megatron')
+MEGATRON_CACHE = os.path.join(os.path.dirname(str(TRANSFORMERS_CACHE)), 'megatron')
 
 CONFIGS = {'345m': {"hidden-size": 1024, "num-attention-heads": 16, "num-layers": 24, "max-seq-length": 512}}
 

--- a/nemo/collections/nlp/nm/trainables/common/transformer/transformer_modules.py
+++ b/nemo/collections/nlp/nm/trainables/common/transformer/transformer_modules.py
@@ -28,13 +28,12 @@ __all__ = []
 
 try:
     from apex.normalization import FusedLayerNorm
+
     # Try to use FusedLayerNorm from Apex - this will trigger an error.
     _ = FusedLayerNorm(8, eps=1e-5)
 
 except Exception as e:
-    logging.warning(
-        "Unable to import FusedLayerNorm  from APEX. Using regular LayerNorm instead."
-    )
+    logging.warning("Unable to import FusedLayerNorm  from APEX. Using regular LayerNorm instead.")
     from torch.nn import LayerNorm as FusedLayerNorm
 
 

--- a/nemo/collections/nlp/nm/trainables/common/transformer/transformer_modules.py
+++ b/nemo/collections/nlp/nm/trainables/common/transformer/transformer_modules.py
@@ -28,10 +28,12 @@ __all__ = []
 
 try:
     from apex.normalization import FusedLayerNorm
-except (AttributeError, ModuleNotFoundError):
-    # this is lie - it isn't fused in this case
+    # Try to use FusedLayerNorm from Apex - this will trigger an error.
+    _ = FusedLayerNorm(8, eps=1e-5)
+
+except Exception as e:
     logging.warning(
-        "Unable to import APEX. Mixed precision, distributed training and FusedLayerNorm are not available."
+        "Unable to import FusedLayerNorm  from APEX. Using regular LayerNorm instead."
     )
     from torch.nn import LayerNorm as FusedLayerNorm
 

--- a/nemo/collections/tts/data_layers.py
+++ b/nemo/collections/tts/data_layers.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2019 NVIDIA Corporation
 import torch
 
-import nemo
 from .parts.datasets import AudioOnlyDataset
 from nemo.backends.pytorch.nm import DataLayerNM
 from nemo.core import DeviceType

--- a/nemo/collections/tts/data_layers.py
+++ b/nemo/collections/tts/data_layers.py
@@ -8,7 +8,7 @@ from nemo.core import DeviceType
 from nemo.core.neural_types import AudioSignal, LengthsType, NeuralType
 from nemo.utils.decorators import add_port_docs
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 class AudioDataLayer(DataLayerNM):

--- a/nemo/collections/tts/data_layers.py
+++ b/nemo/collections/tts/data_layers.py
@@ -6,9 +6,8 @@ from .parts.datasets import AudioOnlyDataset
 from nemo.backends.pytorch.nm import DataLayerNM
 from nemo.core import DeviceType
 from nemo.core.neural_types import AudioSignal, LengthsType, NeuralType
-from nemo.utils.decorators import add_port_docs
-
 from nemo.utils import logging
+from nemo.utils.decorators import add_port_docs
 
 
 class AudioDataLayer(DataLayerNM):

--- a/nemo/collections/tts/parts/helpers.py
+++ b/nemo/collections/tts/parts/helpers.py
@@ -4,7 +4,6 @@ import matplotlib.pylab as plt
 import numpy as np
 import torch
 
-import nemo
 from nemo.utils import logging
 
 __all__ = [

--- a/nemo/collections/tts/parts/helpers.py
+++ b/nemo/collections/tts/parts/helpers.py
@@ -6,7 +6,7 @@ import torch
 
 import nemo
 
-logging = nemo.logging
+from nemo.utils import logging
 
 __all__ = [
     "waveglow_log_to_tb_func",

--- a/nemo/collections/tts/parts/helpers.py
+++ b/nemo/collections/tts/parts/helpers.py
@@ -5,7 +5,6 @@ import numpy as np
 import torch
 
 import nemo
-
 from nemo.utils import logging
 
 __all__ = [

--- a/nemo/collections/tts/parts/tacotron2.py
+++ b/nemo/collections/tts/parts/tacotron2.py
@@ -1,12 +1,10 @@
 # Copyright (c) 2019 NVIDIA Corporation
-from math import sqrt
 
 import torch
 from torch import nn
 from torch.autograd import Variable
 from torch.nn import functional as F
 
-import nemo
 from nemo.collections.tts.parts.layers import ConvNorm, LinearNorm, get_mask_from_lengths
 from nemo.utils import logging
 

--- a/nemo/collections/tts/parts/tacotron2.py
+++ b/nemo/collections/tts/parts/tacotron2.py
@@ -8,7 +8,6 @@ from torch.nn import functional as F
 
 import nemo
 from nemo.collections.tts.parts.layers import ConvNorm, LinearNorm, get_mask_from_lengths
-
 from nemo.utils import logging
 
 

--- a/nemo/collections/tts/parts/tacotron2.py
+++ b/nemo/collections/tts/parts/tacotron2.py
@@ -9,7 +9,7 @@ from torch.nn import functional as F
 import nemo
 from nemo.collections.tts.parts.layers import ConvNorm, LinearNorm, get_mask_from_lengths
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 class LocationLayer(nn.Module):

--- a/nemo/core/callbacks.py
+++ b/nemo/core/callbacks.py
@@ -34,7 +34,7 @@ try:
 except (ImportError, ModuleNotFoundError):
     _WANDB_AVAILABLE = False
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 class ActionCallback(ABC):

--- a/nemo/core/callbacks.py
+++ b/nemo/core/callbacks.py
@@ -25,7 +25,7 @@ from abc import ABC, abstractmethod
 from collections import namedtuple
 
 import nemo
-from nemo.utils import get_checkpoint_from_dir
+from nemo.utils import get_checkpoint_from_dir, logging
 
 try:
     import wandb
@@ -33,8 +33,6 @@ try:
     _WANDB_AVAILABLE = True
 except (ImportError, ModuleNotFoundError):
     _WANDB_AVAILABLE = False
-
-from nemo.utils import logging
 
 
 class ActionCallback(ABC):

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -38,7 +38,7 @@ from .callbacks import ActionCallback, EvaluatorCallback
 from .neural_types import *
 from nemo.utils.decorators import deprecated
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 class DeploymentFormat(Enum):

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -36,9 +36,8 @@ import nemo
 from ..utils import ExpManager
 from .callbacks import ActionCallback, EvaluatorCallback
 from .neural_types import *
-from nemo.utils.decorators import deprecated
-
 from nemo.utils import logging
+from nemo.utils.decorators import deprecated
 
 
 class DeploymentFormat(Enum):

--- a/nemo/utils/decorators/deprecated.py
+++ b/nemo/utils/decorators/deprecated.py
@@ -22,7 +22,7 @@ import wrapt
 
 from nemo.utils import logging
 
-# logging = nemo.logging
+# from nemo.utils import logging
 
 # Remember which deprecation warnings have been printed already.
 _PRINTED_WARNING = {}

--- a/nemo/utils/exp_logging.py
+++ b/nemo/utils/exp_logging.py
@@ -9,11 +9,11 @@ from nemo.utils import logging
 from nemo.utils.decorators import deprecated
 
 
-# logging = nemo.logging
+# from nemo.utils import logging
 @deprecated(
     version=0.11,
     explanation=(
-        "Please use nemo.logging instead by using logging = nemo.logging and logging.info(), "
+        "Please use nemo.logging instead by using from nemo.utils import logging and logging.info(), "
         "logging.warning() , etc."
     ),
 )

--- a/nemo/utils/helpers.py
+++ b/nemo/utils/helpers.py
@@ -13,7 +13,7 @@ import wget
 import nemo
 from nemo.utils import logging
 
-# logging = nemo.logging
+# from nemo.utils import logging
 
 
 def rgetattr(obj, attr, *args):

--- a/scripts/export_jasper_to_onnx.py
+++ b/scripts/export_jasper_to_onnx.py
@@ -8,7 +8,7 @@ from ruamel.yaml import YAML
 import nemo
 import nemo.collections.asr as nemo_asr
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 def get_parser():

--- a/scripts/export_jasper_to_onnx.py
+++ b/scripts/export_jasper_to_onnx.py
@@ -7,7 +7,6 @@ from ruamel.yaml import YAML
 
 import nemo
 import nemo.collections.asr as nemo_asr
-
 from nemo.utils import logging
 
 

--- a/tests/integration/test_asr_gradient_step_and_eval.py
+++ b/tests/integration/test_asr_gradient_step_and_eval.py
@@ -25,7 +25,6 @@ import pytest
 from ruamel.yaml import YAML
 
 import nemo.collections.asr as nemo_asr
-
 from nemo.utils import logging
 
 

--- a/tests/integration/test_asr_gradient_step_and_eval.py
+++ b/tests/integration/test_asr_gradient_step_and_eval.py
@@ -27,9 +27,11 @@ from ruamel.yaml import YAML
 import nemo.collections.asr as nemo_asr
 from nemo.utils import logging
 
+from nemo.core import SimpleLossLoggerCallback, EvaluatorCallback
+
 
 @pytest.mark.usefixtures("neural_factory")
-class TestASRPytorch(TestCase):
+class TestASRIntegrationPytorch(TestCase):
     labels = [
         " ",
         "a",
@@ -198,7 +200,7 @@ class TestASRPytorch(TestCase):
         )
 
         loss_list = []
-        callback = nemo.core.SimpleLossLoggerCallback(
+        callback = SimpleLossLoggerCallback(
             tensors=[loss], print_func=partial(self.print_and_log_loss, loss_log_list=loss_list), step_freq=1
         )
 
@@ -256,7 +258,7 @@ class TestASRPytorch(TestCase):
         )
 
         loss_list = []
-        callback = nemo.core.SimpleLossLoggerCallback(
+        callback = SimpleLossLoggerCallback(
             tensors=[loss], print_func=partial(self.print_and_log_loss, loss_log_list=loss_list), step_freq=1
         )
 
@@ -313,7 +315,7 @@ class TestASRPytorch(TestCase):
         )
 
         loss_list = []
-        callback = nemo.core.SimpleLossLoggerCallback(
+        callback = SimpleLossLoggerCallback(
             tensors=[loss], print_func=partial(self.print_and_log_loss, loss_log_list=loss_list), step_freq=1
         )
 
@@ -371,7 +373,7 @@ class TestASRPytorch(TestCase):
             process_evaluation_epoch,
         )
 
-        eval_callback = nemo.core.EvaluatorCallback(
+        eval_callback = EvaluatorCallback(
             eval_tensors=[loss, predictions, transcript, transcript_len],
             user_iter_callback=lambda x, y: process_evaluation_batch(x, y, labels=self.labels),
             user_epochs_done_callback=process_evaluation_epoch,

--- a/tests/integration/test_asr_gradient_step_and_eval.py
+++ b/tests/integration/test_asr_gradient_step_and_eval.py
@@ -148,7 +148,7 @@ class TestASRIntegrationPytorch(TestCase):
         )
 
         loss_list = []
-        callback = nemo.core.SimpleLossLoggerCallback(
+        callback = SimpleLossLoggerCallback(
             tensors=[loss], print_func=partial(self.print_and_log_loss, loss_log_list=loss_list), step_freq=1
         )
 

--- a/tests/integration/test_asr_gradient_step_and_eval.py
+++ b/tests/integration/test_asr_gradient_step_and_eval.py
@@ -25,9 +25,8 @@ import pytest
 from ruamel.yaml import YAML
 
 import nemo.collections.asr as nemo_asr
+from nemo.core import EvaluatorCallback, SimpleLossLoggerCallback
 from nemo.utils import logging
-
-from nemo.core import SimpleLossLoggerCallback, EvaluatorCallback
 
 
 @pytest.mark.usefixtures("neural_factory")

--- a/tests/integration/test_asr_gradient_step_and_eval.py
+++ b/tests/integration/test_asr_gradient_step_and_eval.py
@@ -24,10 +24,9 @@ from unittest import TestCase
 import pytest
 from ruamel.yaml import YAML
 
-import nemo
 import nemo.collections.asr as nemo_asr
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 @pytest.mark.usefixtures("neural_factory")

--- a/tests/integration/test_integration_multidataset.py
+++ b/tests/integration/test_integration_multidataset.py
@@ -27,7 +27,7 @@ import nemo
 from nemo.backends.pytorch.common import DataCombination
 from nemo.core import ChannelType, NeuralType
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 @pytest.mark.usefixtures("neural_factory")

--- a/tests/integration/test_integration_multidataset.py
+++ b/tests/integration/test_integration_multidataset.py
@@ -26,7 +26,6 @@ import torch
 import nemo
 from nemo.backends.pytorch.common import DataCombination
 from nemo.core import ChannelType, NeuralType
-
 from nemo.utils import logging
 
 

--- a/tests/integration/test_speaker_recognition_gradient_step.py
+++ b/tests/integration/test_speaker_recognition_gradient_step.py
@@ -25,7 +25,6 @@ from ruamel.yaml import YAML
 
 import nemo
 import nemo.collections.asr as nemo_asr
-
 from nemo.utils import logging
 
 

--- a/tests/integration/test_speaker_recognition_gradient_step.py
+++ b/tests/integration/test_speaker_recognition_gradient_step.py
@@ -26,7 +26,7 @@ from ruamel.yaml import YAML
 import nemo
 import nemo.collections.asr as nemo_asr
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 @pytest.mark.usefixtures("neural_factory")

--- a/tests/integration/test_speechcommands_gradient_step_and_eval.py
+++ b/tests/integration/test_speechcommands_gradient_step_and_eval.py
@@ -26,7 +26,6 @@ from ruamel.yaml import YAML
 
 import nemo
 import nemo.collections.asr as nemo_asr
-
 from nemo.utils import logging
 
 

--- a/tests/integration/test_speechcommands_gradient_step_and_eval.py
+++ b/tests/integration/test_speechcommands_gradient_step_and_eval.py
@@ -27,7 +27,7 @@ from ruamel.yaml import YAML
 import nemo
 import nemo.collections.asr as nemo_asr
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 @pytest.mark.usefixtures("neural_factory")

--- a/tests/integration/test_tts_gradient_step.py
+++ b/tests/integration/test_tts_gradient_step.py
@@ -25,14 +25,11 @@ from unittest import TestCase
 import numpy as np
 import pytest
 
-
 import nemo.collections.asr as nemo_asr
 import nemo.collections.tts as nemo_tts
-
-from nemo.utils import logging
-from nemo.core import SimpleLossLoggerCallback
-
 from nemo.backends.pytorch.actions import PtActions
+from nemo.core import SimpleLossLoggerCallback
+from nemo.utils import logging
 
 
 @pytest.mark.usefixtures("neural_factory")

--- a/tests/integration/test_tts_gradient_step.py
+++ b/tests/integration/test_tts_gradient_step.py
@@ -25,11 +25,14 @@ from unittest import TestCase
 import numpy as np
 import pytest
 
-import nemo
+
 import nemo.collections.asr as nemo_asr
 import nemo.collections.tts as nemo_tts
 
-logging = nemo.logging
+from nemo.utils import logging
+from nemo.core import SimpleLossLoggerCallback
+
+from nemo.backends.pytorch.actions import PtActions
 
 
 @pytest.mark.usefixtures("neural_factory")
@@ -158,11 +161,11 @@ class TestTTSPytorch(TestCase):
         )
         loss_list = []
 
-        callback = nemo.core.SimpleLossLoggerCallback(
+        callback = SimpleLossLoggerCallback(
             tensors=[loss_t], print_func=partial(self.print_and_log_loss, loss_log_list=loss_list), step_freq=1
         )
         # Instantiate an optimizer to perform `train` action
-        optimizer = nemo.backends.pytorch.actions.PtActions()
+        optimizer = PtActions()
         optimizer.train(
             [loss_t], callbacks=[callback], optimizer="sgd", optimization_params={"max_steps": 3, "lr": 0.01}
         )
@@ -212,11 +215,11 @@ class TestTTSPytorch(TestCase):
         loss_t = waveglow_loss(z=z, log_s_list=log_s_list, log_det_W_list=log_det_W_list)
 
         loss_list = []
-        callback = nemo.core.SimpleLossLoggerCallback(
+        callback = SimpleLossLoggerCallback(
             tensors=[loss_t], print_func=partial(self.print_and_log_loss, loss_log_list=loss_list), step_freq=1
         )
         # Instantiate an optimizer to perform `train` action
-        optimizer = nemo.backends.pytorch.actions.PtActions()
+        optimizer = PtActions()
         optimizer.train(
             [loss_t], callbacks=[callback], optimizer="sgd", optimization_params={"max_steps": 3, "lr": 0.01}
         )
@@ -314,11 +317,11 @@ class TestTTSPytorch(TestCase):
         )
 
         loss_list = []
-        callback = nemo.core.SimpleLossLoggerCallback(
+        callback = SimpleLossLoggerCallback(
             tensors=[loss_t], print_func=partial(self.print_and_log_loss, loss_log_list=loss_list), step_freq=1
         )
         # Instantiate an optimizer to perform `train` action
-        optimizer = nemo.backends.pytorch.actions.PtActions()
+        optimizer = PtActions()
         optimizer.train(
             [loss_t], callbacks=[callback], optimizer="sgd", optimization_params={"max_steps": 3, "lr": 0.0003}
         )

--- a/tests/unit/core/test_weight_share.py
+++ b/tests/unit/core/test_weight_share.py
@@ -34,7 +34,6 @@ from nemo.collections.nlp.nm.losses import SmoothedCrossEntropyLoss
 from nemo.collections.nlp.nm.trainables.common import TokenClassifier
 from nemo.core import WeightShareTransform
 from nemo.core.neural_types import *
-
 from nemo.utils import logging
 
 

--- a/tests/unit/core/test_weight_share.py
+++ b/tests/unit/core/test_weight_share.py
@@ -35,7 +35,7 @@ from nemo.collections.nlp.nm.trainables.common import TokenClassifier
 from nemo.core import WeightShareTransform
 from nemo.core.neural_types import *
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 @pytest.mark.usefixtures("neural_factory")

--- a/tests/unit/test_unit_asr.py
+++ b/tests/unit/test_unit_asr.py
@@ -30,7 +30,7 @@ import nemo.collections.asr as nemo_asr
 from nemo.collections.asr.parts import AudioDataset, WaveformFeaturizer, collections, parsers
 from nemo.core import DeviceType
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 freq = 16000

--- a/tests/unit/test_unit_asr.py
+++ b/tests/unit/test_unit_asr.py
@@ -35,7 +35,7 @@ freq = 16000
 
 
 @pytest.mark.usefixtures("neural_factory")
-class TestASRPytorch(TestCase):
+class TestUnitASRPytorch(TestCase):
     labels = [
         " ",
         "a",

--- a/tests/unit/test_unit_asr.py
+++ b/tests/unit/test_unit_asr.py
@@ -29,9 +29,7 @@ import nemo
 import nemo.collections.asr as nemo_asr
 from nemo.collections.asr.parts import AudioDataset, WaveformFeaturizer, collections, parsers
 from nemo.core import DeviceType
-
 from nemo.utils import logging
-
 
 freq = 16000
 

--- a/tests/unit/test_unit_multidataset.py
+++ b/tests/unit/test_unit_multidataset.py
@@ -27,7 +27,7 @@ import nemo
 from nemo.backends.pytorch.common import DataCombination
 from nemo.core import ChannelType, NeuralType
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 @pytest.mark.usefixtures("neural_factory")

--- a/tests/unit/test_unit_multidataset.py
+++ b/tests/unit/test_unit_multidataset.py
@@ -26,7 +26,6 @@ import torch
 import nemo
 from nemo.backends.pytorch.common import DataCombination
 from nemo.core import ChannelType, NeuralType
-
 from nemo.utils import logging
 
 

--- a/tests/unit/test_unit_speech_commands.py
+++ b/tests/unit/test_unit_speech_commands.py
@@ -30,7 +30,7 @@ import nemo.collections.asr as nemo_asr
 from nemo.collections.asr.parts import AudioLabelDataset, WaveformFeaturizer, collections, parsers, perturb
 from nemo.core import DeviceType
 
-logging = nemo.logging
+from nemo.utils import logging
 
 
 freq = 16000

--- a/tests/unit/test_unit_speech_commands.py
+++ b/tests/unit/test_unit_speech_commands.py
@@ -29,9 +29,7 @@ import nemo
 import nemo.collections.asr as nemo_asr
 from nemo.collections.asr.parts import AudioLabelDataset, WaveformFeaturizer, collections, parsers, perturb
 from nemo.core import DeviceType
-
 from nemo.utils import logging
-
 
 freq = 16000
 


### PR DESCRIPTION
This PR focuses on fixing the dependency issue in NeMo:
 * NeMo **optionally** depends on Apex
 * NeMo NLP collection depends on megatron-lm
 * megatron-lm **requires** on Apex
As a result, our `./reinstall/setup.py` might install `megatron`, but without Apex the code will crush. And not one examle - ALL CODE/EXAMPLES/TESTS

Fix:
 * [x] try around megatron-related imports
 * [x] __megatron_..._satisfied flag that is used for injecting megatron-dependent code artifacts

Additionally it cleans up several files from unnecessary importing whole NeMo (`import nemo`):
 * [x] replaces all `logging = nemo.logging` with from `nemo.utils import logging`
 * [x] removes all unused `import nemo'