### PR TITLE
Callchain fix and update logging

### DIFF
--- a/nemo/backends/pytorch/actions.py
+++ b/nemo/backends/pytorch/actions.py
@@ -1468,6 +1468,7 @@ class PtActions(Actions):
                     else:
                         # Skip this step across workers if loss is NaN/inf and using fp32
                         logging.warning('Loss is NaN or inf. Skipping update.')
+                        self._training_state.clear_dict()  # Clear state dict here
                         continue
 
                 if self._optim_level in AmpOptimizations and self._optim_level != Optimization.mxprO0:

--- a/nemo/core/actions.py
+++ b/nemo/core/actions.py
@@ -102,6 +102,8 @@ def topological_sort_from_leaves(leaf_nmtensors: List[NmTensor], cached_training
                 if cached_training_state.check_tensor_cached(input_nmtensor.unique_name):
                     new_tensors.remove(input_nmtensor)
 
+        # Order the new set so that all ranks have the callchain in the same order
+        new_tensors = sorted(list(new_tensors), key=lambda x: str(x))
         for new_nmtensor in new_tensors:
             # put in the start of list
             hooks_lst.insert(0, new_nmtensor)

--- a/nemo/utils/nemo_logging.py
+++ b/nemo/utils/nemo_logging.py
@@ -102,7 +102,10 @@ class Logger(metaclass=Singleton):
                     self.add_stream_handlers()
 
             finally:
-                self.set_verbosity(verbosity_level=Logger.INFO)
+                level = Logger.INFO
+                if get_envbool(NEMO_ENV_VARNAME_TESTING, False):
+                    level = Logger.DEBUG
+                self.set_verbosity(verbosity_level=level)
 
         self._logger.propagate = False
 


### PR DESCRIPTION
1) Adds a fix to make sure that callchains across all ranks are in the same order --- I only ran into this if len(tensors_to_optimize) > 1.
2) Update nemo.logging such that if NEMO_TESTING is set, the default logging level is DEBUG