### PR TITLE
Patch @typecheck() to support containers as outputs

### DIFF
--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -40,7 +40,7 @@ class EncDecClassificationModel(ASRModel):
         self.preprocessor = EncDecClassificationModel.from_config_dict(self._cfg.preprocessor)
         self.encoder = EncDecClassificationModel.from_config_dict(self._cfg.encoder)
         self.decoder = EncDecClassificationModel.from_config_dict(self._cfg.decoder)
-        self.loss = CrossEntropyLoss(logits_ndim=self.decoder.num_classes)
+        self.loss = CrossEntropyLoss()
         if hasattr(self._cfg, 'spec_augment') and self._cfg.spec_augment is not None:
             self.spec_augmentation = EncDecClassificationModel.from_config_dict(self._cfg.spec_augment)
         else:

--- a/nemo/collections/asr/models/label_models.py
+++ b/nemo/collections/asr/models/label_models.py
@@ -143,24 +143,24 @@ class EncDecSpeakerLabelModel(ModelPT):
     # PTL-specific methods
     def training_step(self, batch, batch_nb):
         self.train()
-        audio_signal, audio_signal_len, label, _ = batch
+        audio_signal, audio_signal_len, labels, _ = batch
         logits, _ = self.forward(input_signal=audio_signal, input_signal_length=audio_signal_len)
-        loss_value = self.loss(logits, label)
+        loss_value = self.loss(logits=logits, labels=labels)
         labels_hat = torch.argmax(logits, dim=1)
-        n_correct_pred = torch.sum(label == labels_hat, dim=0).item()
-        tensorboard_logs = {'train_loss': loss_value, 'training_batch_acc': (n_correct_pred / len(label)) * 100}
+        n_correct_pred = torch.sum(labels == labels_hat, dim=0).item()
+        tensorboard_logs = {'train_loss': loss_value, 'training_batch_acc': (n_correct_pred / len(labels)) * 100}
 
-        return {'loss': loss_value, 'log': tensorboard_logs, "n_correct_pred": n_correct_pred, "n_pred": len(label)}
+        return {'loss': loss_value, 'log': tensorboard_logs, "n_correct_pred": n_correct_pred, "n_pred": len(labels)}
 
     def validation_step(self, batch, batch_idx):
         self.eval()
-        audio_signal, audio_signal_len, label, _ = batch
+        audio_signal, audio_signal_len, labels, _ = batch
         logits, _ = self.forward(input_signal=audio_signal, input_signal_length=audio_signal_len)
-        loss_value = self.loss(logits, label)
+        loss_value = self.loss(logits=logits, labels=labels)
         labels_hat = torch.argmax(logits, dim=1)
-        n_correct_pred = torch.sum(label == labels_hat, dim=0).item()
+        n_correct_pred = torch.sum(labels == labels_hat, dim=0).item()
 
-        return {'val_loss': loss_value, "n_correct_pred": n_correct_pred, "n_pred": len(label)}
+        return {'val_loss': loss_value, "n_correct_pred": n_correct_pred, "n_pred": len(labels)}
 
     def validation_epoch_end(self, outputs):
         val_loss_mean = torch.stack([x['val_loss'] for x in outputs]).mean()

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -293,7 +293,7 @@ class AudioToMFCCPreprocessor(AudioPreprocessor):
     """
 
     @property
-    def input_ports(self):
+    def input_types(self):
         """Returns definitions of module input ports.
         """
         return {
@@ -302,7 +302,7 @@ class AudioToMFCCPreprocessor(AudioPreprocessor):
         }
 
     @property
-    def output_ports(self):
+    def output_types(self):
         """Returns definitions of module output ports.
         """
         return {
@@ -521,7 +521,7 @@ class CropOrPadSpectrogramAugmentation(NeuralModule):
         return image, length
 
     @property
-    def input_ports(self):
+    def input_types(self):
         """Returns definitions of module output ports.
         """
         return {
@@ -530,7 +530,7 @@ class CropOrPadSpectrogramAugmentation(NeuralModule):
         }
 
     @property
-    def output_ports(self):
+    def output_types(self):
         """Returns definitions of module output ports.
         """
         return {

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -49,7 +49,7 @@ class ConvASREncoder(NeuralModule):
         pass
 
     @property
-    def input_ports(self):
+    def input_types(self):
         """Returns definitions of module input ports.
         """
         return OrderedDict(
@@ -60,7 +60,7 @@ class ConvASREncoder(NeuralModule):
         )
 
     @property
-    def output_ports(self):
+    def output_types(self):
         """Returns definitions of module output ports.
         """
         return OrderedDict(

--- a/nemo/collections/common/losses/aggregator.py
+++ b/nemo/collections/common/losses/aggregator.py
@@ -31,17 +31,17 @@ class AggregatorLoss(Loss):
     """
 
     @property
-    def input_ports(self):
+    def input_types(self):
         """Returns definitions of module input ports.
         """
-        input_ports = {}
+        input_types = {}
         for i in range(self._num_losses):
-            input_ports["loss_" + str(i + 1)] = NeuralType(elements_type=LossType())
+            input_types["loss_" + str(i + 1)] = NeuralType(elements_type=LossType())
 
-        return input_ports
+        return input_types
 
     @property
-    def output_ports(self):
+    def output_types(self):
         """Returns definitions of module output ports.
         loss:
             NeuralType(None)

--- a/nemo/collections/common/losses/cross_entropy.py
+++ b/nemo/collections/common/losses/cross_entropy.py
@@ -29,7 +29,7 @@ class CrossEntropyLoss(nn.CrossEntropyLoss, Serialization, Typing):
     """
 
     @property
-    def input_ports(self):
+    def input_types(self):
         """Returns definitions of module input ports.
         """
         return {
@@ -39,7 +39,7 @@ class CrossEntropyLoss(nn.CrossEntropyLoss, Serialization, Typing):
         }
 
     @property
-    def output_ports(self):
+    def output_types(self):
         """Returns definitions of module output ports.
         loss:
             NeuralType(None)

--- a/nemo/collections/common/losses/smoothed_cross_entropy.py
+++ b/nemo/collections/common/losses/smoothed_cross_entropy.py
@@ -43,7 +43,7 @@ class SmoothedCrossEntropyLoss(Loss):
     """
 
     @property
-    def input_ports(self):
+    def input_types(self):
         """Returns definitions of module input ports.
         """
         return {
@@ -53,7 +53,7 @@ class SmoothedCrossEntropyLoss(Loss):
         }
 
     @property
-    def output_ports(self):
+    def output_types(self):
         """Returns definitions of module output ports.
         """
         return {"loss": NeuralType(elements_type=LossType())}

--- a/nemo/collections/common/losses/spanning_loss.py
+++ b/nemo/collections/common/losses/spanning_loss.py
@@ -31,7 +31,7 @@ class SpanningLoss(Loss):
     """
 
     @property
-    def input_ports(self):
+    def input_types(self):
         """Returns definitions of module input ports.
         """
         return {
@@ -41,7 +41,7 @@ class SpanningLoss(Loss):
         }
 
     @property
-    def output_ports(self):
+    def output_types(self):
         """Returns definitions of module output ports.
         """
         return {

--- a/nemo/collections/nlp/models/token_classification/ner_model.py
+++ b/nemo/collections/nlp/models/token_classification/ner_model.py
@@ -85,9 +85,9 @@ class NERModel(ModelPT):
 
         if cfg.class_balancing == 'weighted_loss':
             # You may need to increase the number of epochs for convergence when using weighted_loss
-            self.loss = CrossEntropyLoss(weight=self.data_desc.class_weights)
+            self.loss = CrossEntropyLoss(logits_ndim=3, weight=self.data_desc.class_weights)
         else:
-            self.loss = CrossEntropyLoss()
+            self.loss = CrossEntropyLoss(logits_ndim=3)
 
         # setup to track metrics
         self.classification_report = ClassificationReport(

--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
@@ -89,7 +89,7 @@ class PunctuationCapitalizationModel(ModelPT):
             use_transformer_init=cfg.capit_head.use_transformer_init,
         )
 
-        self.loss = CrossEntropyLoss()
+        self.loss = CrossEntropyLoss(logits_ndim=3)
         self.agg_loss = AggregatorLoss(num_inputs=2)
 
         # setup to track metrics

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -146,8 +146,8 @@ class Typing(ABC):
                 self.__check_neural_type(elem, type_val)
 
         if hasattr(obj, 'neural_type') and not type_val.compare(obj.neural_type) in (
-                NeuralTypeComparisonResult.SAME,
-                NeuralTypeComparisonResult.GREATER,
+            NeuralTypeComparisonResult.SAME,
+            NeuralTypeComparisonResult.GREATER,
         ):
             raise TypeError(
                 f"{type_val.compare(obj.neural_type)} : \n"

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -93,7 +93,7 @@ class Typing(ABC):
                         f"Input type found : {value.neural_type}"
                     )
 
-                # Perform recursive neural type check for homogenous elements
+                # Perform recursive neural type check for homogeneous elements
                 elif isinstance(value, list) or isinstance(value, tuple):
                     for ind, val in enumerate(value):
                         self.__check_neural_type(val, self.input_types[key])
@@ -144,6 +144,7 @@ class Typing(ABC):
         if isinstance(obj, tuple) or isinstance(obj, list):
             for elem in obj:
                 self.__check_neural_type(elem, type_val)
+            return  # after processing nest, return to avoid testing nest itself
 
         if hasattr(obj, 'neural_type') and not type_val.compare(obj.neural_type) in (
             NeuralTypeComparisonResult.SAME,
@@ -159,6 +160,7 @@ class Typing(ABC):
         if isinstance(obj, tuple) or isinstance(obj, list):
             for elem in obj:
                 self.__attach_neural_type(elem, type_val)
+            return  # after processing nest, return to avoid argument insertion into nest itself
 
         try:
             obj.neural_type = type_val

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -17,8 +17,8 @@
 from abc import ABC, abstractmethod
 from typing import Dict, Optional
 
-import torch
 import hydra
+import torch
 import wrapt
 from omegaconf import DictConfig, OmegaConf
 

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -45,12 +45,18 @@ class Typing(ABC):
     def _validate_input_types(self, **kwargs):
         # TODO: Properly implement this
         if self.input_types is not None:
-            if len(kwargs) != len(self.input_types):
-                raise TypeError(
-                    "Number of input arguments provided ({}) is not as expected ({})".format(
-                        len(kwargs), len(self.input_types)
+            total_input_types = len(self.input_types)
+            mandatory_input_types = len(
+                [type_val for type_key, type_val in self.input_types.items() if not type_val.optional]
+            )
+
+            if len(kwargs) != total_input_types:
+                if len(kwargs) != mandatory_input_types:
+                    raise TypeError(
+                        "Number of input arguments provided ({}) is not as expected ({})".format(
+                            len(kwargs), len(self.input_types)
+                        )
                     )
-                )
 
             for key, value in kwargs.items():
                 # Check if keys exists in the defined input types
@@ -72,6 +78,20 @@ class Typing(ABC):
                     )
 
     def _attach_and_validate_output_types(self, out_objects):
+        """
+        This function does a few things.
+        1) It ensures that len(out_object) == len(self.output_types).
+        2) If the output is a tensor (or list/tuple of list/tuple ... of tensors), it
+            attaches a neural_type to it. For objects without the neural_type attribute,
+            such as python objects (dictionaries and lists, primitive data types, structs),
+            no neural_type is attached.
+
+            Note: tensor.neural_type is only checked during _validate_input_types which is
+            called prior to forward().
+
+        Args:
+            out_objects: The outputs of the wrapped function.
+        """
         # TODO: Properly implement this
         if self.output_types is not None:
             out_types_list = list(self.output_types.items())

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -18,7 +18,6 @@ from abc import ABC, abstractmethod
 from typing import Dict, Optional
 
 import hydra
-import torch
 import wrapt
 from omegaconf import DictConfig, OmegaConf
 

--- a/tests/core/test_typecheck.py
+++ b/tests/core/test_typecheck.py
@@ -1,0 +1,436 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo.core import NeuralModule, Typing, typecheck
+from nemo.core.neural_types import *
+
+
+class TestNeuralTypeCheckSystem:
+    @pytest.mark.unit
+    def test_no_types_passthrough(self):
+        class NoTypes(Typing):
+            @typecheck()
+            def __call__(self, x):
+                return torch.tensor(1.0)
+
+        obj = NoTypes()
+        result = obj(torch.tensor(1.0))
+
+        assert result == torch.tensor(1.0)
+        assert not hasattr(result, 'neural_type')
+
+    @pytest.mark.unit
+    def test_input_output_types(self):
+        class InputOutputTypes(Typing):
+            @property
+            def input_types(self):
+                return {"x": NeuralType(('B',), ElementType())}
+
+            @property
+            def output_types(self):
+                return {"y": NeuralType(('B',), ElementType())}
+
+            @typecheck()
+            def __call__(self, x):
+                x += 1
+                return x
+
+        obj = InputOutputTypes()
+        result = obj(x=torch.zeros(10))
+
+        assert result.sum() == torch.tensor(10.0)
+        assert result.neural_type.compare(NeuralType(('B',), ElementType())) == NeuralTypeComparisonResult.SAME
+
+        # Test passing wrong key for input
+        with pytest.raises(TypeError):
+            _ = obj(a=torch.zeros(10))
+
+        # Test using positional args
+        with pytest.raises(TypeError):
+            _ = obj(torch.zeros(10))
+
+    @pytest.mark.unit
+    def test_input_types_only(self):
+        class InputTypes(Typing):
+            @property
+            def input_types(self):
+                return {"x": NeuralType(('B',), ElementType())}
+
+            @typecheck()
+            def __call__(self, x):
+                x += 1
+                return x
+
+        obj = InputTypes()
+        result = obj(x=torch.zeros(10))
+
+        assert result.sum() == torch.tensor(10.0)
+        assert hasattr(result, 'neural_type') is False
+
+    @pytest.mark.unit
+    def test_output_types_only(self):
+        class OutputTypes(Typing):
+            @property
+            def output_types(self):
+                return {"y": NeuralType(('B',), ElementType())}
+
+            @typecheck()
+            def __call__(self, x):
+                x += 1
+                return x
+
+        obj = OutputTypes()
+        result = obj(x=torch.zeros(10))
+
+        assert result.sum() == torch.tensor(10.0)
+        assert result.neural_type.compare(NeuralType(('B',), ElementType())) == NeuralTypeComparisonResult.SAME
+
+        # Test passing positional args
+        # Positional args allowed if input types is not set !
+        result = obj(torch.zeros(10))
+        assert result.sum() == torch.tensor(10.0)
+
+    @pytest.mark.unit
+    def test_incorrect_inheritance(self):
+        class IncorrectInheritance(object):
+            @property
+            def input_types(self):
+                return {"x": NeuralType(('B',), ElementType())}
+
+            @property
+            def output_types(self):
+                return {"y": NeuralType(('B',), ElementType())}
+
+            @typecheck()
+            def __call__(self, x):
+                x += 1
+                return x
+
+        obj = IncorrectInheritance()
+
+        with pytest.raises(RuntimeError):
+            _ = obj(x=torch.zeros(10))
+
+    @pytest.mark.unit
+    def test_port_definition_rejection(self):
+        class InputPortDefinitionRejection(Typing):
+            @property
+            def input_types(self):
+                return {"x": NeuralType(('B',), ElementType())}
+
+            @property
+            def output_types(self):
+                return {"w": NeuralType(('B',), ElementType()), "u": NeuralType(('B',), ElementType())}
+
+            @typecheck()
+            def __call__(self, x, y):
+                x += 1
+                y -= 1
+                return x, y
+
+        # Test input port mismatch
+        obj = InputPortDefinitionRejection()
+
+        with pytest.raises(TypeError):
+            _ = obj(x=torch.zeros(10), y=torch.zeros(10))
+
+        class OutputPortDefinitionRejection(Typing):
+            @property
+            def input_types(self):
+                return {"x": NeuralType(('B',), ElementType())}
+
+            @property
+            def output_types(self):
+                return {
+                    "w": NeuralType(('B',), ElementType()),
+                }
+
+            @typecheck()
+            def __call__(self, x):
+                return x + 1, x - 1
+
+        obj = OutputPortDefinitionRejection()
+
+        with pytest.raises(TypeError):
+            _ = obj(x=torch.zeros(10))
+
+    @pytest.mark.unit
+    def test_positional_args(self):
+        # Test positional check on input type
+        class InputPositional(Typing):
+            @property
+            def input_types(self):
+                return {"x": NeuralType(('B',), ElementType())}
+
+            @typecheck()
+            def __call__(self, x):
+                x += 1
+                return x
+
+        obj = InputPositional()
+
+        with pytest.raises(TypeError):
+            _ = obj(torch.zeros(10))
+
+        # Test positional pass-through for only output ports defined
+        # NOTE: This is required behaviour to support type checking of NeMo Dataset class
+        # during collate_fn() call.
+        class OutputPositionalPassthrough(Typing):
+            @property
+            def output_types(self):
+                return {"y": NeuralType(('B',), ElementType())}
+
+            @typecheck()
+            def __call__(self, x):
+                x += 1
+                return x
+
+        obj = OutputPositionalPassthrough()
+        result = obj(torch.zeros(10))
+
+        assert result.sum() == torch.tensor(10.0)
+
+    @pytest.mark.unit
+    def test_optional_types(self):
+        class InputOptionalTypes(Typing):
+            @property
+            def input_types(self):
+                return {"x": NeuralType(('B',), ElementType()), "y": NeuralType(('B',), ElementType(), optional=True)}
+
+            @typecheck()
+            def __call__(self, x, y=None):
+                if y is None:
+                    x += 1
+                else:
+                    x += y
+                return x
+
+        obj = InputOptionalTypes()
+        result = obj(x=torch.zeros(10))
+
+        assert result.sum() == torch.tensor(10.0)
+        assert hasattr(result, 'neural_type') is False
+
+        result2 = obj(x=torch.zeros(10), y=torch.full([10], fill_value=5))
+
+        assert result2.sum() == torch.tensor(10 * 5)
+        assert hasattr(result, 'neural_type') is False
+
+    @pytest.mark.unit
+    def test_input_output_neural_types(self):
+        class NodeA(Typing):
+            @property
+            def input_types(self):
+                return {"x": NeuralType(('B',), ElementType())}
+
+            @property
+            def output_types(self):
+                return {"y": NeuralType(('B', 'D'), LogitsType())}
+
+            @typecheck()
+            def __call__(self, x):
+                y = torch.randn(x.shape[0], 4)
+                return y
+
+        class NodeB(Typing):
+            @property
+            def input_types(self):
+                return {"w": NeuralType(('B', 'D'), LogitsType())}
+
+            @property
+            def output_types(self):
+                return {"u": NeuralType(('B',), LabelsType())}
+
+            @typecheck()
+            def __call__(self, w):
+                _, u = w.max(-1)
+                return u
+
+        nodeA = NodeA()
+        nodeB = NodeB()
+
+        outA = nodeA(x=torch.zeros(10))
+        outB = nodeB(w=outA)
+
+        assert outB.shape == torch.Size([10])
+        assert outB.neural_type.compare(NeuralType(('B',), LabelsType())) == NeuralTypeComparisonResult.SAME
+
+    @pytest.mark.unit
+    def test_nested_input_output_neural_types(self):
+        class NestedNodeA(Typing):
+            @property
+            def input_types(self):
+                return {"x": NeuralType(('B',), ElementType())}
+
+            @property
+            def output_types(self):
+                return {
+                    "y0": NeuralType(('B', 'D'), LogitsType()),
+                    "y1": NeuralType(('B', 'D'), LogitsType()),
+                }
+
+            @typecheck()
+            def __call__(self, x):
+                # input x = [[x1, x2], [x3]]
+                x0 = x[0][0]
+                y = torch.randn(x0.shape[0], 4)
+                return [[y, y], [y]]
+
+        # Non-homogeneous output types
+        class NestedNodeB(Typing):
+            @property
+            def input_types(self):
+                return {"w": NeuralType(('B', 'D'), LogitsType())}
+
+            @property
+            def output_types(self):
+                return {
+                    "u0": NeuralType(('B',), LogprobsType()),  # check non homogeneous type
+                    "u1": NeuralType(('B',), LabelsType()),
+                }
+
+            @typecheck()
+            def __call__(self, w):
+                # input x = [[x1, x2], [x3]]
+                _, u00 = w[0][0].max(-1)
+                _, u01 = w[0][1].max(-1)
+                _, u10 = w[1][0].max(-1)
+                return [[u00, u01], [u10]]
+
+        nodeA = NestedNodeA()
+        nodeB = NestedNodeB()
+
+        input_nest = [[torch.zeros(10), torch.zeros(10)], [torch.zeros(10)]]
+        outA = nodeA(x=input_nest)
+        outB = nodeB(w=outA)
+
+        # Perform recursive shape assert
+        def recursive_assert_shape(x, shape):
+            if isinstance(x, list) or isinstance(x, tuple):
+                for xi in x:
+                    recursive_assert_shape(xi, shape)
+                return
+
+            assert x.shape == shape
+
+        recursive_assert_shape(outB, torch.Size([10]))
+
+        # Assert non-homogeneous type assertions
+        assert outB[0][0].neural_type.compare(NeuralType(('B',), LogprobsType())) == NeuralTypeComparisonResult.SAME
+        assert outB[0][1].neural_type.compare(NeuralType(('B',), LogprobsType())) == NeuralTypeComparisonResult.SAME
+        assert outB[1][0].neural_type.compare(NeuralType(('B',), LabelsType())) == NeuralTypeComparisonResult.SAME
+
+    @pytest.mark.unit
+    def test_multi_forward_type(self):
+        class AdaptiveTypeCheck(Typing):
+            @property
+            def input_types(self):
+                if self.mode == 'train':
+                    return {"x": NeuralType(('B',), ElementType())}
+
+                elif self.mode == 'infer':
+                    return {"y": NeuralType(('B',), ChannelType())}
+
+                elif self.mode == 'eval':
+                    return {"x": NeuralType(('B',), ElementType()), "y": NeuralType(('B',), ChannelType())}
+                else:
+                    raise ValueError("Wrong mode of operation")
+
+            @property
+            def output_types(self):
+                if self.mode == 'train':
+                    return {"u": NeuralType(('B',), ElementType())}
+
+                elif self.mode == 'infer':
+                    return {"v": NeuralType(('B',), ChannelType())}
+
+                elif self.mode == 'eval':
+                    return {"u": NeuralType(('B',), ElementType()), "v": NeuralType(('B',), ChannelType())}
+                else:
+                    raise ValueError("Wrong mode of operation")
+
+            def __init__(self):
+                self.mode = 'train'
+
+            def __call__(self, **kwargs):
+                # Call should call and forward appropriate method in its own mode
+                if self.mode == 'train':
+                    return self.train_forward(x=kwargs['x'])
+
+                elif self.mode == 'eval':
+                    return self.eval_forward(x=kwargs['x'], y=kwargs['y'])
+
+                elif self.mode == 'infer':
+                    return self.infer_forward(y=kwargs['y'])
+
+            @typecheck()
+            def train_forward(self, x):
+                return x + 10
+
+            @typecheck()
+            def eval_forward(self, x, y):
+                return x - 1, y - 1
+
+            @typecheck()
+            def infer_forward(self, y):
+                return y - 10
+
+            @property
+            def mode(self):
+                return self._mode
+
+            @mode.setter
+            def mode(self, val):
+                if val not in ['train', 'infer', 'eval']:
+                    raise ValueError('mode must be either train infer or eval')
+                self._mode = val
+
+        obj = AdaptiveTypeCheck()
+
+        x = torch.zeros(10)
+        y = torch.full([10], fill_value=5)
+
+        obj.mode = 'train'
+        x = obj(x=x)
+
+        assert torch.all(x == 10)
+        assert x.neural_type.compare(NeuralType(('B',), ElementType())) == NeuralTypeComparisonResult.SAME
+
+        obj.mode = 'eval'
+        x, y = obj(x=x, y=y)
+
+        assert torch.all(x == 9)
+        assert torch.all(y == 4)
+        assert x.neural_type.compare(NeuralType(('B',), ElementType())) == NeuralTypeComparisonResult.SAME
+        assert y.neural_type.compare(NeuralType(('B',), ChannelType())) == NeuralTypeComparisonResult.SAME
+
+        obj.mode = 'infer'
+        y = obj(y=y)
+
+        assert torch.all(y == -6)
+        assert y.neural_type.compare(NeuralType(('B',), ChannelType())) == NeuralTypeComparisonResult.SAME
+
+        # Now perform assertions of wrong mode with wrong input combinations
+        obj.mode = 'train'
+
+        # In train mode, call infer
+        with pytest.raises(TypeError):
+            _ = obj.eval_forward(x=x, y=y)
+
+        with pytest.raises(TypeError):
+            # wrong input + wrong mode
+            _ = obj.infer_forward(x=x)


### PR DESCRIPTION
# Changelog

- `@typecheck()` will now enforce that `input_types()` and `output_types()` are defined, not `input_ports()` and `output_ports()`.
- `@typecheck()` will now recursively attempt to attach neural type to outputs which are of type list / tuple. Note- it will fail silently if types cannot be attached (say items of container are primitive types)
- `@typecheck()` will now test number of output ports and number of provided outputs match exactly.
- Add unittests for `@typecheck()`

Signed-off-by: smajumdar <titu1994@gmail.com>