### PR TITLE
[WIP] Megatron Model Parallelism in NeMo

### DIFF
--- a/examples/nlp/glue_benchmark/glue_benchmark_with_bert.py
+++ b/examples/nlp/glue_benchmark/glue_benchmark_with_bert.py
@@ -227,13 +227,6 @@ nf = nemo_core.NeuralModuleFactory(
     random_seed=args.random_seed,
 )
 
-# print(f'World size: {nf.world_size}')
-# print(f'Model parallel size: {nf.model_parallel_size}')
-# print(f'Data Parallel Size: {nf.data_parallel_size}')
-# print(f'Global rank: {nf.global_rank}')
-# print(f'Local rank: {nf.local_rank}')
-# print(f'Model parallel rank: {nf.model_parallel_rank}')
-# print(f'Data parallel rank: {nf.data_parallel_rank}')
 
 logging.info(f"Args: {args}")
 
@@ -244,9 +237,6 @@ model = nemo_nlp.nm.trainables.get_pretrained_lm_model(
     checkpoint=args.bert_checkpoint,
     local_rank=nf.local_rank,
 )
-import time
-# print('Loaded Megatron and now sleeping for 20')
-# time.sleep(20)
 
 tokenizer = nemo.collections.nlp.data.tokenizers.get_tokenizer(
     tokenizer_name=args.tokenizer,
@@ -273,8 +263,6 @@ else:
         dropout=args.fc_dropout)
     glue_loss = CrossEntropyLossNM()
 
-# print('Instantiated classifier and now sleeping for 20')
-# time.sleep(20)
 
 def create_pipeline(
     max_seq_length=args.max_seq_length,

--- a/examples/nlp/glue_benchmark/glue_benchmark_with_bert.py
+++ b/examples/nlp/glue_benchmark/glue_benchmark_with_bert.py
@@ -357,9 +357,8 @@ callback_train = nemo_core.SimpleLossLoggerCallback(
 ckpt_callback = nemo_core.CheckpointCallback(
     folder=nf.checkpoint_dir, epoch_freq=args.save_epoch_freq, step_freq=args.save_step_freq
 )
-# callbacks = [callback_train, ckpt_callback] + callbacks_eval
 
-callbacks = [callback_train] + callbacks_eval
+callbacks = [callback_train, ckpt_callback] + callbacks_eval
 
 logging.info(f"callbacks: {callbacks}")
 

--- a/examples/nlp/glue_benchmark/glue_benchmark_with_bert.py
+++ b/examples/nlp/glue_benchmark/glue_benchmark_with_bert.py
@@ -141,16 +141,13 @@ parser.add_argument("--lr", default=5e-5, type=float, help="The initial learning
 parser.add_argument("--lr_warmup_proportion", default=0.1, type=float, help="Learning rate warm up proportion")
 parser.add_argument("--weight_decay", default=0.0, type=float, help="Weight decay if we apply some.")
 parser.add_argument("--grad_norm_clip", default=1.0, type=float)
-parser.add_argument("--lr_policy", default="WarmupAnnealing", type=str)
-parser.add_argument("--lr", default=5e-5, type=float, help="The initial learning rate.")
-parser.add_argument("--lr_warmup_proportion", default=0.1, type=float)
 parser.add_argument("--weight_decay", default=0.0, type=float, help="Weight deay if we apply some.")
 parser.add_argument("--fc_dropout", default=0.1, type=float)
 parser.add_argument("--num_fc_layers", default=1, type=int)
 parser.add_argument("--num_workers", default=1, type=int, help="Num workers to use with data loader.")
 parser.add_argument("--num_epochs", default=3, type=int, help="Total number of training epochs to perform.")
 parser.add_argument("--batch_size", default=8, type=int, help="Batch size per GPU/CPU for training/evaluation.")
-parser.add_argument("--num_gpus", default=1, type=int, help="Number of GPUs")
+parser.add_argument("--num_gpus", default=1, type=int, help="Number of GPUs (number of logical GPUs if using model parallelism)")
 parser.add_argument(
     "--amp_opt_level", default="O0", type=str, choices=["O0", "O1", "O2"], help="01/02 to enable mixed precision"
 )

--- a/examples/nlp/glue_benchmark/glue_benchmark_with_bert.py
+++ b/examples/nlp/glue_benchmark/glue_benchmark_with_bert.py
@@ -141,7 +141,6 @@ parser.add_argument("--lr", default=5e-5, type=float, help="The initial learning
 parser.add_argument("--lr_warmup_proportion", default=0.1, type=float, help="Learning rate warm up proportion")
 parser.add_argument("--weight_decay", default=0.0, type=float, help="Weight decay if we apply some.")
 parser.add_argument("--grad_norm_clip", default=1.0, type=float)
-parser.add_argument("--weight_decay", default=0.0, type=float, help="Weight deay if we apply some.")
 parser.add_argument("--fc_dropout", default=0.1, type=float)
 parser.add_argument("--num_fc_layers", default=1, type=int)
 parser.add_argument("--num_workers", default=1, type=int, help="Num workers to use with data loader.")

--- a/examples/nlp/glue_benchmark/glue_benchmark_with_bert.py
+++ b/examples/nlp/glue_benchmark/glue_benchmark_with_bert.py
@@ -146,7 +146,9 @@ parser.add_argument("--num_fc_layers", default=1, type=int)
 parser.add_argument("--num_workers", default=1, type=int, help="Num workers to use with data loader.")
 parser.add_argument("--num_epochs", default=3, type=int, help="Total number of training epochs to perform.")
 parser.add_argument("--batch_size", default=8, type=int, help="Batch size per GPU/CPU for training/evaluation.")
-parser.add_argument("--num_gpus", default=1, type=int, help="Number of GPUs (number of logical GPUs if using model parallelism)")
+parser.add_argument(
+    "--num_gpus", default=1, type=int, help="Number of GPUs (number of logical GPUs if using model parallelism)"
+)
 parser.add_argument(
     "--amp_opt_level", default="O0", type=str, choices=["O0", "O1", "O2"], help="01/02 to enable mixed precision"
 )
@@ -250,9 +252,7 @@ hidden_size = model.hidden_size
 
 # uses [CLS] token for classification (the first token)
 if args.task_name == "sts-b":
-    pooler = SequenceRegression(
-        hidden_size=hidden_size,
-        dropout=args.fc_dropout)
+    pooler = SequenceRegression(hidden_size=hidden_size, dropout=args.fc_dropout)
     glue_loss = MSELoss()
 else:
     pooler = SequenceClassifier(
@@ -260,7 +260,8 @@ else:
         num_classes=num_labels,
         log_softmax=False,
         num_layers=args.num_fc_layers,
-        dropout=args.fc_dropout)
+        dropout=args.fc_dropout,
+    )
     glue_loss = CrossEntropyLossNM()
 
 
@@ -309,7 +310,7 @@ def create_pipeline(
 
 token_params = {"bos_token": None, "eos_token": "[SEP]", "pad_token": "[PAD]", "cls_token": "[CLS]"}
 
-#train_loss, steps_per_epoch, _, _ = create_pipeline()
+# train_loss, steps_per_epoch, _, _ = create_pipeline()
 train_loss, steps_per_epoch, train_data_layer, _ = create_pipeline()
 
 logging.info(f'steps_per_epoch: {steps_per_epoch}')
@@ -356,7 +357,7 @@ callback_train = nemo_core.SimpleLossLoggerCallback(
 ckpt_callback = nemo_core.CheckpointCallback(
     folder=nf.checkpoint_dir, epoch_freq=args.save_epoch_freq, step_freq=args.save_step_freq
 )
-#callbacks = [callback_train, ckpt_callback] + callbacks_eval
+# callbacks = [callback_train, ckpt_callback] + callbacks_eval
 
 callbacks = [callback_train] + callbacks_eval
 
@@ -373,9 +374,7 @@ if args.wandb_project and args.wandb_experiment:
     callbacks.append(wand_callback)
 
 lr_policy_fn = get_lr_policy(
-    args.lr_policy,
-    total_steps=args.num_epochs * steps_per_epoch,
-    warmup_ratio=args.lr_warmup_proportion
+    args.lr_policy, total_steps=args.num_epochs * steps_per_epoch, warmup_ratio=args.lr_warmup_proportion
 )
 
 

--- a/examples/nlp/question_answering/question_answering_squad.py
+++ b/examples/nlp/question_answering/question_answering_squad.py
@@ -191,6 +191,8 @@ def parse_args():
         "--amp_opt_level", default="O0", type=str, choices=["O0", "O1", "O2"], help="01/02 to enable mixed precision"
     )
     parser.add_argument("--local_rank", type=int, default=None, help="For distributed training: local_rank")
+    parser.add_argument("--model-parallel-size", default=None, type=int, help="For Megatron style model parallelism.")
+    parser.add_argument("--random_seed", default=None, type=int)
     parser.add_argument(
         "--work_dir",
         default='output_squad',
@@ -251,6 +253,7 @@ def parse_args():
         default="nbest.json",
         help="File to write nbest predictions to. Only in evaluation or test mode.",
     )
+    parser.add_argument("--no_time_to_log_dir", action="store_true", help="whether to add time to work_dir or not")
     args = parser.parse_args()
     return args
 
@@ -338,7 +341,9 @@ if __name__ == "__main__":
         log_dir=args.work_dir,
         create_tb_writer=True,
         files_to_copy=[__file__],
-        add_time_to_log_dir=False,
+        add_time_to_log_dir=not args.no_time_to_log_dir,
+        model_parallel_size=args.model_parallel_size,
+        random_seed=args.random_seed,
     )
 
     model = nemo_nlp.nm.trainables.get_pretrained_lm_model(
@@ -346,6 +351,7 @@ if __name__ == "__main__":
         config=args.bert_config,
         vocab=args.vocab_file,
         checkpoint=args.bert_checkpoint,
+        local_rank=args.local_rank,
     )
 
     tokenizer = nemo.collections.nlp.data.tokenizers.get_tokenizer(

--- a/examples/nlp/question_answering/question_answering_squad.py
+++ b/examples/nlp/question_answering/question_answering_squad.py
@@ -341,7 +341,7 @@ if __name__ == "__main__":
         log_dir=args.work_dir,
         create_tb_writer=True,
         files_to_copy=[__file__],
-        add_time_to_log_dir=not args.no_time_to_log_dir,
+        add_time_to_log_dir=False,
         model_parallel_size=args.model_parallel_size,
         random_seed=args.random_seed,
     )

--- a/examples/nlp/token_classification/token_classification.py
+++ b/examples/nlp/token_classification/token_classification.py
@@ -153,10 +153,11 @@ nf = nemo.core.NeuralModuleFactory(
     create_tb_writer=True,
     files_to_copy=[__file__],
     add_time_to_log_dir=not args.no_time_to_log_dir,
+    model_parallel_size=args.model-parallel-size,
+    random_seed=args.random_seed,
 )
 
 output_file = f'{nf.work_dir}/output.txt'
-
 
 model = nemo_nlp.nm.trainables.get_pretrained_lm_model(
     pretrained_model_name=args.pretrained_model_name,

--- a/examples/nlp/token_classification/token_classification.py
+++ b/examples/nlp/token_classification/token_classification.py
@@ -165,6 +165,7 @@ model = nemo_nlp.nm.trainables.get_pretrained_lm_model(
     config=args.bert_config,
     vocab=args.vocab_file,
     checkpoint=args.bert_checkpoint,
+    local_rank=nf.local_rank,
 )
 
 hidden_size = model.hidden_size

--- a/examples/nlp/token_classification/token_classification.py
+++ b/examples/nlp/token_classification/token_classification.py
@@ -146,6 +146,7 @@ if not os.path.exists(args.data_dir):
         "-NER/tree/master/data."
     )
 
+
 nf = nemo.core.NeuralModuleFactory(
     local_rank=args.local_rank,
     optimization_level=args.amp_opt_level,
@@ -153,7 +154,7 @@ nf = nemo.core.NeuralModuleFactory(
     create_tb_writer=True,
     files_to_copy=[__file__],
     add_time_to_log_dir=not args.no_time_to_log_dir,
-    model_parallel_size=args.model-parallel-size,
+    model_parallel_size=args.model_parallel_size,
     random_seed=args.random_seed,
 )
 

--- a/examples/nlp/token_classification/token_classification.py
+++ b/examples/nlp/token_classification/token_classification.py
@@ -30,8 +30,8 @@ from nemo.collections.nlp.callbacks.token_classification_callback import eval_ep
 from nemo.collections.nlp.data.datasets.datasets_utils.data_preprocessing import calc_class_weights
 from nemo.collections.nlp.nm.data_layers import BertTokenClassificationDataLayer
 from nemo.collections.nlp.nm.trainables import TokenClassifier
-from nemo.utils.lr_policies import get_lr_policy
 from nemo.utils.app_state import AppState
+from nemo.utils.lr_policies import get_lr_policy
 
 # Parsing arguments
 """Provide extra arguments required for tasks."""
@@ -288,9 +288,7 @@ ckpt_callback = nemo.core.CheckpointCallback(
 # callbacks.append(ckpt_callback)
 
 lr_policy_fn = get_lr_policy(
-    args.lr_policy,
-    total_steps=args.num_epochs * steps_per_epoch,
-    warmup_ratio=args.lr_warmup_proportion
+    args.lr_policy, total_steps=args.num_epochs * steps_per_epoch, warmup_ratio=args.lr_warmup_proportion
 )
 
 
@@ -304,6 +302,6 @@ nf.train(
         "num_epochs": args.num_epochs,
         "lr": args.lr,
         "weight_decay": args.weight_decay,
-        "grad_norm_clip": args.grad_norm_clip
+        "grad_norm_clip": args.grad_norm_clip,
     },
 )

--- a/examples/nlp/token_classification/token_classification.py
+++ b/examples/nlp/token_classification/token_classification.py
@@ -37,7 +37,9 @@ from nemo.utils.lr_policies import get_lr_policy
 parser = argparse.ArgumentParser(description="Token classification with pretrained BERT")
 parser.add_argument("--local_rank", default=None, type=int)
 
-# training arguments
+# Training arguments
+parser.add_argument("--model-parallel-size", default=None, type=int)
+parser.add_argument("--random_seed", default=None, type=int)
 parser.add_argument(
     "--work_dir",
     default='output',
@@ -48,6 +50,12 @@ parser.add_argument("--no_time_to_log_dir", action="store_true", help="whether t
 parser.add_argument("--num_gpus", default=1, type=int)
 parser.add_argument("--num_epochs", default=5, type=int)
 parser.add_argument("--amp_opt_level", default="O0", type=str, choices=["O0", "O1", "O2"])
+parser.add_argument(
+    "--checkpoints_to_keep",
+    default=4,
+    type=int,
+    help="Number of checkpoints to keep",
+)
 parser.add_argument(
     "--save_epoch_freq",
     default=1,
@@ -119,9 +127,13 @@ parser.add_argument(
     help="Name of the pre-trained model",
     choices=nemo_nlp.nm.trainables.get_pretrained_lm_models_list(),
 )
-parser.add_argument("--bert_checkpoint", default=None, type=str, help="Path to bert pretrained  checkpoint")
+parser.add_argument(
+    "--bert_checkpoint",
+    default=None,
+    type=str,
+    help="Path to model file. (If using model parallel, path to checkpoint directory.)"
+)
 parser.add_argument("--bert_config", default=None, type=str, help="Path to bert config file in json format")
-
 
 args = parser.parse_args()
 logging.info(args)

--- a/examples/nlp/token_classification/token_classification.py
+++ b/examples/nlp/token_classification/token_classification.py
@@ -51,10 +51,7 @@ parser.add_argument("--num_gpus", default=1, type=int)
 parser.add_argument("--num_epochs", default=5, type=int)
 parser.add_argument("--amp_opt_level", default="O0", type=str, choices=["O0", "O1", "O2"])
 parser.add_argument(
-    "--checkpoints_to_keep",
-    default=4,
-    type=int,
-    help="Number of checkpoints to keep",
+    "--checkpoints_to_keep", default=4, type=int, help="Number of checkpoints to keep",
 )
 parser.add_argument(
     "--save_epoch_freq",
@@ -131,7 +128,7 @@ parser.add_argument(
     "--bert_checkpoint",
     default=None,
     type=str,
-    help="Path to model file. (If using model parallel, path to checkpoint directory.)"
+    help="Path to model file. (If using model parallel, path to checkpoint directory.)",
 )
 parser.add_argument("--bert_config", default=None, type=str, help="Path to bert config file in json format")
 

--- a/examples/nlp/token_classification/token_classification.py
+++ b/examples/nlp/token_classification/token_classification.py
@@ -31,6 +31,7 @@ from nemo.collections.nlp.data.datasets.datasets_utils.data_preprocessing import
 from nemo.collections.nlp.nm.data_layers import BertTokenClassificationDataLayer
 from nemo.collections.nlp.nm.trainables import TokenClassifier
 from nemo.utils.lr_policies import get_lr_policy
+from nemo.utils.app_state import AppState
 
 # Parsing arguments
 """Provide extra arguments required for tasks."""
@@ -163,7 +164,7 @@ model = nemo_nlp.nm.trainables.get_pretrained_lm_model(
     config=args.bert_config,
     vocab=args.vocab_file,
     checkpoint=args.bert_checkpoint,
-    local_rank=nf.local_rank,
+    local_rank=AppState().local_rank,
 )
 
 hidden_size = model.hidden_size

--- a/examples/nlp/token_classification/token_classification.py
+++ b/examples/nlp/token_classification/token_classification.py
@@ -285,7 +285,7 @@ if "eval" in args.mode:
 ckpt_callback = nemo.core.CheckpointCallback(
     folder=nf.checkpoint_dir, epoch_freq=args.save_epoch_freq, step_freq=args.save_step_freq
 )
-# callbacks.append(ckpt_callback)
+callbacks.append(ckpt_callback)
 
 lr_policy_fn = get_lr_policy(
     args.lr_policy, total_steps=args.num_epochs * steps_per_epoch, warmup_ratio=args.lr_warmup_proportion

--- a/nemo/backends/pytorch/actions.py
+++ b/nemo/backends/pytorch/actions.py
@@ -453,16 +453,13 @@ class PtActions(Actions):
                 assert dist.is_initialized()
                 is_distributed = True
                 world_size = torch.distributed.get_world_size()
-<<<<<<< HEAD
 
-=======
                 # logging.info(
                 #     "Doing distributed evaluation. Rank {0} of {1}".format(
                 #         self.local_rank, world_size
                 #     )
                 # )
                 logging.info(f'Data parallel size: {self.data_parallel_size}')
->>>>>>> updated _train and _eval to use data_parallel_group for DDP and data_parallel_rank/size for DistributedSampler
                 if dl_nm.dataset is not None:
                     sampler = None
                     if not isinstance(dl_nm.dataset, torch.utils.data.IterableDataset):
@@ -1393,9 +1390,7 @@ class PtActions(Actions):
                             )
                             sync_batchnorm_group = torch.distributed.new_group(group_rank_ids)
 
-<<<<<<< HEAD
                         module = nn.SyncBatchNorm.convert_sync_batchnorm(module, process_group=sync_batchnorm_group)
-=======
                         # By default, disable broadcast_buffers. This disables batch norm synchronization on forward
                         # pass
                         # pmodule = DDP(
@@ -1407,7 +1402,6 @@ class PtActions(Actions):
                             pmodule, device_ids=[i], output_device=i, 
                             process_group=self.data_parallel_group
                         )
->>>>>>> updated _train and _eval to use data_parallel_group for DDP and data_parallel_rank/size for DistributedSampler
 
                     # By default, disable broadcast_buffers. This disables batch norm synchronization on forward
                     # pass

--- a/nemo/backends/pytorch/actions.py
+++ b/nemo/backends/pytorch/actions.py
@@ -51,7 +51,13 @@ _float_2_half_req = {
 
 class PtActions(Actions):
     def __init__(
-        self, local_rank=None, global_rank=None, tb_writer=None, optimization_level=Optimization.mxprO0,
+        self,
+        local_rank=None,
+        global_rank=None,
+        dp_rank=None,
+        mp_rank=None,
+        tb_writer=None,
+        optimization_level=Optimization.mxprO0,
     ):
         need_apex = local_rank is not None or optimization_level != Optimization.mxprO0
         if need_apex:
@@ -81,7 +87,11 @@ class PtActions(Actions):
                 )
 
         super(PtActions, self).__init__(
-            local_rank=local_rank, global_rank=global_rank, optimization_level=optimization_level,
+            local_rank=local_rank,
+            global_rank=global_rank,
+            dp_rank=dp_rank,
+            mp_rank=mp_rank,
+            optimization_level=optimization_level,
         )
 
         self._step = 0

--- a/nemo/backends/pytorch/actions.py
+++ b/nemo/backends/pytorch/actions.py
@@ -1394,16 +1394,24 @@ class PtActions(Actions):
                         #     pmodule, device_ids=[self.local_rank],
                         #     broadcast_buffers=False, find_unused_parameters=True
                         # )
-                        i = torch.cuda.current_device()
-                        pmodule = DDP(
-                            pmodule, device_ids=[i], output_device=i, 
-                            process_group=self.data_parallel_group
-                        )
+                        # i = torch.cuda.current_device()
+                        # pmodule = DDP(
+                        #     pmodule, device_ids=[i], output_device=i, 
+                        #     process_group=AppState().data_parallel_group
+                        # )
 
                     # By default, disable broadcast_buffers. This disables batch norm synchronization on forward
                     # pass
+                    # module = DDP(
+                    #     module, device_ids=[self.local_rank], broadcast_buffers=False, find_unused_parameters=True
+                    # )
                     module = DDP(
-                        module, device_ids=[self.local_rank], broadcast_buffers=False, find_unused_parameters=True
+                        module,
+                        device_ids=[AppState().local_rank],
+                        output_device=AppState().local_rank,
+                        broadcast_buffers=False,
+                        find_unused_parameters=True,
+                        process_group=AppState().data_parallel_group
                     )
                     self.ddp_module_dict[key] = module
 

--- a/nemo/backends/pytorch/actions.py
+++ b/nemo/backends/pytorch/actions.py
@@ -51,12 +51,8 @@ _float_2_half_req = {
 
 class PtActions(Actions):
     def __init__(
-        self,
-        local_rank=None,
-        global_rank=None,
-        tb_writer=None,
-        optimization_level=Optimization.mxprO0,
-        ):
+        self, local_rank=None, global_rank=None, tb_writer=None, optimization_level=Optimization.mxprO0,
+    ):
         need_apex = local_rank is not None or optimization_level != Optimization.mxprO0
         if need_apex:
             try:
@@ -85,9 +81,7 @@ class PtActions(Actions):
                 )
 
         super(PtActions, self).__init__(
-            local_rank=local_rank,
-            global_rank=global_rank,
-            optimization_level=optimization_level,
+            local_rank=local_rank, global_rank=global_rank, optimization_level=optimization_level,
         )
 
         self._step = 0
@@ -444,7 +438,7 @@ class PtActions(Actions):
             if dl_nm.placement == DeviceType.AllGpu:
                 assert dist.is_initialized()
                 is_distributed = True
-                #world_size = torch.distributed.get_world_size()
+                # world_size = torch.distributed.get_world_size()
                 world_size = AppState().world_size
 
                 # logging.info(
@@ -455,13 +449,15 @@ class PtActions(Actions):
                 if dl_nm.dataset is not None:
                     sampler = None
                     if not isinstance(dl_nm.dataset, torch.utils.data.IterableDataset):
-                        #TODO: add num_replicas = data parallel world size from attribute
+                        # TODO: add num_replicas = data parallel world size from attribute
                         # sampler = torch.utils.data.distributed.DistributedSampler(
                         #     dataset=dl_nm.dataset, shuffle=dl_nm.shuffle
                         # )
                         sampler = torch.utils.data.distributed.DistributedSampler(
-                            dataset=dl_nm.dataset, shuffle=dl_nm.shuffle, rank=AppState().data_parallel_rank,
-                            num_replicas=AppState().data_parallel_size
+                            dataset=dl_nm.dataset,
+                            shuffle=dl_nm.shuffle,
+                            rank=AppState().data_parallel_rank,
+                            num_replicas=AppState().data_parallel_size,
                         )
                     dataloader_params = {
                         'dataset': dl_nm.dataset,
@@ -642,7 +638,7 @@ class PtActions(Actions):
                     raise NotImplementedError("Caching is not available for distributed training.")
                 assert dist.is_initialized()
                 is_distributed = True
-                #world_size = torch.distributed.get_world_size()
+                # world_size = torch.distributed.get_world_size()
                 world_size = AppState().world_size
                 if dl_nm.dataset is not None:
                     sampler = None
@@ -651,7 +647,7 @@ class PtActions(Actions):
                             dataset=dl_nm.dataset,
                             shuffle=dl_nm.shuffle,
                             rank=AppState().data_parallel_rank,
-                            num_replicas=AppState().data_parallel_size
+                            num_replicas=AppState().data_parallel_size,
                         )
                     dataloader_params = {
                         'dataset': dl_nm.dataset,
@@ -1336,7 +1332,7 @@ class PtActions(Actions):
                         dataset=t_dataset,
                         shuffle=dataNM.shuffle,
                         rank=AppState().data_parallel_rank,
-                        num_replicas=AppState().data_parallel_size
+                        num_replicas=AppState().data_parallel_size,
                     )
                     # train_sampler = torch.utils.data.distributed.DistributedSampler(
                     #     dataset=t_dataset, shuffle=dataNM.shuffle, rank=self.dp_rank,
@@ -1396,7 +1392,7 @@ class PtActions(Actions):
                         # )
                         # i = torch.cuda.current_device()
                         # pmodule = DDP(
-                        #     pmodule, device_ids=[i], output_device=i, 
+                        #     pmodule, device_ids=[i], output_device=i,
                         #     process_group=AppState().data_parallel_group
                         # )
 
@@ -1411,7 +1407,7 @@ class PtActions(Actions):
                         output_device=AppState().local_rank,
                         broadcast_buffers=False,
                         find_unused_parameters=True,
-                        process_group=AppState().data_parallel_group
+                        process_group=AppState().data_parallel_group,
                     )
                     self.ddp_module_dict[key] = module
 

--- a/nemo/collections/nlp/nm/trainables/common/common_utils.py
+++ b/nemo/collections/nlp/nm/trainables/common/common_utils.py
@@ -83,6 +83,7 @@ def get_pretrained_lm_model(pretrained_model_name, config=None, vocab=None, chec
     if checkpoint:
         if pretrained_model_name == 'megatron-bert-cased' or pretrained_model_name == 'megatron-bert-uncased':
             model.megatron_restore_from(checkpoint, local_rank)
-        model.restore_from(checkpoint, local_rank)
+        else:
+            model.restore_from(checkpoint, local_rank)
         logging.info(f"{pretrained_model_name} model restored from {checkpoint}")
     return model

--- a/nemo/collections/nlp/nm/trainables/common/common_utils.py
+++ b/nemo/collections/nlp/nm/trainables/common/common_utils.py
@@ -88,7 +88,7 @@ def get_pretrained_lm_model(
         raise ValueError(f'{pretrained_model_name} is not supported')
 
     if checkpoint:
-        if pretrained_model_name == 'megatron-bert-cased' or pretrained_model_name == 'megatron-bert-uncased':
+        if 'megatron' in pretrained_model_name:
             model.megatron_restore_from(checkpoint, local_rank)
         else:
             model.restore_from(checkpoint, local_rank)

--- a/nemo/collections/nlp/nm/trainables/common/common_utils.py
+++ b/nemo/collections/nlp/nm/trainables/common/common_utils.py
@@ -42,7 +42,13 @@ def get_pretrained_lm_models_list():
         return get_huggingface_lm_models_list()
 
 
-def get_pretrained_lm_model(pretrained_model_name, config=None, vocab=None, checkpoint=None, local_rank=None):
+def get_pretrained_lm_model(
+    pretrained_model_name,
+    config=None,
+    vocab=None,
+    checkpoint=None,
+    local_rank=None
+    ):
     '''
     Returns pretrained model
     Args:
@@ -51,6 +57,7 @@ def get_pretrained_lm_model(pretrained_model_name, config=None, vocab=None, chec
         config (str): path to the model configuration file
         vocab (str): path to the vocabulary file used during model training 
         checkpoint (str): path to the pretrained model checkpoint
+        local_rank (int): Process rank. Should be set by distributed runner
     Returns:
         Pretrained model (NM)
     '''

--- a/nemo/collections/nlp/nm/trainables/common/common_utils.py
+++ b/nemo/collections/nlp/nm/trainables/common/common_utils.py
@@ -42,7 +42,7 @@ def get_pretrained_lm_models_list():
         return get_huggingface_lm_models_list()
 
 
-def get_pretrained_lm_model(pretrained_model_name, config=None, vocab=None, checkpoint=None):
+def get_pretrained_lm_model(pretrained_model_name, config=None, vocab=None, checkpoint=None, local_rank=None):
     '''
     Returns pretrained model
     Args:
@@ -81,6 +81,8 @@ def get_pretrained_lm_model(pretrained_model_name, config=None, vocab=None, chec
         raise ValueError(f'{pretrained_model_name} is not supported')
 
     if checkpoint:
-        model.restore_from(checkpoint)
+        if pretrained_model_name == 'megatron-bert-cased' or pretrained_model_name == 'megatron-bert-uncased':
+            model.megatron_restore_from(checkpoint, local_rank)
+        model.restore_from(checkpoint, local_rank)
         logging.info(f"{pretrained_model_name} model restored from {checkpoint}")
     return model

--- a/nemo/collections/nlp/nm/trainables/common/common_utils.py
+++ b/nemo/collections/nlp/nm/trainables/common/common_utils.py
@@ -89,7 +89,7 @@ def get_pretrained_lm_model(
 
     if checkpoint:
         if 'megatron' in pretrained_model_name:
-            model.megatron_restore_from(checkpoint, local_rank)
+            model.restore_model_parallel_megatron(checkpoint, local_rank)
         else:
             model.restore_from(checkpoint, local_rank)
         logging.info(f"{pretrained_model_name} model restored from {checkpoint}")

--- a/nemo/collections/nlp/nm/trainables/common/common_utils.py
+++ b/nemo/collections/nlp/nm/trainables/common/common_utils.py
@@ -42,13 +42,7 @@ def get_pretrained_lm_models_list():
         return get_huggingface_lm_models_list()
 
 
-def get_pretrained_lm_model(
-    pretrained_model_name,
-    config=None,
-    vocab=None,
-    checkpoint=None,
-    local_rank=None
-    ):
+def get_pretrained_lm_model(pretrained_model_name, config=None, vocab=None, checkpoint=None, local_rank=None):
     '''
     Returns pretrained model
     Args:

--- a/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
+++ b/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
@@ -17,7 +17,7 @@
 import os
 
 import torch
-from megatron.initialize import set_global_variables, _set_random_seed
+from megatron.initialize import _set_random_seed, set_global_variables
 from megatron.model.bert_model import bert_attention_mask_func, bert_extended_attention_mask, bert_position_ids
 from megatron.model.language_model import get_language_model
 from megatron.model.utils import init_method_normal, scaled_init_method_normal
@@ -90,9 +90,7 @@ class MegatronBERT(TrainableNM):
             "vocab_file": vocab_file,
         }
 
-        set_global_variables(extra_args_provider=None,
-                args_defaults=megatron_args,
-                ignore_unknown_args=True)
+        set_global_variables(extra_args_provider=None, args_defaults=megatron_args, ignore_unknown_args=True)
         if self.factory._random_seed is None:
             raise ValueError("Megatron Neural Module requires Neural Factory to have random_seed is not None.")
         _set_random_seed(self.factory._random_seed)
@@ -130,17 +128,13 @@ class MegatronBERT(TrainableNM):
             input_ids, position_ids, extended_attention_mask, tokentype_ids=token_type_ids
         )
         return sequence_output
-    
-    def restore_model_parallel_megatron(self, path, local_rank=None): 
+
+    def restore_model_parallel_megatron(self, path, local_rank=None):
         if not os.path.isdir(path):
             raise ValueError(f'Megatron checkpoint directory {path} not found')
         if self.factory.model_parallel_size is not None:
             checkpoint_directory = path
-            path = os.path.join(
-                path,
-                f'mp_rank_{self.factory.mp_rank:02d}',
-                'model_optim_rng.pt'
-                )
+            path = os.path.join(path, f'mp_rank_{self.factory.mp_rank:02d}', 'model_optim_rng.pt')
             if not os.path.isfile(path):
                 value_error = (
                     f'Megatron checkpoint file {path} not found.\n'

--- a/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
+++ b/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
@@ -130,8 +130,18 @@ class MegatronBERT(TrainableNM):
             input_ids, position_ids, extended_attention_mask, tokentype_ids=token_type_ids
         )
         return sequence_output
+    
+    def megatron_restore_from(self, path, local_rank=None): 
+        # megatron mp checkpoints must be in the form "path/mp_rank_0X/model_optim_rng.pt"
+        if self.factory.model_parallel_size is not None:
+            path = os.path.join(
+                path,
+                f'mp_rank_{self.factory.mp_rank:02d}',
+                'model_optim_rng.pt'
+                )
+        self.restore_from(path, local_rank)
 
-    def restore_from(self, path, local_rank=0):
+    def restore_from(self, path, local_rank=None):
         if self.placement == DeviceType.AllGpu:
             load_device = f"cuda:{local_rank}"
         else:

--- a/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
+++ b/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
@@ -26,6 +26,7 @@ from nemo.backends.pytorch.nm import TrainableNM
 from nemo.core import DeviceType
 from nemo.core.neural_types import ChannelType, NeuralType
 from nemo.utils.decorators import add_port_docs
+from nemo.utils import logging
 
 __all__ = ['MegatronBERT']
 
@@ -92,7 +93,13 @@ class MegatronBERT(TrainableNM):
 
         set_global_variables(extra_args_provider=None, args_defaults=megatron_args, ignore_unknown_args=True)
         if self.factory._random_seed is None:
-            raise ValueError("Megatron Neural Module requires Neural Factory to have random_seed is not None.")
+            self.factory._random_seed = 1234
+            logging.warning(
+                (
+                    f"Megatron Neural Module requires Neural Factory to have random_seed is not None. "
+                    f"_random_seed has been set to 1234"
+                )
+            )
         _set_random_seed(self.factory._random_seed)
 
         init_method = init_method_normal(init_method_std)

--- a/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
+++ b/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
@@ -17,7 +17,7 @@
 import os
 
 import torch
-from megatron.initialize import initialize_megatron
+from megatron.initialize import set_global_variables, _set_random_seed
 from megatron.model.bert_model import bert_attention_mask_func, bert_extended_attention_mask, bert_position_ids
 from megatron.model.language_model import get_language_model
 from megatron.model.utils import init_method_normal, scaled_init_method_normal
@@ -90,7 +90,13 @@ class MegatronBERT(TrainableNM):
             "vocab_file": vocab_file,
         }
 
-        initialize_megatron(None, megatron_args, ignore_unknown_args=True)
+        set_global_variables(extra_args_provider=None,
+                args_defaults=megatron_args,
+                ignore_unknown_args=True)
+        if self.factory._random_seed is None:
+            raise ValueError("Megatron Neural Module requires Neural Factory to have random_seed is not None.")
+        _set_random_seed(self.factory._random_seed)
+
         init_method = init_method_normal(init_method_std)
 
         self.language_model, self._language_model_key = get_language_model(

--- a/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
+++ b/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
@@ -25,8 +25,8 @@ from megatron.model.utils import init_method_normal, scaled_init_method_normal
 from nemo.backends.pytorch.nm import TrainableNM
 from nemo.core import DeviceType
 from nemo.core.neural_types import ChannelType, NeuralType
-from nemo.utils.decorators import add_port_docs
 from nemo.utils import logging
+from nemo.utils.decorators import add_port_docs
 
 __all__ = ['MegatronBERT']
 

--- a/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
+++ b/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
@@ -92,7 +92,6 @@ class MegatronBERT(TrainableNM):
             "vocab_file": vocab_file,
         }
 
-
         if self.factory.model_parallel_size is not None:
             set_global_variables(extra_args_provider=None, args_defaults=megatron_args, ignore_unknown_args=True)
             if self.factory._random_seed is None:

--- a/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
+++ b/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
@@ -17,7 +17,6 @@
 import os
 
 import torch
-
 from megatron.initialize import set_global_variables
 from megatron.model.bert_model import bert_attention_mask_func, bert_extended_attention_mask, bert_position_ids
 from megatron.model.language_model import get_language_model
@@ -110,7 +109,7 @@ class MegatronBERT(TrainableNM):
                 value_error = (
                     f'_random_seed {self.factory._random_seed} should be a positive integer'
                     f'for model parallel megatron'
-                    )
+                )
                 raise ValueError(value_error)
 
         init_method = init_method_normal(init_method_std)

--- a/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
+++ b/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
@@ -130,7 +130,8 @@ class MegatronBERT(TrainableNM):
                 model_parallel_cuda_manual_seed(AppState().random_seed)
             else:
                 value_error = (
-                    f'_random_seed {AppState().random_seed} should be a positive integer' f'for model parallel megatron'
+                    f'_random_seed {AppState().random_seed} should be a positive integer'
+                    f'for model parallel megatron'
                 )
                 raise ValueError(value_error)
 

--- a/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
+++ b/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
@@ -128,8 +128,8 @@ class MegatronBERT(TrainableNM):
                 )
             )
 
-        if isinstance(AppState().random_seed, int) and AppState().random_seed() > 0:
-            model_parallel_cuda_manual_seed(AppState()._random_seed)
+        if isinstance(AppState().random_seed, int) and AppState().random_seed > 0:
+            model_parallel_cuda_manual_seed(AppState().random_seed)
         else:
             value_error = (
                 f'_random_seed {AppState().random_seed} should be a positive integer'

--- a/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
+++ b/nemo/collections/nlp/nm/trainables/common/megatron/megatron_bert_nm.py
@@ -24,13 +24,12 @@ from megatron.model.language_model import get_language_model
 from megatron.model.utils import init_method_normal, scaled_init_method_normal
 from megatron.mpu import model_parallel_cuda_manual_seed
 
-
 from nemo.backends.pytorch.nm import TrainableNM
 from nemo.core import DeviceType
 from nemo.core.neural_types import ChannelType, NeuralType
 from nemo.utils import logging
-from nemo.utils.decorators import add_port_docs
 from nemo.utils.app_state import AppState
+from nemo.utils.decorators import add_port_docs
 
 __all__ = ['MegatronBERT']
 
@@ -110,12 +109,11 @@ class MegatronBERT(TrainableNM):
         self.language_model.to(self._device)
         self._hidden_size = self.language_model.hidden_size
 
-
     def initialize_megatron(self, megatron_args):
         if AppState().model_parallel_size is None:
             # megatron-lm still needs to initialize model parallel for model parallel size 1
             mpu.initialize.initialize_model_parallel(1)
-        
+
         set_global_variables(extra_args_provider=None, args_defaults=megatron_args, ignore_unknown_args=True)
 
         if self.factory.random_seed is None:
@@ -132,8 +130,7 @@ class MegatronBERT(TrainableNM):
             model_parallel_cuda_manual_seed(AppState().random_seed)
         else:
             value_error = (
-                f'_random_seed {AppState().random_seed} should be a positive integer'
-                f'for model parallel megatron'
+                f'_random_seed {AppState().random_seed} should be a positive integer' f'for model parallel megatron'
             )
             raise ValueError(value_error)
 

--- a/nemo/core/callbacks.py
+++ b/nemo/core/callbacks.py
@@ -110,23 +110,9 @@ def on_epoch_start(func):
     on_epoch_start callback event.
     """
 
-<<<<<<< HEAD
     class NeMoCallbackWrapper(NeMoCallback):
         def __init__(self, my_func):
             self._func = my_func
-=======
-    @property
-    def global_rank(self):
-        return self.action.global_rank
-    
-    @property
-    def mp_rank(self):
-        return self.action.mp_rank
-
-    @property
-    def dp_rank(self):
-        return self.action.dp_rank
->>>>>>> Added mp checkpoint support to CheckpointCallback
 
         def on_epoch_start(self, state):
             self._func(state)
@@ -441,14 +427,8 @@ class CheckpointCallback(NeMoCallback):
         # If True, run will fail if we cannot load module weights
         self._force_load = force_load
 
-<<<<<<< HEAD
     def __save_to(self, path, state):
         if state["global_rank"] is not None and state["global_rank"] != 0:
-=======
-    def __save_to(self, path):
-        # only data parallel rank 0 saves to disk
-        if self.dp_rank is not None and self.dp_rank != 0:
->>>>>>> Added mp checkpoint support to CheckpointCallback
             return
         if self.mp_rank is not None:
             path = os.path.join(
@@ -489,16 +469,7 @@ class CheckpointCallback(NeMoCallback):
             self._saved_ckpts = self._saved_ckpts[-self._ckpt2keep :]
         logging.info(f'Saved checkpoint: {path}/{filename}')
 
-<<<<<<< HEAD
     def __restore_from(self, path, state):
-=======
-    def __restore_from(self, path):
-        if self.mp_rank is not None:
-            path = os.path.join(
-            path,
-            f'mp_rank_{self.mp_rank:02d}',
-            )
->>>>>>> Added mp checkpoint support to CheckpointCallback
         if not os.path.isdir(path):
             if self._force_load:
                 raise ValueError("force_load was set to True for checkpoint callback but a checkpoint was not found.")

--- a/nemo/core/callbacks.py
+++ b/nemo/core/callbacks.py
@@ -431,10 +431,7 @@ class CheckpointCallback(NeMoCallback):
         if state["global_rank"] is not None and state["global_rank"] != 0:
             return
         if self.mp_rank is not None:
-            path = os.path.join(
-                path,
-                f'mp_rank_{self.mp_rank:02d}',
-                )
+            path = os.path.join(path, f'mp_rank_{self.mp_rank:02d}',)
         if not os.path.isdir(path):
             logging.info(f"Creating {path} folder")
             os.makedirs(path, exist_ok=True)

--- a/nemo/core/callbacks.py
+++ b/nemo/core/callbacks.py
@@ -110,9 +110,23 @@ def on_epoch_start(func):
     on_epoch_start callback event.
     """
 
+<<<<<<< HEAD
     class NeMoCallbackWrapper(NeMoCallback):
         def __init__(self, my_func):
             self._func = my_func
+=======
+    @property
+    def global_rank(self):
+        return self.action.global_rank
+    
+    @property
+    def mp_rank(self):
+        return self.action.mp_rank
+
+    @property
+    def dp_rank(self):
+        return self.action.dp_rank
+>>>>>>> Added mp checkpoint support to CheckpointCallback
 
         def on_epoch_start(self, state):
             self._func(state)
@@ -427,9 +441,20 @@ class CheckpointCallback(NeMoCallback):
         # If True, run will fail if we cannot load module weights
         self._force_load = force_load
 
+<<<<<<< HEAD
     def __save_to(self, path, state):
         if state["global_rank"] is not None and state["global_rank"] != 0:
+=======
+    def __save_to(self, path):
+        # only data parallel rank 0 saves to disk
+        if self.dp_rank is not None and self.dp_rank != 0:
+>>>>>>> Added mp checkpoint support to CheckpointCallback
             return
+        if self.mp_rank is not None:
+            path = os.path.join(
+                path,
+                f'mp_rank_{self.mp_rank:02d}',
+                )
         if not os.path.isdir(path):
             logging.info(f"Creating {path} folder")
             os.makedirs(path, exist_ok=True)
@@ -464,7 +489,16 @@ class CheckpointCallback(NeMoCallback):
             self._saved_ckpts = self._saved_ckpts[-self._ckpt2keep :]
         logging.info(f'Saved checkpoint: {path}/{filename}')
 
+<<<<<<< HEAD
     def __restore_from(self, path, state):
+=======
+    def __restore_from(self, path):
+        if self.mp_rank is not None:
+            path = os.path.join(
+            path,
+            f'mp_rank_{self.mp_rank:02d}',
+            )
+>>>>>>> Added mp checkpoint support to CheckpointCallback
         if not os.path.isdir(path):
             if self._force_load:
                 raise ValueError("force_load was set to True for checkpoint callback but a checkpoint was not found.")

--- a/nemo/core/callbacks.py
+++ b/nemo/core/callbacks.py
@@ -430,8 +430,6 @@ class CheckpointCallback(NeMoCallback):
     def __save_to(self, path, state):
         if state["global_rank"] is not None and state["global_rank"] != 0:
             return
-        if self.mp_rank is not None:
-            path = os.path.join(path, f'mp_rank_{self.mp_rank:02d}',)
         if not os.path.isdir(path):
             logging.info(f"Creating {path} folder")
             os.makedirs(path, exist_ok=True)

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -129,13 +129,9 @@ class NeuralModuleFactory(object):
         self._local_rank = local_rank
         AppState().local_rank = local_rank
         self._global_rank = None
-        self._model_parallel_rank = None
-        self._data_parallel_rank = None
 
-        AppState().model_parallel_size = model_parallel_size
         self._model_parallel_size = model_parallel_size
-        self._data_parallel_size = None  # depends on mp size and world size
-        self._data_parallel_group = None  # needed for model parallel
+        AppState().model_parallel_size = model_parallel_size
 
         self._random_seed = random_seed
         AppState().random_seed = random_seed
@@ -492,16 +488,8 @@ class NeuralModuleFactory(object):
         return self._world_size
 
     @property
-    def data_parallel_size(self):
-        return self._data_parallel_size
-
-    @property
     def model_parallel_size(self):
         return self._model_parallel_size
-
-    @property
-    def data_parallel_group(self):
-        return self._data_parallel_group
 
     @property
     def tb_writer(self):
@@ -532,21 +520,5 @@ class NeuralModuleFactory(object):
         return self._local_rank
 
     @property
-    def model_parallel_rank(self):
-        return self._model_parallel_rank
-
-    @property
-    def data_parallel_rank(self):
-        return self._data_parallel_rank
-
-    @property
     def random_seed(self):
         return self._random_seed
-
-    @property
-    def random_seed(self):
-        return self._random_seed
-
-    @random_seed.setter
-    def random_seed(self, seed):
-        self._random_seed = seed

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -252,7 +252,7 @@ class NeuralModuleFactory(object):
                     self._data_parallel_rank = self._global_rank
                     AppState().data_parallel_rank = AppState().global_rank
                     self._data_parallel_size = self._world_size 
-                    AppState().data_parallel_size = Appstate().world_size
+                    AppState().data_parallel_size = AppState().world_size
 
                 def torch_broadcast_wrapper(str_len=None, string=None, src=0):
                     """Wrapper function to broadcast string values across all

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -138,6 +138,7 @@ class NeuralModuleFactory(object):
         self._data_parallel_group = None # needed for model parallel
 
         self._random_seed = random_seed
+        AppState().random_seed = random_seed
 
         if isinstance(optimization_level, str):
             optimization_level = _str_to_opt_level(optimization_level)

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -230,14 +230,11 @@ class NeuralModuleFactory(object):
                     from megatron import mpu
 
                     mpu.initialize.initialize_model_parallel(self._model_parallel_size)
-                    # self._model_parallel_rank = mpu.get_model_parallel_rank()
                     AppState().model_parallel_rank = mpu.get_model_parallel_rank()
-                    # self._data_parallel_rank = mpu.get_data_parallel_rank()
+                    AppState().model_parallel_group = mpu.get_model_parallel_group()
                     AppState().data_parallel_rank = mpu.get_data_parallel_rank()
-                    # self._data_parallel_size = mpu.get_data_parallel_world_size()
                     AppState().data_parallel_size = mpu.get_data_parallel_world_size()
                     AppState().data_parallel_group = mpu.get_data_parallel_group()
-                    # TODO: update app_state properties here
                     logging.info(f'World size: {AppState().world_size}')
                     logging.info(f'Model parallel size: {AppState().model_parallel_size}')
                     logging.info(f'Data parallel size: {AppState().data_parallel_size}')
@@ -247,12 +244,8 @@ class NeuralModuleFactory(object):
                     logging.info(f'Data parallel rank: {AppState().data_parallel_rank}')
                 else:
                     # data parallel only
-                    self._data_parallel_size = self._world_size
                     AppState().data_parallel_size = AppState().world_size
-                    self._data_parallel_rank = self._global_rank
                     AppState().data_parallel_rank = AppState().global_rank
-                    self._data_parallel_size = self._world_size
-                    AppState().data_parallel_size = AppState().world_size
 
                 def torch_broadcast_wrapper(str_len=None, string=None, src=0):
                     """Wrapper function to broadcast string values across all

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -428,6 +428,8 @@ class NeuralModuleFactory(object):
                     self._model_parallel_rank = mpu.get_model_parallel_rank()
                     self._data_parallel_rank = mpu.get_data_parallel_rank()
                     self._data_parallel_size = mpu.get_data_parallel_world_size()
+                    # TODO: update app_state properties here
+                    logging.info(f'World size: {self.world_size}')
                     logging.info(f'Model parallel size: {self.model_parallel_size}')
                     logging.info(f'Model parallel rank: {self.model_parallel_rank}')
                     logging.info(f'Data parallel size: {self.data_parallel_size}')
@@ -630,6 +632,7 @@ class NeuralModuleFactory(object):
     def _get_trainer(self, tb_writer=None):
         if True:  # self._backend == Backend.PyTorch:
             constructor = NeuralModuleFactory.__name_import("nemo.backends.pytorch.PtActions")
+            # TODO: instead of passing in here, get from app_state
             instance = constructor(
                 local_rank=self.local_rank,
                 global_rank=self.global_rank,

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -525,4 +525,4 @@ class NeuralModuleFactory(object):
 
     @random_seed.setter
     def random_seed(self, seed):
-        return self._random_seed = seed
+        self._random_seed = seed

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -77,9 +77,18 @@ class DeviceType(Enum):
 class Actions(ABC):
     """Basic actions allowed on graphs of Neural Modules"""
 
-    def __init__(self, local_rank, global_rank, optimization_level=Optimization.mxprO0):
+    def __init__(
+        self,
+        local_rank,
+        global_rank,
+        dp_rank,
+        mp_rank,
+        optimization_level=Optimization.mxprO0,
+        ):
         self._local_rank = local_rank
         self._global_rank = global_rank
+        self._dp_rank = dp_rank
+        self._mp_rank = mp_rank
         self._optim_level = optimization_level
         self.step = None
         self.epoch_num = None

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -522,3 +522,7 @@ class NeuralModuleFactory(object):
     @property
     def random_seed(self):
         return self._random_seed
+
+    @random_seed.setter
+    def random_seed(self, seed):
+        return self._random_seed = seed

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -78,13 +78,8 @@ class Actions(ABC):
     """Basic actions allowed on graphs of Neural Modules"""
 
     def __init__(
-        self,
-        local_rank,
-        global_rank,
-        dp_rank,
-        mp_rank,
-        optimization_level=Optimization.mxprO0,
-        ):
+        self, local_rank, global_rank, dp_rank, mp_rank, optimization_level=Optimization.mxprO0,
+    ):
         self._local_rank = local_rank
         self._global_rank = global_rank
         self._dp_rank = dp_rank
@@ -110,7 +105,7 @@ class Actions(ABC):
             (int) rank or worker or None if not in distributed model
         """
         return self._global_rank
-    
+
     @property
     def mp_rank(self):
         """Model parallel rank. None if not using model parallelism
@@ -418,6 +413,7 @@ class NeuralModuleFactory(object):
 
                 if self._model_parallel_size is not None:
                     from megatron import mpu
+
                     mpu.initialize.initialize_model_parallel(self._model_parallel_size)
                     self._mp_rank = mpu.get_model_parallel_rank()
                     self._dp_rank = mpu.get_data_parallel_rank()
@@ -647,7 +643,7 @@ class NeuralModuleFactory(object):
     @property
     def world_size(self):
         return self._world_size
-    
+
     @property
     def model_parallel_size(self):
         return self._model_parallel_size
@@ -675,11 +671,11 @@ class NeuralModuleFactory(object):
     @property
     def global_rank(self):
         return self._global_rank
-    
+
     @property
     def local_rank(self):
         return self._local_rank
-    
+
     @property
     def mp_rank(self):
         return self._mp_rank

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -454,10 +454,6 @@ class NeuralModuleFactory(object):
             instance = constructor(
                 local_rank=self.local_rank,
                 global_rank=self.global_rank,
-                data_parallel_rank=self.data_parallel_rank,
-                model_parallel_rank=self.model_parallel_rank,
-                data_parallel_group=self.data_parallel_group,
-                data_parallel_size=self.data_parallel_size,
                 tb_writer=tb_writer,
                 optimization_level=self._optim_level,
             )

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -72,6 +72,182 @@ class DeviceType(Enum):
     AllGpu = 3
 
 
+<<<<<<< HEAD
+=======
+class Actions(ABC):
+    """Basic actions allowed on graphs of Neural Modules"""
+
+    def __init__(self, local_rank, global_rank, optimization_level=Optimization.mxprO0):
+        self._local_rank = local_rank
+        self._global_rank = global_rank
+        self._optim_level = optimization_level
+        self.step = None
+        self.epoch_num = None
+
+    @property
+    def local_rank(self):
+        """Local rank during distributed execution. None if single GPU/CPU
+
+        Returns:
+            (int) rank or worker or None if not in distributed model
+        """
+        return self._local_rank
+
+    @property
+    def global_rank(self):
+        """Global rank during distributed execution. None if single GPU/CPU
+
+        Returns:
+            (int) rank or worker or None if not in distributed model
+        """
+        return self._global_rank
+    
+    @property
+    def mp_rank(self):
+        """Model parallel rank. None if not using model parallelism
+        Returns:
+            (int) model parallel rank or None if not using model parallelism
+        """
+        return self._mp_rank
+
+    @property
+    def dp_rank(self):
+        """Data parallel rank. None if not using data or model parallelism
+        Returns:
+            (int) data parallel rank or None if not using data or model parallelism
+        """
+        return self._dp_rank
+
+    @abstractmethod
+    def train(
+        self,
+        tensors_to_optimize: List[NmTensor],
+        callbacks: Optional[List[ActionCallback]],
+        lr_policy=None,
+        batches_per_step=None,
+        stop_on_nan_loss=False,
+    ):
+        """This action executes training and (optionally) evaluation.
+
+        Args:
+            tensors_to_optimize: which tensors to optimize. Typically this is
+                single loss tesnor.
+            callbacks: list of callback objects
+            lr_policy: function which should take (initial_lr, step, epoch) and
+                return learning rate
+            batches_per_step: number of mini-batches to process before one
+                optimizer step. (default: None, same as 1). Use this
+                to simulate larger batch sizes on hardware which could not fit
+                larger batch in memory otherwise. Effectively, this will make
+                "algorithmic" batch size per GPU/worker = batches_per_step*
+                batch_size
+            stop_on_nan_loss: (default: False) If set to True, the training
+                will stop if loss=nan or inf. If set to False, the training
+                will continue.
+
+        Returns:
+            None
+        """
+        pass
+
+    @abstractmethod
+    def infer(self, tensors: List[NmTensor]):
+        """This action executes inference. Nothing is optimized.
+        Args:
+          tensors: which tensors to evaluate.
+
+        Returns:
+          None
+        """
+        pass
+
+    @abstractmethod
+    def save_state_to(self, path: str):
+        """
+        Saves current state such as step, epoch and optimizer parameters
+        Args:
+          path:
+
+        Returns:
+
+        """
+        pass
+
+    @abstractmethod
+    def restore_state_from(self, path: str):
+        """
+        Restores state such as step, epoch and optimizer parameters
+        Args:
+          path:
+
+        Returns:
+
+        """
+        pass
+
+    @abstractmethod
+    def create_optimizer(self, optimizer, things_to_optimize, optimizer_params):
+        """
+        Creates an optimizer object to be use in the train() method.
+
+        Args:
+            optimizer: Specifies which optimizer to use.
+            things_to_optimize: A list of neural modules or tensors to be
+                optimized.
+            optimizer_params: Specifies the parameters of the optimizer
+
+        Returns:
+            Optimizer
+        """
+        pass
+
+    def _perform_on_iteration_start(self, callbacks):
+        # TODO: Most of these checks can be relaxed since we enforce callbacks
+        # to be a list of ActionCallback objects
+        if callbacks is not None and isinstance(callbacks, List) and len(callbacks) > 0:
+            for callback in callbacks:
+                callback.on_iteration_start()
+
+    def _perform_on_iteration_end(self, callbacks):
+        if callbacks is not None and isinstance(callbacks, List) and len(callbacks) > 0:
+            for callback in callbacks:
+                callback.on_iteration_end()
+
+    def _perform_on_action_start(self, callbacks):
+        if callbacks is not None and isinstance(callbacks, List) and len(callbacks) > 0:
+            for callback in callbacks:
+                callback.on_action_start()
+
+    def _perform_on_action_end(self, callbacks):
+        if callbacks is not None and isinstance(callbacks, List) and len(callbacks) > 0:
+            for callback in callbacks:
+                callback.on_action_end()
+
+    def _perform_on_epoch_start(self, callbacks):
+        if callbacks is not None and isinstance(callbacks, List) and len(callbacks) > 0:
+            for callback in callbacks:
+                callback.on_epoch_start()
+
+    def _perform_on_epoch_end(self, callbacks):
+        if callbacks is not None and isinstance(callbacks, List) and len(callbacks) > 0:
+            for callback in callbacks:
+                callback.on_epoch_end()
+
+    def _init_callbacks(self, callbacks):
+        if callbacks is not None and isinstance(callbacks, List) and len(callbacks) > 0:
+            for callback in callbacks:
+                callback.action = self
+
+    def _update_callbacks(
+        self, callbacks=None, registered_tensors=None,
+    ):
+        # if self.local_rank is None or self.local_rank == 0:
+        if callbacks is not None and isinstance(callbacks, List) and len(callbacks) > 0:
+            for callback in callbacks:
+                callback._registered_tensors = registered_tensors
+
+
+>>>>>>> Added model parallel intialization and properties
 def _str_to_opt_level(opt_str: str) -> Optimization:
     number = int(opt_str[1:])
     if number not in Optimization._value2member_map_:
@@ -105,6 +281,7 @@ class NeuralModuleFactory(object):
             indication
         set_default (bool): (default True) True if should set this instance as
             default factory for modules instantiating.
+        model_parallel_size (int): Number of GPUs to use for model parallelism.
     """
 
     def __init__(
@@ -121,9 +298,16 @@ class NeuralModuleFactory(object):
         create_tb_writer=False,
         files_to_copy=None,
         add_time_to_log_dir=False,
+        model_parallel_size=None,
     ):
         self._local_rank = local_rank
         self._global_rank = None
+        self._mp_rank = None
+        self._dp_rank = None
+
+        self._model_parallel_size = model_parallel_size
+
+        self._random_seed = random_seed
 
         if isinstance(optimization_level, str):
             optimization_level = _str_to_opt_level(optimization_level)
@@ -222,6 +406,14 @@ class NeuralModuleFactory(object):
                     return return_string
 
                 broadcast_func = torch_broadcast_wrapper
+
+                if self._model_parallel_size is not None:
+                    from megatron import mpu
+                    mpu.initialize.initialize_model_parallel(self._model_parallel_size)
+                    self._mp_rank = mpu.get_model_parallel_rank()
+                    self._dp_rank = mpu.get_data_parallel_rank()
+                else:
+                    self._dp_rank = self._global_rank
         else:
             raise NotImplementedError("Only Pytorch backend is currently supported.")
 
@@ -446,6 +638,10 @@ class NeuralModuleFactory(object):
     @property
     def world_size(self):
         return self._world_size
+    
+    @property
+    def model_parallel_size(self):
+        return self._model_parallel_size
 
     @property
     def tb_writer(self):
@@ -470,3 +666,15 @@ class NeuralModuleFactory(object):
     @property
     def global_rank(self):
         return self._global_rank
+    
+    @property
+    def local_rank(self):
+        return self._local_rank
+    
+    @property
+    def mp_rank(self):
+        return self._mp_rank
+
+    @property
+    def dp_rank(self):
+        return self._dp_rank

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -134,8 +134,8 @@ class NeuralModuleFactory(object):
 
         AppState().model_parallel_size = model_parallel_size
         self._model_parallel_size = model_parallel_size
-        self._data_parallel_size = None # depends on mp size and world size
-        self._data_parallel_group = None # needed for model parallel
+        self._data_parallel_size = None  # depends on mp size and world size
+        self._data_parallel_group = None  # needed for model parallel
 
         self._random_seed = random_seed
         AppState().random_seed = random_seed
@@ -223,18 +223,18 @@ class NeuralModuleFactory(object):
                 self._global_rank = torch.distributed.get_rank()
                 AppState().global_rank = torch.distributed.get_rank()
 
-
                 if self.model_parallel_size is not None:
                     logging.info(f'Model parallel being initialized by Megatron-LM')
                     logging.info(f'Updating AppState()')
 
                     from megatron import mpu
+
                     mpu.initialize.initialize_model_parallel(self._model_parallel_size)
-                    #self._model_parallel_rank = mpu.get_model_parallel_rank()
+                    # self._model_parallel_rank = mpu.get_model_parallel_rank()
                     AppState().model_parallel_rank = mpu.get_model_parallel_rank()
-                    #self._data_parallel_rank = mpu.get_data_parallel_rank()
+                    # self._data_parallel_rank = mpu.get_data_parallel_rank()
                     AppState().data_parallel_rank = mpu.get_data_parallel_rank()
-                    #self._data_parallel_size = mpu.get_data_parallel_world_size()
+                    # self._data_parallel_size = mpu.get_data_parallel_world_size()
                     AppState().data_parallel_size = mpu.get_data_parallel_world_size()
                     AppState().data_parallel_group = mpu.get_data_parallel_group()
                     # TODO: update app_state properties here
@@ -251,7 +251,7 @@ class NeuralModuleFactory(object):
                     AppState().data_parallel_size = AppState().world_size
                     self._data_parallel_rank = self._global_rank
                     AppState().data_parallel_rank = AppState().global_rank
-                    self._data_parallel_size = self._world_size 
+                    self._data_parallel_size = self._world_size
                     AppState().data_parallel_size = AppState().world_size
 
                 def torch_broadcast_wrapper(str_len=None, string=None, src=0):
@@ -497,15 +497,15 @@ class NeuralModuleFactory(object):
     @property
     def world_size(self):
         return self._world_size
-    
+
     @property
-    def  data_parallel_size(self):
+    def data_parallel_size(self):
         return self._data_parallel_size
 
     @property
     def model_parallel_size(self):
         return self._model_parallel_size
-    
+
     @property
     def data_parallel_group(self):
         return self._data_parallel_group

--- a/nemo/core/neural_factory.py
+++ b/nemo/core/neural_factory.py
@@ -549,3 +549,11 @@ class NeuralModuleFactory(object):
     @property
     def random_seed(self):
         return self._random_seed
+
+    @property
+    def random_seed(self):
+        return self._random_seed
+
+    @random_seed.setter
+    def random_seed(self, seed):
+        self._random_seed = seed

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -141,80 +141,180 @@ class AppState(metaclass=Singleton):
 
     @property
     def world_size(self):
+        """ Property returns the total number of GPUs.
+
+            Returns:
+                Total number of GPUs.
+        """
         return self._world_size
 
     @world_size.setter
     def world_size(self, size):
+        """ Property sets the total number of GPUs.
+
+            Args:
+                size (int):  Total number of GPUs.
+        """
         self._world_size = size
 
     @property
     def model_parallel_size(self):
+        """ Property returns the number of GPUs in each model parallel group.
+
+            Returns:
+                Number of GPUs in each model parallel group.
+        """
         return self._model_parallel_size
 
     @model_parallel_size.setter
     def model_parallel_size(self, size):
+        """ Property sets the number of GPUs in each model parallel group.
+
+            Args:
+                size (int):  Number of GPUs in each model parallel group.
+        """
         self._model_parallel_size = size
 
     @property
     def data_parallel_size(self):
+        """ Property returns the number of GPUs in each data parallel group.
+
+            Returns:
+                Number of GPUs in each data parallel group.
+        """
         return self._data_parallel_size
 
     @data_parallel_size.setter
     def data_parallel_size(self, size):
+        """ Property sets the number of GPUs in each data parallel group.
+
+            Args:
+                size (int):  Number of GPUs in each data parallel group.
+        """
         self._data_parallel_size = size
 
     @property
     def local_rank(self):
+        """ Property returns the local rank.
+
+            Returns:
+                Local rank.
+        """
         return self._local_rank
 
     @local_rank.setter
     def local_rank(self, rank):
+        """ Property sets the local rank.
+
+            Args:
+                rank (int):  Local rank.
+        """
         self._local_rank = rank
 
     @property
     def global_rank(self):
+        """ Property returns the global rank.
+
+            Returns:
+                Global rank.
+        """
         return self._global_rank
 
     @global_rank.setter
     def global_rank(self, rank):
+        """ Property sets the global rank.
+
+            Args:
+                rank (int):  Global rank.
+        """
         self._global_rank = rank
 
     @property
     def model_parallel_rank(self):
+        """ Property returns the model parallel rank.
+
+            Returns:
+                Model parallel rank.
+        """
         return self._model_parallel_rank
 
     @model_parallel_rank.setter
     def model_parallel_rank(self, rank):
+        """ Property sets the model parallel rank.
+
+            Args:
+                rank (int):  Model parallel rank.
+        """
         self._model_parallel_rank = rank
 
     @property
     def model_parallel_group(self):
+        """ Property returns the model parallel group.
+
+            Returns:
+                Model parallel group.
+        """
         return self._model_parallel_group
 
     @model_parallel_group.setter
     def model_parallel_group(self, group):
+        """ Property sets the model parallel group.
+
+            Args:
+                group:  Model parallel group.
+        """
         self._model_parallel_group = group
 
     @property
     def data_parallel_rank(self):
+        """ Property returns the data parallel rank.
+
+            Returns:
+                Data parallel rank.
+        """
         return self._data_parallel_rank
 
     @data_parallel_rank.setter
     def data_parallel_rank(self, rank):
+        """ Property sets the data parallel rank.
+
+            Args:
+                rank (int):  Data parallel rank.
+        """
         self._data_parallel_rank = rank
 
     @property
     def data_parallel_group(self):
+        """ Property returns the data parallel group.
+
+            Returns:
+                Data parallel group.
+        """
         return self._data_parallel_group
 
     @data_parallel_group.setter
     def data_parallel_group(self, group):
+        """ Property sets the data parallel group.
+
+            Args:
+                group:  Data parallel group.
+        """
         self._data_parallel_group = group
 
     @property
     def random_seed(self):
+        """ Property returns the random seed.
+
+            Returns:
+                Random seed.
+        """
         return self._random_seed
 
     @random_seed.setter
     def random_seed(self, seed):
+        """ Property sets the random seed.
+
+            Args:
+                seed (int):  Random seed.
+        """
         self._random_seed = seed

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -137,11 +137,11 @@ class AppState(metaclass=Singleton):
                 graph: Neural graph object that will become active.
         """
         self._neural_graph_manager.active_graph = graph
-    
+
     @property
     def world_size(self):
         return self._world_size
-    
+
     @world_size.setter
     def world_size(self, size):
         self._world_size = size
@@ -149,7 +149,7 @@ class AppState(metaclass=Singleton):
     @property
     def model_parallel_size(self):
         return self._model_parallel_size
-    
+
     @model_parallel_size.setter
     def model_parallel_size(self, size):
         self._model_parallel_size = size
@@ -157,7 +157,7 @@ class AppState(metaclass=Singleton):
     @property
     def data_parallel_size(self):
         return self._data_parallel_size
-    
+
     @data_parallel_size.setter
     def data_parallel_size(self, size):
         self._data_parallel_size = size
@@ -165,7 +165,7 @@ class AppState(metaclass=Singleton):
     @property
     def local_rank(self):
         return self._local_rank
-    
+
     @local_rank.setter
     def local_rank(self, rank):
         self._local_rank = rank
@@ -173,7 +173,7 @@ class AppState(metaclass=Singleton):
     @property
     def global_rank(self):
         return self._global_rank
-    
+
     @global_rank.setter
     def global_rank(self, rank):
         self._global_rank = rank
@@ -181,7 +181,7 @@ class AppState(metaclass=Singleton):
     @property
     def model_parallel_rank(self):
         return self._model_parallel_rank
-    
+
     @model_parallel_rank.setter
     def model_parallel_rank(self, rank):
         self._model_parallel_rank = rank
@@ -189,7 +189,7 @@ class AppState(metaclass=Singleton):
     @property
     def data_parallel_rank(self):
         return self._data_parallel_rank
-    
+
     @data_parallel_rank.setter
     def data_parallel_rank(self, rank):
         self._data_parallel_rank = rank
@@ -197,7 +197,7 @@ class AppState(metaclass=Singleton):
     @property
     def data_parallel_group(self):
         return self._data_parallel_group
-    
+
     @data_parallel_group.setter
     def data_parallel_group(self, group):
         self._data_parallel_group = group
@@ -205,7 +205,7 @@ class AppState(metaclass=Singleton):
     @property
     def random_seed(self):
         return self._random_seed
-    
+
     @random_seed.setter
     def random_seed(self, seed):
         self._random_seed = seed

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -201,3 +201,11 @@ class AppState(metaclass=Singleton):
     @data_parallel_group.setter
     def data_parallel_group(self, group):
         self._data_parallel_group = group
+
+    @property
+    def random_seed(self):
+        return self._random_seed
+    
+    @random_seed.setter
+    def random_seed(self, seed):
+        self._random_seed = seed

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -57,7 +57,7 @@ class AppState(metaclass=Singleton):
         self._model_parallel_rank = None
         self._data_parallel_rank = None
 
-        self._world_size
+        self._world_size = None
         self._model_parallel_size = None
         self._data_parallel_size = None
         self._data_parallel_group = None
@@ -174,7 +174,7 @@ class AppState(metaclass=Singleton):
     def model_parallel_rank(self):
         return self._model_parallel_rank
     
-    @model_parallel.setter
+    @model_parallel_rank.setter
     def model_parallel_rank(self, rank):
         self._model_parallel_rank = rank
 

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -59,6 +59,7 @@ class AppState(metaclass=Singleton):
 
         self._world_size = None
         self._model_parallel_size = None
+        self._model_parallel_group = None
         self._data_parallel_size = None
         self._data_parallel_group = None
 
@@ -185,6 +186,14 @@ class AppState(metaclass=Singleton):
     @model_parallel_rank.setter
     def model_parallel_rank(self, rank):
         self._model_parallel_rank = rank
+
+    @property
+    def model_parallel_group(self):
+        return self._model_parallel_group
+
+    @model_parallel_group.setter
+    def model_parallel_group(self, group):
+        self._model_parallel_group = group
 
     @property
     def data_parallel_rank(self):

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -51,6 +51,19 @@ class AppState(metaclass=Singleton):
         # Create NmTensor registry
         self._nmtensor_name_registry = NmTensorNameRegistry()
 
+        # World info
+        self._local_rank = None
+        self._global_rank = None
+        self._model_parallel_rank = None
+        self._data_parallel_rank = None
+
+        self._world_size
+        self._model_parallel_size = None
+        self._data_parallel_size = None
+        self._data_parallel_group = None
+
+        self._random_seed = None
+
     @property
     def tensor_names(self):
         """ Property returning the NmTensorNameRegistry which maps user-defined names to tensor's unique_names.
@@ -124,3 +137,59 @@ class AppState(metaclass=Singleton):
                 graph: Neural graph object that will become active.
         """
         self._neural_graph_manager.active_graph = graph
+    
+    @property
+    def world_size(self):
+        return self._world_size
+    
+    @world_size.setter
+    def world_size(self, size):
+        self._world_size = size
+
+    @property
+    def model_parallel_size(self):
+        return self._model_parallel_size
+    
+    @model_parallel_size.setter
+    def model_parallel_size(self, size):
+        self._model_parallel_size = size
+
+    @property
+    def data_parallel_size(self):
+        return self._data_parallel_size
+    
+    @data_parallel_size.setter
+    def data_parallel_size(self, size):
+        self._data_parallel_size = size
+
+    @property
+    def local_rank(self):
+        return self._local_rank
+    
+    @local_rank.setter
+    def local_rank(self, rank):
+        self._local_rank = rank
+
+    @property
+    def model_parallel_rank(self):
+        return self._model_parallel_rank
+    
+    @model_parallel.setter
+    def model_parallel_rank(self, rank):
+        self._model_parallel_rank = rank
+
+    @property
+    def data_parallel_rank(self):
+        return self._data_parallel_rank
+    
+    @data_parallel_rank.setter
+    def data_parallel_rank(self, rank):
+        self._data_parallel_rank = rank
+
+    @property
+    def data_parallel_group(self):
+        return self._data_parallel_group
+    
+    @data_parallel_group.setter
+    def data_parallel_group(self, group):
+        self._data_parallel_group = group

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -171,6 +171,14 @@ class AppState(metaclass=Singleton):
         self._local_rank = rank
 
     @property
+    def global_rank(self):
+        return self._global_rank
+    
+    @global_rank.setter
+    def global_rank(self, rank):
+        self._global_rank = rank
+
+    @property
     def model_parallel_rank(self):
         return self._model_parallel_rank
     


### PR DESCRIPTION
NeMo should have model parallelism because state of the art NLP models often require more model capacity than can fit on a single GPU.

In this PR we begin to add model parallelism to NeMo by first supporting finetuning with the Megatron BERT Neural Module.

Integrating model parallel Megatron models into NeMo requires a little bit of care as Megatron-LM is built from the ground up with model + data parallelism.
Megatron-LM always assumes model parallelism even if it is the trivial case of model parallel size 1.

NeMo's approach to distributed PyTorch assumes data parallelism only. 
After integrating model parallel Megatron models into NeMo, NeMo will have a more robust and intuitive approach to distributed PyTorch.

# TODO
- [x] Update NeMo so that model parallel Megatron models can be trained easily.
  - [x] User only needs to specify model_parallel_size flag in neural factory
  - [ ] Callback works automatically for model parallel
  - [x] Training works automatically for model parallel
  - [x] Eval works automatically for model parallel
  - [ ] Infer works automatically for model parallel
- [x] Validate that Model Parallel Megatron BERT models trained with NeMo achieve similar accuracies to those trained with Megatron-LM
  - [x] GLUE
    - [x] MNLI
    - [x] QQP
  - [x] SQUAD
    - [x] 1.1
    - [x] 2.0
  - [ ] RACE (not in NeMo NLP Examples)
- [ ] Validate scaling performance
  - [x] High GPU Utilization during training
  - [ ] Near linear data parallel scaling

# Changes needed for Megatron Style Model Parallel Training
- [x] Initialization
  - [x] Model parallel intialization should happen when instantiating the factory
  - [x] Model parallel rank
  - [x] Model parallel size
  - [x] Model parallel group
  - [x] Data Parallel rank
  - [x] Data parallel size
  - [x] Data parallel group
- [ ] Checkpointing
  - [x] Restore checkpoints from Megatron-LM
  - [ ] Models now have checkpoints for each model parallel rank
  - [ ] Directory should be given to restore checkpoints from
  - [ ] Checkpoint callback should save and restore mp checkpoints
  - [ ] Only data parallel rank 0 should be saving checkpoints
- [ ] Training
  - [x] Distributed data parallel (DDP)
    - [x] process_group is the data_parallel_group
  - [x] Distributed Sampler
    - [x] rank is data_parallel_rank
    - [x] num_replicas is data_parallel_size
  - [ ] Data Broadcast (for pretraining only)
    - [ ] Data should only be broadcast from CPU to model parallel rank 0
  - [x] Gradient clipping - reduce grads across model parallel group
  - [x] Apex Amp Loss Scaling - reduce overflow across model parallel group
  - [ ] Weight Decay - Megatron-LM does not decay layer norms and biases

# Changes Made

## **nemo/core**
neural_factory.py
- Update model parallel rank, size, and data parallel rank, size, group properties in AppState() after torch distributed initialization
- Add model parallel size argument to NeuralModuleFactory
- Add random_seed argument to NeuralModuleFactory and update AppState()
- Add megatron model parallel initialization to NeuralModuleFactory

## **nemo/utils**
app_state.py
- Add model parallel rank, size, and data parallel rank, size, group properties in AppState()

## **nemo/backends/pytorch**
actions.py
- Added data_parallel_rank/size/group and model_parallel_rank to PtActions
- Update DDP proces_group to data_parallel_group
- Update distributed sampler for _train, _eval to use rank is data_parallel_rank and num_replicas is data_parallel_size
- Add mpu gradient clipping
- Add monkey patch for apex amp loss scaling

## **collections/nlp**
megatron_bert_nm.py
- Remove initialize_megatron call since model and data parallel groups are being initialized from the factory
- Add remaining initializations needed for megatron-lm
- Add megatron_restore_from to load pre-trained models coming from megatron_lm

common_utils.py
- Add megatron_restore_from if megatron checkpoint

## **examples/nlp**
token_classification.py,
glue_benchmark_with_bert.py,
question_answering_squad.py
- Update to work with model parallel megatron