### PR TITLE
speech_commands: read audio length and preprocessor type from config

### DIFF
--- a/examples/asr/configs/quartznet_speech_commands_3x1_v1.yaml
+++ b/examples/asr/configs/quartznet_speech_commands_3x1_v1.yaml
@@ -1,5 +1,8 @@
 model: "QuartzNet"
 sample_rate: &sample_rate 16000
+# number of timesteps model is trained on
+timesteps: 128
+preprocessor: "AudioToMFCCPreprocessor"
 dropout: &drop 0.0
 repeat:  &rep  1
 augment: true

--- a/examples/asr/configs/quartznet_speech_commands_3x1_v2.yaml
+++ b/examples/asr/configs/quartznet_speech_commands_3x1_v2.yaml
@@ -1,5 +1,8 @@
 model: "QuartzNet"
 sample_rate: &sample_rate 16000
+# number of timesteps model is trained on
+timesteps: 128
+preprocessor: "AudioToMFCCPreprocessor"
 dropout: &drop 0.0
 repeat:  &rep  1
 augment: true


### PR DESCRIPTION
Audio length and type of preprocessor is hardcoded in the script. This change provides a way to configure it from config file.