### PR TITLE
Refactor optimizers and schedulers to have a shallow hierarchy

### DIFF
--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -142,12 +142,8 @@ model:
     # cls: nemo.core.optim.optimizers.Novograd
     lr: .01
     # optimizer arguments
-    args:
-      name: auto
-      # cls: nemo.core.config.optimizers.NovogradParams
-      params:
-        betas: [0.8, 0.5]
-        weight_decay: 0.001
+    betas: [0.8, 0.5]
+    weight_decay: 0.001
 
     # scheduler setup
     sched:
@@ -159,15 +155,11 @@ model:
       monitor: val_loss
       reduce_on_plateau: false
 
-      # scheduler config override
-      args:
-        name: auto
-        # cls: nemo.core.config.schedulers.CosineAnnealingParams
-        params:
-          warmup_steps: null
-          warmup_ratio: null
-          min_lr: 0.0
-          last_epoch: -1
+      # Scheduler params
+      warmup_steps: null
+      warmup_ratio: null
+      min_lr: 0.0
+      last_epoch: -1
 
 pl:
   trainer:

--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -148,12 +148,10 @@ model:
     # scheduler setup
     sched:
       name: CosineAnnealing
-      iters_per_batch: null # computed at runtime
-      max_steps: null # computed at runtime or explicitly set here
 
       # pytorch lightning args
-      monitor: val_loss
-      reduce_on_plateau: false
+      # monitor: val_loss
+      # reduce_on_plateau: false
 
       # Scheduler params
       warmup_steps: null

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -120,6 +120,10 @@ class ModelPT(LightningModule, Model):
         optim_config = OmegaConf.create(optim_config)
 
         # Setup optimizer and scheduler
+
+        if optim_config is not None:
+            optim_config = OmegaConf.to_container(optim_config)
+
         if 'sched' in optim_config and self._trainer is not None:
             if not isinstance(self._trainer.accumulate_grad_batches, int):
                 raise ValueError("We do not currently support gradient acculumation that is not an integer.")
@@ -133,9 +137,9 @@ class ModelPT(LightningModule, Model):
                     iters_per_batch = self._trainer.max_epochs / float(
                         self._trainer.num_gpus * self._trainer.num_nodes * self._trainer.accumulate_grad_batches
                     )
-                optim_config.sched.iters_per_batch = iters_per_batch
+                optim_config['sched']['iters_per_batch'] = iters_per_batch
             else:
-                optim_config.sched.max_steps = self._trainer.max_steps
+                optim_config['sched']['max_steps'] = self._trainer.max_steps
 
         # Force into DictConfig from nested structure
         optim_config = OmegaConf.create(optim_config)

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -121,7 +121,7 @@ class ModelPT(LightningModule, Model):
 
         # Setup optimizer and scheduler
 
-        if optim_config is not None:
+        if optim_config is not None and isinstance(optim_config, DictConfig):
             optim_config = OmegaConf.to_container(optim_config)
 
         if 'sched' in optim_config and self._trainer is not None:

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -114,13 +114,18 @@ class ModelPT(LightningModule, Model):
                 The list of "arg_value" will be parsed and a dictionary of optimizer
                 kwargs will be built and supplied to instantiate the optimizer.
         """
-        optim_config = optim_config or {}  # In case null was passed as optim_params
+        # If config was not explicitly passed to us
+        if optim_config is None:
+            # See if internal config has `optim` namespace
+            if self._cfg is not None and hasattr(self._cfg, 'optim'):
+                optim_config = self._cfg.optim
 
-        # Force into DictConfig from nested structure
-        optim_config = OmegaConf.create(optim_config)
+        # If config is still None, or internal config has no Optim, return without instantiation
+        if optim_config is None:
+            logging.info('No optimizer config provided, therefore no optimizer was created')
+            return
 
         # Setup optimizer and scheduler
-
         if optim_config is not None and isinstance(optim_config, DictConfig):
             optim_config = OmegaConf.to_container(optim_config)
 

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -505,7 +505,8 @@ def prepare_lr_scheduler(
 
     else:
         raise ValueError(
-            "Neither `max_steps` nor `iters_per_batch` were provided, cannot compute " "effective `max_steps` !"
+            "Neither `max_steps` nor `iters_per_batch` were provided to `optim.sched`, "
+            "cannot compute effective `max_steps` !"
         )
 
     # Inject max_steps (effective or provided) into the scheduler config


### PR DESCRIPTION
# Refactor Optimizers and Schedulers to support shallow hierarchy 
--------

Optimizer hierarchy has been slightly flattened to the following : 
```yaml
model:
  ...
  optim:
    name: novograd
    # cls: nemo.core.optim.optimizers.Novograd
    lr: .01

    # optimizer arguments
    betas: [0.8, 0.5]
    weight_decay: 0.001

    # scheduler setup
    sched:
      name: CosineAnnealing

      # Scheduler params
      warmup_steps: null
      warmup_ratio: null
      min_lr: 0.0
      last_epoch: -1

      # iters_per_batch: null # computed at runtime, not needed to be set explicitly anymore
      # max_steps: null # computed at runtime or explicitly set here

      # pytorch lightning args
      # monitor: val_loss
      # reduce_on_plateau: false
```

## Optimizer namespace
`name` and `lr` are still mandatory arguments. Additional arguments for the optimizer can be flattened out into this namespace directly.

1) `betas` and `weight_decay` now fall directly under `optim` namespace.
2) They can be overriden with the following techniques - 

```python
python <filename>.py \
  model.optim.betas=[0.95,0.9] \
  model.optim.weight_decay=0.0000001
```

## Scheduler namespace

`name` is the only mandatory argument now. Additional arguments for the optimizer can be flattened out into this namespace directly.

`monitor` and `reduce_on_plateau` are optional arguments that you should add if you use `ReduceLROnPlatue` scheduler.

1) Other than name, all other arguments are considered arguments to be directly passed to scheduler.
2) They can be overriden with the following techniques - 

```python
python <filename>.py \
  model.optimsched.warmup_steps=1000 \
  model.optim.sched.min_lr=0.000001
```

# Support for Explicit Configs
The codebase will fully support the explicit declaration as before 

```yaml
model:
  ...
  optim:
    name: novograd
    # cls: nemo.core.optim.optimizers.Novograd
    lr: .01
    # optimizer arguments
    args:
      name: auto
      # cls: nemo.core.config.optimizers.NovogradParams
      params:
        betas: [0.8, 0.5]
        weight_decay: 0.001

    # scheduler setup
    sched:
      name: CosineAnnealing
      iters_per_batch: null # computed at runtime
      max_steps: null # computed at runtime or explicitly set here

      # pytorch lightning args
      monitor: val_loss
      reduce_on_plateau: false

      # scheduler config override
      args:
        name: auto
        # cls: nemo.core.config.schedulers.CosineAnnealingParams
        params:
          warmup_steps: null
          warmup_ratio: null
          min_lr: 0.0
          last_epoch: -1
```


Signed-off-by: smajumdar <titu1994@gmail.com>