### PR TITLE
Add new dataset schema as well as new typechecking for dataset items

### DIFF
--- a/examples/asr/speech_to_text.py
+++ b/examples/asr/speech_to_text.py
@@ -13,8 +13,14 @@
 # limitations under the License.
 
 # TODO: This is WIP and needs a lot of polishing
-# python examples/asr/spech2text.py --asr_model=examples/asr/bad_asr_config.yaml --train_data=/Users/okuchaiev/Data/an4_dataset/an4_train.json --eval_dataset=/Users/okuchaiev/Data/an4_dataset/an4_val.json
-# python spech2text.py --asr_model=./bad_asr_config.yaml --train_data=./an4/train_manifest.json --eval_dataset=./an4/test_manifest.json
+# python speech_to_text.py \
+#         --asr_model "bad_quartznet15x5.yaml" \
+#         --train_dataset "./an4/train_manifest.json" \
+#         --eval_dataset "./an4/test_manifest.json" \
+#         --gpus 4 \
+#         --distributed_backend "ddp" \
+#         --max_epochs 1 \
+#         --fast_dev_run \
 
 from argparse import ArgumentParser
 

--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -19,7 +19,7 @@ from typing import Dict, Optional
 import torch
 
 from nemo.collections.asr.parts import collections, parsers
-from nemo.core.classes import Dataset, typecheck
+from nemo.core.classes import Dataset
 from nemo.core.neural_types import *
 from nemo.utils.decorators import experimental
 

--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -14,10 +14,13 @@
 
 __all__ = ['AudioToTextDataset']
 
+from typing import Dict, Optional
+
 import torch
 
 from nemo.collections.asr.parts import collections, parsers
 from nemo.core.classes import Dataset, typecheck
+from nemo.core.neural_types import *
 from nemo.utils.decorators import experimental
 
 
@@ -51,6 +54,22 @@ class AudioToTextDataset(Dataset):
         load_audio: Boolean flag indicate whether do or not load audio
         add_misc: True if add additional info dict.
     """
+
+    @property
+    def output_types(self) -> Optional[Dict[str, NeuralType]]:
+        """Returns definitions of module output ports.
+               """
+        return {
+            'audio_signal': NeuralType(
+                ('B', 'T'),
+                AudioSignal(freq=self._sample_rate)
+                if self is not None and hasattr(self, '_sample_rate')
+                else AudioSignal(),
+            ),
+            'a_sig_length': NeuralType(tuple('B'), LengthsType()),
+            'transcripts': NeuralType(('B', 'T'), LabelsType()),
+            'transcript_length': NeuralType(tuple('B'), LengthsType()),
+        }
 
     def __init__(
         self,
@@ -126,7 +145,7 @@ class AudioToTextDataset(Dataset):
     def __len__(self):
         return len(self.collection)
 
-    def collate_fn(self, batch):
+    def _collate_fn(self, batch):
         """collate batch of audio sig, audio len, tokens, tokens len
         Args:
             batch (Optional[FloatTensor], Optional[LongTensor], LongTensor,

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -53,11 +53,19 @@ class Typing(ABC):
                 )
 
             for key, value in kwargs.items():
+                # Check if keys exists in the defined input types
+                if key not in self.input_types:
+                    raise TypeError(f"Input argument {key} has no corresponding input_type match. "
+                                    f"Existing input_types = {self.input_types.keys()}")
+
+                # Perform neural type check
                 if (
                     hasattr(value, 'neural_type')
                     and self.input_types[key].compare(value.neural_type) != NeuralTypeComparisonResult.SAME
                 ):
-                    raise TypeError(f"{self.input_types[key].compare(value.neural_type)}")
+                    raise TypeError(f"{self.input_types[key].compare(value.neural_type)} : \n"
+                                    f"Input type expected = {self.input_types[key]} | \n"
+                                    f"Input type found : {value.neural_type}")
 
     def _attach_and_validate_output_types(self, out_objects):
         # TODO: Properly implement this
@@ -253,12 +261,12 @@ class typecheck:
         if not isinstance(instance, Typing):
             raise RuntimeError("Only classes which inherit nemo.core.Typing can use this decorator !")
 
-        # If types are not defined, skip type checks and just call the
+        # If types are not defined, skip type checks and just call the wrapped method
         if instance.input_types is None and instance.output_types is None:
             return wrapped(*args, **kwargs)
 
         # Check that all arguments are kwargs
-        if len(args) > 0:
+        if instance.input_types is not None and len(args) > 0:
             raise TypeError("All arguments must be passed by kwargs only for typed methods")
 
         # Perform rudimentary input checks here

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -55,17 +55,21 @@ class Typing(ABC):
             for key, value in kwargs.items():
                 # Check if keys exists in the defined input types
                 if key not in self.input_types:
-                    raise TypeError(f"Input argument {key} has no corresponding input_type match. "
-                                    f"Existing input_types = {self.input_types.keys()}")
+                    raise TypeError(
+                        f"Input argument {key} has no corresponding input_type match. "
+                        f"Existing input_types = {self.input_types.keys()}"
+                    )
 
                 # Perform neural type check
                 if (
                     hasattr(value, 'neural_type')
                     and self.input_types[key].compare(value.neural_type) != NeuralTypeComparisonResult.SAME
                 ):
-                    raise TypeError(f"{self.input_types[key].compare(value.neural_type)} : \n"
-                                    f"Input type expected = {self.input_types[key]} | \n"
-                                    f"Input type found : {value.neural_type}")
+                    raise TypeError(
+                        f"{self.input_types[key].compare(value.neural_type)} : \n"
+                        f"Input type expected = {self.input_types[key]} | \n"
+                        f"Input type found : {value.neural_type}"
+                    )
 
     def _attach_and_validate_output_types(self, out_objects):
         # TODO: Properly implement this

--- a/nemo/core/classes/dataset.py
+++ b/nemo/core/classes/dataset.py
@@ -17,16 +17,78 @@ __all__ = ['Dataset']
 
 from torch.utils import data
 
-from nemo.core.classes import Serialization, Typing
+from nemo.core.classes import Serialization, Typing, typecheck
 
 
 class Dataset(data.Dataset, Typing, Serialization):
-    """Dataset with output ports"""
+    """Dataset with output ports
 
-    pass
+    Please Note: Subclasses of IterableDataset should *not* implement input_types.
+    """
+
+    def _collate_fn(self, batch):
+        """
+        A default implementation of a collation function.
+        Users should override this method to define custom data loaders.
+        """
+        return data.dataloader.default_collate(batch)
+
+    @typecheck()
+    def collate_fn(self, batch):
+        """
+        This is the method that user pass as functor to DataLoader.
+        The method optionally performs neural type checking and add types to the outputs.
+
+        Please note, subclasses of Dataset should not implement `input_types`.
+
+        # Usage:
+        dataloader = torch.utils.data.DataLoader(
+                ....,
+                collate_fn=dataset.collate_fn,
+                ....
+        )
+
+        Returns:
+            Collated batch, with or without types.
+        """
+        if self.input_types is not None:
+            raise TypeError("Datasets should not implement `input_types` as they are not checked")
+
+        # Simply forward the inner `_collate_fn`
+        return self._collate_fn(batch)
 
 
 class IterableDataset(data.IterableDataset, Typing, Serialization):
-    """Iterable Dataset with output ports"""
+    """Iterable Dataset with output ports
 
-    pass
+    Please Note: Subclasses of IterableDataset should *not* implement input_types.
+    """
+
+    def _collate_fn(self, batch):
+        """
+        A default implementation of a collation function.
+        Users should override this method to define custom data loaders.
+        """
+        return data.dataloader.default_collate(batch)
+
+    @typecheck()
+    def collate_fn(self, batch):
+        """
+        This is the method that user pass as functor to DataLoader.
+        The method optionally performs neural type checking and add types to the outputs.
+
+        # Usage:
+        dataloader = torch.utils.data.DataLoader(
+                ....,
+                collate_fn=dataset.collate_fn,
+                ....
+        )
+
+        Returns:
+            Collated batch, with or without types.
+        """
+        if self.input_types is not None:
+            raise TypeError("Datasets should not implement `input_types` as they are not checked")
+
+        # Simply forward the inner `_collate_fn`
+        return self._collate_fn(batch)


### PR DESCRIPTION
# Primary changes for end users

##  Custom datasets inherit from `nemo.core.classes.Dataset` or `nemo.core.classes.IterableDataset`

- You can override either `__getitem__(self, index)` or `__iter__` depending on which class you inherit.
- Do *not* override `input_types` - dataset items do not perform input type checking.
- Implement `output_types` iff you want the dataset batched output to be typechecked.

## If there is a need to override the default pytorch collate function, then override `def _collate_fn(self, batch)` 

- It is important to note, we are overriding the private method `_collate_fn`, *not* the public api `collate_fn`. 

In general, there will be almost no cases necessary to override the public api version - however if it is necessary, please explicitly add the `@typecheck()` decorator to the overriden `collate_fn(self, batch)`/

## In order to properly initialize the DataLoader, please follow the steps below : 

```python

 dataset = ClassWhichExtendsDataset(...)

 dataloader = torch.utils.data.DataLoader(
            dataset=dataset,
            collate_fn=dataset.collate_fn,   # Please note, we directly pass dataset.collate_fn. Do *not* call it here.
            .....
        )

```

Signed-off-by: smajumdar <titu1994@gmail.com>