### PR TITLE
Warning message about mismatched steps when restoring

### DIFF
--- a/nemo/core/callbacks.py
+++ b/nemo/core/callbacks.py
@@ -485,12 +485,9 @@ class CheckpointCallback(NeMoCallback):
                 for step in steps:
                     if step_check is None:
                         step_check = step
-                    else:
-                        if step != step_check:
-                            logging.warning(
-                                "Restoring from modules checkpoints where the training step does not match"
-                            )
-                            break
+                    elif step != step_check:
+                        logging.warning("Restoring from modules checkpoints where the training step does not match")
+                        break
 
                 for mod, checkpoint in zip(modules_to_restore, module_checkpoints):
                     mod.restore_from(checkpoint, state["local_rank"])

--- a/nemo/core/callbacks.py
+++ b/nemo/core/callbacks.py
@@ -477,8 +477,20 @@ class CheckpointCallback(NeMoCallback):
                 if module.num_weights > 0:
                     modules_to_restore.append(module)
                     modules_to_restore_name.append(str(module))
+            step_check = None
             try:
-                module_checkpoints = get_checkpoint_from_dir(modules_to_restore_name, path)
+                module_checkpoints, steps = get_checkpoint_from_dir(modules_to_restore_name, path, return_steps=True)
+
+                # If the steps are different, print a warning message
+                for step in steps:
+                    if step_check is None:
+                        step_check = step
+                    else:
+                        if step != step_check:
+                            logging.warning(
+                                "Restoring from modules checkpoints where the training step does not match"
+                            )
+                            break
 
                 for mod, checkpoint in zip(modules_to_restore, module_checkpoints):
                     mod.restore_from(checkpoint, state["local_rank"])
@@ -495,7 +507,12 @@ class CheckpointCallback(NeMoCallback):
                 return
 
             try:
-                trainer_checkpoints = get_checkpoint_from_dir(["trainer"], path)
+                trainer_checkpoints, steps = get_checkpoint_from_dir(["trainer"], path, return_steps=True)
+                if step_check is not None and step_check != steps[0]:
+                    logging.error(
+                        "The step we are restoring from the trainer checkpoint does not match one or more steps that "
+                        "are being restored from modules."
+                    )
                 state.restore_state_from(trainer_checkpoints[0])
             except (ValueError) as e:
                 logging.warning(e)

--- a/nemo/utils/helpers.py
+++ b/nemo/utils/helpers.py
@@ -27,7 +27,7 @@ def rsetattr(obj, attr, val):
     return setattr(rgetattr(obj, pre) if pre else obj, post, val)
 
 
-def get_checkpoint_from_dir(module_names, cpkt_dir, ckpt_pattern=''):
+def get_checkpoint_from_dir(module_names, cpkt_dir, ckpt_pattern='', return_steps=False):
     """ Grab all the modules with match a certain pattern in cpkt_dir
     If multiple checkpoints found, by default, use the one last created.
     """
@@ -38,6 +38,7 @@ def get_checkpoint_from_dir(module_names, cpkt_dir, ckpt_pattern=''):
         module_names = [module_names]
 
     ckpts = []
+    steps = []
 
     for module in module_names:
         if not isinstance(module, str):
@@ -59,7 +60,10 @@ def get_checkpoint_from_dir(module_names, cpkt_dir, ckpt_pattern=''):
         if len(module_ckpts) > 1:
             module_ckpt = max(module_ckpts, key=step_from_checkpoint)
         ckpts.append(module_ckpt)
+        steps.append(step_from_checkpoint(module_ckpt))
 
+    if return_step:
+        return ckpts, steps
     return ckpts
 
 

--- a/nemo/utils/helpers.py
+++ b/nemo/utils/helpers.py
@@ -62,7 +62,7 @@ def get_checkpoint_from_dir(module_names, cpkt_dir, ckpt_pattern='', return_step
         ckpts.append(module_ckpt)
         steps.append(step_from_checkpoint(module_ckpt))
 
-    if return_step:
+    if return_steps:
         return ckpts, steps
     return ckpts
 


### PR DESCRIPTION
Adds a warning and/or error message if module checkpoints and trainer checkpoints have mismatched steps.

