### PR TITLE
Add `hydra_runner` decorator to inject args to ease logging via ExpManager

### DIFF
--- a/examples/asr/speech_to_text.py
+++ b/examples/asr/speech_to_text.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import hydra
+
 import pytorch_lightning as pl
 
 from nemo.collections.asr.models import EncDecCTCModel
+from nemo.core.config import hydra_runner
 from nemo.utils.exp_manager import exp_manager
 
 
@@ -62,7 +63,7 @@ Overide optimizer entirely
 """
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra_runner(config_path="conf", config_name="config")
 def main(cfg):
     trainer = pl.Trainer(**cfg.pl.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))

--- a/examples/asr/speech_to_text_bpe.py
+++ b/examples/asr/speech_to_text_bpe.py
@@ -29,16 +29,15 @@ python speech_to_text_bpe.py \
     model.logger.project_name="AN4_BPE_1024_candidate" \
     hydra.run.dir=.
 """
-
-import hydra
 import pytorch_lightning as pl
 
 from nemo.collections.asr.models.ctc_bpe_models import EncDecCTCModelBPE
+from nemo.core.config import hydra_runner
 from nemo.utils import logging
 from nemo.utils.exp_manager import exp_manager
 
 
-@hydra.main(config_path="experimental/configs/", config_name="config_bpe")
+@hydra_runner(config_path="experimental/configs/", config_name="config_bpe")
 def main(cfg):
     logging.info(f'Hydra config: {cfg.pretty()}')
     trainer = pl.Trainer(**cfg.pl.trainer)

--- a/examples/nlp/question_answering/question_answering_squad.py
+++ b/examples/nlp/question_answering/question_answering_squad.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 
-import hydra
 import pytorch_lightning as pl
 from omegaconf import DictConfig
 
 from nemo.collections.nlp.models.qa_model import QAModel
+from nemo.core.config import hydra_runner
 from nemo.utils import logging
 from nemo.utils.exp_manager import exp_manager
 
 
-@hydra.main(config_path="conf", config_name="config")
+@hydra_runner(config_path="conf", config_name="config")
 def main(cfg: DictConfig) -> None:
     logging.info(f'Config: {cfg.pretty()}')
     trainer = pl.Trainer(**cfg.pl.trainer)

--- a/examples/nlp/text_classification/text_classification_with_bert.py
+++ b/examples/nlp/text_classification/text_classification_with_bert.py
@@ -13,16 +13,16 @@
 # limitations under the License.
 
 
-import hydra
 import pytorch_lightning as pl
 from omegaconf import DictConfig
 
 from nemo.collections.nlp.models.text_classification import TextClassificationModel
+from nemo.core.config import hydra_runner
 from nemo.utils import logging
 from nemo.utils.exp_manager import exp_manager
 
 
-@hydra.main(config_path="conf", config_name="text_classification_config")
+@hydra_runner(config_path="conf", config_name="text_classification_config")
 def main(cfg: DictConfig) -> None:
     logging.info(f'Config Params:\n {cfg.pretty()}')
     trainer = pl.Trainer(**cfg.pl.trainer)

--- a/examples/nlp/token_classification/ner.py
+++ b/examples/nlp/token_classification/ner.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hydra
 import pytorch_lightning as pl
 from omegaconf import DictConfig
 
 from nemo.collections.nlp.models import NERModel
+from nemo.core.config import hydra_runner
 from nemo.utils import logging
 
 
-@hydra.main(config_path="conf", config_name="ner_config")
+@hydra_runner(config_path="conf", config_name="ner_config")
 def main(cfg: DictConfig) -> None:
     logging.info(f'Config: {cfg.pretty()}')
     trainer = pl.Trainer(**cfg.pl.trainer)

--- a/examples/nlp/token_classification/punctuation_capitalization.py
+++ b/examples/nlp/token_classification/punctuation_capitalization.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import hydra
 import pytorch_lightning as pl
 from omegaconf import DictConfig
 
 from nemo.collections.nlp.models import PunctuationCapitalizationModel
+from nemo.core.config import hydra_runner
 from nemo.utils import logging
 
 
-@hydra.main(config_path="conf", config_name="punctuation_capitalization_config")
+@hydra_runner(config_path="conf", config_name="punctuation_capitalization_config")
 def main(cfg: DictConfig) -> None:
     logging.info(f'Config: {cfg.pretty()}')
     trainer = pl.Trainer(**cfg.pl.trainer)

--- a/nemo/core/config/__init__.py
+++ b/nemo/core/config/__init__.py
@@ -45,4 +45,4 @@ from nemo.core.config.schedulers import (
     get_scheduler_config,
     register_scheduler_params,
 )
-from nemo.core.config.set_config import set_config
+from nemo.core.config.set_config import hydra_runner, set_config

--- a/nemo/core/config/set_config.py
+++ b/nemo/core/config/set_config.py
@@ -17,7 +17,6 @@
 import functools
 from typing import Any, Callable, Optional
 
-import hydra
 from hydra._internal.utils import get_args_parser, run_hydra
 from hydra.core.config_store import ConfigStore
 from hydra.types import TaskFunction

--- a/nemo/core/config/set_config.py
+++ b/nemo/core/config/set_config.py
@@ -45,18 +45,20 @@ def hydra_runner(
             else:
                 args = get_args_parser()
 
-                # Force working directory to current dir
+                # Parse arguments in order to retrieve overrides
                 parsed_args = args.parse_args()
 
                 # Get overriding args in dot string format
-                overrides = parsed_args.overrides
+                overrides = parsed_args.overrides  # type: list
 
-                # Update override to include hydra.run.dir=.
+                # Update overrides
                 overrides.append("hydra.run.dir=.")
                 overrides.append('hydra.job_logging.root.handlers=null')
 
+                # Wrap a callable object with name `parse_args`
+                # This is to mimic the ArgParser.parse_args() API.
                 class _argparse_wrapper:
-                    def parse_args(self):
+                    def parse_args(self, args=None, namespace=None):
                         return parsed_args
 
                 # no return value from run_hydra() as it may sometime actually run the task_function


### PR DESCRIPTION
Hydra decorator to provide same interface as hydra, while automatically injecting the `hydra.run.dir=.` and `hydra.job_logging.root.handlers=null` overrides to all callers of this decorator.

# Usage

```python
from nemo.core.config import hydra_runner

# replace @hydra.main(...) with @hydra_runner(...) and all else is same.
@hydra_runner(config_path="conf", config_name="config")
def main(cfg):
   ...
```

Signed-off-by: smajumdar <titu1994@gmail.com>