### PR TITLE
Nmtensor rename bug fix

### DIFF
--- a/nemo/core/actions.py
+++ b/nemo/core/actions.py
@@ -88,7 +88,7 @@ def topological_sort_from_leaves(leaf_nmtensors: List[NmTensor], cached_training
             all_nodes[node] = {k: None for k in nmtensor.producer.output_ports}
         # second, populate output port with current nmtensor
         # where applicable
-        all_nodes[node][nmtensor.name] = nmtensor
+        all_nodes[node][nmtensor.output_port_name] = nmtensor
         processed_nmtensors.add(nmtensor)
 
         new_tensors = set()

--- a/nemo/core/neural_types/neural_type.py
+++ b/nemo/core/neural_types/neural_type.py
@@ -200,9 +200,9 @@ class NeuralType(object):
 
 
 class NmTensor(NeuralType):
-    """Class representing data which flows between NeuralModules' ports.
-    It also has a type of NeuralType represented by inheriting from NeuralType
-    object."""
+    """Class representing data which flows between NeuralModules' ports. It also has a type of NeuralType represented
+    by inheriting from NeuralType object.
+    """
 
     def __init__(self, producer, producer_args, output_port_name, ntype=None):
         """NmTensor constructor.
@@ -221,6 +221,7 @@ class NmTensor(NeuralType):
         self._producer_args = producer_args
         self._output_port_name = output_port_name
         self._name = output_port_name
+        self._output_port_name = output_port_name
         self._uuid = str(uuid.uuid4())
         # Remember step at which this tensor was created.
         self._step_number = AppState().active_graph.step_number
@@ -232,7 +233,7 @@ class NmTensor(NeuralType):
     def producer(self):
         """
         Returns:
-          NeuralModule object which produced this NmTensor.
+            NeuralModule object which produced this NmTensor.
         """
         return AppState().modules[self._producer_name]
 
@@ -248,8 +249,7 @@ class NmTensor(NeuralType):
     def producer_step_number(self) -> int:
         """
         Returns:
-            Step number indicating when the tensor was produced.
-            (It also indicates who produced the tensor.)
+            Step number indicating when the tensor was produced. (It also indicates who produced the tensor.)
         """
         return self._step_number
 
@@ -257,7 +257,7 @@ class NmTensor(NeuralType):
     def producer_step_module_port(self) -> StepModulePort:
         """
         Returns:
-          A tuple containing step number, module name and corresponding output port name.
+            A tuple containing step number, module name and corresponding output port name.
         """
         return StepModulePort(self._step_number, self._producer_name, self._output_port_name)
 
@@ -265,7 +265,7 @@ class NmTensor(NeuralType):
     def consumers(self) -> List[StepModulePort]:
         """
         Returns:
-          A list of tuples containing consumer step number, module name and corresponding input port names.
+            A list of tuples containing consumer step number, module name and corresponding input port names.
         """
         return self._consumers
 
@@ -289,7 +289,6 @@ class NmTensor(NeuralType):
     def connections(self):
         """
             "Serializes" the tensor to a list of connections (step/producer/port, step/consumer/port).
-
         """
         connections = []
         for con_mod_port in self._consumers:
@@ -300,8 +299,7 @@ class NmTensor(NeuralType):
     def producer_args(self):
         """
         Returns:
-          a dictionary of port_name->NmTensor value
-          of arguments which were sent to producer to create this object
+            A dictionary of port_name->NmTensor value of arguments which were sent to producer to create this object
         """
         return self._producer_args
 
@@ -309,19 +307,26 @@ class NmTensor(NeuralType):
     def name(self):
         """
         Returns:
-          A NmTensor's name which should be equal to
-          the NeuralModule's output port's name which created it
+            A NmTensor's name. By default, it is equal to self.output_port_name, but can be renamed using self.rename.
+            Used in self.__str__() to obtain a string representation of a nmtensor.
         """
         return self._name
 
     @property
+    def output_port_name(self):
+        """
+        Returns:
+            The name of the output port it is associated with. This is used in DAG creation.
+        """
+        return self._output_port_name
+
+    @property
     def unique_name(self):
         """Unique NMTensor name.
-        It is composed of non-unique name (self.name) and uuid of NeuralModule
-        which created this tensor.
+        It is composed of non-unique name (self.name) and uuid of NeuralModule which created this tensor.
 
         Returns:
-          str: unique name
+            str: unique name
         """
         if self._producer_name is None:
             raise ValueError("This NmTensor does not have a unique name")

--- a/tests/unit/core/test_nemo_callbacks.py
+++ b/tests/unit/core/test_nemo_callbacks.py
@@ -109,7 +109,7 @@ class TestNeMoCallbacks:
         with logging.patch_stdout_handler(StringIO()) as std_out:
             self.nf.train(
                 tensors_to_optimize=[loss_tensor],
-                callbacks=[SimpleLogger(step_freq=1, tensors_to_log=['y_pred', extra_tensor])],
+                callbacks=[SimpleLogger(step_freq=1, tensors_to_log=['test_name', extra_tensor])],
                 optimization_params={"max_steps": 4, "lr": 0.01},
                 optimizer="sgd",
             )

--- a/tests/unit/core/test_nemo_callbacks.py
+++ b/tests/unit/core/test_nemo_callbacks.py
@@ -102,8 +102,8 @@ class TestNeMoCallbacks:
         test = DummyNM()
         extra_tensor = test(x=y_pred)
 
-        y_pred.rename("y_pred")
-        assert y_pred.name == "y_pred"
+        y_pred.rename("test_name")
+        assert y_pred.name == "test_name"
 
         # Mock up both std and stderr streams.
         with logging.patch_stdout_handler(StringIO()) as std_out:


### PR DESCRIPTION
This fix addresses a bug where if tensor.rename is called, the resulting call DAG will error out because the call DAG used to rely on tensor.name.
fixed by adding a new property to nmtensor called output_port_name which is used in DAG construction as opposed to tensor.name.
Updates the relevant test to be more robust as well.