### PR TITLE
Add MatchboxNet + ASR Classification model support

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,9 +104,7 @@ pipeline {
             model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json \
             model.validation_ds.manifest_filepath=/home/TestData/an4_dataset/an4_val.json \
             pl.trainer.gpus=[0] \
-            +pl.trainer.fast_dev_run=True \
-            model.preprocessor.cls=nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor \
-            ~model.preprocessor.params.n_mfcc
+            +pl.trainer.fast_dev_run=True
             '
             sh 'rm -rf examples/asr/NeMo_experiments'
           }
@@ -114,7 +112,14 @@ pipeline {
 
         stage('Speech to Label') {
           steps {
-            sh 'python examples/asr/speech_to_label.py model.train_ds.manifest_filepath=/home/TestData/speech_commands/train_manifest.json model.validation_ds.manifest_filepath=/home/TestData/speech_commands/test_manifest.json pl.trainer.gpus=[1] +pl.trainer.fast_dev_run=True'
+            sh 'python examples/asr/speech_to_label.py \
+            model.train_ds.manifest_filepath=/home/TestData/speech_commands/train_manifest.json \
+            model.validation_ds.manifest_filepath=/home/TestData/speech_commands/test_manifest.json \
+            pl.trainer.gpus=[1] \
+            +pl.trainer.fast_dev_run=True \
+            model.preprocessor.cls=nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor \
+            ~model.preprocessor.params.n_mfcc
+            '
             sh 'rm -rf examples/asr/NeMo_experiments'
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,8 +115,16 @@ pipeline {
     }
     
     stage('L2: Speaker Recognition dev run') {
+       when {
+        anyOf{
+          branch 'candidate'
+          changeRequest target: 'candidate'
+        }
+      }
+      failFast true
       steps {
         sh 'python examples/speaker_recognition/speaker_reco.py model.train_ds.batch_size=10 model.validation_ds.batch_size=2 model.train_ds.manifest_filepath=/home/TestData/an4_speaker/train.json model.validation_ds.manifest_filepath=/home/TestData/an4_speaker/dev.json pl.trainer.gpus=[1] +pl.trainer.fast_dev_run=True'
+        sh 'rm -rf examples/speaker_recognition/NeMo_experiments'
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
             pl.trainer.gpus=[1] \
             +pl.trainer.fast_dev_run=True \
             model.preprocessor.cls=nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor \
-            ~model.preprocessor.params.n_mfcc'
+            ~model.preprocessor.params'
             sh 'rm -rf examples/asr/NeMo_experiments'
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,8 +104,9 @@ pipeline {
             model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json \
             model.validation_ds.manifest_filepath=/home/TestData/an4_dataset/an4_val.json \
             pl.trainer.gpus=[0] \
-            +pl.trainer.fast_dev_run=True'
-            sh 'rm -rf examples/asr/NeMo_experiments'
+            +pl.trainer.fast_dev_run=True \
+            exp_manager.root_dir=examples/asr/speech_to_text_results'
+            sh 'rm -rf examples/asr/speech_to_text_results'
           }
         }
 
@@ -117,8 +118,9 @@ pipeline {
             pl.trainer.gpus=[1] \
             +pl.trainer.fast_dev_run=True \
             model.preprocessor.cls=nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor \
-            model.preprocessor.params=null'
-            sh 'rm -rf examples/asr/NeMo_experiments'
+            model.preprocessor.params=null \
+            exp_manager.root_dir=examples/asr/speech_to_label_results'
+            sh 'rm -rf examples/asr/speech_to_label_results'
           }
         }
 
@@ -130,8 +132,9 @@ pipeline {
             model.train_ds.manifest_filepath=/home/TestData/an4_speaker/train.json \
             model.validation_ds.manifest_filepath=/home/TestData/an4_speaker/dev.json \
             pl.trainer.gpus=[1] \
-            +pl.trainer.fast_dev_run=True'
-            sh 'rm -rf examples/speaker_recognition/NeMo_experiments'
+            +pl.trainer.fast_dev_run=True \
+            exp_manager.root_dir=examples/speaker_recognition/speaker_recognition_results'
+            sh 'rm -rf examples/speaker_recognition/speaker_recognition_results'
           }
         }
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,8 +104,7 @@ pipeline {
             model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json \
             model.validation_ds.manifest_filepath=/home/TestData/an4_dataset/an4_val.json \
             pl.trainer.gpus=[0] \
-            +pl.trainer.fast_dev_run=True
-            '
+            +pl.trainer.fast_dev_run=True'
             sh 'rm -rf examples/asr/NeMo_experiments'
           }
         }
@@ -118,8 +117,7 @@ pipeline {
             pl.trainer.gpus=[1] \
             +pl.trainer.fast_dev_run=True \
             model.preprocessor.cls=nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor \
-            ~model.preprocessor.params.n_mfcc
-            '
+            ~model.preprocessor.params.n_mfcc'
             sh 'rm -rf examples/asr/NeMo_experiments'
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -121,22 +121,23 @@ pipeline {
             sh 'rm -rf examples/asr/NeMo_experiments'
           }
         }
+
+        stage('Speaker Recognition') {
+          steps {
+            sh 'python examples/speaker_recognition/speaker_reco.py \
+            model.train_ds.batch_size=10 \
+            model.validation_ds.batch_size=2 \
+            model.train_ds.manifest_filepath=/home/TestData/an4_speaker/train.json \
+            model.validation_ds.manifest_filepath=/home/TestData/an4_speaker/dev.json \
+            pl.trainer.gpus=[1] \
+            +pl.trainer.fast_dev_run=True'
+            sh 'rm -rf examples/speaker_recognition/NeMo_experiments'
+          }
+        }
       }
     }
     
-    stage('L2: Speaker Recognition dev run') {
-       when {
-        anyOf{
-          branch 'candidate'
-          changeRequest target: 'candidate'
-        }
-      }
-      failFast true
-      steps {
-        sh 'python examples/speaker_recognition/speaker_reco.py model.train_ds.batch_size=10 model.validation_ds.batch_size=2 model.train_ds.manifest_filepath=/home/TestData/an4_speaker/train.json model.validation_ds.manifest_filepath=/home/TestData/an4_speaker/dev.json pl.trainer.gpus=[1] +pl.trainer.fast_dev_run=True'
-        sh 'rm -rf examples/speaker_recognition/NeMo_experiments'
-      }
-    }
+
 
     stage('L2: Parallel BERT SQUAD v1.1 / v2.0') {
       when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,7 +100,14 @@ pipeline {
       parallel {
         stage('Speech to Text') {
           steps {
-            sh 'python examples/asr/speech_to_text.py model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json model.validation_ds.manifest_filepath=/home/TestData/an4_dataset/an4_val.json pl.trainer.gpus=[0] +pl.trainer.fast_dev_run=True'
+            sh 'python examples/asr/speech_to_text.py \
+            model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json \
+            model.validation_ds.manifest_filepath=/home/TestData/an4_dataset/an4_val.json \
+            pl.trainer.gpus=[0] \
+            +pl.trainer.fast_dev_run=True \
+            model.preprocessor.cls=nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor \
+            ~model.preprocessor.params.n_mfcc
+            '
             sh 'rm -rf examples/asr/NeMo_experiments'
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,7 +117,7 @@ pipeline {
             pl.trainer.gpus=[1] \
             +pl.trainer.fast_dev_run=True \
             model.preprocessor.cls=nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor \
-            ~model.preprocessor.params'
+            model.preprocessor.params=null'
             sh 'rm -rf examples/asr/NeMo_experiments'
           }
         }

--- a/examples/asr/conf/matchboxnet_3x1x64.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64.yaml
@@ -1,0 +1,183 @@
+name: &name "QuartzNet15x5"
+sample_rate: &sample_rate 16000
+repeat: &repeat 1
+dropout: &dropout 0.0
+separable: &separable true
+labels: &labels [" ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+         "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'"]
+
+model:
+  train_ds:
+    manifest_filepath: '/Users/okuchaiev/Data/an4_dataset/an4_train.json'
+    sample_rate: 16000
+    labels: *labels
+    batch_size: 32
+    trim_silence: True
+    max_duration: 16.7
+    shuffle: True
+
+  validation_ds:
+    manifest_filepath: '/Users/okuchaiev/Data/an4_dataset/an4_val.json'
+    sample_rate: 16000
+    labels: *labels
+    batch_size: 32
+    shuffle: False
+
+  preprocessor:
+    cls: nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor
+    params:
+      normalize: "per_feature"
+      window_size: 0.02
+      sample_rate: *sample_rate
+      window_stride: 0.01
+      window: "hann"
+      features: &n_mels 64
+      n_fft: 512
+      frame_splicing: 1
+      dither: 0.00001
+      stft_conv: false
+
+  spec_augment:
+    cls: nemo.collections.asr.modules.SpectrogramAugmentation
+    params:
+      rect_freq: 50
+      rect_masks: 5
+      rect_time: 120
+
+  encoder:
+    cls: nemo.collections.asr.modules.ConvASREncoder
+    params:
+      feat_in: *n_mels
+      activation: relu
+      conv_mask: true
+
+      jasper:
+        - filters: 128
+          repeat: 1
+          kernel: [11]
+          stride: [1]
+          dilation: [1]
+          dropout: *dropout
+          residual: true
+          separable: *separable
+          se: true
+          se_context_size: -1
+
+        - filters: 256
+          repeat: *repeat
+          kernel: [13]
+          stride: [1]
+          dilation: [1]
+          dropout: *dropout
+          residual: true
+          separable: *separable
+          se: true
+          se_context_size: -1
+
+        - filters: 256
+          repeat: *repeat
+          kernel: [15]
+          stride: [1]
+          dilation: [1]
+          dropout: *dropout
+          residual: true
+          separable: *separable
+          se: true
+          se_context_size: -1
+
+        - filters: 256
+          repeat: *repeat
+          kernel: [17]
+          stride: [1]
+          dilation: [1]
+          dropout: *dropout
+          residual: true
+          separable: *separable
+          se: true
+          se_context_size: -1
+
+        - filters: 256
+          repeat: *repeat
+          kernel: [19]
+          stride: [1]
+          dilation: [1]
+          dropout: *dropout
+          residual: true
+          separable: *separable
+          se: true
+          se_context_size: -1
+
+        - filters: 256
+          repeat: 1
+          kernel: [21]
+          stride: [1]
+          dilation: [1]
+          dropout: 0.0
+          residual: false
+          separable: *separable
+          se: true
+          se_context_size: -1
+
+        - filters: &enc_feat_out 1024
+          repeat: 1
+          kernel: [1]
+          stride: [1]
+          dilation: [1]
+          dropout: 0.0
+          residual: false
+          separable: *separable
+          se: true
+          se_context_size: -1
+
+  decoder:
+    cls: nemo.collections.asr.modules.ConvASRDecoder
+    params:
+      feat_in: 1024
+      num_classes: 28
+      vocabulary: *labels
+
+  optim:
+    name: novograd
+    # cls: nemo.core.optim.optimizers.Novograd
+    lr: .01
+    # optimizer arguments
+    betas: [0.8, 0.5]
+    weight_decay: 0.001
+
+    # scheduler setup
+    sched:
+      name: CosineAnnealing
+
+      # pytorch lightning args
+      # monitor: val_loss
+      # reduce_on_plateau: false
+
+      # Scheduler params
+      warmup_steps: null
+      warmup_ratio: null
+      min_lr: 0.0
+      last_epoch: -1
+
+pl:
+  trainer:
+    gpus: 0 # number of gpus
+    max_epochs: 5
+    max_steps: null # computed at runtime if not set
+    num_nodes: 1
+    distributed_backend: ddp
+    accumulate_grad_batches: 1
+    checkpoint_callback: False  # Provided by exp_manager
+    logger: False  # Provided by exp_manager
+
+exp_manager:
+  root_dir: null
+  name: *name
+  create_tensorboard_logger: True
+  create_checkpoint_callback: True
+
+hydra:
+  run:
+    dir: .
+  job_logging:
+    root:
+      handlers: null

--- a/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
@@ -1,23 +1,33 @@
-name: &name "QuartzNet15x5"
+name: &name "MatchboxNet-3x1x64"
 sample_rate: &sample_rate 16000
+
+timesteps: 128
 repeat: &repeat 1
 dropout: &dropout 0.0
-separable: &separable true
-labels: &labels [" ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
-         "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'"]
+kernel_size_factor: &kfactor 1.0
+
+labels: &labels ['bed', 'bird', 'cat', 'dog', 'down', 'eight', 'five', 'four', 'go', 'happy', 'house', 'left', 'marvin',
+                 'nine', 'no', 'off', 'on', 'one', 'right', 'seven', 'sheila', 'six', 'stop', 'three', 'tree', 'two', 'up', 'wow', 'yes', 'zero']
 
 model:
   train_ds:
-    manifest_filepath: '/Users/okuchaiev/Data/an4_dataset/an4_train.json'
+    manifest_filepath: ???
     sample_rate: 16000
     labels: *labels
-    batch_size: 32
-    trim_silence: True
-    max_duration: 16.7
+    batch_size: 128
     shuffle: True
+    augmentor:
+      shift:
+        prob: 1.0
+        min_shift_ms: -5.0
+        max_shift_ms: 5.0
+      white_noise:
+        prob: 1.0
+        min_level: -90
+        max_level: -46
 
   validation_ds:
-    manifest_filepath: '/Users/okuchaiev/Data/an4_dataset/an4_val.json'
+    manifest_filepath: ???
     sample_rate: 16000
     labels: *labels
     batch_size: 32
@@ -27,7 +37,7 @@ model:
     cls: nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor
     params:
       normalize: "per_feature"
-      window_size: 0.02
+      window_size: 0.025
       sample_rate: *sample_rate
       window_stride: 0.01
       window: "hann"
@@ -40,9 +50,13 @@ model:
   spec_augment:
     cls: nemo.collections.asr.modules.SpectrogramAugmentation
     params:
-      rect_freq: 50
+      freq_masks: 2
+      time_masks: 2
+      freq_width: 15
+      time_width: 25
       rect_masks: 5
-      rect_time: 120
+      rect_time: 25
+      rect_freq: 15
 
   encoder:
     cls: nemo.collections.asr.modules.ConvASREncoder
@@ -58,83 +72,65 @@ model:
           stride: [1]
           dilation: [1]
           dropout: *dropout
-          residual: true
-          separable: *separable
-          se: true
-          se_context_size: -1
+          residual: false
+          separable: true
+          kernel_size_factor: *kfactor
 
-        - filters: 256
+        - filters: 64
           repeat: *repeat
           kernel: [13]
           stride: [1]
           dilation: [1]
           dropout: *dropout
           residual: true
-          separable: *separable
-          se: true
-          se_context_size: -1
+          separable: true
+          kernel_size_factor: *kfactor
 
-        - filters: 256
+        - filters: 64
           repeat: *repeat
           kernel: [15]
           stride: [1]
           dilation: [1]
           dropout: *dropout
           residual: true
-          separable: *separable
-          se: true
-          se_context_size: -1
+          separable: true
+          kernel_size_factor: *kfactor
 
-        - filters: 256
+        - filters: 64
           repeat: *repeat
           kernel: [17]
           stride: [1]
           dilation: [1]
           dropout: *dropout
           residual: true
-          separable: *separable
-          se: true
-          se_context_size: -1
+          separable: true
+          kernel_size_factor: *kfactor
 
-        - filters: 256
-          repeat: *repeat
-          kernel: [19]
-          stride: [1]
-          dilation: [1]
-          dropout: *dropout
-          residual: true
-          separable: *separable
-          se: true
-          se_context_size: -1
-
-        - filters: 256
+        - filters: 128
           repeat: 1
-          kernel: [21]
+          kernel: [29]
           stride: [1]
-          dilation: [1]
-          dropout: 0.0
+          dilation: [2]
+          dropout: *dropout
           residual: false
-          separable: *separable
-          se: true
-          se_context_size: -1
+          separable: true
+          kernel_size_factor: *kfactor
 
-        - filters: &enc_feat_out 1024
+        - filters: &enc_final_filters 128
           repeat: 1
           kernel: [1]
           stride: [1]
           dilation: [1]
-          dropout: 0.0
+          dropout: *dropout
           residual: false
-          separable: *separable
-          se: true
-          se_context_size: -1
 
   decoder:
-    cls: nemo.collections.asr.modules.ConvASRDecoder
+    cls: nemo.collections.asr.modules.ConvASRDecoderClassification
     params:
-      feat_in: 1024
-      num_classes: 28
-      vocabulary: *labels
+      feat_in: *enc_final_filters
+      num_classes: 30
+      return_logits: True
+      pooling_type: 'avg'
 
   optim:
     name: novograd

--- a/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
@@ -1,4 +1,4 @@
-name: &name "MatchboxNet-3x1x64-v1"
+name: &name "MatchboxNet-3x1x64-v2"
 sample_rate: &sample_rate 16000
 
 timesteps: &timesteps 128
@@ -6,9 +6,9 @@ repeat: &repeat 1
 dropout: &dropout 0.0
 kernel_size_factor: &kfactor 1.0
 
-labels: &labels ['bed', 'bird', 'cat', 'dog', 'down', 'eight', 'five', 'four', 'go', 'happy', 'house', 'left', 'marvin',
-                 'nine', 'no', 'off', 'on', 'one', 'right', 'seven', 'sheila', 'six', 'stop', 'three', 'tree', 'two', 'up',
-                 'wow', 'yes', 'zero']
+labels: &labels ['visual', 'wow', 'learn', 'backward', 'dog', 'two', 'left', 'happy', 'nine', 'go', 'up', 'bed', 'stop',
+                 'one', 'zero', 'tree', 'seven', 'on', 'four', 'bird', 'right', 'eight', 'no', 'six', 'forward', 'house',
+                 'marvin', 'sheila', 'five', 'off', 'three', 'down', 'cat', 'follow', 'yes']
 
 model:
   train_ds:
@@ -137,7 +137,7 @@ model:
     cls: nemo.collections.asr.modules.ConvASRDecoderClassification
     params:
       feat_in: *enc_final_filters
-      num_classes: 30
+      num_classes: 35
       return_logits: true
       pooling_type: 'avg'
 

--- a/examples/asr/speech_to_label.py
+++ b/examples/asr/speech_to_label.py
@@ -1,0 +1,75 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import hydra
+import pytorch_lightning as pl
+
+from nemo.collections.asr.models import EncDecClassificationModel
+from nemo.utils.exp_manager import exp_manager
+
+
+"""
+Basic run (on CPU for 50 epochs):
+    python examples/asr/speech_to_text.py \
+        model.train_ds.manifest_filepath="/Users/okuchaiev/Data/an4_dataset/an4_train.json" \
+        model.validation_ds.manifest_filepath="/Users/okuchaiev/Data/an4_dataset/an4_val.json" \
+        hydra.run.dir="." \
+        pl.trainer.gpus=0 \
+        pl.trainer.max_epochs=50
+
+
+Add PyTorch Lightning Trainer arguments from CLI:
+    python speech_to_text.py \
+        ... \
+        +pl.trainer.fast_dev_run=true
+
+Hydra logs will be found in "$(./outputs/$(date +"%y-%m-%d")/$(date +"%H-%M-%S")/.hydra)"
+PTL logs will be found in "$(./outputs/$(date +"%y-%m-%d")/$(date +"%H-%M-%S")/lightning_logs)"
+
+Override some args of optimizer:
+    python speech_to_text.py \
+    model.train_ds.manifest_filepath="./an4/train_manifest.json" \
+    model.validation_ds.manifest_filepath="./an4/test_manifest.json" \
+    hydra.run.dir="." \
+    pl.trainer.gpus=2 \
+    pl.trainer.max_epochs=2 \
+    model.optim.args.params.betas=[0.8,0.5] \
+    model.optim.args.params.weight_decay=0.0001
+
+Overide optimizer entirely
+    python speech_to_text.py \
+    model.train_ds.manifest_filepath="./an4/train_manifest.json" \
+    model.validation_ds.manifest_filepath="./an4/test_manifest.json" \
+    hydra.run.dir="." \
+    pl.trainer.gpus=2 \
+    pl.trainer.max_epochs=2 \
+    model.optim.name=adamw \
+    model.optim.lr=0.001 \
+    ~model.optim.args \
+    +model.optim.args.betas=[0.8,0.5]\
+    +model.optim.args.weight_decay=0.0005
+
+"""
+
+
+@hydra.main(config_path="conf", config_name="matchboxnet_3x1x64_v1.yaml")
+def main(cfg):
+    trainer = pl.Trainer(**cfg.pl.trainer)
+    exp_manager(trainer, cfg.get("exp_manager", None))
+    asr_model = EncDecClassificationModel(cfg=cfg.model, trainer=trainer)
+
+    trainer.fit(asr_model)
+
+
+if __name__ == '__main__':
+    main()  # noqa pylint: disable=no-value-for-parameter

--- a/examples/asr/speech_to_label.py
+++ b/examples/asr/speech_to_label.py
@@ -19,46 +19,14 @@ from nemo.utils.exp_manager import exp_manager
 
 
 """
-Basic run (on CPU for 50 epochs):
-    python examples/asr/speech_to_text.py \
-        model.train_ds.manifest_filepath="/Users/okuchaiev/Data/an4_dataset/an4_train.json" \
-        model.validation_ds.manifest_filepath="/Users/okuchaiev/Data/an4_dataset/an4_val.json" \
-        hydra.run.dir="." \
-        pl.trainer.gpus=0 \
-        pl.trainer.max_epochs=50
-
-
-Add PyTorch Lightning Trainer arguments from CLI:
-    python speech_to_text.py \
-        ... \
-        +pl.trainer.fast_dev_run=true
-
-Hydra logs will be found in "$(./outputs/$(date +"%y-%m-%d")/$(date +"%H-%M-%S")/.hydra)"
-PTL logs will be found in "$(./outputs/$(date +"%y-%m-%d")/$(date +"%H-%M-%S")/lightning_logs)"
-
-Override some args of optimizer:
-    python speech_to_text.py \
-    model.train_ds.manifest_filepath="./an4/train_manifest.json" \
-    model.validation_ds.manifest_filepath="./an4/test_manifest.json" \
-    hydra.run.dir="." \
-    pl.trainer.gpus=2 \
-    pl.trainer.max_epochs=2 \
-    model.optim.args.params.betas=[0.8,0.5] \
-    model.optim.args.params.weight_decay=0.0001
-
-Overide optimizer entirely
-    python speech_to_text.py \
-    model.train_ds.manifest_filepath="./an4/train_manifest.json" \
-    model.validation_ds.manifest_filepath="./an4/test_manifest.json" \
-    hydra.run.dir="." \
-    pl.trainer.gpus=2 \
-    pl.trainer.max_epochs=2 \
-    model.optim.name=adamw \
-    model.optim.lr=0.001 \
-    ~model.optim.args \
-    +model.optim.args.betas=[0.8,0.5]\
-    +model.optim.args.weight_decay=0.0005
-
+Basic run (on 1 GPU + AMP O1 for 200 epochs):
+    python examples/asr/speech_to_label.py \
+        model.train_ds.manifest_filepath="<path to train manifest>" \
+        model.validation_ds.manifest_filepath="<path to test manifest>" \
+        pl.trainer.gpus=1 \
+        pl.trainer.max_epochs=200 \
+        +pl.trainer.precision=16 \
+        +pl.trainer.amp_level=O1
 """
 
 

--- a/examples/asr/speech_to_label.py
+++ b/examples/asr/speech_to_label.py
@@ -11,10 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import hydra
+
 import pytorch_lightning as pl
 
 from nemo.collections.asr.models import EncDecClassificationModel
+from nemo.core.config import hydra_runner
 from nemo.utils.exp_manager import exp_manager
 
 
@@ -30,7 +31,7 @@ Basic run (on 1 GPU + AMP O1 for 200 epochs):
 """
 
 
-@hydra.main(config_path="conf", config_name="matchboxnet_3x1x64_v1.yaml")
+@hydra_runner(config_path="conf", config_name="matchboxnet_3x1x64_v1.yaml")
 def main(cfg):
     trainer = pl.Trainer(**cfg.pl.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))

--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union
 
 import torch
 
@@ -20,7 +20,47 @@ from nemo.core.classes import Dataset
 from nemo.core.neural_types import *
 from nemo.utils.decorators import experimental
 
-__all__ = ['AudioToCharDataset', 'AudioToBPEDataset']
+__all__ = ['AudioToCharDataset', 'AudioToBPEDataset', 'AudioLabelDataset']
+
+
+def _speech_collate_fn(batch, pad_id):
+    """collate batch of audio sig, audio len, tokens, tokens len
+    Args:
+        batch (Optional[FloatTensor], Optional[LongTensor], LongTensor,
+               LongTensor):  A tuple of tuples of signal, signal lengths,
+               encoded tokens, and encoded tokens length.  This collate func
+               assumes the signals are 1d torch tensors (i.e. mono audio).
+    """
+    _, audio_lengths, _, tokens_lengths = zip(*batch)
+    max_audio_len = 0
+    has_audio = audio_lengths[0] is not None
+    if has_audio:
+        max_audio_len = max(audio_lengths).item()
+    max_tokens_len = max(tokens_lengths).item()
+
+    audio_signal, tokens = [], []
+    for sig, sig_len, tokens_i, tokens_i_len in batch:
+        if has_audio:
+            sig_len = sig_len.item()
+            if sig_len < max_audio_len:
+                pad = (0, max_audio_len - sig_len)
+                sig = torch.nn.functional.pad(sig, pad)
+            audio_signal.append(sig)
+        tokens_i_len = tokens_i_len.item()
+        if tokens_i_len < max_tokens_len:
+            pad = (0, max_tokens_len - tokens_i_len)
+            tokens_i = torch.nn.functional.pad(tokens_i, pad, value=pad_id)
+        tokens.append(tokens_i)
+
+    if has_audio:
+        audio_signal = torch.stack(audio_signal)
+        audio_lengths = torch.stack(audio_lengths)
+    else:
+        audio_signal, audio_lengths = None, None
+    tokens = torch.stack(tokens)
+    tokens_lengths = torch.stack(tokens_lengths)
+
+    return audio_signal, audio_lengths, tokens, tokens_lengths
 
 
 class _AudioDataset(Dataset):
@@ -130,36 +170,7 @@ class _AudioDataset(Dataset):
                    encoded tokens, and encoded tokens length.  This collate func
                    assumes the signals are 1d torch tensors (i.e. mono audio).
         """
-        _, audio_lengths, _, tokens_lengths = zip(*batch)
-        max_audio_len = 0
-        has_audio = audio_lengths[0] is not None
-        if has_audio:
-            max_audio_len = max(audio_lengths).item()
-        max_tokens_len = max(tokens_lengths).item()
-
-        audio_signal, tokens = [], []
-        for sig, sig_len, tokens_i, tokens_i_len in batch:
-            if has_audio:
-                sig_len = sig_len.item()
-                if sig_len < max_audio_len:
-                    pad = (0, max_audio_len - sig_len)
-                    sig = torch.nn.functional.pad(sig, pad)
-                audio_signal.append(sig)
-            tokens_i_len = tokens_i_len.item()
-            if tokens_i_len < max_tokens_len:
-                pad = (0, max_tokens_len - tokens_i_len)
-                tokens_i = torch.nn.functional.pad(tokens_i, pad, value=self.pad_id)
-            tokens.append(tokens_i)
-
-        if has_audio:
-            audio_signal = torch.stack(audio_signal)
-            audio_lengths = torch.stack(audio_lengths)
-        else:
-            audio_signal, audio_lengths = None, None
-        tokens = torch.stack(tokens)
-        tokens_lengths = torch.stack(tokens_lengths)
-
-        return audio_signal, audio_lengths, tokens, tokens_lengths
+        return _speech_collate_fn(batch, pad_id=self.pad_id)
 
 
 @experimental
@@ -317,3 +328,89 @@ class AudioToBPEDataset(_AudioDataset):
             load_audio=load_audio,
             add_misc=add_misc,
         )
+
+
+# Ported from https://github.com/NVIDIA/OpenSeq2Seq/blob/master/open_seq2seq/data/speech2text/speech_commands.py
+@experimental
+class AudioLabelDataset(Dataset):
+    """
+    Dataset that loads tensors via a json file containing paths to audio
+    files, command class, and durations (in seconds). Each new line is a
+    different sample. Example below:
+    {"audio_filepath": "/path/to/audio.wav", "label":
+    "label", "duration": 23.147}
+    ...
+    {"audio_filepath": "/path/to/audio.wav", "label": "label",
+    "offset": 301.75, "duration": 0.82}
+    Args:
+        manifest_filepath: Path to manifest json as described above. Can
+            be comma-separated paths.
+        labels (Optional[list]): String containing all the possible labels to map to
+            if None then automatically picks from ASRSpeechLabel collection.
+        featurizer: Initialized featurizer class that converts paths of
+            audio to feature tensors
+        max_duration: If audio exceeds this length, do not include in dataset
+        min_duration: If audio is less than this length, do not include
+            in dataset
+        trim: Boolean flag whether to trim the audio
+        load_audio: Boolean flag indicate whether do or not load audio
+    """
+
+    def __init__(
+        self,
+        manifest_filepath,
+        featurizer,
+        labels=None,
+        max_duration=None,
+        min_duration=None,
+        trim=False,
+        load_audio=True,
+    ):
+        self.collection = collections.ASRSpeechLabel(
+            manifests_files=manifest_filepath.split(','), min_duration=min_duration, max_duration=max_duration,
+        )
+
+        self.featurizer = featurizer
+        self.trim = trim
+        self.load_audio = load_audio
+
+        self.labels = labels if labels else self.collection.uniq_labels
+        self.num_commands = len(self.labels)
+
+        self.label2id, self.id2label = {}, {}
+        for label_id, label in enumerate(self.labels):
+            self.label2id[label] = label_id
+            self.id2label[label_id] = label
+
+    def __getitem__(self, index):
+        sample = self.collection[index]
+        if self.load_audio:
+            offset = sample.offset
+
+            if offset is None:
+                offset = 0
+
+            features = self.featurizer.process(
+                sample.audio_file, offset=offset, duration=sample.duration, trim=self.trim
+            )
+            f, fl = features, torch.tensor(features.shape[0]).long()
+        else:
+            f, fl = None, None
+
+        t = self.label2id[sample.label]
+        tl = 1  # For compatibility with collate_fn used later
+
+        return f, fl, torch.tensor(t).long(), torch.tensor(tl).long()
+
+    def __len__(self):
+        return len(self.collection)
+
+    def _collate_fn(self, batch):
+        """collate batch of audio sig, audio len, tokens (single token), tokens len (1)
+        Args:
+            batch (Optional[FloatTensor], Optional[LongTensor], LongTensor,
+                   LongTensor):  A tuple of tuples of signal, signal lengths,
+                   encoded tokens, and encoded tokens length.  This collate func
+                   assumes the signals are 1d torch tensors (i.e. mono audio).
+        """
+        return _speech_collate_fn(batch, pad_id=0)

--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 import torch
 

--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -33,7 +33,7 @@ from nemo.utils.decorators import experimental
 __all__ = ['EncDecClassificationModel', 'MatchboxNet']
 
 
-# @experimental
+@experimental
 class EncDecClassificationModel(ASRModel):
     """Encoder decoder CTC-based models."""
 

--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -1,0 +1,219 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Optional, Union
+
+import torch
+import torch.distributed as dist
+from omegaconf import DictConfig
+from pytorch_lightning import Trainer
+
+from nemo import logging
+from nemo.collections.asr.data.audio_to_text import AudioLabelDataset
+from nemo.collections.asr.models.asr_model import ASRModel
+from nemo.collections.asr.parts.features import WaveformFeaturizer
+from nemo.collections.asr.parts.perturb import process_augmentations
+from nemo.collections.common.losses import CrossEntropyLoss
+from nemo.collections.common.metrics import TopKClassificationAccuracy, compute_topk_accuracy
+from nemo.core.classes.common import typecheck
+from nemo.core.neural_types import *
+from nemo.utils.decorators import experimental
+
+__all__ = ['EncDecClassificationModel', 'MatchboxNet']
+
+
+# @experimental
+class EncDecClassificationModel(ASRModel):
+    """Encoder decoder CTC-based models."""
+
+    def __init__(self, cfg: DictConfig, trainer: Trainer = None):
+        super().__init__(cfg=cfg, trainer=trainer)
+        self.preprocessor = EncDecClassificationModel.from_config_dict(self._cfg.preprocessor)
+        self.encoder = EncDecClassificationModel.from_config_dict(self._cfg.encoder)
+        self.decoder = EncDecClassificationModel.from_config_dict(self._cfg.decoder)
+        self.loss = CrossEntropyLoss(logits_ndim=self.decoder.num_classes)
+        if hasattr(self._cfg, 'spec_augment') and self._cfg.spec_augment is not None:
+            self.spec_augmentation = EncDecClassificationModel.from_config_dict(self._cfg.spec_augment)
+        else:
+            self.spec_augmentation = None
+        if hasattr(self._cfg, 'crop_or_pad_augment') and self._cfg.crop_or_pad_augment is not None:
+            self.crop_or_pad = EncDecClassificationModel.from_config_dict(self._cfg.crop_or_pad_augment)
+        else:
+            self.crop_or_pad = None
+        # Optimizer setup needs to happen after all model weights are ready
+        self.setup_optimization()
+        # Setup metric objects
+
+        self._accuracy = TopKClassificationAccuracy()
+
+    def transcribe(self, path2audio_file: str) -> str:
+        raise NotImplementedError("Classification models do not transcribe audio.")
+
+    def _setup_dataloader_from_config(self, config: Optional[Dict]):
+        if 'augmentor' in config:
+            augmentor = process_augmentations(config['augmentor'])
+        else:
+            augmentor = None
+
+        featurizer = WaveformFeaturizer(
+            sample_rate=config['sample_rate'], int_values=config.get('int_values', False), augmentor=augmentor
+        )
+        dataset = AudioLabelDataset(
+            manifest_filepath=config['manifest_filepath'],
+            labels=config['labels'],
+            featurizer=featurizer,
+            max_duration=config.get('max_duration', None),
+            min_duration=config.get('min_duration', None),
+            trim=config.get('trim_silence', True),
+            load_audio=config.get('load_audio', True),
+        )
+
+        return torch.utils.data.DataLoader(
+            dataset=dataset,
+            batch_size=config['batch_size'],
+            collate_fn=dataset.collate_fn,
+            drop_last=config.get('drop_last', False),
+            shuffle=config['shuffle'],
+            num_workers=config.get('num_workers', 0),
+        )
+
+    def setup_training_data(self, train_data_config: Optional[Union[DictConfig, Dict]]):
+        if 'shuffle' not in train_data_config:
+            train_data_config['shuffle'] = True
+        self._train_dl = self._setup_dataloader_from_config(config=train_data_config)
+
+    def setup_validation_data(self, val_data_config: Optional[Union[DictConfig, Dict]]):
+        if 'shuffle' not in val_data_config:
+            val_data_config['shuffle'] = False
+        self._validation_dl = self._setup_dataloader_from_config(config=val_data_config)
+
+    def setup_test_data(self, test_data_config: Optional[Union[DictConfig, Dict]]):
+        if 'shuffle' not in test_data_config:
+            test_data_config['shuffle'] = False
+        self._test_dl = self._setup_dataloader_from_config(config=test_data_config)
+
+    def test_dataloader(self):
+        if self._test_dl is not None:
+            return self._test_dl
+
+    @classmethod
+    def list_available_models(cls) -> Optional[Dict[str, str]]:
+        pass
+
+    @classmethod
+    def from_pretrained(cls, name: str):
+        pass
+
+    def export(self, **kwargs):
+        pass
+
+    @property
+    def input_types(self) -> Optional[Dict[str, NeuralType]]:
+        if hasattr(self.preprocessor, '_sample_rate'):
+            audio_eltype = AudioSignal(freq=self.preprocessor._sample_rate)
+        else:
+            audio_eltype = AudioSignal()
+        return {
+            "input_signal": NeuralType(('B', 'T'), audio_eltype),
+            "input_signal_length": NeuralType(tuple('B'), LengthsType()),
+        }
+
+    @property
+    def output_types(self) -> Optional[Dict[str, NeuralType]]:
+        return {"outputs": NeuralType(('B', 'D'), LogitsType())}
+
+    @typecheck()
+    def forward(self, input_signal, input_signal_length):
+        processed_signal, processed_signal_len = self.preprocessor(
+            input_signal=input_signal, length=input_signal_length,
+        )
+        # Crop or pad is always applied
+        if self.crop_or_pad is not None:
+            processed_signal, processed_signal_len = self.crop_or_pad(
+                input_signal=processed_signal, length=processed_signal_len
+            )
+        # Spec augment is not applied during evaluation/testing
+        if self.spec_augmentation is not None and self.training:
+            processed_signal = self.spec_augmentation(input_spec=processed_signal)
+        encoded, encoded_len = self.encoder(audio_signal=processed_signal, length=processed_signal_len)
+        logits = self.decoder(encoder_output=encoded)
+        return logits
+
+    # PTL-specific methods
+    def training_step(self, batch, batch_nb):
+        self.training_step_end()
+        audio_signal, audio_signal_len, labels, labels_len = batch
+        logits = self.forward(input_signal=audio_signal, input_signal_length=audio_signal_len)
+        loss_value = self.loss(logits=logits, labels=labels)
+
+        tensorboard_logs = {
+            'train_loss': loss_value,
+            'learning_rate': self._optimizer.param_groups[0]['lr'],
+        }
+
+        correct_counts, total_counts = self._accuracy(logits=logits, labels=labels)
+
+        for ki in range(correct_counts.shape[-1]):
+            correct_count = correct_counts[ki]
+            total_count = total_counts[ki]
+            top_k = self._accuracy.top_k[ki]
+
+            tensorboard_logs['training_batch_accuracy_top@{}'.format(top_k)] = correct_count / float(total_count)
+
+        return {'loss': loss_value, 'log': tensorboard_logs}
+
+    def validation_step(self, batch, batch_idx):
+        audio_signal, audio_signal_len, labels, labels_len = batch
+        logits = self.forward(input_signal=audio_signal, input_signal_length=audio_signal_len)
+        loss_value = self.loss(logits=logits, labels=labels)
+        correct_counts, total_counts = self._accuracy(logits=logits, labels=labels)
+        return {'val_loss': loss_value, 'val_correct_counts': correct_counts, 'val_total_counts': total_counts}
+
+    def test_step(self, batch, batch_idx):
+        audio_signal, audio_signal_len, labels, labels_len = batch
+        logits = self.forward(input_signal=audio_signal, input_signal_length=audio_signal_len)
+        loss_value = self.loss(logits=logits, labels=labels)
+        correct_counts, total_counts = self._accuracy(logits=logits, labels=labels)
+        return {'test_loss': loss_value, 'test_correct_counts': correct_counts, 'test_total_counts': total_counts}
+
+    def validation_epoch_end(self, outputs):
+        val_loss_mean = torch.stack([x['val_loss'] for x in outputs]).mean()
+        correct_counts = torch.stack([x['val_correct_counts'] for x in outputs])
+        total_counts = torch.stack([x['val_total_counts'] for x in outputs])
+
+        topk_scores = compute_topk_accuracy(correct_counts, total_counts)
+
+        tensorboard_log = {'val_loss': val_loss_mean}
+        for top_k, score in zip(self._accuracy.top_k, topk_scores):
+            tensorboard_log['val_epoch_top@{}'.format(top_k)] = score
+
+        return {'log': tensorboard_log}
+
+    def test_epoch_end(self, outputs):
+        test_loss_mean = torch.stack([x['test_loss'] for x in outputs]).mean()
+        correct_counts = torch.stack([x['test_correct_counts'].unsqueeze(0) for x in outputs])
+        total_counts = torch.stack([x['test_total_counts'].unsqueeze(0) for x in outputs])
+
+        topk_scores = compute_topk_accuracy(correct_counts, total_counts)
+
+        tensorboard_log = {'test_loss': test_loss_mean}
+        for top_k, score in zip(self._accuracy.top_k, topk_scores):
+            tensorboard_log['test_epoch_top@{}'.format(top_k)] = score
+
+        return {'log': tensorboard_log}
+
+
+@experimental
+class MatchboxNet(EncDecClassificationModel):
+    pass

--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -15,11 +15,9 @@
 from typing import Dict, Optional, Union
 
 import torch
-import torch.distributed as dist
 from omegaconf import DictConfig
 from pytorch_lightning import Trainer
 
-from nemo import logging
 from nemo.collections.asr.data.audio_to_text import AudioLabelDataset
 from nemo.collections.asr.models.asr_model import ASRModel
 from nemo.collections.asr.parts.features import WaveformFeaturizer

--- a/nemo/collections/asr/modules/__init__.py
+++ b/nemo/collections/asr/modules/__init__.py
@@ -12,5 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo.collections.asr.modules.audio_preprocessing import AudioToMelSpectrogramPreprocessor, SpectrogramAugmentation
-from nemo.collections.asr.modules.conv_asr import ConvASRDecoder, ConvASREncoder, SpeakerDecoder, ConvASRDecoderClassification
+from nemo.collections.asr.modules.audio_preprocessing import (
+    AudioToMelSpectrogramPreprocessor,
+    AudioToMFCCPreprocessor,
+    CropOrPadSpectrogramAugmentation,
+    SpectrogramAugmentation,
+)
+from nemo.collections.asr.modules.conv_asr import ConvASRDecoder, ConvASRDecoderClassification, ConvASREncoder, SpeakerDecoder

--- a/nemo/collections/asr/modules/__init__.py
+++ b/nemo/collections/asr/modules/__init__.py
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 from nemo.collections.asr.modules.audio_preprocessing import AudioToMelSpectrogramPreprocessor, SpectrogramAugmentation
-from nemo.collections.asr.modules.conv_asr import ConvASRDecoder, ConvASREncoder, SpeakerDecoder
+from nemo.collections.asr.modules.conv_asr import ConvASRDecoder, ConvASREncoder, SpeakerDecoder, ConvASRDecoderClassification

--- a/nemo/collections/asr/modules/__init__.py
+++ b/nemo/collections/asr/modules/__init__.py
@@ -18,4 +18,9 @@ from nemo.collections.asr.modules.audio_preprocessing import (
     CropOrPadSpectrogramAugmentation,
     SpectrogramAugmentation,
 )
-from nemo.collections.asr.modules.conv_asr import ConvASRDecoder, ConvASRDecoderClassification, ConvASREncoder, SpeakerDecoder
+from nemo.collections.asr.modules.conv_asr import (
+    ConvASRDecoder,
+    ConvASRDecoderClassification,
+    ConvASREncoder,
+    SpeakerDecoder,
+)

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -30,6 +30,7 @@ from nemo.core.neural_types import (
     NeuralType,
     SpectrogramType,
 )
+from nemo.utils.decorators import experimental
 
 try:
     import torchaudio
@@ -42,7 +43,6 @@ try:
     HAVE_TORCHAUDIO = True
 except ModuleNotFoundError:
     HAVE_TORCHAUDIO = False
-    logging.warning('Could not import torchaudio. Some features might not work.')
 
 __all__ = [
     'AudioToMelSpectrogramPreprocessor',
@@ -73,6 +73,7 @@ class AudioPreprocessor(NeuralModule, ABC):
             None: torch.ones,
         }
 
+    @typecheck()
     @torch.no_grad()
     def forward(self, input_signal, length):
         processed_signal = self.get_features(input_signal, length)
@@ -254,6 +255,7 @@ class AudioToMelSpectrogramPreprocessor(AudioPreprocessor):
         return self.featurizer.filter_banks
 
 
+@experimental
 class AudioToMFCCPreprocessor(AudioPreprocessor):
     """Preprocessor that converts wavs to MFCCs.
     Uses torchaudio.transforms.MFCC.
@@ -334,6 +336,8 @@ class AudioToMFCCPreprocessor(AudioPreprocessor):
     ):
         self._sample_rate = sample_rate
         if not HAVE_TORCHAUDIO:
+            logging.error('Could not import torchaudio. Some features might not work.')
+
             raise ModuleNotFoundError(
                 "torchaudio is not installed but is necessary for "
                 "AudioToMFCCPreprocessor. We recommend you try "
@@ -482,6 +486,7 @@ class CropOrPadSpectrogramAugmentation(NeuralModule):
         super(CropOrPadSpectrogramAugmentation, self).__init__()
         self.audio_length = audio_length
 
+    @typecheck()
     @torch.no_grad()
     def forward(self, input_signal, length):
         image = input_signal

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -12,17 +12,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from abc import ABC, abstractmethod
 
 import torch
+from packaging import version
 
+from nemo import logging
 from nemo.collections.asr.parts.features import FilterbankFeatures
 from nemo.collections.asr.parts.spectr_augment import SpecAugment, SpecCutout
 from nemo.core.classes import NeuralModule, typecheck
-from nemo.core.neural_types import AudioSignal, LengthsType, MelSpectrogramType, NeuralType, SpectrogramType
-from nemo.utils.decorators import experimental
+from nemo.core.neural_types import (
+    AudioSignal,
+    LengthsType,
+    MelSpectrogramType,
+    MFCCSpectrogramType,
+    NeuralType,
+    SpectrogramType,
+)
 
-__all__ = ['AudioToMelSpectrogramPreprocessor', 'SpectrogramAugmentation']
+try:
+    import torchaudio
+    import torchaudio.transforms
+    import torchaudio.functional
+
+    TORCHAUDIO_VERSION = version.parse(torchaudio.__version__)
+    TORCHAUDIO_VERSION_MIN = version.parse('0.5')
+
+    HAVE_TORCHAUDIO = True
+except ModuleNotFoundError:
+    HAVE_TORCHAUDIO = False
+    logging.warning('Could not import torchaudio. Some features might not work.')
+
+__all__ = [
+    'AudioToMelSpectrogramPreprocessor',
+    'AudioToMFCCPreprocessor',
+    'SpectrogramAugmentation',
+    'CropOrPadSpectrogramAugmentation',
+]
 
 
 class AudioPreprocessor(NeuralModule, ABC):
@@ -227,6 +254,139 @@ class AudioToMelSpectrogramPreprocessor(AudioPreprocessor):
         return self.featurizer.filter_banks
 
 
+class AudioToMFCCPreprocessor(AudioPreprocessor):
+    """Preprocessor that converts wavs to MFCCs.
+    Uses torchaudio.transforms.MFCC.
+    Args:
+        sample_rate: The sample rate of the audio.
+            Defaults to 16000.
+        window_size: Size of window for fft in seconds. Used to calculate the
+            win_length arg for mel spectrogram.
+            Defaults to 0.02
+        window_stride: Stride of window for fft in seconds. Used to caculate
+            the hop_length arg for mel spect.
+            Defaults to 0.01
+        n_window_size: Size of window for fft in samples
+            Defaults to None. Use one of window_size or n_window_size.
+        n_window_stride: Stride of window for fft in samples
+            Defaults to None. Use one of window_stride or n_window_stride.
+        window: Windowing function for fft. can be one of ['hann',
+            'hamming', 'blackman', 'bartlett', 'none', 'null'].
+            Defaults to 'hann'
+        n_fft: Length of FT window. If None, it uses the smallest power of 2
+            that is larger than n_window_size.
+            Defaults to None
+        lowfreq (int): Lower bound on mel basis in Hz.
+            Defaults to 0
+        highfreq  (int): Lower bound on mel basis in Hz.
+            Defaults to None
+        n_mels: Number of mel filterbanks.
+            Defaults to 64
+        n_mfcc: Number of coefficients to retain
+            Defaults to 64
+        dct_type: Type of discrete cosine transform to use
+        norm: Type of norm to use
+        log: Whether to use log-mel spectrograms instead of db-scaled.
+            Defaults to True.
+    """
+
+    @property
+    def input_ports(self):
+        """Returns definitions of module input ports.
+        """
+        return {
+            "input_signal": NeuralType(('B', 'T'), AudioSignal(freq=self._sample_rate)),
+            "length": NeuralType(tuple('B'), LengthsType()),
+        }
+
+    @property
+    def output_ports(self):
+        """Returns definitions of module output ports.
+        """
+        return {
+            "processed_signal": NeuralType(('B', 'D', 'T'), MFCCSpectrogramType()),
+            "processed_length": NeuralType(tuple('B'), LengthsType()),
+        }
+
+    def save_to(self, save_path: str):
+        pass
+
+    @classmethod
+    def restore_from(cls, restore_path: str):
+        pass
+
+    def __init__(
+        self,
+        sample_rate=16000,
+        window_size=0.02,
+        window_stride=0.01,
+        n_window_size=None,
+        n_window_stride=None,
+        window='hann',
+        n_fft=None,
+        lowfreq=0.0,
+        highfreq=None,
+        n_mels=64,
+        n_mfcc=64,
+        dct_type=2,
+        norm='ortho',
+        log=True,
+    ):
+        self._sample_rate = sample_rate
+        if not HAVE_TORCHAUDIO:
+            raise ModuleNotFoundError(
+                "torchaudio is not installed but is necessary for "
+                "AudioToMFCCPreprocessor. We recommend you try "
+                "building it from source for the PyTorch version you have."
+            )
+        if window_size and n_window_size:
+            raise ValueError(f"{self} received both window_size and " f"n_window_size. Only one should be specified.")
+        if window_stride and n_window_stride:
+            raise ValueError(
+                f"{self} received both window_stride and " f"n_window_stride. Only one should be specified."
+            )
+        # Get win_length (n_window_size) and hop_length (n_window_stride)
+        if window_size:
+            n_window_size = int(window_size * self._sample_rate)
+        if window_stride:
+            n_window_stride = int(window_stride * self._sample_rate)
+
+        super().__init__(n_window_size, n_window_stride)
+
+        mel_kwargs = {}
+
+        mel_kwargs['f_min'] = lowfreq
+        mel_kwargs['f_max'] = highfreq
+        mel_kwargs['n_mels'] = n_mels
+
+        mel_kwargs['n_fft'] = n_fft or 2 ** math.ceil(math.log2(n_window_size))
+
+        mel_kwargs['win_length'] = n_window_size
+        mel_kwargs['hop_length'] = n_window_stride
+
+        # Set window_fn. None defaults to torch.ones.
+        window_fn = self.torch_windows.get(window, None)
+        if window_fn is None:
+            raise ValueError(
+                f"Window argument for AudioProcessor is invalid: {window}."
+                f"For no window function, use 'ones' or None."
+            )
+        mel_kwargs['window_fn'] = window_fn
+
+        # Use torchaudio's implementation of MFCCs as featurizer
+        self.featurizer = torchaudio.transforms.MFCC(
+            sample_rate=self._sample_rate,
+            n_mfcc=n_mfcc,
+            dct_type=dct_type,
+            norm=norm,
+            log_mels=log,
+            melkwargs=mel_kwargs,
+        )
+
+    def get_features(self, input_signal, length):
+        return self.featurizer(input_signal)
+
+
 class SpectrogramAugmentation(NeuralModule):
     """
     Performs time and freq cuts in one of two ways.
@@ -307,3 +467,75 @@ class SpectrogramAugmentation(NeuralModule):
         augmented_spec = self.spec_cutout(input_spec)
         augmented_spec = self.spec_augment(augmented_spec)
         return augmented_spec
+
+
+class CropOrPadSpectrogramAugmentation(NeuralModule):
+    """
+    Pad or Crop the incoming Spectrogram to a certain shape.
+    Args:
+        audio_length (int): the final number of timesteps that is required.
+            The signal will be either padded or cropped temporally to this
+            size.
+    """
+
+    def __init__(self, audio_length):
+        super(CropOrPadSpectrogramAugmentation, self).__init__()
+        self.audio_length = audio_length
+
+    @torch.no_grad()
+    def forward(self, input_signal, length):
+        image = input_signal
+        num_images = image.shape[0]
+
+        audio_length = self.audio_length
+        image_len = image.shape[-1]
+
+        # Crop long signal
+        if image_len > audio_length:  # randomly slice
+            cutout_images = []
+            offset = torch.randint(low=0, high=image_len - audio_length + 1, size=[num_images])
+
+            for idx, offset in enumerate(offset):
+                cutout_images.append(image[idx : idx + 1, :, offset : offset + audio_length])
+
+            image = torch.cat(cutout_images, dim=0)
+            del cutout_images
+
+        else:  # symmetrically pad short signal with zeros
+            pad_left = (audio_length - image_len) // 2
+            pad_right = (audio_length - image_len) // 2
+
+            if (audio_length - image_len) % 2 == 1:
+                pad_right += 1
+
+            image = torch.nn.functional.pad(image, [pad_left, pad_right], mode="constant", value=0)
+
+        # Replace dynamic length sequences with static number of timesteps
+        length = (length * 0) + audio_length
+
+        return image, length
+
+    @property
+    def input_ports(self):
+        """Returns definitions of module output ports.
+        """
+        return {
+            "input_signal": NeuralType(('B', 'D', 'T'), SpectrogramType()),
+            "length": NeuralType(tuple('B'), LengthsType()),
+        }
+
+    @property
+    def output_ports(self):
+        """Returns definitions of module output ports.
+        """
+        return {
+            "processed_signal": NeuralType(('B', 'D', 'T'), SpectrogramType()),
+            "processed_length": NeuralType(tuple('B'), LengthsType()),
+        }
+
+    def save_to(self, save_path: str):
+        pass
+
+    @classmethod
+    def restore_from(cls, restore_path: str):
+        pass

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -29,7 +29,7 @@ from nemo.core.neural_types import (
 )
 from nemo.utils.decorators import experimental
 
-__all__ = ['ConvASRDecoder', 'ConvASREncoder', 'SpeakerDecoder']
+__all__ = ['ConvASRDecoder', 'ConvASREncoder', 'ConvASRDecoderClassification']
 
 
 @experimental
@@ -204,6 +204,63 @@ class ConvASRDecoder(NeuralModule):
 
     @property
     def num_classes_with_blank(self):
+        return self._num_classes
+
+
+@experimental
+class ConvASRDecoderClassification(NeuralModule):
+    """Simple ASR Decoder for use with classification models such as JasperNet and QuartzNet
+
+     Based on these papers:
+        https://arxiv.org/pdf/2005.04290.pdf
+    """
+
+    def save_to(self, save_path: str):
+        pass
+
+    @classmethod
+    def restore_from(cls, restore_path: str):
+        pass
+
+    @property
+    def input_types(self):
+        return OrderedDict({"encoder_output": NeuralType(('B', 'D', 'T'), AcousticEncodedRepresentation())})
+
+    @property
+    def output_types(self):
+        return OrderedDict({"logits": NeuralType(('B', 'D'), LogitsType())})
+
+    def __init__(self, feat_in, num_classes, init_mode="xavier_uniform", return_logits=True, pooling_type='avg'):
+        super().__init__()
+
+        self._feat_in = feat_in
+        self._return_logits = return_logits
+        self._num_classes = num_classes
+
+        if pooling_type == 'avg':
+            self.pooling = torch.nn.AdaptiveAvgPool1d(1)
+        elif pooling_type == 'max':
+            self.pooling = torch.nn.AdaptiveMaxPool1d(1)
+        else:
+            raise ValueError('Pooling type chosen is not valid. Must be either `avg` or `max`')
+
+        self.decoder_layers = torch.nn.Sequential(torch.nn.Linear(self._feat_in, self._num_classes, bias=True))
+        self.apply(lambda x: init_weights(x, mode=init_mode))
+
+    @typecheck()
+    def forward(self, encoder_output):
+        batch, in_channels, timesteps = encoder_output.size()
+
+        encoder_output = self.pooling(encoder_output).view(batch, in_channels)  # [B, C]
+        logits = self.decoder_layers(encoder_output)  # [B, num_classes]
+
+        if self._return_logits:
+            return logits
+
+        return torch.nn.functional.softmax(logits, dim=-1)
+
+    @property
+    def num_classes(self):
         return self._num_classes
 
 

--- a/nemo/collections/asr/parts/perturb.py
+++ b/nemo/collections/asr/parts/perturb.py
@@ -5,6 +5,7 @@ import random
 
 import librosa
 import numpy as np
+from omegaconf import DictConfig, OmegaConf
 from scipy import signal
 
 from nemo import logging
@@ -421,8 +422,11 @@ def process_augmentations(augmenter) -> AudioAugmentor:
     if isinstance(augmenter, AudioAugmentor):
         return augmenter
 
-    if not type(augmenter) == dict:
+    if not type(augmenter) in {dict, DictConfig}:
         raise ValueError("Cannot parse augmenter. Must be a dict or an AudioAugmentor object ")
+
+    if isinstance(augmenter, DictConfig):
+        augmenter = OmegaConf.to_container(augmenter, resolve=True)
 
     augmenter = copy.deepcopy(augmenter)
 

--- a/nemo/collections/common/metrics/__init__.py
+++ b/nemo/collections/common/metrics/__init__.py
@@ -12,7 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo.collections.asr.models.asr_model import ASRModel
-from nemo.collections.asr.models.classification_models import EncDecClassificationModel
-from nemo.collections.asr.models.ctc_models import EncDecCTCModel
-from nemo.collections.asr.models.label_models import EncDecSpeakerLabelModel
+from nemo.collections.common.metrics.classification_accuracy import TopKClassificationAccuracy, compute_topk_accuracy

--- a/nemo/collections/common/metrics/classification_accuracy.py
+++ b/nemo/collections/common/metrics/classification_accuracy.py
@@ -1,0 +1,106 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+
+import editdistance
+import torch
+from pytorch_lightning.metrics import TensorMetric
+
+__all__ = ['TopKClassificationAccuracy', 'compute_topk_accuracy']
+
+
+def compute_topk_accuracy(correct_counts, total_counts):
+    """
+    Computes the top-k accuracy when provided with a stacked tensor from multiple
+    DDP processes.
+
+    Args:
+        correct_counts: Tensor of shape [D, K], D being the number of processes
+            and K being the top-k parameter.
+        total_counts: Tensor of shape [D, K], D being the number of processes
+            and K being the top-k parameter.
+
+    Returns:
+        A list of length `K`, such that k-th index corresponds to top-k accuracy
+        over all distributed processes.
+    """
+    top_k_scores = []
+
+    for ki in range(correct_counts.shape[-1]):
+        correct_count = correct_counts[:, ki].sum()
+        total_count = total_counts[:, ki].sum()
+        top_k_scores.append(correct_count / float(total_count))
+
+    return top_k_scores
+
+
+class TopKClassificationAccuracy(TensorMetric):
+    """
+    This metric computes numerator and denominator for Overall Accuracy between logits and labels.
+    When doing distributed training/evaluation the result of res=TopKClassificationAccuracy(logits, labels) calls
+    will be all-reduced between all workers using SUM operations.
+    Here contains two numbers res=[correctly_predicted, total_samples]. Accuracy=correctly_predicted/total_samples.
+
+    If used with PytorchLightning LightningModule, include correct_count and total_count inside validation_step results.
+    Then aggregate (sum) then at the end of validation epoch to correctly compute validation WER.
+
+    Example:
+        def validation_step(self, batch, batch_idx):
+            ...
+            correct_count, total_count = self._accuracy(logits, labels)
+            return {'val_loss': loss_value, 'val_correct_count': correct_count, 'val_total_count': total_count}
+
+        def validation_epoch_end(self, outputs):
+            ...
+            correct_count = torch.stack([x['val_correct_count'] for x in outputs]).sum()
+            total_count = torch.stack([x['val_total_count'] for x in outputs]).sum()
+            tensorboard_logs = {'validation_loss': val_loss_mean, 'validation_avg_acc': correct_count / total_count}
+            return {'val_loss': val_loss_mean, 'log': tensorboard_logs}
+
+    Args:
+        top_k: Optional list of integers. Defaults to [1].
+
+    Returns:
+        res: a torch.Tensor object with two elements: [correct_count, total_count]. To correctly compute average
+        accuracy, compute acc=correct_count/total_count
+    """
+
+    def __init__(self, top_k=None):
+        super(TopKClassificationAccuracy, self).__init__(name="TopKClassificationAccuracy")
+
+        if top_k is None:
+            top_k = [1]
+
+        self.top_k = top_k
+
+    def forward(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
+        max_k = max(self.top_k)
+
+        _, predictions = logits.topk(max_k, dim=1, largest=True, sorted=True)
+        predictions = predictions.t()
+        correct = predictions.eq(labels.view(1, -1)).expand_as(predictions)
+
+        correct_counts_k = []
+        total_counts_k = []
+
+        for k in self.top_k:
+            correct_k = correct[:k].view(-1).float().sum()
+            total_k = labels.shape[0]
+
+            correct_counts_k.append(correct_k)
+            total_counts_k.append(total_k)
+
+        results = torch.tensor([correct_counts_k, total_counts_k], dtype=labels.dtype, device=labels.device)
+        return results

--- a/nemo/collections/common/metrics/classification_accuracy.py
+++ b/nemo/collections/common/metrics/classification_accuracy.py
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List
-
-import editdistance
 import torch
 from pytorch_lightning.metrics import TensorMetric
 

--- a/nemo/collections/common/metrics/classification_accuracy.py
+++ b/nemo/collections/common/metrics/classification_accuracy.py
@@ -86,21 +86,23 @@ class TopKClassificationAccuracy(TensorMetric):
         self.top_k = top_k
 
     def forward(self, logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor:
-        max_k = max(self.top_k)
+        with torch.no_grad():
+            max_k = max(self.top_k)
 
-        _, predictions = logits.topk(max_k, dim=1, largest=True, sorted=True)
-        predictions = predictions.t()
-        correct = predictions.eq(labels.view(1, -1)).expand_as(predictions)
+            _, predictions = logits.topk(max_k, dim=1, largest=True, sorted=True)
+            predictions = predictions.t()
+            correct = predictions.eq(labels.view(1, -1)).expand_as(predictions)
 
-        correct_counts_k = []
-        total_counts_k = []
+            correct_counts_k = []
+            total_counts_k = []
 
-        for k in self.top_k:
-            correct_k = correct[:k].view(-1).float().sum()
-            total_k = labels.shape[0]
+            for k in self.top_k:
+                correct_k = correct[:k].view(-1).float().sum()
+                total_k = labels.shape[0]
 
-            correct_counts_k.append(correct_k)
-            total_counts_k.append(total_k)
+                correct_counts_k.append(correct_k)
+                total_counts_k.append(total_k)
 
-        results = torch.tensor([correct_counts_k, total_counts_k], dtype=labels.dtype, device=labels.device)
+            results = torch.tensor([correct_counts_k, total_counts_k], dtype=labels.dtype, device=labels.device)
+
         return results

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -60,9 +60,9 @@ class Typing(ABC):
                     )
 
                 # Perform neural type check
-                if (
-                    hasattr(value, 'neural_type')
-                    and self.input_types[key].compare(value.neural_type) != NeuralTypeComparisonResult.SAME
+                if hasattr(value, 'neural_type') and not self.input_types[key].compare(value.neural_type) in (
+                    NeuralTypeComparisonResult.SAME,
+                    NeuralTypeComparisonResult.GREATER,
                 ):
                     raise TypeError(
                         f"{self.input_types[key].compare(value.neural_type)} : \n"

--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -163,6 +163,8 @@ def exp_manager(trainer: 'pytorch_lightning.Trainer', cfg: Optional[Union[DictCo
 
             trainer.configure_logger(logger_list)
 
+            logging.info("WandBLogger has been setup in addition to TensorboardLogger")
+
     # Create the logging directory if it does not exist
     log_dir = Path(_root_dir, name, version)
     os.makedirs(log_dir, exist_ok=True)  # Cannot limit creation to global zero as all ranks write to own log file

--- a/tests/collections/asr/test_asr_classification_model.py
+++ b/tests/collections/asr/test_asr_classification_model.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from omegaconf import DictConfig
+
+from nemo.collections.asr.models import EncDecClassificationModel
+
+
+class TestEncDecClassificationModel:
+    @pytest.mark.unit
+    def test_constructor(self):
+        preprocessor = {'cls': 'nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor', 'params': dict({})}
+        encoder = {
+            'cls': 'nemo.collections.asr.modules.ConvASREncoder',
+            'params': {
+                'feat_in': 64,
+                'activation': 'relu',
+                'conv_mask': True,
+                'jasper': [
+                    {
+                        'filters': 32,
+                        'repeat': 1,
+                        'kernel': [1],
+                        'stride': [1],
+                        'dilation': [1],
+                        'dropout': 0.0,
+                        'residual': False,
+                        'separable': True,
+                        'se': True,
+                        'se_context_size': -1,
+                    }
+                ],
+            },
+        }
+
+        decoder = {
+            'cls': 'nemo.collections.asr.modules.ConvASRDecoderClassification',
+            'params': {'feat_in': 32, 'num_classes': 30,},
+        }
+
+        modelConfig = DictConfig(
+            {'preprocessor': DictConfig(preprocessor), 'encoder': DictConfig(encoder), 'decoder': DictConfig(decoder)}
+        )
+        asr_model = EncDecClassificationModel(cfg=modelConfig)
+        asr_model.train()
+
+        conv_cnt = (64 * 32 * 1 + 32) + (64 * 1 * 1 + 32)  # separable kernel + bias + pointwise kernel + bias
+        bn_cnt = (4 * 32) * 2  # 2 * moving averages
+        dec_cnt = 32 * 30 + 30  # fc + bias
+
+        param_count = conv_cnt + bn_cnt + dec_cnt
+        assert asr_model.num_weights == param_count
+
+        # Check to/from config_dict:
+        confdict = asr_model.to_config_dict()
+        instance2 = EncDecClassificationModel.from_config_dict(confdict)
+
+        assert isinstance(instance2, EncDecClassificationModel)

--- a/tests/collections/asr/test_asr_modules.py
+++ b/tests/collections/asr/test_asr_modules.py
@@ -15,15 +15,15 @@
 import pytest
 import torch
 
-from nemo.collections.asr.modules import AudioToMelSpectrogramPreprocessor, SpectrogramAugmentation
+from nemo.collections.asr import modules
 
 
 class TestASRModulesBasicTests:
     @pytest.mark.unit
     def test_AudioToMelSpectrogramPreprocessor(self):
         # Make sure constructor works
-        instance1 = AudioToMelSpectrogramPreprocessor(dither=0)
-        assert isinstance(instance1, AudioToMelSpectrogramPreprocessor)
+        instance1 = modules.AudioToMelSpectrogramPreprocessor(dither=0)
+        assert isinstance(instance1, modules.AudioToMelSpectrogramPreprocessor)
 
         # Make sure forward doesn't throw with expected input
         input_signal = torch.randn(size=(4, 512))
@@ -35,14 +35,31 @@ class TestASRModulesBasicTests:
     @pytest.mark.unit
     def test_SpectrogramAugmentationr(self):
         # Make sure constructor works
-        instance1 = SpectrogramAugmentation(freq_masks=10, time_masks=3, rect_masks=3)
-        assert isinstance(instance1, SpectrogramAugmentation)
+        instance1 = modules.SpectrogramAugmentation(freq_masks=10, time_masks=3, rect_masks=3)
+        assert isinstance(instance1, modules.SpectrogramAugmentation)
 
         # Make sure forward doesn't throw with expected input
-        instance0 = AudioToMelSpectrogramPreprocessor(dither=0)
+        instance0 = modules.AudioToMelSpectrogramPreprocessor(dither=0)
         input_signal = torch.randn(size=(4, 512))
         length = torch.randint(low=4, high=444, size=[4])
         res0 = instance0(input_signal=input_signal, length=length)
         res = instance1(input_spec=res0[0])
 
         assert res.shape == res0[0].shape
+
+    @pytest.mark.unit
+    def test_CropOrPadSpectrogramAugmentation(self):
+        # Make sure constructor works
+        audio_length = 128
+        instance1 = modules.CropOrPadSpectrogramAugmentation(audio_length=audio_length)
+        assert isinstance(instance1, modules.CropOrPadSpectrogramAugmentation)
+
+        # Make sure forward doesn't throw with expected input
+        instance0 = modules.AudioToMelSpectrogramPreprocessor(dither=0)
+        input_signal = torch.randn(size=(4, 512))
+        length = torch.randint(low=4, high=444, size=[4])
+        res0 = instance0(input_signal=input_signal, length=length)
+        res, new_length = instance1(input_signal=res0[0], length=length)
+
+        assert res.shape == torch.Size([4, 64, audio_length])
+        assert all(new_length == torch.tensor([128] * 4))

--- a/tests/collections/common/test_metrics.py
+++ b/tests/collections/common/test_metrics.py
@@ -19,11 +19,7 @@ from nemo.collections.common.metrics.classification_accuracy import TopKClassifi
 
 
 class TestCommonMetrics:
-    top_k_logits = torch.tensor(
-        [[0.1, 0.3, 0.2, 0.0],  # 1
-         [0.9, 0.6, 0.2, 0.3],  # 0
-         [0.2, 0.1, 0.4, 0.3]],  # 2
-    )
+    top_k_logits = torch.tensor([[0.1, 0.3, 0.2, 0.0], [0.9, 0.6, 0.2, 0.3], [0.2, 0.1, 0.4, 0.3]],)  # 1  # 0  # 2
 
     @pytest.mark.unit
     def test_top_1_accuracy(self):
@@ -83,8 +79,10 @@ class TestCommonMetrics:
         # Simulate test on 2 process DDP execution
         accuracy = TopKClassificationAccuracy(top_k=None)
         correct1, total1 = accuracy(logits=self.top_k_logits, labels=torch.tensor([0, 0, 2]))
-        correct2, total2 = accuracy(logits=torch.flip(self.top_k_logits, dims=[1])[:2, :],  # reverse logits, select first 2 samples
-                                    labels=torch.tensor([2, 0]))  # reduce number of labels
+        correct2, total2 = accuracy(
+            logits=torch.flip(self.top_k_logits, dims=[1])[:2, :],  # reverse logits, select first 2 samples
+            labels=torch.tensor([2, 0]),
+        )  # reduce number of labels
 
         correct = torch.stack([correct1, correct2])
         total = torch.stack([total1, total2])

--- a/tests/collections/common/test_metrics.py
+++ b/tests/collections/common/test_metrics.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo.collections.common.metrics.classification_accuracy import TopKClassificationAccuracy, compute_topk_accuracy
+
+
+class TestCommonMetrics:
+    top_k_logits = torch.tensor(
+        [[0.1, 0.3, 0.2, 0.0],  # 1
+         [0.9, 0.6, 0.2, 0.3],  # 0
+         [0.2, 0.1, 0.4, 0.3]],  # 2
+    )
+
+    @pytest.mark.unit
+    def test_top_1_accuracy(self):
+        labels = torch.tensor([0, 0, 2], dtype=torch.long)
+
+        accuracy = TopKClassificationAccuracy(top_k=None)
+        correct, total = accuracy(logits=self.top_k_logits, labels=labels)
+
+        assert correct.shape == torch.Size([1])
+        assert total.shape == torch.Size([1])
+        assert abs((correct / total) - 0.667) < 1e-3
+
+    @pytest.mark.unit
+    def test_top_1_2_accuracy(self):
+        labels = torch.tensor([0, 1, 0], dtype=torch.long)
+
+        accuracy = TopKClassificationAccuracy(top_k=[1, 2])
+        correct, total = accuracy(logits=self.top_k_logits, labels=labels)
+
+        assert correct.shape == torch.Size([2])
+        assert total.shape == torch.Size([2])
+
+        top1_acc = correct[0] / total[0]
+        top2_acc = correct[1] / total[1]
+
+        assert abs(top1_acc - 0.0) < 1e-3
+        assert abs(top2_acc - 0.333) < 1e-3
+
+    @pytest.mark.unit
+    def test_top_1_accuracy_distributed(self):
+        # Simulate test on 2 process DDP execution
+        labels = torch.tensor([[0, 0, 2], [2, 0, 0]], dtype=torch.long)
+
+        accuracy = TopKClassificationAccuracy(top_k=None)
+        correct1, total1 = accuracy(logits=self.top_k_logits, labels=labels[0])
+        correct2, total2 = accuracy(logits=torch.flip(self.top_k_logits, dims=[1]), labels=labels[1])  # reverse logits
+
+        correct = torch.stack([correct1, correct2])
+        total = torch.stack([total1, total2])
+
+        assert correct.shape == torch.Size([2, 1])
+        assert total.shape == torch.Size([2, 1])
+
+        proc1_acc = correct[0] / total[0]
+        proc2_acc = correct[1] / total[1]
+
+        assert abs(proc1_acc - 0.667) < 1e-3  # 2/3
+        assert abs(proc2_acc - 0.333) < 1e-3  # 1/3
+
+        acc_topk = compute_topk_accuracy(correct, total)
+        acc_top1 = acc_topk[0]
+
+        assert abs(acc_top1 - 0.5) < 1e-3  # 3/6
+
+    @pytest.mark.unit
+    def test_top_1_accuracy_distributed_uneven_batch(self):
+        # Simulate test on 2 process DDP execution
+        accuracy = TopKClassificationAccuracy(top_k=None)
+        correct1, total1 = accuracy(logits=self.top_k_logits, labels=torch.tensor([0, 0, 2]))
+        correct2, total2 = accuracy(logits=torch.flip(self.top_k_logits, dims=[1])[:2, :],  # reverse logits, select first 2 samples
+                                    labels=torch.tensor([2, 0]))  # reduce number of labels
+
+        correct = torch.stack([correct1, correct2])
+        total = torch.stack([total1, total2])
+
+        assert correct.shape == torch.Size([2, 1])
+        assert total.shape == torch.Size([2, 1])
+
+        proc1_acc = correct[0] / total[0]
+        proc2_acc = correct[1] / total[1]
+
+        assert abs(proc1_acc - 0.667) < 1e-3  # 2/3
+        assert abs(proc2_acc - 0.500) < 1e-3  # 1/2
+
+        acc_topk = compute_topk_accuracy(correct, total)
+        acc_top1 = acc_topk[0]
+
+        assert abs(acc_top1 - 0.6) < 1e-3  # 3/5


### PR DESCRIPTION
# Changelog
- Adds Matchboxnet 3x1x64 for v1 and v2 datasets.
- Adds ASR Classification based Model
- Adds ConvASRDecoderClassification, AudioLabelDataset, AudioToMFCCPreprocessor, CropOrPadSpectrogramAugmentation
- Adds metric - TopKClassificationAccuracy and related tests
- Refactors collate_fn for speech models to `_speech_collate_fn`
- Fixes support of DictConfig for Augmentor 
- Adds a info message to exp_manager to inform if wandb was initialized or not
