### PR TITLE
fix speech to text and revert serialization to original state

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,6 +89,12 @@ pipeline {
     //   }
     // }
 
+    stage('L2: Speech 2 Text dev run') {
+      steps {
+        sh 'python examples/asr/speech_to_text.py model.train_ds.manifest_filepath=/home/TestData/an4_train.json model.validation_ds.manifest_filepath=/home/TestData/an4_val.json pl.trainer.gpus=1 +pl.trainer.fast_dev_run=True'
+      }
+    }
+
     stage('L2: BERT Squad v1.1') {
       when {
         anyOf{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -91,7 +91,7 @@ pipeline {
 
     stage('L2: Speech 2 Text dev run') {
       steps {
-        sh 'python examples/asr/speech_to_text.py model.train_ds.manifest_filepath=/home/TestData/an4_train.json model.validation_ds.manifest_filepath=/home/TestData/an4_val.json pl.trainer.gpus=1 +pl.trainer.fast_dev_run=True'
+        sh 'python examples/asr/speech_to_text.py model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json model.validation_ds.manifest_filepath=/home/TestData/an4_dataset/an4_val.json pl.trainer.gpus=1 +pl.trainer.fast_dev_run=True'
       }
     }
 

--- a/examples/asr/speech_to_text.py
+++ b/examples/asr/speech_to_text.py
@@ -65,7 +65,7 @@ Overide optimizer entirely
 @hydra.main(config_path="conf", config_name="config")
 def main(cfg):
     trainer = pl.Trainer(**cfg.pl.trainer)
-    exp_manager(trainer, cfg.get("exp_manager", None))
+    # exp_manager(trainer, cfg.get("exp_manager", None))
     asr_model = EncDecCTCModel(cfg=cfg.model, trainer=trainer)
     trainer.fit(asr_model)
 

--- a/examples/asr/speech_to_text.py
+++ b/examples/asr/speech_to_text.py
@@ -65,7 +65,7 @@ Overide optimizer entirely
 @hydra.main(config_path="conf", config_name="config")
 def main(cfg):
     trainer = pl.Trainer(**cfg.pl.trainer)
-    # exp_manager(trainer, cfg.get("exp_manager", None))
+    exp_manager(trainer, cfg.get("exp_manager", None))
     asr_model = EncDecCTCModel(cfg=cfg.model, trainer=trainer)
     trainer.fit(asr_model)
 

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -30,7 +30,7 @@ from nemo.utils.decorators import experimental
 __all__ = ['EncDecCTCModel', 'JasperNet', 'QuartzNet']
 
 
-@experimental
+# @experimental
 class EncDecCTCModel(ASRModel):
     """Encoder decoder CTC-based models."""
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.18.2
 onnx
 onnxruntime
-pytorch-lightning
+pytorch-lightning>=0.8.5
 pandas
 python-dateutil
 tensorboardX


### PR DESCRIPTION
Changes in the PR

1.  This PR makes speech_to_text.py run again
2. Reverts serialization to its original stage - this is because logic there is wrong and need to unblock (1)
3. Adds Jenkins test for speech_to_text

This PR removes @experimental decorator from EncDecCTCModel class as it confuses PTL saving/restoring. I guess that decorator needs more work outside of scope of this PR