### PR TITLE
Clean up TTS and GAN Requirements

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -11,3 +11,4 @@ wget
 wrapt
 ruamel.yaml
 sklearn
+scipy

--- a/requirements/requirements_simple_gan.txt
+++ b/requirements/requirements_simple_gan.txt
@@ -1,2 +1,1 @@
 matplotlib
-torchvision

--- a/requirements/requirements_tts.txt
+++ b/requirements/requirements_tts.txt
@@ -1,5 +1,3 @@
-librosa
 matplotlib
 pypinyin
-scipy
 attrdict


### PR DESCRIPTION
Remove torchvision from GAN as it is already in requirements.txt
Move scipy from TTS to requirements.txt
Remove librosa from TTS as it is already in ASR and TTS depends on ASR.