### PR TITLE
Add LR Scheduler support to candidate

### DIFF
--- a/examples/asr/speech_to_text.py
+++ b/examples/asr/speech_to_text.py
@@ -29,6 +29,7 @@ import pytorch_lightning as pl
 from ruamel.yaml import YAML
 
 from nemo.collections.asr.models import EncDecCTCModel
+from nemo.core.optim.lr_scheduler import CosineAnnealing
 from nemo.utils.arguments import add_asr_args, add_optimizer_args, add_scheduler_args
 
 
@@ -50,7 +51,31 @@ def main(args):
     model_config['AudioToTextDataLayer_eval']['manifest_filepath'] = args.eval_dataset
     asr_model.setup_training_data(model_config['AudioToTextDataLayer'])
     asr_model.setup_validation_data(model_config['AudioToTextDataLayer_eval'])
-    asr_model.setup_optimization(optim_params={'optimizer': args.optimizer, 'lr': args.lr, 'opt_args': args.opt_args})
+
+    # Setup optimizer and scheduler
+    scheduler_args = {
+        'monitor': 'val_loss',  # pytorch lightning requires this value
+        'warmup_ratio': args.warmup_ratio,
+        'warmup_steps': args.warmup_steps,
+        'min_lr': args.min_lr,
+        'last_epoch': args.last_epoch,
+    }
+
+    if args.max_steps is None:
+        iters_per_sample = args.max_epochs / float(args.gpus * args.num_nodes * args.accumulate_grad_batches)
+        scheduler_args['iters_per_sample'] = iters_per_sample
+    else:
+        scheduler_args['max_steps'] = args.max_steps
+
+    asr_model.setup_optimization(
+        optim_params={
+            'optimizer': args.optimizer,
+            'lr': args.lr,
+            'opt_args': args.opt_args,
+            'scheduler': CosineAnnealing,
+            'scheduler_args': scheduler_args,
+        }
+    )
     # trainer = pl.Trainer(
     #     val_check_interval=1, amp_level='O1', precision=16, gpus=4, max_epochs=123, distributed_backend='ddp'
     # )

--- a/examples/asr/speech_to_text.py
+++ b/examples/asr/speech_to_text.py
@@ -50,7 +50,7 @@ def main(args):
     model_config['AudioToTextDataLayer']['manifest_filepath'] = args.train_dataset
     model_config['AudioToTextDataLayer_eval']['manifest_filepath'] = args.eval_dataset
     asr_model.setup_training_data(model_config['AudioToTextDataLayer'])
-    asr_model.setup_validation_data(model_config['AudioToTextDataLayer_eval'])
+    # asr_model.setup_validation_data(model_config['AudioToTextDataLayer_eval'])
 
     # Setup optimizer and scheduler
     scheduler_args = {
@@ -62,8 +62,8 @@ def main(args):
     }
 
     if args.max_steps is None:
-        iters_per_sample = args.max_epochs / float(args.gpus * args.num_nodes * args.accumulate_grad_batches)
-        scheduler_args['iters_per_sample'] = iters_per_sample
+        iters_per_batch = args.max_epochs / float(args.gpus * args.num_nodes * args.accumulate_grad_batches)
+        scheduler_args['iters_per_batch'] = iters_per_batch
     else:
         scheduler_args['max_steps'] = args.max_steps
 

--- a/examples/asr/speech_to_text.py
+++ b/examples/asr/speech_to_text.py
@@ -28,9 +28,8 @@ from argparse import ArgumentParser
 import pytorch_lightning as pl
 from ruamel.yaml import YAML
 
-from nemo.collections.asr.arguments import add_asr_args
 from nemo.collections.asr.models import EncDecCTCModel
-from nemo.core.optim.optimizers import add_optimizer_args
+from nemo.utils.arguments import add_asr_args, add_optimizer_args, add_scheduler_args
 
 
 def main(args):
@@ -65,6 +64,7 @@ if __name__ == '__main__':
     parser = pl.Trainer.add_argparse_args(parser)
     parser = add_asr_args(parser)
     parser = add_optimizer_args(parser)
+    parser = add_scheduler_args(parser)
 
     args = parser.parse_args()
 

--- a/examples/asr/speech_to_text.py
+++ b/examples/asr/speech_to_text.py
@@ -50,7 +50,7 @@ def main(args):
     model_config['AudioToTextDataLayer']['manifest_filepath'] = args.train_dataset
     model_config['AudioToTextDataLayer_eval']['manifest_filepath'] = args.eval_dataset
     asr_model.setup_training_data(model_config['AudioToTextDataLayer'])
-    # asr_model.setup_validation_data(model_config['AudioToTextDataLayer_eval'])
+    asr_model.setup_validation_data(model_config['AudioToTextDataLayer_eval'])
 
     # Setup optimizer and scheduler
     scheduler_args = {

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -23,8 +23,7 @@ from nemo.collections.asr.models.asr_model import ASRModel
 from nemo.collections.asr.parts.features import WaveformFeaturizer
 from nemo.core.classes.common import Serialization, typecheck
 from nemo.core.neural_types import *
-from nemo.core.optim import CosineAnnealing, prepare_lr_scheduler
-from nemo.utils import logging
+from nemo.core.optim import prepare_lr_scheduler
 from nemo.utils.decorators import experimental
 
 __all__ = ['EncDecCTCModel', 'JasperNet', 'QuartzNet']
@@ -81,8 +80,9 @@ class EncDecCTCModel(ASRModel):
 
     def setup_optimization(self, optim_params: Optional[Dict] = None) -> torch.optim.Optimizer:
         self.__optimizer = super().setup_optimization(optim_params)
-        self.__scheduler = prepare_lr_scheduler(optimizer=self.__optimizer, scheduler_config=optim_params,
-                                                train_dataloader=self.__train_dl)
+        self.__scheduler = prepare_lr_scheduler(
+            optimizer=self.__optimizer, scheduler_config=optim_params, train_dataloader=self.__train_dl
+        )
 
     @classmethod
     def list_available_models(cls) -> Optional[Dict[str, str]]:

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -83,7 +83,7 @@ class EncDecCTCModel(ASRModel):
         self.__optimizer = super().setup_optimization(optim_params)
 
         # hard code the scheduler for now
-        total_steps = optim_params.get('total_steps')
+        total_steps = optim_params.get('max_steps')
         warmup_steps = optim_params.get('warmup_steps', None)
         warmup_ratio = optim_params.get('warmup_ratio', None)
         min_lr = optim_params.get('min_lr', 0.0)
@@ -215,7 +215,6 @@ class EncDecCTCModel(ASRModel):
         if self.__scheduler is None:
             return self.__optimizer
         else:
-            # needs to have 1:1 list size for optimizer : scheduler
             return [self.__optimizer], [self.__scheduler]
 
     def train_dataloader(self):

--- a/nemo/core/optim/__init__.py
+++ b/nemo/core/optim/__init__.py
@@ -14,3 +14,16 @@
 
 from nemo.core.optim.novograd import Novograd
 from nemo.core.optim.optimizers import add_optimizer_args, get_optimizer, parse_optimizer_args, register_optimizer
+
+from nemo.core.optim.lr_scheduler import (
+    CosineAnnealing,
+    InverseSquareRootAnnealing,
+    PolynomialDecayAnnealing,
+    PolynomialHoldDecayAnnealing,
+    SquareAnnealing,
+    SquareRootAnnealing,
+    WarmupAnnealing,
+    WarmupHoldPolicy,
+    WarmupPolicy,
+    prepare_scheduler,
+)

--- a/nemo/core/optim/__init__.py
+++ b/nemo/core/optim/__init__.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo.core.optim.novograd import Novograd
-from nemo.core.optim.optimizers import add_optimizer_args, get_optimizer, parse_optimizer_args, register_optimizer
-
 from nemo.core.optim.lr_scheduler import (
     CosineAnnealing,
     InverseSquareRootAnnealing,
@@ -25,5 +22,8 @@ from nemo.core.optim.lr_scheduler import (
     WarmupAnnealing,
     WarmupHoldPolicy,
     WarmupPolicy,
-    prepare_scheduler,
+    prepare_lr_scheduler,
 )
+from nemo.core.optim.novograd import Novograd
+from nemo.core.optim.optimizers import get_optimizer, parse_optimizer_args, register_optimizer
+from nemo.utils.arguments import add_optimizer_args

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -1,0 +1,301 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import math
+import sys
+import warnings
+
+from torch.optim.lr_scheduler import _LRScheduler
+
+#
+# __all__ = [
+#     'WarmupPolicy',
+#     'WarmupHoldPolicy',
+#     'SquareAnnealing',
+#     'CosineAnnealing',
+#     'WarmupAnnealing',
+#     'InverseSquareRootAnnealing',
+#     'SquareRootAnnealing',
+#     'PolynomialDecayAnnealing',
+#     'PolynomialHoldDecayAnnealing',
+# ]
+
+
+class WarmupPolicy(_LRScheduler):
+    """Adds warmup kwargs and warmup logic to lr policy.
+    All arguments should be passed as kwargs for clarity,
+    Args:
+        warmup_steps: Number of training steps in warmup stage
+        warmup_ratio: Ratio of warmup steps to total steps
+        total_steps: Total number of steps while training or `None` for
+            infinite training
+    """
+
+    def __init__(self, optimizer, *, warmup_steps=None, warmup_ratio=None, total_steps=None, last_epoch=-1):
+        assert not (
+            warmup_steps is not None and warmup_ratio is not None
+        ), "Either use particular number of step or ratio"
+        assert warmup_ratio is None or total_steps is not None, "If there is a ratio, there should be a total steps"
+
+        super().__init__(optimizer, last_epoch)
+
+        self.total_steps = total_steps
+        if warmup_steps is not None:
+            self.warmup_steps = warmup_steps
+        elif warmup_ratio is not None:
+            self.warmup_steps = int(warmup_ratio * total_steps)
+        else:
+            self.warmup_steps = 0
+
+    def get_lr(self):
+        if not self._get_lr_called_within_step:
+            warnings.warn(
+                "To get the last learning rate computed by the scheduler, " "please use `get_last_lr()`.", UserWarning
+            )
+
+        step = self.last_epoch
+
+        if step <= self.warmup_steps:
+            lr_val = (step + 1) / (self.warmup_steps + 1)
+            return [initial_lr * lr_val for initial_lr in self.base_lrs]
+
+        if step > self.total_steps:
+            return [0.0 for _ in self.base_lrs]
+
+        return self._get_lr(step)
+
+    def _get_lr(self, step):
+        """Simple const lr policy"""
+        return self.base_lrs
+
+
+class WarmupHoldPolicy(WarmupPolicy):
+    """Variant of WarmupPolicy which maintains high learning rate for a defined number of steps.
+    All arguments should be passed as kwargs for clarity,
+    Args:
+        warmup_steps: Number of training steps in warmup stage
+        warmup_ratio: Ratio of warmup steps to total steps
+        hold_steps: Number of training steps to hold the learning rate after warm up
+        hold_ratio: Ratio of hold steps to total steps
+        total_steps: Total number of steps while training or `None` for
+            infinite training
+    """
+
+    def __init__(
+        self,
+        optimizer,
+        *,
+        warmup_steps=None,
+        warmup_ratio=None,
+        hold_steps=None,
+        hold_ratio=None,
+        total_steps=None,
+        min_lr=0.0,
+        last_epoch=-1,
+    ):
+        assert not (hold_steps is not None and hold_ratio is not None), "Either use particular number of step or ratio"
+        assert hold_ratio is None or total_steps is not None, "If there is a ratio, there should be a total steps"
+        super().__init__(optimizer, warmup_steps=warmup_steps, warmup_ratio=warmup_ratio, total_steps=total_steps,
+                         last_epoch=last_epoch)
+
+        self._min_lr = min_lr
+        self._last_warmup_lr = 0.0
+
+        if hold_steps is not None:
+            self.hold_steps = hold_steps + self.warmup_steps
+        elif hold_ratio is not None:
+            self.hold_steps = int(hold_ratio * total_steps) + self.warmup_steps
+        else:
+            self.hold_steps = 0
+
+    def get_lr(self):
+        if not self._get_lr_called_within_step:
+            warnings.warn(
+                "To get the last learning rate computed by the scheduler, " "please use `get_last_lr()`.", UserWarning
+            )
+
+        step = self.last_epoch
+
+        # Warmup phase
+        if step <= self.warmup_steps:
+            lr_val = (step + 1) / (self.warmup_steps + 1)
+            return [initial_lr * lr_val for initial_lr in self.base_lrs]
+
+        # Hold phase
+        if (step >= self.warmup_steps) and (step < self.hold_steps):
+            return self.base_lrs
+
+        if step > self.total_steps:
+            return [0.0 for _ in self.base_lrs]
+
+        return self._get_lr(step)
+#
+#
+# def _squareroot_annealing(initial_lr, step, total_steps, min_lr):
+#     mult = ((total_steps - step) / total_steps) ** 0.5
+#     out_lr = initial_lr * mult
+#     out_lr = max(out_lr, min_lr)
+#     return out_lr
+#
+#
+# def _square_annealing(initial_lr, step, total_steps, min_lr):
+#     mult = ((total_steps - step) / total_steps) ** 2
+#     out_lr = initial_lr * mult
+#     out_lr = max(out_lr, min_lr)
+#     return out_lr
+#
+#
+# def _cosine_annealing(initial_lr, step, total_steps, min_lr):
+#     mult = 0.5 * (1 + math.cos(math.pi * step / total_steps))
+#     out_lr = (initial_lr - min_lr) * mult + min_lr
+#     return out_lr
+#
+#
+# def _poly_decay(initial_lr, step, decay_steps, power, min_lr, cycle):
+#     if cycle:
+#         multiplier = 1.0 if step == 0 else math.ceil(step / decay_steps)
+#         decay_steps *= multiplier
+#     else:
+#         step = min(step, decay_steps)
+#     p = step / decay_steps
+#     lr = (initial_lr - min_lr) * math.pow(1.0 - p, power)
+#     lr += min_lr
+#     return lr
+#
+#
+# class SquareAnnealing(WarmupPolicy):
+#     def __init__(self, total_steps, min_lr=1e-5, **kwargs):
+#         super().__init__(total_steps=total_steps, **kwargs)
+#         self.min_lr = min_lr
+#
+#     def _get_lr(self, initial_lr, step, epoch):
+#         return _square_annealing(
+#             initial_lr=initial_lr,
+#             step=step - self.warmup_steps,
+#             total_steps=self.total_steps - self.warmup_steps,
+#             min_lr=self.min_lr,
+#         )
+#
+#
+# class SquareRootAnnealing(WarmupPolicy):
+#     def __init__(self, total_steps, min_lr=0, **kwargs):
+#         super().__init__(total_steps=total_steps, **kwargs)
+#         self.min_lr = min_lr
+#
+#     def _get_lr(self, initial_lr, step, epoch):
+#         return _squareroot_annealing(
+#             initial_lr=initial_lr, step=step, total_steps=self.total_steps, min_lr=self.min_lr,
+#         )
+#
+#
+# class CosineAnnealing(WarmupPolicy):
+#     def __init__(self, total_steps, min_lr=0, **kwargs):
+#         self.min_lr = min_lr
+#         super().__init__(total_steps=total_steps, **kwargs)
+#
+#     def _get_lr(self, initial_lr, step, epoch):
+#         if initial_lr < self.min_lr:
+#             raise ValueError(
+#                 f"{self} received an initial learning rate that " f"was lower than the minimum learning rate."
+#             )
+#         return _cosine_annealing(
+#             initial_lr=initial_lr,
+#             step=step - self.warmup_steps,
+#             total_steps=self.total_steps - self.warmup_steps,
+#             min_lr=self.min_lr,
+#         )
+#
+#
+# class WarmupAnnealing(WarmupPolicy):
+#     def __init__(self, total_steps, **kwargs):
+#         super().__init__(total_steps=total_steps, **kwargs)
+#
+#     def _get_lr(self, initial_lr, step, epoch):
+#         progress = float(step / self.total_steps)
+#         warmup_ratio = float(self.warmup_steps / self.total_steps)
+#
+#         mult = max((progress - 1.0) / (warmup_ratio - 1.0), 0.0)
+#         out_lr = initial_lr * mult
+#
+#         return out_lr
+#
+#
+# class InverseSquareRootAnnealing(WarmupPolicy):
+#     def __init__(self, total_steps, **kwargs):
+#         super().__init__(total_steps=total_steps, **kwargs)
+#
+#     def _get_lr(self, initial_lr, step, epoch):
+#         denom = ((step + 1) / (self.warmup_steps + 1)) ** 0.5
+#         out_lr = initial_lr / denom
+#         return out_lr
+#
+#
+# class PolynomialDecayAnnealing(WarmupPolicy):
+#     def __init__(self, total_steps, min_lr=0.0, power=1.0, cycle=False, **kwargs):
+#         super().__init__(total_steps=total_steps, **kwargs)
+#         self.min_lr = min_lr
+#         self.power = power
+#         self.cycle = cycle
+#
+#     def _get_lr(self, initial_lr, step, epoch):
+#         return _poly_decay(
+#             initial_lr,
+#             step=step - self.warmup_steps,
+#             decay_steps=self.total_steps - self.warmup_steps,
+#             power=self.power,
+#             min_lr=self.min_lr,
+#             cycle=self.cycle,
+#         )
+#
+#
+# class PolynomialHoldDecayAnnealing(WarmupHoldPolicy):
+#     def __init__(self, total_steps, min_lr=0.0, power=1.0, cycle=False, **kwargs):
+#         super().__init__(total_steps=total_steps, **kwargs)
+#         self.min_lr = min_lr
+#         self.power = power
+#         self.cycle = cycle
+#
+#     def _get_lr(self, initial_lr, step, epoch):
+#         return _poly_decay(
+#             initial_lr,
+#             step=step - self.hold_steps,
+#             decay_steps=self.total_steps - max(self.warmup_steps, self.hold_steps),
+#             power=self.power,
+#             min_lr=self.min_lr,
+#             cycle=self.cycle,
+#         )
+
+
+def get_all_lr_classes():
+    """ Get all LR classes defined within this module
+    """
+    lr_classes = {}
+    for name, obj in inspect.getmembers(sys.modules[__name__]):
+        if inspect.isclass(obj) and name != 'ABC':
+            lr_classes[name] = obj
+    return lr_classes
+
+
+def get_lr_policy(lr_policy, **kwargs):
+    lr_classes = get_all_lr_classes()
+    if lr_policy not in lr_classes:
+        raise ValueError(
+            f'{lr_policy} is not a supported lr policy. ' f'Supported lr policies are {lr_classes.keys()}.'
+        )
+    return lr_classes[lr_policy](**kwargs)
+
+
+if __name__ == '__main__':
+    pass

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -12,25 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import math
-import sys
 import warnings
 
 from torch.optim.lr_scheduler import _LRScheduler
 
-#
-# __all__ = [
-#     'WarmupPolicy',
-#     'WarmupHoldPolicy',
-#     'SquareAnnealing',
-#     'CosineAnnealing',
-#     'WarmupAnnealing',
-#     'InverseSquareRootAnnealing',
-#     'SquareRootAnnealing',
-#     'PolynomialDecayAnnealing',
-#     'PolynomialHoldDecayAnnealing',
-# ]
+__all__ = [
+    'WarmupPolicy',
+    'WarmupHoldPolicy',
+    'SquareAnnealing',
+    'CosineAnnealing',
+    'WarmupAnnealing',
+    'InverseSquareRootAnnealing',
+    'SquareRootAnnealing',
+    'PolynomialDecayAnnealing',
+    'PolynomialHoldDecayAnnealing',
+]
 
 
 class WarmupPolicy(_LRScheduler):
@@ -49,8 +46,8 @@ class WarmupPolicy(_LRScheduler):
         ), "Either use particular number of step or ratio"
         assert warmup_ratio is None or total_steps is not None, "If there is a ratio, there should be a total steps"
 
-        super().__init__(optimizer, last_epoch)
-
+        # It is necessary to assign all attributes *before* __init__,
+        # as class is wrapped by inner class.
         self.total_steps = total_steps
         if warmup_steps is not None:
             self.warmup_steps = warmup_steps
@@ -58,6 +55,8 @@ class WarmupPolicy(_LRScheduler):
             self.warmup_steps = int(warmup_ratio * total_steps)
         else:
             self.warmup_steps = 0
+
+        super().__init__(optimizer, last_epoch)
 
     def get_lr(self):
         if not self._get_lr_called_within_step:
@@ -107,11 +106,18 @@ class WarmupHoldPolicy(WarmupPolicy):
     ):
         assert not (hold_steps is not None and hold_ratio is not None), "Either use particular number of step or ratio"
         assert hold_ratio is None or total_steps is not None, "If there is a ratio, there should be a total steps"
-        super().__init__(optimizer, warmup_steps=warmup_steps, warmup_ratio=warmup_ratio, total_steps=total_steps,
-                         last_epoch=last_epoch)
 
         self._min_lr = min_lr
         self._last_warmup_lr = 0.0
+
+        # Necessary to duplicate as class attributes are hidden in inner class
+        self.total_steps = total_steps
+        if warmup_steps is not None:
+            self.warmup_steps = warmup_steps
+        elif warmup_ratio is not None:
+            self.warmup_steps = int(warmup_ratio * total_steps)
+        else:
+            self.warmup_steps = 0
 
         if hold_steps is not None:
             self.hold_steps = hold_steps + self.warmup_steps
@@ -119,6 +125,14 @@ class WarmupHoldPolicy(WarmupPolicy):
             self.hold_steps = int(hold_ratio * total_steps) + self.warmup_steps
         else:
             self.hold_steps = 0
+
+        super().__init__(
+            optimizer,
+            warmup_steps=warmup_steps,
+            warmup_ratio=warmup_ratio,
+            total_steps=total_steps,
+            last_epoch=last_epoch,
+        )
 
     def get_lr(self):
         if not self._get_lr_called_within_step:
@@ -141,161 +155,163 @@ class WarmupHoldPolicy(WarmupPolicy):
             return [0.0 for _ in self.base_lrs]
 
         return self._get_lr(step)
-#
-#
-# def _squareroot_annealing(initial_lr, step, total_steps, min_lr):
-#     mult = ((total_steps - step) / total_steps) ** 0.5
-#     out_lr = initial_lr * mult
-#     out_lr = max(out_lr, min_lr)
-#     return out_lr
-#
-#
-# def _square_annealing(initial_lr, step, total_steps, min_lr):
-#     mult = ((total_steps - step) / total_steps) ** 2
-#     out_lr = initial_lr * mult
-#     out_lr = max(out_lr, min_lr)
-#     return out_lr
-#
-#
-# def _cosine_annealing(initial_lr, step, total_steps, min_lr):
-#     mult = 0.5 * (1 + math.cos(math.pi * step / total_steps))
-#     out_lr = (initial_lr - min_lr) * mult + min_lr
-#     return out_lr
-#
-#
-# def _poly_decay(initial_lr, step, decay_steps, power, min_lr, cycle):
-#     if cycle:
-#         multiplier = 1.0 if step == 0 else math.ceil(step / decay_steps)
-#         decay_steps *= multiplier
-#     else:
-#         step = min(step, decay_steps)
-#     p = step / decay_steps
-#     lr = (initial_lr - min_lr) * math.pow(1.0 - p, power)
-#     lr += min_lr
-#     return lr
-#
-#
-# class SquareAnnealing(WarmupPolicy):
-#     def __init__(self, total_steps, min_lr=1e-5, **kwargs):
-#         super().__init__(total_steps=total_steps, **kwargs)
-#         self.min_lr = min_lr
-#
-#     def _get_lr(self, initial_lr, step, epoch):
-#         return _square_annealing(
-#             initial_lr=initial_lr,
-#             step=step - self.warmup_steps,
-#             total_steps=self.total_steps - self.warmup_steps,
-#             min_lr=self.min_lr,
-#         )
-#
-#
-# class SquareRootAnnealing(WarmupPolicy):
-#     def __init__(self, total_steps, min_lr=0, **kwargs):
-#         super().__init__(total_steps=total_steps, **kwargs)
-#         self.min_lr = min_lr
-#
-#     def _get_lr(self, initial_lr, step, epoch):
-#         return _squareroot_annealing(
-#             initial_lr=initial_lr, step=step, total_steps=self.total_steps, min_lr=self.min_lr,
-#         )
-#
-#
-# class CosineAnnealing(WarmupPolicy):
-#     def __init__(self, total_steps, min_lr=0, **kwargs):
-#         self.min_lr = min_lr
-#         super().__init__(total_steps=total_steps, **kwargs)
-#
-#     def _get_lr(self, initial_lr, step, epoch):
-#         if initial_lr < self.min_lr:
-#             raise ValueError(
-#                 f"{self} received an initial learning rate that " f"was lower than the minimum learning rate."
-#             )
-#         return _cosine_annealing(
-#             initial_lr=initial_lr,
-#             step=step - self.warmup_steps,
-#             total_steps=self.total_steps - self.warmup_steps,
-#             min_lr=self.min_lr,
-#         )
-#
-#
-# class WarmupAnnealing(WarmupPolicy):
-#     def __init__(self, total_steps, **kwargs):
-#         super().__init__(total_steps=total_steps, **kwargs)
-#
-#     def _get_lr(self, initial_lr, step, epoch):
-#         progress = float(step / self.total_steps)
-#         warmup_ratio = float(self.warmup_steps / self.total_steps)
-#
-#         mult = max((progress - 1.0) / (warmup_ratio - 1.0), 0.0)
-#         out_lr = initial_lr * mult
-#
-#         return out_lr
-#
-#
-# class InverseSquareRootAnnealing(WarmupPolicy):
-#     def __init__(self, total_steps, **kwargs):
-#         super().__init__(total_steps=total_steps, **kwargs)
-#
-#     def _get_lr(self, initial_lr, step, epoch):
-#         denom = ((step + 1) / (self.warmup_steps + 1)) ** 0.5
-#         out_lr = initial_lr / denom
-#         return out_lr
-#
-#
-# class PolynomialDecayAnnealing(WarmupPolicy):
-#     def __init__(self, total_steps, min_lr=0.0, power=1.0, cycle=False, **kwargs):
-#         super().__init__(total_steps=total_steps, **kwargs)
-#         self.min_lr = min_lr
-#         self.power = power
-#         self.cycle = cycle
-#
-#     def _get_lr(self, initial_lr, step, epoch):
-#         return _poly_decay(
-#             initial_lr,
-#             step=step - self.warmup_steps,
-#             decay_steps=self.total_steps - self.warmup_steps,
-#             power=self.power,
-#             min_lr=self.min_lr,
-#             cycle=self.cycle,
-#         )
-#
-#
-# class PolynomialHoldDecayAnnealing(WarmupHoldPolicy):
-#     def __init__(self, total_steps, min_lr=0.0, power=1.0, cycle=False, **kwargs):
-#         super().__init__(total_steps=total_steps, **kwargs)
-#         self.min_lr = min_lr
-#         self.power = power
-#         self.cycle = cycle
-#
-#     def _get_lr(self, initial_lr, step, epoch):
-#         return _poly_decay(
-#             initial_lr,
-#             step=step - self.hold_steps,
-#             decay_steps=self.total_steps - max(self.warmup_steps, self.hold_steps),
-#             power=self.power,
-#             min_lr=self.min_lr,
-#             cycle=self.cycle,
-#         )
 
 
-def get_all_lr_classes():
-    """ Get all LR classes defined within this module
-    """
-    lr_classes = {}
-    for name, obj in inspect.getmembers(sys.modules[__name__]):
-        if inspect.isclass(obj) and name != 'ABC':
-            lr_classes[name] = obj
-    return lr_classes
+def _squareroot_annealing(initial_lr, step, total_steps, min_lr):
+    mult = ((total_steps - step) / total_steps) ** 0.5
+    out_lr = initial_lr * mult
+    out_lr = max(out_lr, min_lr)
+    return out_lr
 
 
-def get_lr_policy(lr_policy, **kwargs):
-    lr_classes = get_all_lr_classes()
-    if lr_policy not in lr_classes:
-        raise ValueError(
-            f'{lr_policy} is not a supported lr policy. ' f'Supported lr policies are {lr_classes.keys()}.'
-        )
-    return lr_classes[lr_policy](**kwargs)
+def _square_annealing(initial_lr, step, total_steps, min_lr):
+    mult = ((total_steps - step) / total_steps) ** 2
+    out_lr = initial_lr * mult
+    out_lr = max(out_lr, min_lr)
+    return out_lr
 
 
-if __name__ == '__main__':
-    pass
+def _cosine_annealing(initial_lr, step, total_steps, min_lr):
+    mult = 0.5 * (1 + math.cos(math.pi * step / total_steps))
+    out_lr = (initial_lr - min_lr) * mult + min_lr
+    return out_lr
+
+
+def _poly_decay(initial_lr, step, decay_steps, power, min_lr, cycle):
+    if cycle:
+        multiplier = 1.0 if step == 0 else math.ceil(step / decay_steps)
+        decay_steps *= multiplier
+    else:
+        step = min(step, decay_steps)
+    p = step / decay_steps
+    lr = (initial_lr - min_lr) * math.pow(1.0 - p, power)
+    lr += min_lr
+    return lr
+
+
+class SquareAnnealing(WarmupPolicy):
+    def __init__(self, optimizer, *, total_steps, min_lr=1e-5, last_epoch=-1, **kwargs):
+        self.min_lr = min_lr
+
+        super().__init__(optimizer=optimizer, total_steps=total_steps, last_epoch=last_epoch, **kwargs)
+
+    def _get_lr(self, step):
+        new_lrs = [
+            _square_annealing(
+                initial_lr=initial_lr,
+                step=step - self.warmup_steps,
+                total_steps=self.total_steps - self.warmup_steps,
+                min_lr=self.min_lr,
+            )
+            for initial_lr in self.base_lrs
+        ]
+        return new_lrs
+
+
+class SquareRootAnnealing(WarmupPolicy):
+    def __init__(self, optimizer, *, total_steps, min_lr=0, last_epoch=-1, **kwargs):
+        self.min_lr = min_lr
+
+        super().__init__(optimizer=optimizer, total_steps=total_steps, last_epoch=last_epoch, **kwargs)
+
+    def _get_lr(self, step):
+        new_lrs = [
+            _squareroot_annealing(initial_lr=initial_lr, step=step, total_steps=self.total_steps, min_lr=self.min_lr,)
+            for initial_lr in self.base_lrs
+        ]
+        return new_lrs
+
+
+class CosineAnnealing(WarmupPolicy):
+    def __init__(self, optimizer, *, total_steps, min_lr=0, last_epoch=-1, **kwargs):
+        self.min_lr = min_lr
+
+        super().__init__(optimizer=optimizer, total_steps=total_steps, last_epoch=last_epoch, **kwargs)
+
+    def _get_lr(self, step):
+        for initial_lr in self.base_lrs:
+            if initial_lr < self.min_lr:
+                raise ValueError(
+                    f"{self} received an initial learning rate that " f"was lower than the minimum learning rate."
+                )
+
+        new_lrs = [
+            _cosine_annealing(
+                initial_lr=initial_lr,
+                step=step - self.warmup_steps,
+                total_steps=self.total_steps - self.warmup_steps,
+                min_lr=self.min_lr,
+            )
+            for initial_lr in self.base_lrs
+        ]
+        return new_lrs
+
+
+class WarmupAnnealing(WarmupPolicy):
+    def __init__(self, optimizer, *, total_steps, last_epoch=-1, **kwargs):
+        super().__init__(optimizer=optimizer, total_steps=total_steps, last_epoch=last_epoch, **kwargs)
+
+    def _get_lr(self, step):
+        progress = float(step / self.total_steps)
+        warmup_ratio = float(self.warmup_steps / self.total_steps)
+
+        mult = max((progress - 1.0) / (warmup_ratio - 1.0), 0.0)
+        out_lr = [initial_lr * mult for initial_lr in self.base_lrs]
+
+        return out_lr
+
+
+class InverseSquareRootAnnealing(WarmupPolicy):
+    def __init__(self, optimizer, *, total_steps, last_epoch=-1, **kwargs):
+        super().__init__(optimizer=optimizer, total_steps=total_steps, **kwargs, last_epoch=last_epoch)
+
+    def _get_lr(self, step):
+        denom = ((step + 1) / (self.warmup_steps + 1)) ** 0.5
+        out_lr = [initial_lr / denom for initial_lr in self.base_lrs]
+        return out_lr
+
+
+class PolynomialDecayAnnealing(WarmupPolicy):
+    def __init__(self, optimizer, *, total_steps, min_lr=0.0, power=1.0, cycle=False, last_epoch=-1, **kwargs):
+        self.min_lr = min_lr
+        self.power = power
+        self.cycle = cycle
+
+        super().__init__(optimizer=optimizer, total_steps=total_steps, last_epoch=last_epoch, **kwargs)
+
+    def _get_lr(self, step):
+        new_lrs = [
+            _poly_decay(
+                initial_lr,
+                step=step - self.warmup_steps,
+                decay_steps=self.total_steps - self.warmup_steps,
+                power=self.power,
+                min_lr=self.min_lr,
+                cycle=self.cycle,
+            )
+            for initial_lr in self.base_lrs
+        ]
+        return new_lrs
+
+
+class PolynomialHoldDecayAnnealing(WarmupHoldPolicy):
+    def __init__(self, optimizer, *, total_steps, min_lr=0.0, power=1.0, cycle=False, last_epoch=-1, **kwargs):
+        self.min_lr = min_lr
+        self.power = power
+        self.cycle = cycle
+
+        super().__init__(optimizer=optimizer, total_steps=total_steps, last_epoch=last_epoch, **kwargs)
+
+    def _get_lr(self, step):
+        new_lrs = [
+            _poly_decay(
+                initial_lr,
+                step=step - self.hold_steps,
+                decay_steps=self.total_steps - max(self.warmup_steps, self.hold_steps),
+                power=self.power,
+                min_lr=self.min_lr,
+                cycle=self.cycle,
+            )
+            for initial_lr in self.base_lrs
+        ]
+        return new_lrs

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -15,6 +15,7 @@
 import math
 import warnings
 
+import torch.optim.lr_scheduler as pt_scheduler
 from torch.optim.lr_scheduler import _LRScheduler
 
 __all__ = [
@@ -315,3 +316,16 @@ class PolynomialHoldDecayAnnealing(WarmupHoldPolicy):
             for initial_lr in self.base_lrs
         ]
         return new_lrs
+
+
+def prepare_scheduler(scheduler: _LRScheduler, monitor: str = 'val_loss'):
+
+    if isinstance(scheduler, pt_scheduler.ReduceLROnPlateau):
+        reduce_lr_on_plateau = {'reduce_on_plateau': True}
+    else:
+        reduce_lr_on_plateau = {'reduce_on_plateau': False}
+
+    schedule_dict = {'scheduler': scheduler, 'interval': 'step', 'frequency': 1, 'monitor': monitor}
+    schedule_dict.update(reduce_lr_on_plateau)
+
+    return schedule_dict

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -374,7 +374,7 @@ def prepare_lr_scheduler(
     if 'iters_per_batch' in scheduler_args:
         if train_dataloader is None:
             raise ValueError(
-                'As `iters_per_sample` is provided, it is required to pass the train dataloader in order '
+                'As `iters_per_batch` is provided, it is required to pass the train dataloader in order '
                 'to compute effective maximum number of steps'
             )
 
@@ -398,11 +398,15 @@ def prepare_lr_scheduler(
     # Wrap the schedule in PTL arguments to perform stepwise computation
     # Rather than epoch level computation
     if isinstance(schedule, optim.lr_scheduler.ReduceLROnPlateau):
-        reduce_lr_on_plateau = {'reduce_on_plateau': True}
+        reduce_lr_on_plateau = True
     else:
-        reduce_lr_on_plateau = {'reduce_on_plateau': False}
+        reduce_lr_on_plateau = False
 
-    schedule_dict = {'scheduler': schedule, 'interval': 'step', 'frequency': 1, 'monitor': monitor}
-    schedule_dict.update(reduce_lr_on_plateau)
-
+    schedule_dict = {
+        'scheduler': schedule,
+        'interval': 'step',
+        'frequency': 1,
+        'monitor': monitor,
+        'reduce_on_plateau': reduce_lr_on_plateau,
+    }
     return schedule_dict

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -381,10 +381,7 @@ def prepare_lr_scheduler(
         iters_per_batch = scheduler_args.pop('iters_per_batch')
         num_samples = len(train_dataloader.dataset)
         batch_size = train_dataloader.batch_size
-        max_steps = int(num_samples * iters_per_batch / float(batch_size))
-
-        additional_step = int(num_samples * iters_per_batch // float(batch_size)) % 2
-        max_steps += additional_step
+        max_steps = round(num_samples * iters_per_batch / float(batch_size))
 
         scheduler_args['max_steps'] = max_steps
 

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -48,7 +48,7 @@ class WarmupPolicy(_LRScheduler):
         assert warmup_ratio is None or total_steps is not None, "If there is a ratio, there should be a total steps"
 
         # It is necessary to assign all attributes *before* __init__,
-        # as class is wrapped by inner class.
+        # as class is wrapped by an inner class.
         self.total_steps = total_steps
         if warmup_steps is not None:
             self.warmup_steps = warmup_steps

--- a/nemo/core/optim/optimizers.py
+++ b/nemo/core/optim/optimizers.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from argparse import ArgumentParser
 from functools import partial
 from typing import Any, Dict, List, Optional, Union
 
@@ -22,7 +21,7 @@ from torch.optim.optimizer import Optimizer
 
 from nemo.core.optim.novograd import Novograd
 
-__all__ = ['get_optimizer', 'register_optimizer', 'parse_optimizer_args', 'add_optimizer_args']
+__all__ = ['get_optimizer', 'register_optimizer', 'parse_optimizer_args']
 
 
 AVAILABLE_OPTIMIZERS = {
@@ -131,46 +130,6 @@ def parse_optimizer_args(optimizer_kwargs: Union[Dict[str, Any], List[str]]) -> 
         kwargs[key] = value
 
     return kwargs
-
-
-def add_optimizer_args(
-    parent_parser: ArgumentParser,
-    optimizer: str = 'adam',
-    default_lr: float = None,
-    default_opt_args: Optional[Union[Dict[str, Any], List[str]]] = None,
-) -> ArgumentParser:
-    """Extends existing argparse with support for optimizers.
-
-    # Example of adding optimizer args to command line :
-    python train_script.py ... --optimizer "novograd" --lr 0.01 \
-        --opt_args betas=0.95,0.5 weight_decay=0.001
-
-    Args:
-        parent_parser (ArgumentParser): Custom CLI parser that will be extended.
-        optimizer (str): Default optimizer required.
-        default_lr (float): Default learning rate that should be overriden during training.
-        default_opt_args (list(str)): List of overriding arguments for the instantiated optimizer.
-
-    Returns:
-        ArgumentParser: Parser extended by Optimizers arguments.
-    """
-    if default_opt_args is None:
-        default_opt_args = []
-
-    parser = ArgumentParser(parents=[parent_parser], add_help=True, conflict_handler='resolve')
-
-    parser.add_argument('--optimizer', type=str, default=optimizer, help='Name of the optimizer. Defaults to Adam.')
-    parser.add_argument('--lr', type=float, default=default_lr, help='Learning rate of the optimizer.')
-    parser.add_argument(
-        '--opt_args',
-        default=default_opt_args,
-        nargs='+',
-        type=str,
-        help='Overriding arguments for the optimizer. \n Must follow the pattern : \n name=value separated by spaces.'
-        'Example: --opt_args weight_decay=0.001 eps=1e-8 betas=0.9,0.999',
-    )
-
-    return parser
 
 
 def register_optimizer(name: str, optimizer: Optimizer):

--- a/nemo/utils/arguments.py
+++ b/nemo/utils/arguments.py
@@ -29,3 +29,36 @@ def add_asr_args(parent_parser: ArgumentParser) -> ArgumentParser:
     parser.add_argument("--train_dataset", type=str, required=True, default=None, help="training dataset path")
     parser.add_argument("--eval_dataset", type=str, required=True, help="evaluation dataset path")
     return parser
+
+
+def add_scheduler_args(parent_parser: ArgumentParser) -> ArgumentParser:
+    """Extends existing argparse with default LR scheduler args.
+
+    Args:
+        parent_parser (ArgumentParser): Custom CLI parser that will be extended.
+
+    Returns:
+        ArgumentParser: Parser extended by LR Scheduler arguments.
+    """
+    parser = ArgumentParser(parents=[parent_parser], add_help=False, conflict_handler='resolve')
+    parser.add_argument("--warmup_steps", type=int, required=False, default=None, help="Number of warmup steps")
+    parser.add_argument(
+        "--warmup_ratio",
+        type=float,
+        required=False,
+        default=None,
+        help="Number of warmup steps as a percentage of total training steps",
+    )
+    parser.add_argument("--hold_steps", type=int, required=False, default=None, help="Number of hold LR steps")
+    parser.add_argument(
+        "--hold_ratio",
+        type=float,
+        required=False,
+        default=None,
+        help="Number of hold LR steps as a percentage of total training steps",
+    )
+    parser.add_argument("--min_lr", type=float, required=False, default=0.0, help="Minimum learning rate")
+    parser.add_argument(
+        "--last_epoch", type=int, required=False, default=-1, help="Last epoch id. -1 indicates training from scratch"
+    )
+    return parser


### PR DESCRIPTION
# LR Scheduler Support

- Adds all of NeMo's schedulers to namespace `nemo.core.optim.lr_scheduler` - can be accessed via `nemo.core.optim` directly.
- Adds `prepare_scheduler` method which consumes a configuration dictionary for the scheduler and generates a LR scheduler contained in a dictionary which is required by PTL.
- Refactors arguments to fall under the name space `nemo.utils.arguments`.

# Usage

## Inside a model training script - 
### Import `from nemo.utils.arguments import add_asr_args, add_optimizer_args, add_scheduler_args` and add to argparse.

### Construct a config dictionary for optimizer and scheduler support

```python
    # Setup optimizer and scheduler
    scheduler_args = {
        'monitor': 'val_loss',  # pytorch lightning requires this value only when using ReduceLROnPlateau; ignored otherwise.
        'warmup_ratio': args.warmup_ratio,
        'warmup_steps': args.warmup_steps,
        'min_lr': args.min_lr,
        'last_epoch': args.last_epoch,
    }

    if args.max_steps is None:
        iters_per_batch = args.max_epochs / float(args.gpus * args.num_nodes * args.accumulate_grad_batches)
        scheduler_args['iters_per_batch '] = iters_per_batch 
    else:
        scheduler_args['max_steps'] = args.max_steps
```

### Feed this config to `ModelPT.setup_optimization()` as follows : 

```python
    asr_model.setup_optimization(
        optim_params={
            'optimizer': args.optimizer,
            'lr': args.lr,
            'opt_args': args.opt_args,
            'scheduler': CosineAnnealing,
            'scheduler_args': scheduler_args,
        }
    )
```

## Inside a ModelPT subclass

### Import `from nemo.core.optim import prepare_lr_scheduler`

### Override `setup_optimization()` as follows : 

```python
    def setup_optimization(self, optim_params: Optional[Dict] = None) -> torch.optim.Optimizer:
        self.__optimizer = super().setup_optimization(optim_params)
        self.__scheduler = prepare_lr_scheduler(optimizer=self.__optimizer, scheduler_config=optim_params,
                                                train_dataloader=self.__train_dl)
```

### Override `configure_optimizers()` as follows : [Note, those extra lists around optimizer and scheduler is important, pytorch lightning expects it in this format]

```python
    def configure_optimizers(self):
        if self.__scheduler is None:
            return self.__optimizer
        else:
            return [self.__optimizer], [self.__scheduler]
```