### PR TITLE
Add full support for optimizer and scheduler to yaml based config based models

### DIFF
--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -6,7 +6,9 @@ separable: &separable true
 
 optim:
   name: novograd
+  # cls: nemo.core.optim.optimizers.Novograd
   lr: .01
+
   # optimizer arguments
   args:
     name: auto

--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -1,11 +1,40 @@
 #model: "QuartzNet15x5"
 sample_rate: &sample_rate 16000
-accumulate_grad_batches: &accumulate_grad_batches 1
+repeat: &repeat 1
+dropout: &dropout 0.0
+separable: &separable true
 
-optim_params:
-  name: adam 
+optim:
+  name: novograd
   lr: .01
-  args: {}
+  # optimizer arguments
+  args:
+    name: auto
+    # cls: nemo.core.config.optimizers.NovogradParams
+    params:
+      betas: [0.8, 0.5]
+      weight_decay: 0.001
+
+  # scheduler setup
+  sched:
+    name: CosineAnnealing
+
+    # pytorch lightning args
+    monitor: val_loss
+    iters_per_batch: null # computed at runtime
+    max_steps: null # computed at runtime or explicitly set here
+    reduce_on_plateau: false
+
+    # scheduler config override
+    args:
+      name: auto
+      # cls: nemo.core.config.schedulers.CosineAnnealingParams
+      params:
+        warmup_steps: null
+        warmup_ratio: null
+        min_lr: 0.0
+        last_epoch: -1
+
 
 pl:
   trainer:
@@ -14,17 +43,8 @@ pl:
     max_steps: null # computed at runtime if not set
     num_nodes: 1
     distributed_backend: ddp
-    accumulate_grad_batches: *accumulate_grad_batches
+    accumulate_grad_batches: 1
 
-lr_scheduler:
-  name: CosineAnnealing
-  monitor: val_loss
-  iters_per_batch: null # computed at runtime
-  args:
-    #warmup_ratio: .02
-    min_lr: 0.0
-    last_epoch: false
-    max_steps: null # computed at runtime
 
 labels: &labels [" ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
          "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'"]
@@ -33,7 +53,7 @@ AudioToTextDataLayer:
     manifest_filepath: '/raid/data/an4/an4/train_manifest.json'
     sample_rate: 16000
     labels: *labels
-    batch_size: 8
+    batch_size: 32
     trim_silence: True
     max_duration: 16.7
     shuffle: True
@@ -42,7 +62,7 @@ AudioToTextDataLayer_eval:
     manifest_filepath: '/raid/data/an4/an4/test_manifest.json'
     sample_rate: 16000
     labels: *labels
-    batch_size: 8
+    batch_size: 32
     shuffle: False
 
 preprocessor:
@@ -57,7 +77,7 @@ preprocessor:
         n_fft: 512
         frame_splicing: 1
         dither: 0.00001
-        stft_conv: true
+        stft_conv: false
 
 spec_augment:
     cls: nemo.collections.asr.modules.SpectrogramAugmentation
@@ -69,153 +89,87 @@ spec_augment:
 encoder:
     cls: nemo.collections.asr.modules.ConvASREncoder
     params:
+        feat_in: *n_mels
         activation: relu
         conv_mask: true
-        feat_in: *n_mels
+
         jasper:
-        - dilation: [1]
-          dropout: 0.0
-          filters: 256
-          kernel: [33]
-          repeat: 1
-          residual: false
-          separable: true
-          stride: [2]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 256
-          kernel: [33]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 256
-          kernel: [33]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 256
-          kernel: [33]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 256
-          kernel: [39]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 256
-          kernel: [39]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 256
-          kernel: [39]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 512
-          kernel: [51]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 512
-          kernel: [51]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 512
-          kernel: [51]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 512
-          kernel: [63]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 512
-          kernel: [63]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 512
-          kernel: [63]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 512
-          kernel: [75]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 512
-          kernel: [75]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 512
-          kernel: [75]
-          repeat: 5
-          residual: true
-          separable: true
-          stride: [1]
-        - dilation: [2]
-          dropout: 0.0
-          filters: 512
-          kernel: [87]
-          repeat: 1
-          residual: false
-          separable: true
-          stride: [1]
-        - dilation: [1]
-          dropout: 0.0
-          filters: 1024
-          kernel: [1]
-          repeat: 1
-          residual: false
-          stride: [1]
+          - filters: 128
+            repeat: 1
+            kernel: [11]
+            stride: [1]
+            dilation: [1]
+            dropout: *dropout
+            residual: true
+            separable: *separable
+            se: true
+            se_context_size: -1
+
+          - filters: 256
+            repeat: *repeat
+            kernel: [13]
+            stride: [1]
+            dilation: [1]
+            dropout: *dropout
+            residual: true
+            separable: *separable
+            se: true
+            se_context_size: -1
+
+          - filters: 256
+            repeat: *repeat
+            kernel: [15]
+            stride: [1]
+            dilation: [1]
+            dropout: *dropout
+            residual: true
+            separable: *separable
+            se: true
+            se_context_size: -1
+
+          - filters: 256
+            repeat: *repeat
+            kernel: [17]
+            stride: [1]
+            dilation: [1]
+            dropout: *dropout
+            residual: true
+            separable: *separable
+            se: true
+            se_context_size: -1
+
+          - filters: 256
+            repeat: *repeat
+            kernel: [19]
+            stride: [1]
+            dilation: [1]
+            dropout: *dropout
+            residual: true
+            separable: *separable
+            se: true
+            se_context_size: -1
+
+          - filters: 256
+            repeat: 1
+            kernel: [21]
+            stride: [1]
+            dilation: [1]
+            dropout: 0.0
+            residual: false
+            separable: *separable
+            se: true
+            se_context_size: -1
+
+          - filters: &enc_feat_out 1024
+            repeat: 1
+            kernel: [1]
+            stride: [1]
+            dilation: [1]
+            dropout: 0.0
+            residual: false
+            separable: *separable
+            se: true
+            se_context_size: -1
 
 decoder:
     cls: nemo.collections.asr.modules.ConvASRDecoder

--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -18,11 +18,11 @@ optim:
   # scheduler setup
   sched:
     name: CosineAnnealing
+    iters_per_batch: null # computed at runtime
+    max_steps: null # computed at runtime or explicitly set here
 
     # pytorch lightning args
     monitor: val_loss
-    iters_per_batch: null # computed at runtime
-    max_steps: null # computed at runtime or explicitly set here
     reduce_on_plateau: false
 
     # scheduler config override

--- a/examples/asr/speech_to_text.py
+++ b/examples/asr/speech_to_text.py
@@ -36,20 +36,35 @@ Add PyTorch Lightning Trainer arguments from CLI:
 Hydra logs will be found in "$(./outputs/$(date +"%y-%m-%d")/$(date +"%H-%M-%S")/.hydra)"
 PTL logs will be found in "$(./outputs/$(date +"%y-%m-%d")/$(date +"%H-%M-%S")/lightning_logs)"
 
- python speech_to_text.py AudioToTextDataLayer.manifest_filepath="./an4/train_manifest.json" AudioToTextDataLayer_eval.manifest_filepath="./an4/test_manifest.json" hydra.run.dir="." pl.trainer.gpus=2 pl.trainer.max_epochs=100
-
-Override some args of optimizer
- python speech_to_text.py AudioToTextDataLayer.manifest_filepath="./an4/train_manifest.json" AudioToTextDataLayer_eval.manifest_filepath="./an4/test_manifest.json" hydra.run.dir="." pl.trainer.gpus=2 pl.trainer.max_epochs=2 optim.args.params.betas=[0.9,0.22] optim.args.params.weight_decay=0.0000005
+Override some args of optimizer:
+    python speech_to_text.py \
+    AudioToTextDataLayer.manifest_filepath="./an4/train_manifest.json" \
+    AudioToTextDataLayer_eval.manifest_filepath="./an4/test_manifest.json" \
+    hydra.run.dir="." \
+    pl.trainer.gpus=2 \
+    pl.trainer.max_epochs=2 \
+    optim.args.params.betas=[0.8,0.5] \
+    optim.args.params.weight_decay=0.0001
 
 Overide optimizer entirely
- python speech_to_text.py AudioToTextDataLayer.manifest_filepath="./an4/train_manifest.json" AudioToTextDataLayer_eval.manifest_filepath="./an4/test_manifest.json" hydra.run.dir="." pl.trainer.gpus=2 pl.trainer.max_epochs=2 optim.name=adamw optim.lr=0.001 ~optim.args +optim.args.betas=[0.9,0.22] +optim.args.weight_decay=0.0000005
+    python speech_to_text.py \
+    AudioToTextDataLayer.manifest_filepath="./an4/train_manifest.json" \
+    AudioToTextDataLayer_eval.manifest_filepath="./an4/test_manifest.json" \
+    hydra.run.dir="." \
+    pl.trainer.gpus=2 \
+    pl.trainer.max_epochs=2 \
+    optim.name=adamw \
+    optim.lr=0.001 \
+    ~optim.args \
+    +optim.args.betas=[0.8,0.5]\
+    +optim.args.weight_decay=0.0005
 
 """
 
 
 @hydra.main(config_path="conf", config_name="config")
 def main(cfg):
-    print(cfg.pretty())
+    logging.info(f'Hydra config: {cfg.pretty()}')
 
     asr_model = EncDecCTCModel(
         preprocessor_config=cfg.preprocessor,

--- a/examples/nlp/bert_pretraining_from_preprocessed.py
+++ b/examples/nlp/bert_pretraining_from_preprocessed.py
@@ -84,22 +84,32 @@ def main():
         },
     )
 
+    # Setup optimizer and scheduler
     scheduler_args = {
         'monitor': 'val_loss',  # pytorch lightning requires this value
-        'warmup_ratio': args.warmup_ratio,
-        'warmup_steps': args.warmup_steps,
-        'min_lr': args.min_lr,
-        'last_epoch': args.last_epoch,
         'max_steps': args.max_steps,
+    }
+
+    scheduler_args["name"] = args.scheduler  # name of the scheduler
+    scheduler_args["args"] = {
+        "name": "auto",  # name of the scheduler config
+        "params": {
+            'warmup_ratio': args.warmup_ratio,
+            'warmup_steps': args.warmup_steps,
+            'min_lr': args.min_lr,
+            'last_epoch': args.last_epoch,
+        },
     }
 
     bert_model.setup_optimization(
         optim_params={
-            'optimizer': args.optimizer,
+            'name': args.optimizer,  # name of the optimizer
             'lr': args.lr,
-            'opt_args': args.opt_args,
-            'scheduler': getattr(sys.modules[__name__], args.scheduler),
-            'scheduler_args': scheduler_args,
+            'args': {
+                "name": "auto",  # name of the optimizer config
+                "params": {},  # Put args.opt_args here explicitly
+            },
+            'sched': scheduler_args,
         }
     )
     trainer = pl.Trainer(

--- a/examples/nlp/bert_pretraining_from_preprocessed.py
+++ b/examples/nlp/bert_pretraining_from_preprocessed.py
@@ -77,7 +77,7 @@ def main():
     args = add_args(parser)
     bert_model = BERTLMModel(pretrained_model_name=args.pretrained_model_name, config_file=args.config_file)
     bert_model.setup_training_data(
-        train_data_layer_params={
+        train_data_layer_config={
             'train_data': args.data_dir,
             'max_predictions_per_seq': args.max_predictions_per_seq,
             'batch_size': args.batch_size,
@@ -102,7 +102,7 @@ def main():
     }
 
     bert_model.setup_optimization(
-        optim_params={
+        optim_config={
             'name': args.optimizer,  # name of the optimizer
             'lr': args.lr,
             'args': {

--- a/examples/nlp/bert_pretraining_from_text.py
+++ b/examples/nlp/bert_pretraining_from_text.py
@@ -128,7 +128,7 @@ def main():
         'max_steps': args.max_steps,
     }
 
-    scheduler_args["name"] = 'WarmupAnnealing'  # name of the scheduler
+    scheduler_args["name"] = args.scheduler  # name of the scheduler
     scheduler_args["args"] = {
         "name": "auto",  # name of the scheduler config
         "params": {

--- a/examples/nlp/bert_pretraining_from_text.py
+++ b/examples/nlp/bert_pretraining_from_text.py
@@ -104,7 +104,7 @@ def main():
         preprocessing_args=preprocessing_args,
     )
     bert_model.setup_training_data(
-        train_data_layer_params={
+        train_data_layer_config={
             'dataset': train_data_file,
             'batch_size': args.batch_size,
             'max_seq_length': args.max_seq_length,
@@ -113,7 +113,7 @@ def main():
         },
     )
     bert_model.setup_validation_data(
-        val_data_layer_params={
+        val_data_layer_config={
             'dataset': valid_data_file,
             'batch_size': args.batch_size,
             'max_seq_length': args.max_seq_length,
@@ -150,7 +150,7 @@ def main():
         scheduler_args['iters_per_batch'] = None
 
     bert_model.setup_optimization(
-        optim_params={
+        optim_config={
             'name': args.optimizer,  # name of the optimizer
             'lr': args.lr,
             'args': {

--- a/examples/nlp/ner.py
+++ b/examples/nlp/ner.py
@@ -38,9 +38,9 @@ def main():
     args = parser.parse_args()
 
     ner_model = NERModel(num_classes=args.num_classes)
-    ner_model.setup_training_data(args.data_dir, train_data_layer_params={'shuffle': True})
-    ner_model.setup_validation_data(data_dir=args.data_dir, val_data_layer_params={'shuffle': False})
-    ner_model.setup_optimization(optim_params={'lr': 0.0003})
+    ner_model.setup_training_data(args.data_dir, train_data_layer_config={'shuffle': True})
+    ner_model.setup_validation_data(data_dir=args.data_dir, val_data_layer_config={'shuffle': False})
+    ner_model.setup_optimization(optim_config={'lr': 0.0003})
 
     # multi GPU
     trainer = pl.Trainer(

--- a/examples/nlp/question_answering_squad.py
+++ b/examples/nlp/question_answering_squad.py
@@ -155,7 +155,7 @@ def main():
         pretrained_model_name=args.pretrained_model_name, config_file=args.config_file, num_classes=2, num_layers=1,
     )
     model.setup_training_data(
-        train_data_layer_params={
+        train_data_layer_config={
             'data_file': args.train_file,
             'doc_stride': args.doc_stride,
             'max_query_length': args.max_query_length,
@@ -166,7 +166,7 @@ def main():
         },
     )
     model.setup_validation_data(
-        val_data_layer_params={
+        val_data_layer_config={
             'data_file': args.eval_file,
             'doc_stride': args.doc_stride,
             'max_query_length': args.max_query_length,
@@ -197,7 +197,7 @@ def main():
     }
 
     model.setup_optimization(
-        optim_params={
+        optim_config={
             'name': args.optimizer,  # name of the optimizer
             'lr': args.lr,
             'args': {

--- a/examples/nlp/question_answering_squad.py
+++ b/examples/nlp/question_answering_squad.py
@@ -178,23 +178,33 @@ def main():
     )
     scheduler_args = {
         'monitor': 'val_loss',  # pytorch lightning requires this value
-        'warmup_ratio': args.warmup_ratio,
-        'warmup_steps': args.warmup_steps,
-        'last_epoch': args.last_epoch,
+        'max_steps': args.max_steps,
     }
     if args.max_epochs:
         iters_per_batch = args.max_epochs / float(args.gpus * args.num_nodes * args.accumulate_grad_batches)
         scheduler_args['iters_per_batch'] = iters_per_batch
-    if args.max_steps:
-        scheduler_args['max_steps'] = args.max_steps
+    else:
+        scheduler_args['iters_per_batch'] = None
+
+    scheduler_args["name"] = args.scheduler  # name of the scheduler
+    scheduler_args["args"] = {
+        "name": "auto",  # name of the scheduler config
+        "params": {
+            'warmup_ratio': args.warmup_ratio,
+            'warmup_steps': args.warmup_steps,
+            'last_epoch': args.last_epoch,
+        }
+    }
 
     model.setup_optimization(
         optim_params={
-            'optimizer': args.optimizer,
+            'name': args.optimizer,  # name of the optimizer
             'lr': args.lr,
-            'opt_args': args.opt_args,
-            'scheduler': getattr(sys.modules[__name__], args.scheduler),
-            'scheduler_args': scheduler_args,
+            'args': {
+                "name": "auto",  # name of the optimizer config
+                "params": {}  # Put args.opt_args here explicitly
+            },
+            'sched':  scheduler_args
         }
     )
 

--- a/examples/nlp/question_answering_squad.py
+++ b/examples/nlp/question_answering_squad.py
@@ -193,7 +193,7 @@ def main():
             'warmup_ratio': args.warmup_ratio,
             'warmup_steps': args.warmup_steps,
             'last_epoch': args.last_epoch,
-        }
+        },
     }
 
     model.setup_optimization(
@@ -202,9 +202,9 @@ def main():
             'lr': args.lr,
             'args': {
                 "name": "auto",  # name of the optimizer config
-                "params": {}  # Put args.opt_args here explicitly
+                "params": {},  # Put args.opt_args here explicitly
             },
-            'sched':  scheduler_args
+            'sched': scheduler_args,
         }
     )
 

--- a/examples/nlp/text_classification/text_classification_with_bert.py
+++ b/examples/nlp/text_classification/text_classification_with_bert.py
@@ -187,7 +187,7 @@ def main():
         scheduler_args['iters_per_batch'] = None
 
     text_classification_model.setup_optimization(
-        optim_params={
+        optim_config={
             'name': args.optimizer,  # name of the optimizer
             'lr': args.lr,
             'args': {

--- a/examples/nlp/text_classification/text_classification_with_bert.py
+++ b/examples/nlp/text_classification/text_classification_with_bert.py
@@ -163,10 +163,17 @@ def main():
     # Setup optimizer and scheduler
     scheduler_args = {
         'monitor': 'val_loss',  # pytorch lightning requires this value
-        'warmup_ratio': args.warmup_ratio,
-        'warmup_steps': args.warmup_steps,
-        'min_lr': args.min_lr,
-        'last_epoch': args.last_epoch,
+        'max_steps': args.max_steps,
+    }
+
+    scheduler_args["name"] = args.scheduler  # name of the scheduler
+    scheduler_args["args"] = {
+        "name": "auto",  # name of the scheduler config
+        "params": {
+            'warmup_ratio': args.warmup_ratio,
+            'warmup_steps': args.warmup_steps,
+            'last_epoch': args.last_epoch,
+        },
     }
 
     if args.max_steps is None:
@@ -177,15 +184,17 @@ def main():
             iters_per_batch = args.max_epochs / float(args.gpus * args.num_nodes * args.accumulate_grad_batches)
         scheduler_args['iters_per_batch'] = iters_per_batch
     else:
-        scheduler_args['max_steps'] = args.max_steps
+        scheduler_args['iters_per_batch'] = None
 
     text_classification_model.setup_optimization(
         optim_params={
-            'optimizer': args.optimizer,
+            'name': args.optimizer,  # name of the optimizer
             'lr': args.lr,
-            'opt_args': args.opt_args,
-            'scheduler': WarmupAnnealing,
-            'scheduler_args': scheduler_args,
+            'args': {
+                "name": "auto",  # name of the optimizer config
+                "params": {},  # Put args.opt_args here explicitly
+            },
+            'sched': scheduler_args,
         }
     )
 

--- a/examples/nlp/text_classification/text_classification_with_bert.py
+++ b/examples/nlp/text_classification/text_classification_with_bert.py
@@ -166,7 +166,7 @@ def main():
         'max_steps': args.max_steps,
     }
 
-    scheduler_args["name"] = args.scheduler  # name of the scheduler
+    scheduler_args["name"] = 'WarmupAnnealing'  # name of the scheduler
     scheduler_args["args"] = {
         "name": "auto",  # name of the scheduler config
         "params": {

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -18,6 +18,7 @@ import hydra
 import torch
 from omegaconf import DictConfig
 
+from nemo import logging
 from nemo.collections.asr.data.audio_to_text import AudioToTextDataset
 from nemo.collections.asr.losses.ctc import CTCLoss
 from nemo.collections.asr.metrics.wer import WER
@@ -80,7 +81,6 @@ class EncDecCTCModel(ASRModel):
             test_data_layer_params['shuffle'] = False
         self.__test_dl = self.__setup_dataloader_from_config(config=test_data_layer_params)
 
-    # TODO: revert setup_optimization to pass candidate CI, add setup_hydra_optimization for new example
     def setup_optimization(self, optim_params: Optional[Union[DictConfig, dict]] = None) -> torch.optim.Optimizer:
         self.__optimizer = super().setup_optimization(optim_params)
         self.__scheduler = prepare_lr_scheduler(
@@ -190,7 +190,6 @@ class EncDecCTCModel(ASRModel):
         log_probs, encoded_len, predictions = self.forward(
             input_signal=audio_signal, input_signal_length=audio_signal_len
         )
-        # loss_value = self.loss.loss_function(
         loss_value = self.loss(
             log_probs=log_probs, targets=transcript, input_lengths=encoded_len, target_lengths=transcript_len
         )

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -18,7 +18,6 @@ import hydra
 import torch
 from omegaconf import DictConfig
 
-from nemo import logging
 from nemo.collections.asr.data.audio_to_text import AudioToTextDataset
 from nemo.collections.asr.losses.ctc import CTCLoss
 from nemo.collections.asr.metrics.wer import WER
@@ -66,25 +65,25 @@ class EncDecCTCModel(ASRModel):
             num_workers=config.get('num_workers', 0),
         )
 
-    def setup_training_data(self, train_data_layer_params: Optional[Dict]):
-        if 'shuffle' not in train_data_layer_params:
-            train_data_layer_params['shuffle'] = True
-        self.__train_dl = self.__setup_dataloader_from_config(config=train_data_layer_params)
+    def setup_training_data(self, train_data_layer_config: Optional[Union[DictConfig, Dict]]):
+        if 'shuffle' not in train_data_layer_config:
+            train_data_layer_config['shuffle'] = True
+        self.__train_dl = self.__setup_dataloader_from_config(config=train_data_layer_config)
 
-    def setup_validation_data(self, val_data_layer_params: Optional[Dict]):
-        if 'shuffle' not in val_data_layer_params:
-            val_data_layer_params['shuffle'] = False
-        self.__val_dl = self.__setup_dataloader_from_config(config=val_data_layer_params)
+    def setup_validation_data(self, val_data_layer_config: Optional[Union[DictConfig, Dict]]):
+        if 'shuffle' not in val_data_layer_config:
+            val_data_layer_config['shuffle'] = False
+        self.__val_dl = self.__setup_dataloader_from_config(config=val_data_layer_config)
 
-    def setup_test_data(self, test_data_layer_params: Optional[Dict]):
+    def setup_test_data(self, test_data_layer_params: Optional[Union[DictConfig, Dict]]):
         if 'shuffle' not in test_data_layer_params:
             test_data_layer_params['shuffle'] = False
         self.__test_dl = self.__setup_dataloader_from_config(config=test_data_layer_params)
 
-    def setup_optimization(self, optim_params: Optional[Union[DictConfig, dict]] = None) -> torch.optim.Optimizer:
-        self.__optimizer = super().setup_optimization(optim_params)
+    def setup_optimization(self, optim_config: Optional[Union[DictConfig, dict]] = None) -> torch.optim.Optimizer:
+        self.__optimizer = super().setup_optimization(optim_config)
         self.__scheduler = prepare_lr_scheduler(
-            optimizer=self.__optimizer, scheduler_config=optim_params, train_dataloader=self.__train_dl
+            optimizer=self.__optimizer, scheduler_config=optim_config, train_dataloader=self.__train_dl
         )
 
     @classmethod
@@ -193,7 +192,6 @@ class EncDecCTCModel(ASRModel):
         loss_value = self.loss(
             log_probs=log_probs, targets=transcript, input_lengths=encoded_len, target_lengths=transcript_len
         )
-
         wer_num, wer_denom = self.__wer(predictions, transcript, transcript_len)
         return {'val_loss': loss_value, 'val_wer_num': wer_num, 'val_wer_denom': wer_denom}
 

--- a/nemo/collections/cv/models/mnist_lenet5.py
+++ b/nemo/collections/cv/models/mnist_lenet5.py
@@ -125,14 +125,14 @@ class MNISTLeNet5(ModelPT):
     #     )
     #     return [optimizer], [scheduler]
 
-    def setup_optimization(self, optim_params=None) -> Optimizer:
-        optim_params = optim_params or self._cfg.optim
-        self._optimizer = super().setup_optimization(optim_params)
+    def setup_optimization(self, optim_config=None) -> Optimizer:
+        optim_config = optim_config or self._cfg.optim
+        self._optimizer = super().setup_optimization(optim_config)
         self._scheduler = prepare_lr_scheduler(
-            optimizer=self._optimizer, scheduler_config=optim_params, train_dataloader=self._train_dl
+            optimizer=self._optimizer, scheduler_config=optim_config, train_dataloader=self._train_dl
         )
 
-    def setup_training_data(self, train_data_layer_params: Optional[Dict] = None):
+    def setup_training_data(self, train_data_layer_config: Optional[Dict] = None):
         """ Create dataset, wrap it with dataloader and return the latter """
         # Instantiate dataset.
         mnist_ds = MNISTDataset(self._cfg.dataset)
@@ -140,7 +140,7 @@ class MNISTLeNet5(ModelPT):
         train_dataloader = DataLoader(dataset=mnist_ds, **(self._cfg.dataloader))
         self._train_dl = train_dataloader
 
-    def setup_validation_data(self, val_data_layer_params: Optional[Dict] = None):
+    def setup_validation_data(self, val_data_layer_config: Optional[Dict] = None):
         self._val_dl = None
 
     def setup_test_data(self, test_data_layer_params: Optional[Dict] = None):

--- a/nemo/collections/nlp/data/qa_dataset.py
+++ b/nemo/collections/nlp/data/qa_dataset.py
@@ -29,7 +29,6 @@ from nemo import logging
 from nemo.collections.common.parts.utils import _compute_softmax
 from nemo.collections.nlp.data.data_utils import DataProcessor, is_whitespace, normalize_answer
 from nemo.core.classes import Dataset
-
 # WIP add back evaluation metrics
 # from nemo.collections.nlp.metrics.squad_metrics import (
 #     _get_best_indexes,

--- a/nemo/collections/nlp/data/qa_dataset.py
+++ b/nemo/collections/nlp/data/qa_dataset.py
@@ -29,6 +29,7 @@ from nemo import logging
 from nemo.collections.common.parts.utils import _compute_softmax
 from nemo.collections.nlp.data.data_utils import DataProcessor, is_whitespace, normalize_answer
 from nemo.core.classes import Dataset
+
 # WIP add back evaluation metrics
 # from nemo.collections.nlp.metrics.squad_metrics import (
 #     _get_best_indexes,

--- a/nemo/collections/nlp/models/lm_model.py
+++ b/nemo/collections/nlp/models/lm_model.py
@@ -167,31 +167,31 @@ class BERTLMModel(ModelPT):
         avg_loss = torch.stack([x['val_loss'] for x in outputs]).mean()
         return {'val_loss': avg_loss}
 
-    def setup_training_data(self, train_data_layer_params: Optional[Dict]):
-        if 'shuffle' not in train_data_layer_params:
-            train_data_layer_params['shuffle'] = True
+    def setup_training_data(self, train_data_layer_config: Optional[Dict]):
+        if 'shuffle' not in train_data_layer_config:
+            train_data_layer_config['shuffle'] = True
         self.__train_dl = (
-            self.__setup_preprocessed_dataloader(train_data_layer_params)
+            self.__setup_preprocessed_dataloader(train_data_layer_config)
             if self.tokenizer is None
-            else self.__setup_text_dataloader(train_data_layer_params)
+            else self.__setup_text_dataloader(train_data_layer_config)
         )
 
-    def setup_validation_data(self, val_data_layer_params: Optional[Dict]):
-        if 'shuffle' not in val_data_layer_params:
-            val_data_layer_params['shuffle'] = False
+    def setup_validation_data(self, val_data_layer_config: Optional[Dict]):
+        if 'shuffle' not in val_data_layer_config:
+            val_data_layer_config['shuffle'] = False
         self.__val_dl = (
-            self.__setup_preprocessed_dataloader(val_data_layer_params)
+            self.__setup_preprocessed_dataloader(val_data_layer_config)
             if self.tokenizer is None
-            else self.__setup_text_dataloader(val_data_layer_params)
+            else self.__setup_text_dataloader(val_data_layer_config)
         )
 
     def setup_test_data(self, test_data_layer_params: Optional[Dict]):
         pass
 
-    def setup_optimization(self, optim_params: Optional[Dict] = None) -> torch.optim.Optimizer:
-        self.__optimizer = super().setup_optimization(optim_params)
+    def setup_optimization(self, optim_config: Optional[Dict] = None) -> torch.optim.Optimizer:
+        self.__optimizer = super().setup_optimization(optim_config)
         self.__scheduler = prepare_lr_scheduler(
-            optimizer=self.__optimizer, scheduler_config=optim_params, train_dataloader=self.__train_dl
+            optimizer=self.__optimizer, scheduler_config=optim_config, train_dataloader=self.__train_dl
         )
 
     def __setup_preprocessed_dataloader(self, data_layer_params):

--- a/nemo/collections/nlp/models/ner_model.py
+++ b/nemo/collections/nlp/models/ner_model.py
@@ -136,16 +136,16 @@ class NERModel(ModelPT):
         # tensorboard_logs = {'val_loss': avg_loss, 'val_acc': val_acc}
         return {'val_loss': avg_loss}  # , 'log': tensorboard_logs}
 
-    def setup_training_data(self, data_dir, train_data_layer_params: Optional[Dict]):
-        if 'shuffle' not in train_data_layer_params:
-            train_data_layer_params['shuffle'] = True
+    def setup_training_data(self, data_dir, train_data_layer_config: Optional[Dict]):
+        if 'shuffle' not in train_data_layer_config:
+            train_data_layer_config['shuffle'] = True
         text_file = os.path.join(data_dir, 'text_train.txt')
         labels_file = os.path.join(data_dir, 'labels_train.txt')
         self.__train_dl = self.__setup_dataloader_ner(text_file, labels_file)
 
-    def setup_validation_data(self, data_dir, val_data_layer_params: Optional[Dict]):
-        if 'shuffle' not in val_data_layer_params:
-            val_data_layer_params['shuffle'] = False
+    def setup_validation_data(self, data_dir, val_data_layer_config: Optional[Dict]):
+        if 'shuffle' not in val_data_layer_config:
+            val_data_layer_config['shuffle'] = False
         text_file = os.path.join(data_dir, 'text_dev.txt')
         labels_file = os.path.join(data_dir, 'labels_dev.txt')
         self.__val_dl = self.__setup_dataloader_ner(text_file, labels_file)
@@ -153,9 +153,9 @@ class NERModel(ModelPT):
     def setup_test_data(self, test_data_layer_params: Optional[Dict]):
         pass
 
-    def setup_optimization(self, optim_params: Optional[Dict], optimizer='adam'):
+    def setup_optimization(self, optim_config: Optional[Dict], optimizer='adam'):
         if optimizer == 'adam':
-            self.__optimizer = torch.optim.Adam(self.parameters(), lr=optim_params['lr'])
+            self.__optimizer = torch.optim.Adam(self.parameters(), lr=optim_config['lr'])
         else:
             raise NotImplementedError()
 

--- a/nemo/collections/nlp/models/qa_model.py
+++ b/nemo/collections/nlp/models/qa_model.py
@@ -128,25 +128,25 @@ class QAModel(ModelPT):
         tensorboard_logs = {'val_loss': avg_loss}
         return {'val_loss': avg_loss, 'log': tensorboard_logs}
 
-    def setup_training_data(self, train_data_layer_params: Optional[Dict]):
-        if 'shuffle' not in train_data_layer_params:
-            train_data_layer_params['shuffle'] = True
-            train_data_layer_params['mode'] = 'train'
-        self.__train_dl = self.__setup_dataloader(train_data_layer_params)
+    def setup_training_data(self, train_data_layer_config: Optional[Dict]):
+        if 'shuffle' not in train_data_layer_config:
+            train_data_layer_config['shuffle'] = True
+            train_data_layer_config['mode'] = 'train'
+        self.__train_dl = self.__setup_dataloader(train_data_layer_config)
 
-    def setup_validation_data(self, val_data_layer_params: Optional[Dict]):
-        if 'shuffle' not in val_data_layer_params:
-            val_data_layer_params['shuffle'] = False
-            val_data_layer_params['mode'] = 'eval'
-        self.__val_dl = self.__setup_dataloader(val_data_layer_params)
+    def setup_validation_data(self, val_data_layer_config: Optional[Dict]):
+        if 'shuffle' not in val_data_layer_config:
+            val_data_layer_config['shuffle'] = False
+            val_data_layer_config['mode'] = 'eval'
+        self.__val_dl = self.__setup_dataloader(val_data_layer_config)
 
     def setup_test_data(self, test_data_layer_params: Optional[Dict]):
         pass
 
-    def setup_optimization(self, optim_params: Optional[Dict] = None) -> torch.optim.Optimizer:
-        self.__optimizer = super().setup_optimization(optim_params)
+    def setup_optimization(self, optim_config: Optional[Dict] = None) -> torch.optim.Optimizer:
+        self.__optimizer = super().setup_optimization(optim_config)
         self.__scheduler = prepare_lr_scheduler(
-            optimizer=self.__optimizer, scheduler_config=optim_params, train_dataloader=self.__train_dl
+            optimizer=self.__optimizer, scheduler_config=optim_config, train_dataloader=self.__train_dl
         )
 
     def __setup_dataloader(self, data_layer_params):

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -119,16 +119,18 @@ class ModelPT(LightningModule, Model):
 
                 logging.info("About to instantiate optimizer")
 
-                optimizer_instance = hydra.utils.instantiate(optimizer_cls, self.parameters(), **optimizer_config)  # type: DictConfig
+                optimizer_instance = hydra.utils.instantiate(
+                    optimizer_cls, self.parameters(), **optimizer_config
+                )  # type: DictConfig
 
                 logging.info("Optimizer config = %s", str(optimizer_instance))
 
                 return optimizer_instance
 
             except Exception as e:
-                logging.error("Could not instantiate class path - {} with kwargs {}".format(
-                    optimizer_cls, str(optimizer_config)
-                ))
+                logging.error(
+                    "Could not instantiate class path - {} with kwargs {}".format(optimizer_cls, str(optimizer_config))
+                )
                 raise e
 
         else:

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -20,8 +20,8 @@ from omegaconf import DictConfig, OmegaConf
 from pytorch_lightning import LightningModule
 from torch.optim.optimizer import Optimizer
 
+from nemo.core import optim
 from nemo.core.classes.common import Model
-from nemo.core.optim.optimizers import get_optimizer, parse_optimizer_args
 from nemo.utils import logging
 
 __all__ = ['ModelPT']
@@ -33,33 +33,43 @@ class ModelPT(LightningModule, Model):
     """
 
     @abstractmethod
-    def setup_training_data(self, train_data_layer_params: Optional[Dict]):
+    def setup_training_data(self, train_data_layer_config: Union[DictConfig, Dict]):
         """
         Setups data loader to be used in training
         Args:
-            train_data_layer_params: training data layer parameters.
+            train_data_layer_config: training data layer parameters.
         Returns:
 
         """
         pass
 
     @abstractmethod
-    def setup_validation_data(self, val_data_layer_params: Optional[Dict]):
+    def setup_validation_data(self, val_data_layer_config: Union[DictConfig, Dict]):
         """
         (Optionally) Setups data loader to be used in validation
         Args:
-            val_data_layer_params: validation data layer parameters.
+            val_data_layer_config: validation data layer parameters.
         Returns:
 
         """
         pass
 
-    def setup_optimization(self, optim_params: Optional[Union[DictConfig, Dict]] = None) -> Optimizer:
+    def setup_test_data(self, test_data_layer_config: Union[DictConfig, Dict]):
+        """
+        (Optionally) Setups data loader to be used in test
+        Args:
+            test_data_layer_config: test data layer parameters.
+        Returns:
+
+        """
+        raise NotImplementedError()
+
+    def setup_optimization(self, optim_config: Optional[Union[DictConfig, Dict]] = None) -> Optimizer:
         """
         Prepares an optimizer from a string name and its optional config parameters.
 
         Args:
-            optim_params: a dictionary containing the following keys.
+            optim_config: a dictionary containing the following keys.
                 - "lr": mandatory key for learning rate. Will raise ValueError
                 if not provided.
 
@@ -73,29 +83,58 @@ class ModelPT(LightningModule, Model):
         Returns:
             An instance of a torch.optim.Optimizer
         """
-        optim_params = optim_params or {}  # In case null was passed as optim_params
+        optim_config = optim_config or {}  # In case null was passed as optim_params
 
         # Force into DictConfig from nested structure
-        optim_params = OmegaConf.create(optim_params)
+        optim_config = OmegaConf.create(optim_config)
 
         # Check if caller provided optimizer name, default to Adam otherwise
-        optimizer_name = optim_params.get('name', 'adam')
+        optimizer_cls = optim_config.get('cls', None)
 
-        # Check if caller has optimizer kwargs, default to empty dictionary
-        optimizer_args = optim_params.get('args', {})
-        optimizer_args = parse_optimizer_args(optimizer_name, optimizer_args)
+        if optimizer_cls is None:
+            # Try to get optimizer name for dynamic resolution, defaulting to Adam
+            optimizer_name = optim_config.get('name', 'adam')
+        else:
+            # resolve the class name (lowercase) from the class path if not provided
+            optimizer_name = optimizer_cls.split(".")[-1].lower()
 
         # We are guarenteed to have lr since it is required by the argparser
         # But maybe user forgot to pass it to this function
-        lr = optim_params.get('lr', None)
+        lr = optim_config.get('lr', None)
 
         if 'lr' is None:
             raise ValueError('`lr` must be passed to `optimizer_config` when setting up the optimization !')
 
+        # Check if caller has optimizer kwargs, default to empty dictionary
+        optimizer_args = optim_config.get('args', {})
+        optimizer_args = optim.parse_optimizer_args(optimizer_name, optimizer_args)
+
         # Actually instantiate the optimizer
-        optimizer = get_optimizer(optimizer_name)
-        optimizer = optimizer(self.parameters(), lr=lr, **optimizer_args)
+        if optimizer_cls is not None:
+            # Attempt class path resolution
+            try:
+                optimizer_cls = OmegaConf.create({'cls': optimizer_cls})
+                optimizer_config = {'lr': lr}
+                optimizer_config.update(optimizer_args)
 
-        logging.info("Optimizer config = %s", str(optimizer))
+                logging.info("About to instantiate optimizer")
 
-        return optimizer
+                optimizer_instance = hydra.utils.instantiate(optimizer_cls, self.parameters(), **optimizer_config)  # type: DictConfig
+
+                logging.info("Optimizer config = %s", str(optimizer_instance))
+
+                return optimizer_instance
+
+            except Exception as e:
+                logging.error("Could not instantiate class path - {} with kwargs {}".format(
+                    optimizer_cls, str(optimizer_config)
+                ))
+                raise e
+
+        else:
+            optimizer = optim.get_optimizer(optimizer_name)
+            optimizer = optimizer(self.parameters(), lr=lr, **optimizer_args)
+
+            logging.info("Optimizer config = %s", str(optimizer))
+
+            return optimizer

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -16,7 +16,7 @@ from abc import abstractmethod
 from typing import Dict, Optional, Union
 
 import hydra
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 from pytorch_lightning import LightningModule
 from torch.optim.optimizer import Optimizer
 
@@ -73,32 +73,29 @@ class ModelPT(LightningModule, Model):
         Returns:
             An instance of a torch.optim.Optimizer
         """
-        if isinstance(optim_params, Dict):
-            optim_params = optim_params or {}  # In case null was passed as optim_params
+        optim_params = optim_params or {}  # In case null was passed as optim_params
 
-            # Check if caller provided optimizer name, default to Adam otherwise
-            optimizer_name = optim_params.get('optimizer', 'adam')
+        # Force into DictConfig from nested structure
+        optim_params = OmegaConf.create(optim_params)
 
-            # Check if caller has optimizer kwargs, default to empty dictionary
-            optimizer_args = optim_params.get('opt_args', [])
-            optimizer_args = parse_optimizer_args(optimizer_args)
+        # Check if caller provided optimizer name, default to Adam otherwise
+        optimizer_name = optim_params.get('name', 'adam')
 
-            # We are guarenteed to have lr since it is required by the argparser
-            # But maybe user forgot to pass it to this function
-            lr = optim_params.get('lr', None)
+        # Check if caller has optimizer kwargs, default to empty dictionary
+        optimizer_args = optim_params.get('args', {})
+        optimizer_args = parse_optimizer_args(optimizer_name, optimizer_args)
 
-            if 'lr' is None:
-                raise ValueError('`lr` must be passed to `optimizer_config` when setting up the optimization !')
+        # We are guarenteed to have lr since it is required by the argparser
+        # But maybe user forgot to pass it to this function
+        lr = optim_params.get('lr', None)
 
-            # Actually instantiate the optimizer
-            optimizer = get_optimizer(optimizer_name)
-            optimizer = optimizer(self.parameters(), lr=lr, **optimizer_args)
+        if 'lr' is None:
+            raise ValueError('`lr` must be passed to `optimizer_config` when setting up the optimization !')
 
-        else:
-            # TODO: maybe this was why scheduler was not working for me
-            optimizer_cls = get_optimizer(optim_params.name)
-            lr = optim_params.lr
-            optimizer = optimizer_cls(self.parameters(), lr=lr, **optim_params.args)
-            # optimizer = optimizer(self.parameters(), **optimizer_config.args)
+        # Actually instantiate the optimizer
+        optimizer = get_optimizer(optimizer_name)
+        optimizer = optimizer(self.parameters(), lr=lr, **optimizer_args)
+
+        logging.info("Optimizer config = %s", str(optimizer))
 
         return optimizer

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -142,7 +142,9 @@ class ModelPT(LightningModule, Model):
 
                 except Exception as e:
                     logging.error(
-                        "Could not instantiate class path - {} with kwargs {}".format(optimizer_cls, str(optimizer_config))
+                        "Could not instantiate class path - {} with kwargs {}".format(
+                            optimizer_cls, str(optimizer_config)
+                        )
                     )
                     raise e
 

--- a/nemo/core/config/__init__.py
+++ b/nemo/core/config/__init__.py
@@ -15,7 +15,31 @@
 # =============================================================================
 
 from nemo.core.config.base_config import Config
-from nemo.core.config.optimizers import AdamConfig, AdamParams, NovogradConfig, NovogradParams
+from nemo.core.config.optimizers import (
+    AdadeltaParams,
+    AdagradParams,
+    AdamaxParams,
+    AdamParams,
+    AdamWParams,
+    NovogradParams,
+    RMSpropParams,
+    RpropParams,
+    SGDParams,
+    get_optimizer_config,
+)
 from nemo.core.config.pytorch import DataLoaderConfig
 from nemo.core.config.pytorch_lightning import TrainerConfig
+from nemo.core.config.schedulers import (
+    CosineAnnealingParams,
+    InverseSquareRootAnnealingParams,
+    PolynomialDecayAnnealingParams,
+    PolynomialHoldDecayAnnealingParams,
+    SchedulerParams,
+    SquareAnnealingParams,
+    SquareRootAnnealingParams,
+    WarmupAnnealingParams,
+    WarmupHoldSchedulerParams,
+    WarmupSchedulerParams,
+    get_scheduler_config,
+)
 from nemo.core.config.set_config import set_config

--- a/nemo/core/config/__init__.py
+++ b/nemo/core/config/__init__.py
@@ -22,10 +22,12 @@ from nemo.core.config.optimizers import (
     AdamParams,
     AdamWParams,
     NovogradParams,
+    OptimizerParams,
     RMSpropParams,
     RpropParams,
     SGDParams,
     get_optimizer_config,
+    register_optimizer_params,
 )
 from nemo.core.config.pytorch import DataLoaderConfig
 from nemo.core.config.pytorch_lightning import TrainerConfig
@@ -41,5 +43,6 @@ from nemo.core.config.schedulers import (
     WarmupHoldSchedulerParams,
     WarmupSchedulerParams,
     get_scheduler_config,
+    register_scheduler_params,
 )
 from nemo.core.config.set_config import set_config

--- a/nemo/core/config/optimizers.py
+++ b/nemo/core/config/optimizers.py
@@ -203,6 +203,22 @@ class NovogradParams(OptimizerParams):
     luc_eps: float = 1e-8
 
 
+def register_optimizer_params(name: str, optimizer_params: OptimizerParams):
+    """
+    Checks if the optimizer param name exists in the registry, and if it doesnt, adds it.
+
+    This allows custom optimizer params to be added and called by name during instantiation.
+
+    Args:
+        name: Name of the optimizer. Will be used as key to retrieve the optimizer.
+        optimizer_params: Optimizer class
+    """
+    if name in AVAILABLE_OPTIMIZER_PARAMS:
+        raise ValueError(f"Cannot override pre-existing optimizers. Conflicting optimizer name = {name}")
+
+    AVAILABLE_OPTIMIZER_PARAMS[name] = optimizer_params
+
+
 def get_optimizer_config(name: str, **kwargs: Optional[Dict[str, Any]]) -> OptimizerParams:
     """
     Convenience method to obtain a OptimizerParams class and partially instantiate it with optimizer kwargs.
@@ -217,18 +233,18 @@ def get_optimizer_config(name: str, **kwargs: Optional[Dict[str, Any]]) -> Optim
     if name is None:
         return kwargs
 
-    if name not in AVAILABLE_OPTIMIZER_CONFIGS:
+    if name not in AVAILABLE_OPTIMIZER_PARAMS:
         raise ValueError(
             f"Cannot resolve optimizer parameters '{name}'. Available optimizer parameters are : "
-            f"{AVAILABLE_OPTIMIZER_CONFIGS.keys()}"
+            f"{AVAILABLE_OPTIMIZER_PARAMS.keys()}"
         )
 
-    scheduler_params = AVAILABLE_OPTIMIZER_CONFIGS[name]
+    scheduler_params = AVAILABLE_OPTIMIZER_PARAMS[name]
     scheduler_params = partial(scheduler_params, **kwargs)
     return scheduler_params
 
 
-AVAILABLE_OPTIMIZER_CONFIGS = {
+AVAILABLE_OPTIMIZER_PARAMS = {
     'optim_params': OptimizerParams,
     'adam_params': AdamParams,
     'novograd_params': NovogradParams,

--- a/nemo/core/config/pytorch_lightning.py
+++ b/nemo/core/config/pytorch_lightning.py
@@ -48,3 +48,5 @@ class TrainerConfig:
     max_epochs: int = 1000
     min_epochs: int = 1
     distributed_backend: Optional[str] = None
+    max_steps: Optional[int] = None
+    accumulate_grad_batches: int = 1

--- a/nemo/core/config/schedulers.py
+++ b/nemo/core/config/schedulers.py
@@ -129,6 +129,7 @@ class StepLRParams(SchedulerParams):
     Config for StepLR.
     It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
     """
+
     step_size: float = 0.1
     gamma: float = 0.1
 
@@ -139,6 +140,7 @@ class ExponentialLRParams(SchedulerParams):
     Config for ExponentialLR.
     It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
     """
+
     gamma: float = 0.9
 
 
@@ -148,6 +150,7 @@ class ReduceLROnPlateauParams:
     Config for ReduceLROnPlateau.
     It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
     """
+
     mode: str = 'min'
     factor: float = 0.1
     patience: int = 10
@@ -168,12 +171,13 @@ class CyclicLRParams(SchedulerParams):
 
     It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
     """
+
     base_lr: float = 0.001
     max_lr: float = 0.1
     step_size_up: int = 2000
     step_size_down: Optional[int] = None
     mode: str = 'triangular'
-    gamma: float = 1.
+    gamma: float = 1.0
     scale_mode: str = 'cycle'
     # scale_fn is not supported
     cycle_momentum: bool = True

--- a/nemo/core/config/schedulers.py
+++ b/nemo/core/config/schedulers.py
@@ -1,0 +1,156 @@
+# =============================================================================
+# Copyright (c) 2020 NVIDIA. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+from dataclasses import dataclass
+from functools import partial
+from typing import Any, Dict, Optional
+
+
+@dataclass
+class SchedulerParams:
+    """
+    Base configuration for all schedulers.
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+
+    last_epoch: int = -1
+
+
+@dataclass
+class WarmupSchedulerParams(SchedulerParams):
+    """
+    Base configuration for all schedulers.
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+
+    warmup_steps: Optional[float] = None
+    warmup_ratio: Optional[float] = None
+
+
+@dataclass
+class WarmupHoldSchedulerParams(WarmupSchedulerParams):
+    """
+    Base configuration for all schedulers.
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+
+    hold_steps: Optional[float] = None
+    hold_ratio: Optional[float] = None
+    min_lr: float = 0.0
+
+
+@dataclass
+class SquareAnnealingParams(WarmupSchedulerParams):
+    """
+    Square Annealing parameter config
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+
+    min_lr: float = 1e-5
+
+
+@dataclass
+class SquareRootAnnealingParams(WarmupSchedulerParams):
+    """
+    Square Root Annealing parameter config
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+
+    min_lr: float = 0.0
+
+
+@dataclass
+class CosineAnnealingParams(WarmupSchedulerParams):
+    """
+    Cosine Annealing parameter config
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+
+    min_lr: float = 0.0
+
+
+@dataclass
+class WarmupAnnealingParams(WarmupSchedulerParams):
+    """
+    Warmup Annealing parameter config
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+
+
+@dataclass
+class InverseSquareRootAnnealingParams(WarmupSchedulerParams):
+    """
+    Inverse Square Root Annealing parameter config
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+
+
+@dataclass
+class PolynomialDecayAnnealingParams(WarmupSchedulerParams):
+    """
+    Polynomial Decay Annealing parameter config
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+
+    power: float = 1.0
+    cycle: bool = False
+
+
+@dataclass
+class PolynomialHoldDecayAnnealingParams(WarmupSchedulerParams):
+    """
+    Polynomial Hold Decay Annealing parameter config
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+
+    power: float = 1.0
+    cycle: bool = False
+
+
+def get_scheduler_config(name: str, **kwargs: Optional[Dict[str, Any]]) -> SchedulerParams:
+    """
+    Convenience method to obtain a SchedulerParams class and partially instantiate it with optimizer kwargs.
+
+    Args:
+        name: Name of the SchedulerParams in the registry.
+        kwargs: Optional kwargs of the optimizer used during instantiation.
+
+    Returns:
+        a partially instantiated SchedulerParams
+    """
+    if name not in AVAILABLE_SCHEDULER_PARAMS:
+        raise ValueError(
+            f"Cannot resolve scheduler parameters '{name}'. Available scheduler parameters are : "
+            f"{AVAILABLE_SCHEDULER_PARAMS.keys()}"
+        )
+
+    scheduler_params = AVAILABLE_SCHEDULER_PARAMS[name]
+    scheduler_params = partial(scheduler_params, **kwargs)
+    return scheduler_params
+
+
+AVAILABLE_SCHEDULER_PARAMS = {
+    'SchedulerParams': SchedulerParams,
+    'WarmupPolicyParams': WarmupSchedulerParams,
+    'WarmupHoldPolicyParams': WarmupHoldSchedulerParams,
+    'SquareAnnealingParams': SquareAnnealingParams,
+    'SquareRootAnnealingParams': SquareRootAnnealingParams,
+    'InverseSquareRootAnnealingParams': InverseSquareRootAnnealingParams,
+    'CosineAnnealingParams': CosineAnnealingParams,
+    'WarmupAnnealingParams': WarmupAnnealingParams,
+    'PolynomialDecayAnnealingParams': PolynomialDecayAnnealingParams,
+    'PolynomialHoldDecayAnnealingParams': PolynomialHoldDecayAnnealingParams,
+}

--- a/nemo/core/config/schedulers.py
+++ b/nemo/core/config/schedulers.py
@@ -1,5 +1,4 @@
-# =============================================================================
-# Copyright (c) 2020 NVIDIA. All Rights Reserved.
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# =============================================================================
 
 from dataclasses import dataclass
 from functools import partial
@@ -118,6 +116,85 @@ class PolynomialHoldDecayAnnealingParams(WarmupSchedulerParams):
 
     power: float = 1.0
     cycle: bool = False
+
+
+"""
+Pytorch Optimizers
+"""
+
+
+@dataclass
+class StepLRParams(SchedulerParams):
+    """
+    Config for StepLR.
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+    step_size: float = 0.1
+    gamma: float = 0.1
+
+
+@dataclass
+class ExponentialLRParams(SchedulerParams):
+    """
+    Config for ExponentialLR.
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+    gamma: float = 0.9
+
+
+@dataclass
+class ReduceLROnPlateauParams:
+    """
+    Config for ReduceLROnPlateau.
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+    mode: str = 'min'
+    factor: float = 0.1
+    patience: int = 10
+    verbose: bool = False
+    threshold: float = 1e-4
+    threshold_mode: str = 'rel'
+    cooldown: int = 0
+    min_lr: float = 0
+    eps: float = 1e-8
+
+
+@dataclass
+class CyclicLRParams(SchedulerParams):
+    """
+    Config for CyclicLR.
+    NOTE:
+    # `scale_fn` is not supported
+
+    It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
+    """
+    base_lr: float = 0.001
+    max_lr: float = 0.1
+    step_size_up: int = 2000
+    step_size_down: Optional[int] = None
+    mode: str = 'triangular'
+    gamma: float = 1.
+    scale_mode: str = 'cycle'
+    # scale_fn is not supported
+    cycle_momentum: bool = True
+    base_momentum: float = 0.8
+    max_momentum: float = 0.9
+
+
+def register_scheduler_params(name: str, scheduler_params: SchedulerParams):
+    """
+    Checks if the schduler config name exists in the registry, and if it doesnt, adds it.
+
+    This allows custom schedulers to be added and called by name during instantiation.
+
+    Args:
+        name: Name of the optimizer. Will be used as key to retrieve the optimizer.
+        scheduler_params: SchedulerParams class
+    """
+    if name in AVAILABLE_SCHEDULER_PARAMS:
+        raise ValueError(f"Cannot override pre-existing optimizers. Conflicting optimizer name = {name}")
+
+    AVAILABLE_SCHEDULER_PARAMS[name] = scheduler_params
 
 
 def get_scheduler_config(name: str, **kwargs: Optional[Dict[str, Any]]) -> SchedulerParams:

--- a/nemo/core/optim/optimizers.py
+++ b/nemo/core/optim/optimizers.py
@@ -21,7 +21,7 @@ from omegaconf import DictConfig, OmegaConf
 from torch.optim import adadelta, adagrad, adamax, rmsprop, rprop
 from torch.optim.optimizer import Optimizer
 
-from nemo.core.config import get_optimizer_config
+from nemo.core.config import OptimizerParams, get_optimizer_config, register_optimizer_params
 from nemo.core.optim.novograd import Novograd
 
 __all__ = ['get_optimizer', 'register_optimizer', 'parse_optimizer_args']
@@ -115,7 +115,7 @@ def parse_optimizer_args(
     return kwargs
 
 
-def register_optimizer(name: str, optimizer: Optimizer):
+def register_optimizer(name: str, optimizer: Optimizer, optimizer_params: OptimizerParams):
     """
     Checks if the optimizer name exists in the registry, and if it doesnt, adds it.
 
@@ -124,11 +124,15 @@ def register_optimizer(name: str, optimizer: Optimizer):
     Args:
         name: Name of the optimizer. Will be used as key to retrieve the optimizer.
         optimizer: Optimizer class
+        optimizer_params: The parameters as a dataclass of the optimizer
     """
     if name in AVAILABLE_OPTIMIZERS:
         raise ValueError(f"Cannot override pre-existing optimizers. Conflicting optimizer name = {name}")
 
     AVAILABLE_OPTIMIZERS[name] = optimizer
+
+    optim_name = "{}_params".format(optimizer.__name__)
+    register_optimizer_params(name=optim_name, optimizer_params=optimizer_params)
 
 
 def get_optimizer(name: str, **kwargs: Optional[Dict[str, Any]]) -> Optimizer:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,4 +12,4 @@ wrapt
 ruamel.yaml
 scikit-learn
 scipy
-hydra-core
+ --pre hydra-core

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,4 +12,4 @@ wrapt
 ruamel.yaml
 scikit-learn
 scipy
-hydra-core --pre
+hydra-core==1.0.0rc1

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,4 +12,4 @@ wrapt
 ruamel.yaml
 scikit-learn
 scipy
- --pre hydra-core
+hydra-core --pre


### PR DESCRIPTION
# Optimizer and Scheduler support

Following are the various examples on how to add optimizer and scheduler support via either yaml config file or via explicit Config objects.

# Optimizer & Scheduler support via YAML
The following config file can be copy pasted into any new config file, then edited as per requirements

```yaml
optim:
  name: novograd
  lr: .01
  # optimizer arguments
  args:
    name: auto
    # cls: nemo.core.config.optimizers.NovogradParams
    params:
      betas: [0.8, 0.5]
      weight_decay: 0.001

  # scheduler setup
  sched:
    name: CosineAnnealing

    # pytorch lightning args
    monitor: val_loss
    iters_per_batch: null # computed at runtime
    max_steps: null # computed at runtime or explicitly set here
    reduce_on_plateau: false

    # scheduler config override
    args:
      name: auto
      # cls: nemo.core.config.schedulers.CosineAnnealingParams
      params:
        warmup_steps: null
        warmup_ratio: null
        min_lr: 0.0
        last_epoch: -1
```

Step by step breakdown:
## Optimizer section
```yaml
optim:
  name: novograd
  lr: .01
  # optimizer arguments
  args:
    name: auto
    # cls: nemo.core.config.optimizers.NovogradParams
    params:
      betas: [0.8, 0.5]
      weight_decay: 0.001
```

In yaml, we can declare optimizers using `optim` as the master level header, which has two mandatory parameters - `name` and `lr`.

It also has the optional, `args` subdirectory - which configures the parameters of the optimizer config dictionary itself.

`args` comprises of 2 important objects - 

1) `name` or `cls` - `name` is the name of the config object - generally in lowercase it is the name of the optimizer with `_params` appended. So `novograd_params`, `adamw_params` etc...

If we want to be explicit, we can add a full class path with `cls` instead of `name`. 

2) `params` - This is the overriding arguments to the parameters instantiated by the OptimizerConfig object above. Names must match the OptimizerConfig instantiated, otherwise errors will be raised.

### Overrides of YAML based workflow

Following are a few code examples of overrides that can be done for yaml based workflows -

### Use default optimizer with no overrides (by deleting optim.args)

**NOTE**: Note the `~` before `optim.args` - this is used to delete arguments (recursively)

```python
python speech_to_text.py ... ~optim.args
```

### Use default optimizer with lr overrides but nothing else (by deleting optim.args)

```python
python speech_to_text.py ... ~optim.args optim.lr=0.001
```

### Replace different optimizer with lr overrides (by deleting optim.args)

```python
python speech_to_text.py ... optim.name=adamw optim.lr=0.001 ~optim.args
```

### Overriding optimizer parameter arguments

**NOTE**: Here, brackets `[ ]` cannot have spaces in between them, otherwise hydra cannot parse lists properly !

```python
python speech_to_text.py ... optim.args.betas=[0.9,0.5] optim.args.weight_decay=1e-3
```

### Adding optimizer parameter arguments

**NOTE**: Note the `+` before the name, this will create new param under that namespace.

```python
python speech_to_text.py ... +optim.args.eps=1e-7
```

## Scheduler Section

The scheduler section is slightly more involved (with several mandatory arguments)

```yaml
optim:
  ....
   
  # scheduler setup
  sched:
    name: CosineAnnealing
    iters_per_batch: null # computed at runtime
    max_steps: null # computed at runtime or explicitly set here

    # pytorch lightning args
    monitor: val_loss
    reduce_on_plateau: false

    # scheduler config override
    args:
      name: auto
      # cls: nemo.core.config.schedulers.CosineAnnealingParams
      params:
        warmup_steps: null
        warmup_ratio: null
        min_lr: 0.0
        last_epoch: -1
```

In order to add a learning rate scheduler on an optimizer, the `optim` config **must** have a `sched` component. Note, the names need to be the same, and are shortened for overriding conveniene.

If `sched` is detected inside the optimizer config, we then are required to provide a few defaults 

1) `name` - This is the name of the scheduler with `Params` appended to the end. Case must match exactly that of the class. Eg - `CosineAnnealingParams`.
2) `iters_per_batch` - This should be set to null here, as it will be overriden by the train script.
3) `max_steps` - This can be either null or a positive integer. If it is an integer, it overrides the above `iters_per_batch` value.
4) `args` - 
For schedulers, if `sched` is provided, **it is mandatory to also provide `args`**. Even a blank definition for name='auto' and params: last_epoch=-1 is sufficient, but it is necessary to have at the moment.

Similar to `optim.args`, `optim.sched.args` takes two key parameters - `name/cls` and `params` subconfig. 

The most common overrides are provided here - `min_lr`, `warmup_steps` and `warmup_ratio`, so that we can easily edit them from command line.

**NOTE**
There are two arguments which are not mandatory, and can be left out of configs as they are currently not used.

5) `monitor` - Only used if `ReduceLROnPlateau` scheduler is used **(not supported at the moment)**. Leave as loss or val_loss or now as it is not used
6) `reduce_on_plateau` - another requirement for above class (not supported at the moment, but necessary to have)


### Overrides of YAML based workflow 

Following are a few code examples of overrides that can be done for yaml based workflows -

### Changing scheduler from command line

```python
python speech_to_text.py ... optim.sched.name=PolynomialDecayAnnealing +optim.sched.args.params.power=2.0
```

# Optimizer & Scheduler support via Config Objects

For Config object based explicit declaration of the config - we can follow the pattern shown below

## Define the config objects for the Optimizer and nested Scheduler

```python
@dataclass
class NovogradScheduler(Config):
    """
    Scheduler setup for novograd
    """

    # Mandatory parameters
    name: str = "CosineAnnealing"
    args: CosineAnnealingParams = CosineAnnealingParams()  # can be a string to param, or "auto", just like in YAML

    # pytorch lightning parameters
    monitor: str = "val_loss"
    iters_per_batch: Optional[float] = None  # computed at runtime
    max_steps: Optional[int] = None  # computed at runtime or explicitly set here
    reduce_on_plateau: bool = False


@dataclass
class MNISTOptimizer(Config):
    """
    Optimizer setup for novograd
    """

    # Mandatory arguments
    name: str = "novograd"
    lr: float = 0.01

    args: NovogradParams = NovogradParams(betas=(0.8, 0.5))  # overrides should mostly be in code directly
    sched: NovogradScheduler = NovogradScheduler()  # Instantiate above scheduler definition
```

## Attach it to the overall config object and pass to the `super().setup_optimization()` as below

> Attachment to model config

```python
@dataclass
class MNISTLeNet5Config(Config):
    """
    Structured config for LeNet-5 model class - that also contains parameters of dataset and dataloader.

    (This example shows that we can inherit from other configs.)

    Args:
        dataset: MNIST dataset config.
        dataloader: Dataloader config.
        module: module config (default one).
        optim: Optimizer + Scheduler config.
    """

    dataset: MNISTDatasetConfig = MNISTDatasetConfig(width=32, height=32)
    dataloader: DataLoaderConfig = DataLoaderConfig(batch_size=64, shuffle=True)
    module: Config = Config()
    optim: MNISTOptimizer = MNISTOptimizer()  # Attached optimizer config
```

> Attachment to setup optimization

```python
    def setup_optimization(self, optim_params=None) -> Optimizer:
        optim_params = optim_params or self._cfg.optim  # self._cfg contains the above MNISTLeNet5Config() config object
        self._optimizer = super().setup_optimization(optim_params)
        self._scheduler = prepare_lr_scheduler(
            optimizer=self._optimizer, scheduler_config=optim_params, train_dataloader=self._train_dl
        )
```

Command overrides are the same as for yaml.

Signed-off-by: smajumdar <titu1994@gmail.com>