### PR TITLE
speech_commands: read number of timesteps and preprocessor type from …

### DIFF
--- a/examples/asr/configs/quartznet_speech_commands_3x1_v1.yaml
+++ b/examples/asr/configs/quartznet_speech_commands_3x1_v1.yaml
@@ -1,5 +1,8 @@
 model: "QuartzNet"
 sample_rate: &sample_rate 16000
+# number of timesteps model is trained on
+timesteps: 128
+preprocessor: "AudioToMFCCPreprocessor"
 dropout: &drop 0.0
 repeat:  &rep  1
 augment: true

--- a/examples/asr/configs/quartznet_speech_commands_3x1_v2.yaml
+++ b/examples/asr/configs/quartznet_speech_commands_3x1_v2.yaml
@@ -1,5 +1,8 @@
 model: "QuartzNet"
 sample_rate: &sample_rate 16000
+# number of timesteps model is trained on
+timesteps: 128
+preprocessor: "AudioToMFCCPreprocessor"
 dropout: &drop 0.0
 repeat:  &rep  1
 augment: true

--- a/examples/asr/quartznet_speech_commands.py
+++ b/examples/asr/quartznet_speech_commands.py
@@ -83,6 +83,7 @@ def create_all_dags(args, neural_factory):
 
     labels = jasper_params['labels']  # Vocab of tokens
     sample_rate = jasper_params['sample_rate']
+    preprocessor = jasper_params['preprocessor']
 
     # Calculate num_workers for dataloader
     total_cpus = os.cpu_count()
@@ -108,16 +109,19 @@ def create_all_dags(args, neural_factory):
         **train_dl_params,
     )
 
-    crop_pad_augmentation = nemo_asr.CropOrPadSpectrogramAugmentation(audio_length=128)
+    crop_pad_augmentation = nemo_asr.CropOrPadSpectrogramAugmentation(audio_length=jasper_params['timesteps'])
 
     N = len(data_layer)
     steps_per_epoch = math.ceil(N / (args.batch_size * args.iter_per_step * args.num_gpus))
     logging.info('Steps per epoch : {0}'.format(steps_per_epoch))
     logging.info('Have {0} examples to train on.'.format(N))
 
-    data_preprocessor = nemo_asr.AudioToMFCCPreprocessor(
-        sample_rate=sample_rate, **jasper_params["AudioToMFCCPreprocessor"],
-    )
+    if preprocessor == "AudioToMFCCPreprocessor":
+        data_preprocessor = nemo_asr.AudioToMFCCPreprocessor(sample_rate=sample_rate, **jasper_params[preprocessor])
+    elif preprocessor == "AudioToMelSpectrogramPreprocessor":
+        data_preprocessor = nemo_asr.AudioToMelSpectrogramPreprocessor(
+            sample_rate=sample_rate, **jasper_params[preprocessor]
+        )
 
     spectr_augment_config = jasper_params.get('SpectrogramAugmentation', None)
     if spectr_augment_config:


### PR DESCRIPTION
…config (#802)

- Number of timesteps the model is trained on, is read from config
- Type of preprocessor is read from config

Signed-off-by: Viraj Karandikar <vkarandikar@nvidia.com>