### PR TITLE
Add configs/ directory to ASR notebooks/ to standardize loading path

### DIFF
--- a/examples/asr/QuartzNetModel.ipynb
+++ b/examples/asr/QuartzNetModel.ipynb
@@ -55,7 +55,7 @@
     "#First, load the config from YAML file\n",
     "from ruamel.yaml import YAML\n",
     "yaml = YAML(typ=\"safe\")\n",
-    "with open(\"../configs/jasper_an4.yaml\") as file:\n",
+    "with open(\"./configs/jasper_an4.yaml\") as file:\n",
     "    model_definition = yaml.load(file)"
    ]
   },

--- a/examples/asr/notebooks/1_ASR_tutorial_using_NeMo.ipynb
+++ b/examples/asr/notebooks/1_ASR_tutorial_using_NeMo.ipynb
@@ -22,7 +22,7 @@
     "!pip install unidecode\n",
     "\n",
     "!mkdir configs\n",
-    "!wget -P configs/ https://raw.githubusercontent.com/NVIDIA/NeMo/master/examples/asr/configs/jasper_an4.yaml"
+    "!wget -P configs/ https://raw.githubusercontent.com/NVIDIA/NeMo/master/examples/asr/notebooks/configs/jasper_an4.yaml"
    ]
   },
   {
@@ -441,7 +441,7 @@
     "# --- Config Information ---#\n",
     "from ruamel.yaml import YAML\n",
     "\n",
-    "config_path = '../configs/jasper_an4.yaml'\n",
+    "config_path = './configs/jasper_an4.yaml'\n",
     "\n",
     "yaml = YAML(typ='safe')\n",
     "with open(config_path) as f:\n",

--- a/examples/asr/notebooks/configs/jasper_an4.yaml
+++ b/examples/asr/notebooks/configs/jasper_an4.yaml
@@ -1,0 +1,114 @@
+model: "Jasper"
+sample_rate: &sample_rate 16000
+dropout: &drop 0.0
+repeat:  &rep  1
+
+labels: &labels [" ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+         "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'"]
+
+
+AudioToTextDataLayer_train:
+    header:
+        full_spec: nemo.collections.asr.AudioToTextDataLayer
+    init_params:
+        sample_rate: *sample_rate
+        labels: *labels
+        batch_size: 48
+        shuffle: true
+
+
+AudioToTextDataLayer_eval:
+    header:
+        full_spec: nemo.collections.asr.AudioToTextDataLayer
+    init_params:
+        sample_rate: *sample_rate
+        labels: *labels
+        batch_size: 64
+        shuffle: false
+
+
+AudioToMelSpectrogramPreprocessor:
+    header:
+        full_spec: nemo.collections.asr.AudioToMelSpectrogramPreprocessor
+    init_params:
+        normalize: "per_feature"
+        window_size: 0.02
+        sample_rate: *sample_rate
+        window_stride: 0.01
+        window: "hann"
+        features: &n_mels 64
+        n_fft: 512
+        frame_splicing: 1
+        dither: 0.00001
+        stft_conv: true
+
+JasperEncoder:
+    header:
+        full_spec: nemo.collections.asr.JasperEncoder
+    init_params:
+        feat_in: *n_mels
+        activation: "relu"
+
+        jasper:
+            -   filters: 128
+                repeat: 1
+                kernel: [11]
+                stride: [1]
+                dilation: [1]
+                dropout: *drop
+                residual: true
+
+            -   filters: 256
+                repeat: *rep
+                kernel: [13]
+                stride: [1]
+                dilation: [1]
+                dropout: *drop
+                residual: true
+
+            -   filters: 256
+                repeat: *rep
+                kernel: [15]
+                stride: [1]
+                dilation: [1]
+                dropout: *drop
+                residual: true
+
+            -   filters: 256
+                repeat: *rep
+                kernel: [17]
+                stride: [1]
+                dilation: [1]
+                dropout: *drop
+                residual: true
+
+            -   filters: 256
+                repeat: *rep
+                kernel: [19]
+                stride: [1]
+                dilation: [1]
+                dropout: *drop
+                residual: true
+
+            -   filters: 256
+                repeat: 1
+                kernel: [21]
+                stride: [1]
+                dilation: [1]
+                dropout: 0.0
+                residual: false
+
+            -   filters: &enc_feat_out 1024
+                repeat: 1
+                kernel: [1]
+                stride: [1]
+                dilation: [1]
+                dropout: 0.0
+                residual: false
+
+JasperDecoderForCTC:
+    header:
+        full_spec: nemo.collections.asr.JasperDecoderForCTC
+    init_params:
+        feat_in: *enc_feat_out
+        num_classes: 28


### PR DESCRIPTION
Add a configs/ directory to the notebooks directory (and update the path in the notebook) in order to standardize the path from which the jasper_an4.yaml file is loaded. This should also make it less likely for changes for another project/file to break the intro notebook.

Signed-off-by: Jocelyn Huang <jocelynh@nvidia.com>