### PR TITLE
Add Type Support via wrapper

### DIFF
--- a/examples/asr/bad_asr_config.yaml
+++ b/examples/asr/bad_asr_config.yaml
@@ -7,7 +7,7 @@ labels: &labels [" ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l"
          "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'"]
 
 AudioToTextDataLayer:
-    manifest_filepath: '/Users/okuchaiev/Data/an4_dataset/an4_train.json'
+    manifest_filepath: './an4/train_manifest.json'
     sample_rate: 16000
     labels: *labels
     batch_size: 32
@@ -17,7 +17,7 @@ AudioToTextDataLayer:
 
 
 AudioToTextDataLayer_eval:
-    manifest_filepath: '/Users/okuchaiev/Data/an4_dataset/an4_val.json'
+    manifest_filepath: './an4/test_manifest.json'
     sample_rate: 16000
     labels: *labels
     batch_size: 32

--- a/examples/asr/spech2text.py
+++ b/examples/asr/spech2text.py
@@ -14,6 +14,7 @@
 
 # TODO: This is WIP and needs a lot of polishing
 # python examples/asr/spech2text.py --asr_model=examples/asr/bad_asr_config.yaml --train_data=/Users/okuchaiev/Data/an4_dataset/an4_train.json --eval_dataset=/Users/okuchaiev/Data/an4_dataset/an4_val.json
+# python spech2text.py --asr_model=./bad_asr_config.yaml --train_data=./an4/train_manifest.json --eval_dataset=./an4/test_manifest.json
 
 from argparse import ArgumentParser
 

--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -17,7 +17,7 @@ __all__ = ['AudioToTextDataset', 'seq_collate_fn']
 import torch
 
 from nemo.collections.asr.parts import collections, parsers
-from nemo.core.classes import Dataset
+from nemo.core.classes import Dataset, typecheck
 from nemo.utils.decorators import experimental
 
 
@@ -87,7 +87,7 @@ class AudioToTextDataset(Dataset):
         self.load_audio = load_audio
         self._add_misc = add_misc
 
-    # TODO: add typing decorator for datasets here
+    @typecheck()
     def __getitem__(self, index):
         sample = self.collection[index]
         if self.load_audio:

--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -87,7 +87,6 @@ class AudioToTextDataset(Dataset):
         self.load_audio = load_audio
         self._add_misc = add_misc
 
-    @typecheck()
     def __getitem__(self, index):
         sample = self.collection[index]
         if self.load_audio:

--- a/nemo/collections/asr/losses/ctc.py
+++ b/nemo/collections/asr/losses/ctc.py
@@ -20,7 +20,7 @@ __all__ = ['CTCLoss']
 import torch
 from torch import nn
 
-from nemo.core.classes import NeuralModule, Typing
+from nemo.core.classes import NeuralModule, Typing, typecheck
 from nemo.core.neural_types import LabelsType, LengthsType, LogprobsType, LossType, NeuralType
 from nemo.utils.decorators import experimental
 
@@ -69,6 +69,7 @@ class CTCLoss(NeuralModule):
         self._blank = num_classes
         self._criterion = nn.CTCLoss(blank=self._blank, reduction='none', zero_infinity=zero_infinity)
 
+    @typecheck()
     def forward(self, log_probs, targets, input_length, target_length):
         input_length = input_length.long()
         target_length = target_length.long()

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -25,7 +25,7 @@ from nemo.collections.asr.losses.ctc import CTCLoss
 from nemo.collections.asr.metrics.wer import monitor_asr_train_progress
 from nemo.collections.asr.models.asr_model import ASRModel
 from nemo.collections.asr.parts.features import WaveformFeaturizer
-from nemo.core.classes.common import Serialization
+from nemo.core.classes.common import Serialization, typecheck
 from nemo.core.neural_types import NeuralType
 from nemo.utils.decorators import experimental
 
@@ -135,7 +135,7 @@ class EncDecCTCModel(ASRModel):
         # This will be set by setup_optimization
         self.__optimizer = None
 
-    # TODO: typing decorator should go here
+    @typecheck()
     def forward(self, input_signal, input_signal_length):
         processed_signal, processed_signal_len = self.preprocessor(
             input_signal=input_signal, length=input_signal_length,

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -20,7 +20,7 @@ import torch
 
 from nemo.collections.asr.parts.features import FilterbankFeatures
 from nemo.collections.asr.parts.spectr_augment import SpecAugment, SpecCutout
-from nemo.core.classes import NeuralModule
+from nemo.core.classes import NeuralModule, typecheck
 from nemo.core.neural_types import AudioSignal, LengthsType, MelSpectrogramType, NeuralType, SpectrogramType
 from nemo.utils.decorators import experimental
 
@@ -305,6 +305,7 @@ class SpectrogramAugmentation(NeuralModule):
         else:
             self.spec_augment = lambda x: x
 
+    @typecheck()
     def forward(self, input_spec):
         augmented_spec = self.spec_cutout(input_spec)
         augmented_spec = self.spec_augment(augmented_spec)

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -20,7 +20,7 @@ from collections import OrderedDict
 import torch
 
 from nemo.collections.asr.parts.jasper import JasperBlock, init_weights, jasper_activations
-from nemo.core.classes import NeuralModule
+from nemo.core.classes import NeuralModule, typecheck
 from nemo.core.neural_types import (
     AcousticEncodedRepresentation,
     LengthsType,
@@ -138,6 +138,7 @@ class ConvASREncoder(NeuralModule):
         self.encoder = torch.nn.Sequential(*encoder_layers)
         self.apply(lambda x: init_weights(x, mode=init_mode))
 
+    @typecheck()
     def forward(self, audio_signal, length=None):
         s_input, length = self.encoder(([audio_signal], length))
         if length is None:
@@ -189,6 +190,7 @@ class ConvASRDecoder(NeuralModule):
         )
         self.apply(lambda x: init_weights(x, mode=init_mode))
 
+    @typecheck()
     def forward(self, encoder_output):
         return torch.nn.functional.log_softmax(self.decoder_layers(encoder_output).transpose(1, 2), dim=-1)
 

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -14,7 +14,7 @@
 
 
 """Interfaces common to all Neural Modules and Models."""
-__all__ = ['Typing', 'FileIO', 'Model', 'Serialization']
+__all__ = ['Typing', 'FileIO', 'Model', 'Serialization', 'typecheck']
 
 import inspect
 from abc import ABC, abstractmethod
@@ -241,7 +241,7 @@ class typecheck:
     def _attach_and_validate_output_types(self, instance, out_objects):
         # TODO: Properly implement this
         if instance.output_types is not None:
-            out_types_list = list(instance.items())
+            out_types_list = list(instance.output_types.items())
             if not isinstance(out_objects, tuple) and not isinstance(out_objects, list):
                 out_objects.neural_type = out_types_list[0][1]
             else:

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -16,9 +16,11 @@
 """Interfaces common to all Neural Modules and Models."""
 __all__ = ['Typing', 'FileIO', 'Model', 'Serialization']
 
+import inspect
 from abc import ABC, abstractmethod
 from typing import Any, Dict, Optional
 
+import wrapt
 from ruamel.yaml import YAML
 
 from nemo.core.neural_types import NeuralType, NeuralTypeComparisonResult
@@ -39,26 +41,6 @@ class Typing(ABC):
     def output_types(self) -> Optional[Dict[str, NeuralType]]:
         """Define these to enable output neural type checks"""
         return None
-
-    def validate_input_types(self, in_objects):
-        # TODO: Properly implement this
-        if self.input_types is not None:
-            for key, value in in_objects.items():
-                if (
-                    hasattr(value, 'neural_type')
-                    and self.input_types[key].compare(value.neural_type) != NeuralTypeComparisonResult.SAME
-                ):
-                    raise TypeError(f"{self.input_types[key].compare(value.neural_type)}")
-
-    def attach_and_validate_output_types(self, out_objects):
-        # TODO: Properly implement this
-        if self.output_types is not None:
-            out_types_list = list(self.output_types.items())
-            if not isinstance(out_objects, tuple) and not isinstance(out_objects, list):
-                out_objects.neural_type = out_types_list[0][1]
-            else:
-                for ind, res in enumerate(out_objects):
-                    res.neural_type = out_types_list[ind][1]
 
 
 class Serialization(ABC):
@@ -208,3 +190,60 @@ class Model(Typing, Serialization, FileIO):
         Returns:
 
         """
+
+
+class typecheck:
+
+    def __init__(self):
+        pass
+
+    @wrapt.decorator
+    def __call__(self, wrapped, instance: Typing, args, kwargs):
+        if instance is None:
+            raise RuntimeError("Only classes which inherit nemo.core.Typing can use this decorator !")
+
+        if not (hasattr(instance, 'input_types') and hasattr(instance, 'output_types')):
+            raise RuntimeError("Only classes which inherit nemo.core.Typing can use this decorator !")
+
+        # If types are not defined, skip type checks and just call the
+        if instance.input_types is None and instance.output_types is None:
+            return wrapped(*args, **kwargs)
+
+        # Check that all arguments are kwargs
+        if len(args) > 0:
+            raise TypeError("All arguments must be passed by kwargs only for typed methods")
+
+        # Perform rudimentary input checks here
+        self._validate_input_types(instance, kwargs)
+
+        # Call the method - this can be forward, or any other callable method
+        outputs = wrapped(*args, **kwargs)
+
+        self._attach_and_validate_output_types(instance, outputs)
+
+        return outputs
+
+    def _validate_input_types(self, instance, kwargs):
+        # TODO: Properly implement this
+        if instance.input_types is not None:
+            if len(kwargs) != len(instance.input_types):
+                raise TypeError("Number of input arguments provided ({}) is not as expected ({})".format(
+                    len(kwargs), len(instance.input_types))
+                )
+
+            for key, value in kwargs.items():
+                if (
+                    hasattr(value, 'neural_type')
+                    and instance.input_types[key].compare(value.neural_type) != NeuralTypeComparisonResult.SAME
+                ):
+                    raise TypeError(f"{instance.input_types[key].compare(value.neural_type)}")
+
+    def _attach_and_validate_output_types(self, instance, out_objects):
+        # TODO: Properly implement this
+        if instance.output_types is not None:
+            out_types_list = list(instance.items())
+            if not isinstance(out_objects, tuple) and not isinstance(out_objects, list):
+                out_objects.neural_type = out_types_list[0][1]
+            else:
+                for ind, res in enumerate(out_objects):
+                    res.neural_type = out_types_list[ind][1]

--- a/nemo/core/classes/module.py
+++ b/nemo/core/classes/module.py
@@ -24,10 +24,3 @@ class NeuralModule(Module, Typing, Serialization, FileIO):
     """
     Abstract class offering interface shared between all PyTorch Neural Modules.
     """
-
-    def typed_forward(self, **kwargs):
-        # TODO: Consider if this can be turned into decorator for __call__ or forward
-        self.validate_input_types(in_objects=kwargs)
-        result = self.forward(**kwargs)
-        self.attach_and_validate_output_types(out_objects=result)
-        return result


### PR DESCRIPTION
# Adds the wrapper class `typecheck()` which can be wrapped to any method of a class which inherits Typing.

Automatically checks if types are defined,
 - Ignores type checks if None
 - Performs full type check of defined.

# Caution

It is **mandatory** for this decorator to be at the top of all other decorators for a method.
For example, the following will fail : 
```python

@torch.no_grad()
@typecheck()
def forward(self, ...):
    ...
```

Whereas the following will work just fine
```python

@typecheck()
@torch.no_grad()
def forward(self, ...):
    ...
```

