### PR TITLE
Initial support for multi validation dataset + multi test dataset

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,7 +185,7 @@ pipeline {
       }
       failFast true
       parallel {
-        stage('Speech to Text') {
+        stage('Speech to Text multi-dataloader') {
           steps {
             sh 'python examples/asr/speech_to_text.py \
             model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json \
@@ -197,7 +197,7 @@ pipeline {
           }
         }
 
-        stage('Speech to Label') {
+        stage('Speech to Label multi-dataloader') {
           steps {
             sh 'python examples/asr/speech_to_label.py \
             model.train_ds.manifest_filepath=/home/TestData/speech_commands/train_manifest.json \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -176,6 +176,43 @@ pipeline {
       }
     }
 
+    stage('L2: ASR Multi-dataloader dev run') {
+      when {
+        anyOf{
+          branch 'candidate'
+          changeRequest target: 'candidate'
+        }
+      }
+      failFast true
+      parallel {
+        stage('Speech to Text') {
+          steps {
+            sh 'python examples/asr/speech_to_text.py \
+            model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json \
+            model.validation_ds.manifest_filepath=[/home/TestData/an4_dataset/an4_val.json,/home/TestData/an4_dataset/an4_val.json] \
+            trainer.gpus=[0] \
+            trainer.max_epochs=1 \
+            exp_manager.root_dir=examples/asr/speech_to_text_results'
+            sh 'rm -rf examples/asr/speech_to_text_results'
+          }
+        }
+
+        stage('Speech to Label') {
+          steps {
+            sh 'python examples/asr/speech_to_label.py \
+            model.train_ds.manifest_filepath=/home/TestData/speech_commands/train_manifest.json \
+            model.validation_ds.manifest_filepath=[/home/TestData/speech_commands/test_manifest.json,/home/TestData/speech_commands/test_manifest.json] \
+            trainer.gpus=[1] \
+            trainer.max_epochs=1 \
+            model.preprocessor.cls=nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor \
+            model.preprocessor.params=null \
+            exp_manager.root_dir=examples/asr/speech_to_label_results'
+            sh 'rm -rf examples/asr/speech_to_label_results'
+          }
+        }
+      }
+    }
+
     stage('L2: Parallel BERT SQUAD v1.1 / v2.0') {
       when {
         anyOf{

--- a/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
@@ -33,6 +33,7 @@ model:
     labels: *labels
     batch_size: 128
     shuffle: False
+    val_loss_idx: 0
 
 #  test_ds:
 #    manifest_filepath: ???
@@ -40,6 +41,7 @@ model:
 #    labels: *labels
 #    batch_size: 128
 #    shuffle: False
+#    test_loss_idx: 0
 
   preprocessor:
     cls: nemo.collections.asr.modules.AudioToMFCCPreprocessor

--- a/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
@@ -33,6 +33,7 @@ model:
     labels: *labels
     batch_size: 128
     shuffle: False
+    val_loss_idx: 0
 
 #  test_ds:
 #    manifest_filepath: ???
@@ -40,6 +41,7 @@ model:
 #    labels: *labels
 #    batch_size: 128
 #    shuffle: False
+#    test_loss_idx: 0
 
   preprocessor:
     cls: nemo.collections.asr.modules.AudioToMFCCPreprocessor

--- a/nemo/collections/asr/models/asr_model.py
+++ b/nemo/collections/asr/models/asr_model.py
@@ -33,7 +33,7 @@ class ASRModel(ModelPT, ABC):
         """
         pass
 
-    def validation_epoch_end(self, outputs):
+    def multi_validation_epoch_end(self, outputs, idx: int = 0):
         val_loss_mean = torch.stack([x['val_loss'] for x in outputs]).mean()
         wer_num = torch.stack([x['val_wer_num'] for x in outputs]).sum()
         wer_denom = torch.stack([x['val_wer_denom'] for x in outputs]).sum()

--- a/nemo/collections/asr/models/asr_model.py
+++ b/nemo/collections/asr/models/asr_model.py
@@ -33,7 +33,7 @@ class ASRModel(ModelPT, ABC):
         """
         pass
 
-    def multi_validation_epoch_end(self, outputs, idx: int = 0):
+    def multi_validation_epoch_end(self, outputs, dataloader_idx: int = 0):
         val_loss_mean = torch.stack([x['val_loss'] for x in outputs]).mean()
         wer_num = torch.stack([x['val_wer_num'] for x in outputs]).sum()
         wer_denom = torch.stack([x['val_wer_denom'] for x in outputs]).sum()

--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -185,7 +185,7 @@ class EncDecClassificationModel(ASRModel):
         correct_counts, total_counts = self._accuracy(logits=logits, labels=labels)
         return {'test_loss': loss_value, 'test_correct_counts': correct_counts, 'test_total_counts': total_counts}
 
-    def multi_validation_epoch_end(self, outputs, idx: int = 0):
+    def multi_validation_epoch_end(self, outputs, dataloader_idx: int = 0):
         val_loss_mean = torch.stack([x['val_loss'] for x in outputs]).mean()
         correct_counts = torch.stack([x['val_correct_counts'] for x in outputs])
         total_counts = torch.stack([x['val_total_counts'] for x in outputs])
@@ -198,7 +198,7 @@ class EncDecClassificationModel(ASRModel):
 
         return {'log': tensorboard_log}
 
-    def multi_test_epoch_end(self, outputs, idx: int = 0):
+    def multi_test_epoch_end(self, outputs, dataloader_idx: int = 0):
         test_loss_mean = torch.stack([x['test_loss'] for x in outputs]).mean()
         correct_counts = torch.stack([x['test_correct_counts'].unsqueeze(0) for x in outputs])
         total_counts = torch.stack([x['test_total_counts'].unsqueeze(0) for x in outputs])

--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -171,21 +171,21 @@ class EncDecClassificationModel(ASRModel):
 
         return {'loss': loss_value, 'log': tensorboard_logs}
 
-    def validation_step(self, batch, batch_idx):
+    def validation_step(self, batch, batch_idx, dataloader_idx=0):
         audio_signal, audio_signal_len, labels, labels_len = batch
         logits = self.forward(input_signal=audio_signal, input_signal_length=audio_signal_len)
         loss_value = self.loss(logits=logits, labels=labels)
         correct_counts, total_counts = self._accuracy(logits=logits, labels=labels)
         return {'val_loss': loss_value, 'val_correct_counts': correct_counts, 'val_total_counts': total_counts}
 
-    def test_step(self, batch, batch_idx):
+    def test_step(self, batch, batch_idx, dataloader_idx=0):
         audio_signal, audio_signal_len, labels, labels_len = batch
         logits = self.forward(input_signal=audio_signal, input_signal_length=audio_signal_len)
         loss_value = self.loss(logits=logits, labels=labels)
         correct_counts, total_counts = self._accuracy(logits=logits, labels=labels)
         return {'test_loss': loss_value, 'test_correct_counts': correct_counts, 'test_total_counts': total_counts}
 
-    def validation_epoch_end(self, outputs):
+    def multi_validation_epoch_end(self, outputs, idx: int = 0):
         val_loss_mean = torch.stack([x['val_loss'] for x in outputs]).mean()
         correct_counts = torch.stack([x['val_correct_counts'] for x in outputs])
         total_counts = torch.stack([x['val_total_counts'] for x in outputs])
@@ -198,7 +198,7 @@ class EncDecClassificationModel(ASRModel):
 
         return {'log': tensorboard_log}
 
-    def test_epoch_end(self, outputs):
+    def multi_test_epoch_end(self, outputs, idx: int = 0):
         test_loss_mean = torch.stack([x['test_loss'] for x in outputs]).mean()
         correct_counts = torch.stack([x['test_correct_counts'].unsqueeze(0) for x in outputs])
         total_counts = torch.stack([x['test_total_counts'].unsqueeze(0) for x in outputs])

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -165,7 +165,7 @@ class EncDecCTCModel(ASRModel):
         }
         return {'loss': loss_value, 'log': tensorboard_logs}
 
-    def validation_step(self, batch, batch_idx):
+    def validation_step(self, batch, batch_idx, dataloader_idx=0):
         audio_signal, audio_signal_len, transcript, transcript_len = batch
         log_probs, encoded_len, predictions = self.forward(
             input_signal=audio_signal, input_signal_length=audio_signal_len

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -431,6 +431,11 @@ class ModelPT(LightningModule, Model):
 
                 dataloader_logs = dataloader_logs or {}
 
+                # Perform `val_loss` resolution first (if provided outside logs)
+                if 'val_loss' in dataloader_logs:
+                    if 'val_loss' not in output_dict and dataloader_idx == self._validation_loss_idx:
+                        output_dict['val_loss'] = dataloader_logs['val_loss']
+
                 for k, v in dataloader_logs.items():
                     if k == 'log':
                         log_dict = {}
@@ -504,6 +509,11 @@ class ModelPT(LightningModule, Model):
 
                 dataloader_logs = dataloader_logs or {}
 
+                # Perform `test_loss` resolution first (if provided outside logs)
+                if 'test_loss' in dataloader_logs:
+                    if 'test_loss' not in output_dict and dataloader_idx == self._validation_loss_idx:
+                        output_dict['test_loss'] = dataloader_logs['test_loss']
+
                 for k, v in dataloader_logs.items():
                     if k == 'log':
                         log_dict = {}
@@ -542,12 +552,12 @@ class ModelPT(LightningModule, Model):
     def multi_validation_epoch_end(
         self, outputs: List[Dict[str, torch.Tensor]], dataloader_idx: int = 0
     ) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
-        return
+        raise NotImplementedError()
 
     def multi_test_epoch_end(
         self, outputs: List[Dict[str, torch.Tensor]], dataloader_idx: int = 0
     ) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
-        return
+        raise NotImplementedError()
 
     def get_validation_dataloader_prefix(self, dataloader_idx=0):
         return self._validation_names[dataloader_idx]

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -82,9 +82,19 @@ class ModelPT(LightningModule, Model):
                 self.setup_training_data(self._cfg.train_ds)
 
             if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
+                # Set some placeholder overriden by helper method
+                self._validation_loss_idx = 0
+                self._validation_filenames = ['validation_']
+                self._validation_dl = None  # type: torch.utils.data.DataLoader
+
                 model_utils.resolve_validation_dataloaders(model=self)
 
             if 'test_ds' in self._cfg and self._cfg.test_ds is not None:
+                # Set some placeholder overriden by helper method
+                self._test_loss_idx = 0
+                self._test_filenames = ['test_']
+                self._test_dl = None  # type: torch.utils.data.DataLoader
+
                 model_utils.resolve_test_dataloaders(model=self)
 
     def register_artifact(self, config_path: str, src: str):
@@ -423,6 +433,12 @@ class ModelPT(LightningModule, Model):
 
                                 # Also insert duplicate key with prefix for ease of comparison
                                 log_dict[dataloader_prefix + k_log] = v_log
+
+                            elif k_log == 'val_loss' and dataloader_idx != self._validation_loss_idx:
+                                # replace "val_loss" with <prefix> + loss
+                                # this avoid duplication of the word <prefix> + "val_loss" which causes confusion
+                                new_k_log = dataloader_prefix + 'loss'
+
                             else:
                                 new_k_log = dataloader_prefix + k_log
 
@@ -468,6 +484,12 @@ class ModelPT(LightningModule, Model):
 
                                 # Also insert duplicate key with prefix for ease of comparison
                                 log_dict[dataloader_prefix + k_log] = v_log
+
+                            elif k_log == 'test_loss' and dataloader_idx != self._test_loss_idx:
+                                # replace "test_loss" with <prefix> + loss
+                                # this avoid duplication of the word <prefix> + "test_loss" which causes confusion
+                                new_k_log = dataloader_prefix + 'loss'
+
                             else:
                                 new_k_log = dataloader_prefix + k_log
 

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -84,18 +84,26 @@ class ModelPT(LightningModule, Model):
             if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
                 # Set some placeholder overriden by helper method
                 self._validation_loss_idx = 0
-                self._validation_filenames = ['validation_']
+                self._validation_filenames = None
                 self._validation_dl = None  # type: torch.utils.data.DataLoader
 
                 model_utils.resolve_validation_dataloaders(model=self)
 
+                if self._validation_filenames is None:
+                    if self._validation_dl is not None and type(self._validation_dl) in [list, tuple]:
+                        self._validation_filenames = ['val_{}_'.format(idx) for idx in range(len(self._validation_dl))]
+
             if 'test_ds' in self._cfg and self._cfg.test_ds is not None:
                 # Set some placeholder overriden by helper method
                 self._test_loss_idx = 0
-                self._test_filenames = ['test_']
+                self._test_filenames = None
                 self._test_dl = None  # type: torch.utils.data.DataLoader
 
                 model_utils.resolve_test_dataloaders(model=self)
+
+                if self._test_filenames is None:
+                    if self._test_dl is not None and type(self._test_dl) in [list, tuple]:
+                        self._test_filenames = ['test_{}_'.format(idx) for idx in range(len(self._test_dl))]
 
     def register_artifact(self, config_path: str, src: str):
         """

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -396,6 +396,9 @@ class ModelPT(LightningModule, Model):
                         for k_log, v_log in v.items():
                             if k_log == 'val_loss' and 'val_loss' not in output_dict['log']:
                                 new_k_log = 'val_loss'
+
+                                # Also insert duplicate key with prefix for ease of comparison
+                                log_dict[dataloader_prefix + k_log] = v_log
                             else:
                                 new_k_log = dataloader_prefix + k_log
 
@@ -434,6 +437,9 @@ class ModelPT(LightningModule, Model):
                         for k_log, v_log in v.items():
                             if k_log == 'test_loss' and 'test_loss' not in output_dict['log']:
                                 new_k_log = 'test_loss'
+
+                                # Also insert duplicate key with prefix for ease of comparison
+                                log_dict[dataloader_prefix + k_log] = v_log
                             else:
                                 new_k_log = dataloader_prefix + k_log
 

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -84,26 +84,26 @@ class ModelPT(LightningModule, Model):
             if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
                 # Set some placeholder overriden by helper method
                 self._validation_loss_idx = 0
-                self._validation_filenames = None
+                self._validation_names = None
                 self._validation_dl = None  # type: torch.utils.data.DataLoader
 
                 model_utils.resolve_validation_dataloaders(model=self)
 
-                if self._validation_filenames is None:
+                if self._validation_names is None:
                     if self._validation_dl is not None and type(self._validation_dl) in [list, tuple]:
-                        self._validation_filenames = ['val_{}_'.format(idx) for idx in range(len(self._validation_dl))]
+                        self._validation_names = ['val_{}_'.format(idx) for idx in range(len(self._validation_dl))]
 
             if 'test_ds' in self._cfg and self._cfg.test_ds is not None:
                 # Set some placeholder overriden by helper method
                 self._test_loss_idx = 0
-                self._test_filenames = None
+                self._test_names = None
                 self._test_dl = None  # type: torch.utils.data.DataLoader
 
                 model_utils.resolve_test_dataloaders(model=self)
 
-                if self._test_filenames is None:
+                if self._test_names is None:
                     if self._test_dl is not None and type(self._test_dl) in [list, tuple]:
-                        self._test_filenames = ['test_{}_'.format(idx) for idx in range(len(self._test_dl))]
+                        self._test_names = ['test_{}_'.format(idx) for idx in range(len(self._test_dl))]
 
     def register_artifact(self, config_path: str, src: str):
         """
@@ -550,10 +550,10 @@ class ModelPT(LightningModule, Model):
         return
 
     def get_validation_dataloader_prefix(self, dataloader_idx=0):
-        return self._validation_filenames[dataloader_idx]
+        return self._validation_names[dataloader_idx]
 
     def get_test_dataloader_prefix(self, dataloader_idx=0):
-        return self._test_filenames[dataloader_idx]
+        return self._test_names[dataloader_idx]
 
     @property
     def num_weights(self):

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -379,14 +379,14 @@ class ModelPT(LightningModule, Model):
     ) -> Dict[str, Dict[str, torch.Tensor]]:
 
         if type(outputs[0]) == dict:
-            return self.multi_validation_epoch_end(outputs, idx=0)
+            return self.multi_validation_epoch_end(outputs, dataloader_idx=0)
 
         else:
             output_dict = {'log': {}}
 
             for dataloader_idx, val_outputs in enumerate(outputs):
                 dataloader_prefix = self.get_validation_dataloader_prefix(dataloader_idx)
-                dataloader_logs = self.multi_validation_epoch_end(val_outputs, idx=dataloader_idx)
+                dataloader_logs = self.multi_validation_epoch_end(val_outputs, dataloader_idx=dataloader_idx)
 
                 dataloader_logs = dataloader_logs or {}
 
@@ -417,14 +417,14 @@ class ModelPT(LightningModule, Model):
     ) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
 
         if type(outputs[0]) == dict:
-            return self.multi_validation_epoch_end(outputs, idx=0)
+            return self.multi_validation_epoch_end(outputs, dataloader_idx=0)
 
         else:
             output_dict = {'log': {}}
 
             for dataloader_idx, test_outputs in enumerate(outputs):
                 dataloader_prefix = self.get_test_dataloader_prefix(dataloader_idx)
-                dataloader_logs = self.multi_test_epoch_end(test_outputs, idx=dataloader_idx)
+                dataloader_logs = self.multi_test_epoch_end(test_outputs, dataloader_idx=dataloader_idx)
 
                 dataloader_logs = dataloader_logs or {}
 
@@ -451,20 +451,20 @@ class ModelPT(LightningModule, Model):
             return output_dict
 
     def multi_validation_epoch_end(
-        self, outputs: List[Dict[str, torch.Tensor]], idx: int = 0
+        self, outputs: List[Dict[str, torch.Tensor]], dataloader_idx: int = 0
     ) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
         return
 
     def multi_test_epoch_end(
-        self, outputs: List[Dict[str, torch.Tensor]], idx: int = 0
+        self, outputs: List[Dict[str, torch.Tensor]], dataloader_idx: int = 0
     ) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
         return
 
-    def get_validation_dataloader_prefix(self, idx=0):
-        return self._validation_filenames[idx]
+    def get_validation_dataloader_prefix(self, dataloader_idx=0):
+        return self._validation_filenames[dataloader_idx]
 
-    def get_test_dataloader_prefix(self, idx=0):
-        return self._test_filenames[idx]
+    def get_test_dataloader_prefix(self, dataloader_idx=0):
+        return self._test_filenames[dataloader_idx]
 
     @property
     def num_weights(self):

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -386,7 +386,7 @@ class ModelPT(LightningModule, Model):
 
     def validation_epoch_end(
         self, outputs: Union[List[Dict[str, torch.Tensor]], List[List[Dict[str, torch.Tensor]]]]
-    ) -> Dict[str, Dict[str, torch.Tensor]]:
+    ) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
         """
         Default DataLoader for Validation set which automatically supports multiple data loaders
         via `multi_validation_epoch_end`.
@@ -407,6 +407,9 @@ class ModelPT(LightningModule, Model):
             A dictionary containing the union of all items from individual data_loaders,
             along with merged logs from all data loaders.
         """
+
+        if outputs is not None and len(outputs) == 0:
+            return
 
         if type(outputs[0]) == dict:
             return self.multi_validation_epoch_end(outputs, dataloader_idx=0)
@@ -458,6 +461,28 @@ class ModelPT(LightningModule, Model):
     def test_epoch_end(
         self, outputs: Union[List[Dict[str, torch.Tensor]], List[List[Dict[str, torch.Tensor]]]]
     ) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
+        """
+        Default DataLoader for Test set which automatically supports multiple data loaders
+        via `multi_test_epoch_end`.
+
+        If multi dataset support is not required, override this method entirely in base class.
+        In such a case, there is no need to implement `multi_test_epoch_end` either.
+
+        Note:
+            If more than one data loader exists, and they all provide `test_loss`,
+            only the `test_loss` of the first data loader will be used by default.
+            This default can be changed by passing the special key `test_loss_idx: int`
+            inside the `test_ds` config.
+
+        Args:
+            outputs: Single or nested list of tensor outputs from one or more data loaders.
+
+        Returns:
+            A dictionary containing the union of all items from individual data_loaders,
+            along with merged logs from all data loaders.
+        """
+        if outputs is not None and len(outputs) == 0:
+            return
 
         if type(outputs[0]) == dict:
             return self.multi_validation_epoch_end(outputs, dataloader_idx=0)

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -20,12 +20,11 @@ import tarfile
 import tempfile
 from abc import abstractmethod
 from os import path
-from typing import Dict, Optional, Union, List
+from typing import Dict, List, Optional, Union
 
 import hydra
 import torch
 from omegaconf import DictConfig, OmegaConf
-import torch
 from pytorch_lightning import LightningModule, Trainer
 
 from nemo.core import optim
@@ -414,8 +413,7 @@ class ModelPT(LightningModule, Model):
             return output_dict
 
     def test_epoch_end(
-            self,
-            outputs: Union[List[Dict[str, torch.Tensor]], List[List[Dict[str, torch.Tensor]]]]
+        self, outputs: Union[List[Dict[str, torch.Tensor]], List[List[Dict[str, torch.Tensor]]]]
     ) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
 
         if type(outputs[0]) == dict:

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -37,12 +37,10 @@ def resolve_filepath_from_cfg(cfg: DictConfig) -> str:
                     values_are_paths = 0
 
             if values_are_paths == len(value):
-                logging.info("List path : {}".format(str(value)))
                 return key
 
         else:
             if os.path.exists(str(value)) or os.path.isdir(str(value)):
-                logging.info("Key path : {}".format(value))
                 return key
 
     return None
@@ -68,8 +66,6 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
     dataloaders = []
 
     filepath = resolve_filepath_from_cfg(cfg.validation_ds)
-
-    logging.info("Resolved filepath : {}".format(filepath))
 
     if filepath is None:
         logging.debug(

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -20,6 +20,8 @@ from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from nemo import logging
 
+_VAL_TEST_FASTPATH_KEY = 'ds_item'
+
 
 def resolve_dataset_name_from_cfg(cfg: DictConfig) -> str:
     """
@@ -40,8 +42,8 @@ def resolve_dataset_name_from_cfg(cfg: DictConfig) -> str:
         A str representing the `key` of the config which hosts the filepath(s),
         or None in case path could not be resolved.
     """
-    if hasattr(cfg, 'ds_name') and cfg.ds_name is not None:
-        return 'ds_name'
+    if hasattr(cfg, _VAL_TEST_FASTPATH_KEY) and cfg[_VAL_TEST_FASTPATH_KEY] is not None:
+        return _VAL_TEST_FASTPATH_KEY
 
     for key, value in cfg.items():
         if type(value) in [list, tuple, ListConfig]:
@@ -102,7 +104,7 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
     Helper method that operates on the ModelPT class to automatically support
     multiple dataloaders for the validation set.
 
-    It does so by first resolving the path to one/more data files via `resolve_filepath_from_cfg()`.
+    It does so by first resolving the path to one/more data files via `resolve_dataset_name_from_cfg()`.
     If this resolution fails, it assumes the data loader is prepared to manually support / not support
     multiple data loaders and simply calls the appropriate setup method.
 
@@ -173,7 +175,7 @@ def resolve_test_dataloaders(model: 'ModelPT'):
     Helper method that operates on the ModelPT class to automatically support
     multiple dataloaders for the test set.
 
-    It does so by first resolving the path to one/more data files via `resolve_filepath_from_cfg()`.
+    It does so by first resolving the path to one/more data files via `resolve_dataset_name_from_cfg()`.
     If this resolution fails, it assumes the data loader is prepared to manually support / not support
     multiple data loaders and simply calls the appropriate setup method.
 

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -64,7 +64,9 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
 
     else:
         # no manifest filepath, cannot resolve multi paths
-        logging.warning('Cannot resolve multi-dataloader path since `validation_ds` does not contain `manifest_filepath`')
+        logging.warning(
+            'Cannot resolve multi-dataloader path since `validation_ds` does not contain `manifest_filepath`'
+        )
 
         model.setup_validation_data(cfg.validation_ds)
         model._validation_filenames = ['validation_']

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -14,7 +14,8 @@
 
 import copy
 from pathlib import Path
-from omegaconf import ListConfig, DictConfig
+
+from omegaconf import DictConfig, ListConfig
 
 
 def parse_filepath_as_name(filepath: str) -> str:
@@ -45,8 +46,7 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
             dataloaders.append(model._validation_dl)
 
         model._validation_dl = dataloaders
-        model._validation_filenames = [parse_filepath_as_name(fp)
-                                       for fp in manifest_paths]
+        model._validation_filenames = [parse_filepath_as_name(fp) for fp in manifest_paths]
 
         # In fast-dev-run, only one data loader is used
         if model._trainer.fast_dev_run:
@@ -71,8 +71,7 @@ def resolve_test_dataloaders(model: 'ModelPT'):
             dataloaders.append(model._test_dl)
 
         model._test_dl = dataloaders
-        model._test_filenames = [parse_filepath_as_name(fp)
-                                 for fp in manifest_paths]
+        model._test_filenames = [parse_filepath_as_name(fp) for fp in manifest_paths]
 
         # In fast-dev-run, only one data loader is used
         if model._trainer.fast_dev_run:

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -29,16 +29,20 @@ def resolve_filepath_from_cfg(cfg: DictConfig) -> str:
         if type(value) in [list, tuple, ListConfig]:
             values_are_paths = 0
             for val_i in value:
+                val_i = str(val_i)
+
                 if os.path.exists(val_i) or os.path.isdir(val_i):
                     values_are_paths += 1
                 else:
                     values_are_paths = 0
 
             if values_are_paths == len(value):
+                logging.info("List path : {}".format(str(value)))
                 return key
 
         else:
-            if os.path.exists(value) or os.path.isdir(value):
+            if os.path.exists(str(value)) or os.path.isdir(str(value)):
+                logging.info("Key path : {}".format(value))
                 return key
 
     return None

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -64,7 +64,7 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
 
     else:
         # no manifest filepath, cannot resolve multi paths
-        logging.warn('Cannot resolve multi-dataloader path since `validation_ds` does not contain `manifest_filepath`')
+        logging.warning('Cannot resolve multi-dataloader path since `validation_ds` does not contain `manifest_filepath`')
 
         model.setup_validation_data(cfg.validation_ds)
         model._validation_filenames = ['validation_']
@@ -98,7 +98,7 @@ def resolve_test_dataloaders(model: 'ModelPT'):
 
     else:
         # no manifest filepath, cannot resolve multi paths
-        logging.warn('Cannot resolve multi-dataloader path since `test_ds` does not contain `manifest_filepath`')
+        logging.warning('Cannot resolve multi-dataloader path since `test_ds` does not contain `manifest_filepath`')
 
         model.setup_test_data(cfg.test_ds)
         model._test_filenames = ['test_']

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -27,14 +27,14 @@ def resolve_filepath_from_cfg(cfg: DictConfig) -> str:
 
     for key, value in cfg.items():
         if type(value) in [list, tuple, ListConfig]:
-            values_are_paths = True
+            values_are_paths = 0
             for val_i in value:
                 if os.path.exists(val_i) or os.path.isdir(val_i):
-                    values_are_paths = values_are_paths & True
+                    values_are_paths += 1
                 else:
-                    values_are_paths = False
+                    values_are_paths = 0
 
-            if values_are_paths:
+            if values_are_paths == len(value):
                 return key
 
         else:

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -131,8 +131,8 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
 
     if type(manifest_paths) in (list, tuple, ListConfig):
 
-        for filepath_key in manifest_paths:
-            cfg.validation_ds[filepath_key] = filepath_key
+        for filepath_val in manifest_paths:
+            cfg.validation_ds[filepath_key] = filepath_val
             model.setup_validation_data(cfg.validation_ds)
             dataloaders.append(model._validation_dl)
 
@@ -192,8 +192,8 @@ def resolve_test_dataloaders(model: 'ModelPT'):
 
     if type(manifest_paths) in (list, tuple, ListConfig):
 
-        for filepath_key in manifest_paths:
-            cfg.test_ds[filepath_key] = filepath_key
+        for filepath_val in manifest_paths:
+            cfg.test_ds[filepath_key] = filepath_val
             model.setup_test_data(cfg.test_ds)
             dataloaders.append(model._test_dl)
 

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -16,7 +16,7 @@ import copy
 import os
 from pathlib import Path
 
-from omegaconf import DictConfig, ListConfig
+from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from nemo import logging
 
@@ -115,6 +115,17 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
     cfg = copy.deepcopy(model._cfg)
     dataloaders = []
 
+    # process val_loss_idx
+    if hasattr(cfg.validation_ds, 'val_loss_idx'):
+        cfg = OmegaConf.to_container(cfg)
+        val_loss_idx = cfg['validation_ds'].pop('val_loss_idx')
+        cfg = OmegaConf.create(cfg)
+    else:
+        val_loss_idx = 0
+
+    # Set val_loss_idx
+    model._validation_loss_idx = val_loss_idx
+
     filepath_key = resolve_filepath_from_cfg(cfg.validation_ds)
 
     if filepath_key is None:
@@ -175,6 +186,17 @@ def resolve_test_dataloaders(model: 'ModelPT'):
     """
     cfg = copy.deepcopy(model._cfg)
     dataloaders = []
+
+    # process test_loss_idx
+    if hasattr(cfg.test_ds, 'test_loss_idx'):
+        cfg = OmegaConf.to_container(cfg)
+        test_loss_idx = cfg['test_ds'].pop('test_loss_idx')
+        cfg = OmegaConf.create(cfg)
+    else:
+        test_loss_idx = 0
+
+    # Set val_loss_idx
+    model._test_loss_idx = test_loss_idx
 
     filepath_key = resolve_filepath_from_cfg(cfg.test_ds)
 

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -40,7 +40,7 @@ def resolve_dataset_name_from_cfg(cfg: DictConfig) -> str:
         A str representing the `key` of the config which hosts the filepath(s),
         or None in case path could not be resolved.
     """
-    if hasattr(cfg, 'ds_name'):
+    if hasattr(cfg, 'ds_name') and cfg.ds_name is not None:
         return 'ds_name'
 
     for key, value in cfg.items():

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -1,0 +1,84 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import copy
+from pathlib import Path
+from omegaconf import ListConfig, DictConfig
+
+
+def parse_filepath_as_name(filepath: str) -> str:
+    filename = Path(filepath).stem
+
+    # cleanup name
+    filename = filename.replace('-', '_')
+
+    if 'manifest' in filename:
+        filename = filename.replace('manifest', '')
+
+    if '_' != filename[-1]:
+        filename = filename + '_'
+
+    return filename
+
+
+def resolve_validation_dataloaders(model: 'ModelPT'):
+    cfg = copy.deepcopy(model._cfg)
+    manifest_paths = cfg.validation_ds.manifest_filepath
+    dataloaders = []
+
+    if type(manifest_paths) in (list, tuple, ListConfig):
+
+        for filepath in manifest_paths:
+            cfg.validation_ds['manifest_filepath'] = filepath
+            model.setup_validation_data(cfg.validation_ds)
+            dataloaders.append(model._validation_dl)
+
+        model._validation_dl = dataloaders
+        model._validation_filenames = [parse_filepath_as_name(fp)
+                                       for fp in manifest_paths]
+
+        # In fast-dev-run, only one data loader is used
+        if model._trainer.fast_dev_run:
+            model._validation_dl = model._validation_dl[:1]
+            model._validation_filenames = model._validation_filenames[:1]
+
+    else:
+        model.setup_validation_data(cfg.validation_ds)
+        model._validation_filenames = [parse_filepath_as_name(model._cfg.validation_ds.manifest_filepath)]
+
+
+def resolve_test_dataloaders(model: 'ModelPT'):
+    cfg = copy.deepcopy(model._cfg)
+    manifest_paths = cfg.test_ds.manifest_filepath
+    dataloaders = []
+
+    if type(manifest_paths) in (list, tuple, ListConfig):
+
+        for filepath in manifest_paths:
+            cfg.test_ds['manifest_filepath'] = filepath
+            model.setup_test_data(cfg.test_ds)
+            dataloaders.append(model._test_dl)
+
+        model._test_dl = dataloaders
+        model._test_filenames = [parse_filepath_as_name(fp)
+                                 for fp in manifest_paths]
+
+        # In fast-dev-run, only one data loader is used
+        if model._trainer.fast_dev_run:
+            model._test_dl = model._test_dl[:1]
+            model._test_filenames = model._test_filenames[:1]
+
+    else:
+        model.setup_test_data(cfg.test_ds)
+        model._test_filenames = [parse_filepath_as_name(model._cfg.test_ds.manifest_filepath)]

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -86,7 +86,7 @@ def resolve_dataset_name_from_cfg(cfg: DictConfig) -> str:
     if hasattr(cfg, _VAL_TEST_FASTPATH_KEY) and cfg[_VAL_TEST_FASTPATH_KEY] is not None:
         fastpath_key = cfg[_VAL_TEST_FASTPATH_KEY]
 
-        if hasattr(cfg, fastpath_key):
+        if isinstance(fastpath_key, str) and hasattr(cfg, fastpath_key):
             return cfg[fastpath_key]
         else:
             return _VAL_TEST_FASTPATH_KEY

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -41,9 +41,9 @@ def resolve_filepath_from_cfg(cfg: DictConfig) -> str:
             if os.path.exists(value) or os.path.isdir(value):
                 return key
 
-    raise ValueError("Could not resolve any filepath to a file for dataset ! Provided dictionary : {}".format(
-        str(cfg)
-    ))
+    raise ValueError(
+        "Could not resolve any filepath to a file for dataset ! Provided dictionary : {}".format(str(cfg))
+    )
 
 
 def parse_filepath_as_name(filepath: str) -> str:


### PR DESCRIPTION
# API operation
- Internally, ModelPT will now attempt to resolve validation / test data loaders to path names. 
- If it can resolve one or more data loaders, it will preserve a list of `_*_dl` and `_*_filenames`  (*=validation/test)
- It provides default `validation_epoch_end()` and `test_epoch_end()` which by default support single or multiple (or 0 dataloader) cases. 
- If subclass **does overrides** the above `validation_epoch_end` or `test_epoch_end`, they must manage all multiple data loader handling themselves - ModelPT will defer everything to the subclass. **This ensures no older codebase breaks**.
- If subclass **does not** override the above method, they must instead make two changes per * (validation or test)
  - They must first change signature of the data loader to include **dataloader_idx=0** - `def *_loader(self, batch, batch_idx, **dataloader_idx=0**)` 
  - They must change `def *_epoch_end(self, outputs)` by adding **multi_** to the beginning of the function name -  `def multi_*_epoch_end(self, outputs, dataloader_idx=0)`. 
  - This second step is necessary since python does not support method overloading like Java or other languages (so we have to refer to another name of function)

**Thats the only change required in user facing side.** We are only changing signature of dataloader to include `dataloader_idx=0` and changing name of *_epoch_end method to have `multi_` before it and include the `dataloader_idx=0` kwarg inside it. 

All else is managed by the ModelPT class transparently (and your code does not have to be changed or written in any special way to handle the possibility of one or more data loaders - or even 0 data loaders).

## Data Set Name Resolution
- Helper methods will attempt to parse `validation_ds` or `test_ds` passed as configs in yaml or DictConfig

### Usage of fast-path key `ds_item`
- It will first test the existence of a special kwarg `ds_item`, which can be a single value or a list of values.
  - These values can be Any typy or List[Any] type. It is however preferable if these values are a type that can be modified from the command line.
  - It does not particularly need to be a string paths or names, but can be one if necessary due to its priority. Any object necessary by the dataloader can be supplied as values to `ds_item`.
  - Paths resolution is attempted below if `ds_item` is None.
  - **NOTE**: `ds_item` a single value when passed to the `setup_validation_dataloader()` or `setup_test_dataloader()` methods. When using multi data loader setup, the setup method will be called repeatedly with the individual items one at a time. Your data loader (if it uses `ds_item`) only needs to deal with the 1 `ds_item` case.

### Fast-path resolution (via `ds_item`)

In order to handle cases where we need to resolve items that are not paths, a fastpath key can be provided as defined in the global `ds_item`.

This key can be used in two ways :

#### 1) `ds_item` points to another key in the config

If this ds_itempoints to another key in this config itself, then we assume we want to loop through the values of that key. This allows for any key in the config to become a fastpath key.

Example:
```yaml
validation_ds:
    splits: "val"
    ...
    <_VAL_TEST_FASTPATH_KEY>: "splits"  <-- this points to the key name "splits"
```

Then we can write the following when overriding in hydra:
```python
python train_file.py ... \
    model.validation_ds.splits=[val1, val2, dev1, dev2] ...
```

#### 2) `ds_item` itself acts as the resolved key

If this `ds_item` does not point to another key in the config, then it is assumed that the items of this key itself are used for resolution. 

Example:
```yaml
validation_ds:
    ...
    <_VAL_TEST_FASTPATH_KEY>: "val"  <-- this points to the key name "splits"
```

Then we can write the following when overriding in hydra:
```python
python train_file.py ... \
    model.validation_ds.<_VAL_TEST_FASTPATH_KEY>=[val1, val2, dev1, dev2] ...
```


### If `ds_item` does not exist / if `ds_item` is None, then path resolution is attempted.

- The code will attempt this parse by performing the `if os.path.exists(<val>) or os.path.isdir(<val>)` test, for every `<key>:<val>` element inside the `validation_ds` or `test_ds`.
- **NOTE**: This means that the data path **must** exist **inside of these configs**. I.E. if the path exists **outside of these sub-configs**, the filepath resolution fails and ModelPT can no longer distinguish how data loading should be handled automatically. 
  - In such a case, it will simply call the respective `setup_*_dataloader` method with provided arguments and trust your setup method to handle data loader instantiation entirely. 
  - So it becomes the `setup_*_dataloader`'s responsibility to load zero/one/more dataloaders or to even support more than 1 potential data loader.
  - This is an important point since NLP domain seems to keep their data loader path outside their validation_ds and test_ds configs.
- **NOTE** : As a side-effect of name resolution, only the first valid path string / strings will be resolved. So if there exist more than 1 string path / directories inside validation_ds and test_ds, **please make sure the data path is at the top** for correct path resolution.

## Changes required

### Validation side changes
1) `def validation_step(self, batch, batch_idx=0):` => `def validation_step(self, batch, batch_idx, dataloader_idx=0):`
2) `def validation_epoch_end(self, outputs):` => `def multi_validation_epoch_end(self, outputs, dataloader_idx: int = 0):`

### Test side changes
3) `def test_step(self, batch, batch_idx=0):` => `def test_step(self, batch, batch_idx, dataloader_idx=0):`
4) `def test_epoch_end(self, outputs):` => `def multi_test_epoch_end(self, outputs, dataloader_idx: int = 0):`

### Manifest side changes

- If your manifest has a filepath inside the validation_ds or test_ds at the beginning, and this corresponds to the data file / manifest file / some other file path that you want multiple possible values of, then **no change needs to be made** !
  - If it is not at the top, please re-arrange this tag to be at the top.
- If your manifest does not have a file path or a manifest path, but you would like to have multiples of some `<tag>`, **please change that `<tag>` to `ds_item`**.
  - In such a case, your setup methods will need to resolve this `cfg.ds_item` and pass it properly to your dataset. See the ner.py example below for a demonstration. 

## Usage

Simply pass multiple paths to `model.validation_ds.<path_key>=[<path1>,<path2>,...,<pathN>]`. There should be no spaces after `,` in the path, and it must be contained in a `[` and `]` list. Double quotes are optional but recommended for clarity of path.

Example of multi data loader for validation -

```python
# Example of passing a list of manifest paths to data loader
python examples/asr/speech_to_text.py \
            model.train_ds.manifest_filepath="LS/train_clean_100.json,LS/train_clean_360.json,LS/train_other_500.json" \
            model.validation_ds.manifest_filepath=[LS/dev_clean.json,LS/dev_other.json,LS/test_clean.json,LS/test_other.json]

# Example of `ds_item` usage
python examples/cv/mnist.py \
            ... \
            model.validation_ds.ds_item=[byclass,byname,bysplit]
```

## Example 2 (with basic fast path)
Example of setup_validation_dataloader() which handles the `ds_item` usage (taking potentially the `ner_model.py` as random example):

```python
def _setup_dataloader_from_config(self, cfg: DictConfig):
    # Assume that text file was separated into multiple text files (prefix1, prefix2, prefix...)
    # We need to edit one line in yaml: `model.validation_ds.prefix = ???` => `model.validation_ds.ds_item = ???`
    prefix = cfg.ds_item  # <-- ds_item is guarenteed to be a single item (even if a list of items were passed !)

    text_file = os.path.join(self.data_dir , 'text_' + prefix + '.txt')  # < -- change cfg.prefix to prefix
    label_file = os.path.join(self.data_dir , 'labels_' + prefix + '.txt')  # < -- change cfg.prefix to prefix
        
    # Everything else remains the same !
    ....
```

Now you can pass multiple prefix in cfg as follows: 

```python
python examples/nlp/ner.py \
    ... \
    model.validation_ds.ds_item=[prefix1,prefix2,prefix3]
```

## Example 3 (with resolved fast path pointing to config item)
Example of `validation_ds` in which the `ds_item` points towards a key in the same config - (taking potentially the `ner_model.py` as random example):

```yaml
model
  ...
  validation_ds:
    prefix: ???
    ...
    ds_item: "prefix"
```

Now you can pass multiple prefix in cfg as follows: 

```python
python examples/nlp/ner.py \
    ... \
    model.validation_ds.prefix=[prefix1,prefix2,prefix3]
```

Signed-off-by: smajumdar <titu1994@gmail.com>