### PR TITLE
Refactor @experimental decorator to prevent breaking of serialization

### DIFF
--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -31,7 +31,7 @@ from nemo.utils.decorators import experimental
 __all__ = ['EncDecCTCModel', 'JasperNet', 'QuartzNet']
 
 
-# @experimental
+@experimental
 class EncDecCTCModel(ASRModel):
     """Encoder decoder CTC-based models."""
 

--- a/nemo/utils/decorators/experimental.py
+++ b/nemo/utils/decorators/experimental.py
@@ -24,13 +24,12 @@ def experimental(cls):
     """
 
     def wrapped(cls):
-        class WrappedClass(cls):
-            def __init__(self, *args, **kwargs):
-                super().__init__(*args, **kwargs)
-                logging.warning(
-                    f'Module {cls} is experimental, not ready for production and is not supported. Use at your own risk.'
-                )
+        logging.warning(
+            f'Module {cls} is experimental, not ready for production and is not fully supported. Use at your own risk.'
+        )
 
-        return WrappedClass
+        cls.__name__ = cls.__name__ + '(Experimental)'
+
+        return cls
 
     return wrapped(cls=cls)

--- a/nemo/utils/decorators/experimental.py
+++ b/nemo/utils/decorators/experimental.py
@@ -28,8 +28,6 @@ def experimental(cls):
             f'Module {cls} is experimental, not ready for production and is not fully supported. Use at your own risk.'
         )
 
-        cls.__name__ = cls.__name__ + '(Experimental)'
-
         return cls
 
     return wrapped(cls=cls)


### PR DESCRIPTION
`@experimental` decorator now simply - 

1) Logs that the class is not experimental at import / access time once.

Signed-off-by: smajumdar <titu1994@gmail.com>