### PR TITLE
change sklearn to scikit-learn

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,4 +10,4 @@ torchvision
 wget
 wrapt
 ruamel.yaml
-sklearn
+scikit-learn

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -8,7 +8,6 @@ unidecode
 youtokentome
 numpy
 tqdm
-scikit-learn
 rapidfuzz
 gdown
 megatron-lm

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -8,7 +8,7 @@ unidecode
 youtokentome
 numpy
 tqdm
-sklearn
+scikit-learn
 rapidfuzz
 gdown
 megatron-lm


### PR DESCRIPTION
scikit-learn is the official package name with license, sklearn is only a dummy that downloads scikit-learn
Signed-off-by: Yang Zhang <yangzhang@nvidia.com>