### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/nemo/collections/nlp/data/datasets/sgd_dataset/metrics.py
+++ b/nemo/collections/nlp/data/datasets/sgd_dataset/metrics.py
@@ -47,7 +47,7 @@ https://github.com/google-research/google-research/blob/master/schema_guided_dst
 import collections
 
 import numpy as np
-from fuzzywuzzy import fuzz
+from rapidfuzz import fuzz
 
 F1Scores = collections.namedtuple("F1Scores", ["f1", "precision", "recall"])
 

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -9,8 +9,7 @@ youtokentome
 numpy
 tqdm
 sklearn
-fuzzywuzzy
-python-Levenshtein
+rapidfuzz
 gdown
 megatron-lm
 inflect


### PR DESCRIPTION
FuzzyWuzzy and python-Levenshtein are GPLv2 or later licensed which requires to license projects that use them to be GPL Licensed aswell.
For this reason this Pullrequest replaces FuzzyWuzzy with  [RapidFuzz](https://github.com/maxbachmann/rapidfuzz) (I am the author) which is implementing the same algorithms but is based on a old version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy