### PR TITLE
Fix commit id in install_decoders.sh for PaddlePaddle/DeepSpeech

### DIFF
--- a/scripts/install_decoders.sh
+++ b/scripts/install_decoders.sh
@@ -1,8 +1,8 @@
 #!/bin/sh
 set -xe
-git clone https://github.com/PaddlePaddle/DeepSpeech 
+git clone https://github.com/PaddlePaddle/DeepSpeech
 cd DeepSpeech
-git checkout a76fc69
+git checkout b3c728d
 cd ..
 mv DeepSpeech/decoders/swig_wrapper.py DeepSpeech/decoders/swig/ctc_decoders.py
 mv DeepSpeech/decoders/swig ./decoders


### PR DESCRIPTION
Previous KenLM repo is invalid in PaddlePaddle/DeepSpeech.