### PR TITLE
Callbacks Change

### DIFF
--- a/docs/sources/source/tutorials/old_callbacks.rst
+++ b/docs/sources/source/tutorials/old_callbacks.rst
@@ -194,9 +194,15 @@ printing methods such as printing 1 element or 1 dimension, please look into :re
 :class:`nemo.core.callbacks.TensorboardLogger`, ``get_tb_values``, and ``log_to_tb_func`` have been removed. By
 default `TensorboardLogger` assumes each tensors passed to it in ``tensors_to_log`` is a scalar and logs it to
 tensorboard as a scalar. For more advanced functionality, `TensorboardLogger` accepts ``custom_tb_log_func`` which
-accepts one tensor from ``tensors_to_log`` at a time. In peusdocode, its looks like:
+obtains the values of all tensors from ``tensors_to_log``. In peusdocode, its looks like:
 
 .. code-block::
 
+    tensor_values = []
     for tensor in tensors_to_log:
-        custom_tb_log_func(tensor)
+        tensor_values.append(state["tensors"].get_tensor(tensor))  # Appends a pytorch tensor to tensor_values
+    custom_tb_log_func(
+        tensor_values,  # The list of pytorch tensors associated with tensors_to_log
+        self.tb_writer,  # The tensorboard SummaryWriter class
+        state["step"],  # The current training step
+    )

--- a/examples/asr/speech2text.py
+++ b/examples/asr/speech2text.py
@@ -104,9 +104,10 @@ def main():
     # Callbacks which we'll be using:
     callbacks = []
     # SimpleLossLogger prints basic training stats (e.g. loss) to console
-    train_callback = nemo.core.SimpleLogger(
-        tensors_to_log=[loss, predictions, transcript, transcript_len],
+    train_callback = nemo.core.SimpleLossLoggerCallback(
+        tensors=[loss, predictions, transcript, transcript_len],
         step_freq=args.stats_freq,
+        print_func=partial(monitor_asr_train_progress, labels=asr_model.vocabulary),
     )
     callbacks.append(train_callback)
     if args.checkpoint_dir is not None and args.checkpoint_save_freq is not None:

--- a/examples/asr/speech2text.py
+++ b/examples/asr/speech2text.py
@@ -104,10 +104,9 @@ def main():
     # Callbacks which we'll be using:
     callbacks = []
     # SimpleLossLogger prints basic training stats (e.g. loss) to console
-    train_callback = nemo.core.SimpleLossLoggerCallback(
-        tensors=[loss, predictions, transcript, transcript_len],
+    train_callback = nemo.core.SimpleLogger(
+        tensors_to_log=[loss, predictions, transcript, transcript_len],
         step_freq=args.stats_freq,
-        print_func=partial(monitor_asr_train_progress, labels=asr_model.vocabulary),
     )
     callbacks.append(train_callback)
     if args.checkpoint_dir is not None and args.checkpoint_save_freq is not None:


### PR DESCRIPTION
Two changes

- SimpleLogger now prints tensor.data.cpu().numpy() as opposed to just tensor
- TensorboardLogger's `custom_tb_log_func` has been changed to made easier to use