### PR TITLE
Patches to ASR BPE, SentencePiece import and config files

### DIFF
--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -167,6 +167,8 @@ trainer:
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
+  row_log_interval: 1  # Interval of logging.
+  val_check_interval: 1.0 # check once per epoch .25 for 4 times per epoch
 
 exp_manager:
   root_dir: null

--- a/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
@@ -169,7 +169,8 @@ trainer:
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
-  row_log_interval: 1  # Interval of logging
+  row_log_interval: 1  # Interval of logging.
+  val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
 
 exp_manager:
   root_dir: null

--- a/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
@@ -169,6 +169,7 @@ trainer:
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
+  row_log_interval: 1  # Interval of logging
 
 exp_manager:
   root_dir: null

--- a/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
@@ -170,6 +170,7 @@ trainer:
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
   row_log_interval: 1  # Interval of logging.
+  val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
 
 exp_manager:
   root_dir: null

--- a/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
@@ -169,6 +169,7 @@ trainer:
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
+  row_log_interval: 1  # Interval of logging.
 
 exp_manager:
   root_dir: null

--- a/examples/asr/conf/quartznet_15x5.yaml
+++ b/examples/asr/conf/quartznet_15x5.yaml
@@ -251,6 +251,8 @@ trainer:
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
+  row_log_interval: 1  # Interval of logging.
+  val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
 
 exp_manager:
   root_dir: null

--- a/examples/asr/conf/quartznet_15x5.yaml
+++ b/examples/asr/conf/quartznet_15x5.yaml
@@ -1,0 +1,268 @@
+name: &name "QuartzNet15x5"
+sample_rate: &sample_rate 16000
+repeat: &repeat 5
+dropout: &dropout 0.0
+separable: &separable true
+labels: &labels [" ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
+         "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'"]
+
+model:
+  train_ds:
+    manifest_filepath: ???
+    sample_rate: 16000
+    labels: *labels
+    batch_size: 32
+    trim_silence: True
+    max_duration: 16.7
+    shuffle: True
+
+  validation_ds:
+    manifest_filepath: ???
+    sample_rate: 16000
+    labels: *labels
+    batch_size: 32
+    shuffle: False
+
+  preprocessor:
+    cls: nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor
+    params:
+      normalize: "per_feature"
+      window_size: 0.02
+      sample_rate: *sample_rate
+      window_stride: 0.01
+      window: "hann"
+      features: &n_mels 64
+      n_fft: 512
+      frame_splicing: 1
+      dither: 0.00001
+      stft_conv: false
+
+  spec_augment:
+    cls: nemo.collections.asr.modules.SpectrogramAugmentation
+    params:
+      rect_freq: 50
+      rect_masks: 5
+      rect_time: 120
+
+  encoder:
+    cls: nemo.collections.asr.modules.ConvASREncoder
+    params:
+      feat_in: *n_mels
+      activation: relu
+      conv_mask: true
+
+      jasper:
+      - dilation: [1]
+        dropout: *dropout
+        filters: 256
+        kernel: [33]
+        repeat: 1
+        residual: false
+        separable: *separable
+        stride: [2]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 256
+        kernel: [33]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 256
+        kernel: [33]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 256
+        kernel: [33]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 256
+        kernel: [39]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 256
+        kernel: [39]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 256
+        kernel: [39]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 512
+        kernel: [51]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 512
+        kernel: [51]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 512
+        kernel: [51]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 512
+        kernel: [63]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 512
+        kernel: [63]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 512
+        kernel: [63]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 512
+        kernel: [75]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 512
+        kernel: [75]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: 512
+        kernel: [75]
+        repeat: *repeat
+        residual: true
+        separable: *separable
+        stride: [1]
+
+      - dilation: [2]
+        dropout: *dropout
+        filters: 512
+        kernel: [87]
+        repeat: 1
+        residual: false
+        separable: *separable
+        stride: [1]
+
+      - dilation: [1]
+        dropout: *dropout
+        filters: &enc_filters 1024
+        kernel: [1]
+        repeat: 1
+        residual: false
+        stride: [1]
+
+  decoder:
+    cls: nemo.collections.asr.modules.ConvASRDecoder
+    params:
+      feat_in: *enc_filters
+      num_classes: 28
+      vocabulary: *labels
+
+  optim:
+    name: novograd
+    # cls: nemo.core.optim.optimizers.Novograd
+    lr: .01
+    # optimizer arguments
+    betas: [0.8, 0.5]
+    weight_decay: 0.001
+
+    # scheduler setup
+    sched:
+      name: CosineAnnealing
+
+      # pytorch lightning args
+      # monitor: val_loss
+      # reduce_on_plateau: false
+
+      # Scheduler params
+      warmup_steps: null
+      warmup_ratio: null
+      min_lr: 0.0
+      last_epoch: -1
+
+trainer:
+  gpus: 0 # number of gpus
+  max_epochs: 5
+  max_steps: null # computed at runtime if not set
+  num_nodes: 1
+  distributed_backend: ddp
+  accumulate_grad_batches: 1
+  checkpoint_callback: False  # Provided by exp_manager
+  logger: False  # Provided by exp_manager
+
+exp_manager:
+  root_dir: null
+  name: *name
+  create_tensorboard_logger: True
+  create_checkpoint_callback: True
+  wandb_exp: null
+  wandb_project: null
+
+hydra:
+  run:
+    dir: .
+  job_logging:
+    root:
+      handlers: null

--- a/examples/asr/experimental/configs/config_bpe.yaml
+++ b/examples/asr/experimental/configs/config_bpe.yaml
@@ -164,6 +164,8 @@ trainer:
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
+  row_log_interval: 1  # Interval of logging.
+  val_check_interval: 1.0 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
 
 exp_manager:
   root_dir: null

--- a/examples/nlp/question_answering/conf/config.yaml
+++ b/examples/nlp/question_answering/conf/config.yaml
@@ -14,6 +14,7 @@ trainer:
   val_check_interval: 1.0 # check once per epoch .25 for 4 times per epoch
   checkpoint_callback: false # provided by exp_manager
   logger: false # provided by exp_manager
+  row_log_interval: 1  # Interval of logging.
 
 model:
 

--- a/examples/nlp/text_classification/conf/text_classification_config.yaml
+++ b/examples/nlp/text_classification/conf/text_classification_config.yaml
@@ -26,6 +26,8 @@ trainer:
   distributed_backend: ddp
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
+  row_log_interval: 1  # Interval of logging.
+  val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
 
 model:
   data_dir: ??? # /path/to/data

--- a/examples/nlp/token_classification/conf/ner_config.yaml
+++ b/examples/nlp/token_classification/conf/ner_config.yaml
@@ -10,6 +10,8 @@ trainer:
   distributed_backend: ddp
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
+  row_log_interval: 1  # Interval of logging.
+  val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
 
 model:
   data_dir: ??? # /path/to/data

--- a/examples/nlp/token_classification/conf/punctuation_capitalization_config.yaml
+++ b/examples/nlp/token_classification/conf/punctuation_capitalization_config.yaml
@@ -10,6 +10,8 @@ trainer:
   distributed_backend: ddp
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
+  row_log_interval: 1  # Interval of logging.
+  val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
 
 model:
   data_dir: ??? # /path/to/data

--- a/examples/speaker_recognition/conf/config.yaml
+++ b/examples/speaker_recognition/conf/config.yaml
@@ -139,6 +139,8 @@ trainer:
   amp_level: O1
   checkpoint_callback: False 
   logger: False
+  row_log_interval: 1  # Interval of logging.
+  val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
 
 exp_manager:
   root_dir: null

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -103,10 +103,10 @@ class EncDecCTCModelBPE(EncDecCTCModel):
         if cfg.decoder.params['num_classes'] < 1:
             logging.info(
                 "\nReplacing placeholder number of classes ({}) with actual number of classes - {}".format(
-                    cfg.decoder.params['num_classes'], self.tokenizer.vocab_size
+                    cfg.decoder.params['num_classes'], len(vocabulary)
                 )
             )
-            cfg.decoder.params['num_classes'] = self.tokenizer.vocab_size
+            cfg.decoder.params['num_classes'] = len(vocabulary)
 
         super().__init__(cfg=cfg, trainer=trainer)
 


### PR DESCRIPTION
# Bugfixes

- Corrects an import issue with SentencePieceTokenizer which inadvertently links the common collection to NLP collection.
- Patches a bug in WPE behavior of automatically allocating the number of classes for CTC BPE models.

# Additions
- Adds two flags to all configs, `row_log_interval: 1` (which will log every train step rather than the current default of 1 log every 10 steps) and `val_check_interval: 1.0` which runs eval loop for every 100% completion of the train loop. If this float < 1.0, will do multiple validations per epoch, if > 1.0 will do one eval every few epochs. If an explicit integer, will perform validation every N train steps.
- Adds the QuartzNet 15x5 model for CTC Librispeech from master to candidate