### PR TITLE
Exportable interface

### DIFF
--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -45,7 +45,7 @@ class ConvASREncoder(NeuralModule, Exportable):
         https://arxiv.org/pdf/1910.10261.pdf
     """
 
-    def prepare_for_export(self) -> (Optional[torch.Tensor], Optional[torch.Tensor]):
+    def _prepare_for_export(self) -> (Optional[torch.Tensor], Optional[torch.Tensor]):
         m_count = 0
         for m in self.modules():
             if type(m).__name__ == "MaskedConv1d":

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -54,7 +54,17 @@ class ConvASREncoder(NeuralModule, Exportable):
         logging.warning(f"Turned off {m_count} masked convolutions")
 
         input_example = torch.randn(16, self.__feat_in, 256)
-        return (input_example, None)
+        return input_example, None
+
+    @property
+    def disabled_deployment_input_names(self):
+        """Implement this method to return a set of input names disabled for export"""
+        return set(["length"])
+
+    @property
+    def disabled_deployment_output_names(self):
+        """Implement this method to return a set of output names disabled for export"""
+        return set(["encoded_lengths"])
 
     def save_to(self, save_path: str):
         pass

--- a/nemo/core/classes/__init__.py
+++ b/nemo/core/classes/__init__.py
@@ -15,6 +15,7 @@
 
 from nemo.core.classes.common import FileIO, Model, Serialization, Typing, typecheck
 from nemo.core.classes.dataset import Dataset, IterableDataset
+from nemo.core.classes.exportable import Exportable, ExportFormat
 from nemo.core.classes.loss import Loss
 from nemo.core.classes.modelPT import ModelPT
 from nemo.core.classes.module import NeuralModule

--- a/nemo/core/classes/exportable.py
+++ b/nemo/core/classes/exportable.py
@@ -1,0 +1,136 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+from abc import ABC, abstractmethod
+from collections import defaultdict
+from enum import Enum
+from typing import Dict, Optional
+
+import torch
+
+from nemo.core.neural_types import AxisKind, NeuralType
+
+__all__ = ['ExportFormat', 'Exportable']
+
+
+class ExportFormat(Enum):
+    """Which format to use when exporting a Neural Module for deployment"""
+
+    ONNX = 0
+
+
+class Exportable(ABC):
+    """
+    This Interface should be implemented by particular classes derived from nemo.core.NeuralModule or nemo.core.ModelPT.
+    It gives these entities ability to be exported for deployment to formats such as ONNX.
+    """
+
+    def export(
+        self,
+        output: str,
+        input_example=None,
+        output_example=None,
+        format: ExportFormat = ExportFormat.ONNX,
+        onnx_opset_version=11,
+    ):
+        _in_example, _out_example = self.prepare_for_export()
+        if input_example is not None:
+            _in_example = input_example
+        if output_example is not None:
+            _out_example = output_example
+
+        # Check if output already exists
+        if os.path.exists(output):
+            raise FileExistsError(f"Destination {output} already exists. " f"Aborting export.")
+
+        if not (hasattr(self, 'input_types') and hasattr(self, 'output_types')):
+            raise NotImplementedError('For export to work you must define input and output types')
+        input_names = list(self.input_types.keys())
+        output_names = list(self.output_types.keys())
+        dynamic_axes = defaultdict(list)
+
+        # extract dynamic axes and remove unnecessary inputs/outputs
+        # for input_ports
+        for _name, ntype in self.input_types.items():
+            if _name in self.disabled_deployment_input_names:
+                input_names.remove(_name)
+                continue
+            self.__extract_dynamic_axes(_name, ntype, dynamic_axes)
+        # for output_ports
+        for _name, ntype in self.output_types.items():
+            if _name in self.disabled_deployment_output_names:
+                output_names.remove(_name)
+                continue
+            self.__extract_dynamic_axes(_name, ntype, dynamic_axes)
+
+        if len(dynamic_axes) == 0:
+            dynamic_axes = None
+
+        # Set module to eval mode
+        self.eval()
+
+        # Attempt export
+        if format == ExportFormat.ONNX:
+            if _in_example is None:
+                raise ValueError(f'Example input is None, but ONNX tracing was attempted')
+            if _out_example is None:
+                if isinstance(input_example, tuple):
+                    _out_example = self.forward(*_in_example)
+                else:
+                    _out_example = self.forward(_in_example)
+            with torch.jit.optimized_execution(True):
+                jitted_model = torch.jit.trace(self, _in_example)
+
+            torch.onnx.export(
+                jitted_model,
+                _in_example,
+                output,
+                input_names=input_names,
+                output_names=output_names,
+                verbose=False,
+                export_params=True,
+                do_constant_folding=True,
+                dynamic_axes=dynamic_axes,
+                opset_version=onnx_opset_version,
+                example_outputs=_out_example,
+            )
+        else:
+            raise ValueError(f'Encountered unknown export format {format}.')
+
+    @property
+    def disabled_deployment_input_names(self):
+        """Implement this method to return a list of input names disabled for export"""
+        return []
+
+    @property
+    def disabled_deployment_output_names(self):
+        """Implement this method to return a list of output names disabled for export"""
+        return []
+
+    @staticmethod
+    def __extract_dynamic_axes(port_name, ntype: NeuralType, dynamic_axes: defaultdict):
+        if ntype.axes:
+            for ind, axis in enumerate(ntype.axes):
+                if axis.kind == AxisKind.Batch or axis.kind == AxisKind.Time:
+                    dynamic_axes[port_name].append(ind)
+
+    def prepare_for_export(self) -> (Optional[torch.Tensor], Optional[torch.Tensor]):
+        """
+        Implement this method to prepare module for export. Do all necessary changes on module pre-export here.
+        Also, return a pair in input, output examples for tracing.
+        Returns:
+            A pair of (input, output) examples.
+        """
+        pass
+        # return (None, None)

--- a/nemo/core/classes/exportable.py
+++ b/nemo/core/classes/exportable.py
@@ -85,7 +85,7 @@ class Exportable(ABC):
             if _in_example is None:
                 raise ValueError(f'Example input is None, but ONNX tracing was attempted')
             if _out_example is None:
-                if isinstance(input_example, tuple):
+                if isinstance(_in_example, tuple):
                     _out_example = self.forward(*_in_example)
                 else:
                     _out_example = self.forward(_in_example)
@@ -110,13 +110,13 @@ class Exportable(ABC):
 
     @property
     def disabled_deployment_input_names(self):
-        """Implement this method to return a list of input names disabled for export"""
-        return []
+        """Implement this method to return a set of input names disabled for export"""
+        return set()
 
     @property
     def disabled_deployment_output_names(self):
-        """Implement this method to return a list of output names disabled for export"""
-        return []
+        """Implement this method to return a set of output names disabled for export"""
+        return set()
 
     @staticmethod
     def __extract_dynamic_axes(port_name, ntype: NeuralType, dynamic_axes: defaultdict):

--- a/tests/core/test_exportable.py
+++ b/tests/core/test_exportable.py
@@ -1,0 +1,48 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from omegaconf import DictConfig
+
+from nemo.collections.asr.modules import ConvASREncoder
+
+
+class TestExportable:
+    @pytest.mark.unit
+    def test_ConvASREncoder_export_to_onnx(self):
+        encoder_dict = {
+            'cls': 'nemo.collections.asr.modules.ConvASREncoder',
+            'params': {
+                'feat_in': 64,
+                'activation': 'relu',
+                'conv_mask': True,
+                'jasper': [
+                    {
+                        'filters': 1024,
+                        'repeat': 1,
+                        'kernel': [1],
+                        'stride': [1],
+                        'dilation': [1],
+                        'dropout': 0.0,
+                        'residual': False,
+                        'separable': True,
+                        'se': True,
+                        'se_context_size': -1,
+                    }
+                ],
+            },
+        }
+        encoder_instance = ConvASREncoder.from_config_dict(DictConfig(encoder_dict))
+        assert isinstance(encoder_instance, ConvASREncoder)
+        encoder_instance.export(output='encoder.onnx')

--- a/tests/core/test_exportable.py
+++ b/tests/core/test_exportable.py
@@ -11,6 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os
+import tempfile
 
 import pytest
 from omegaconf import DictConfig
@@ -43,6 +45,10 @@ class TestExportable:
                 ],
             },
         }
-        encoder_instance = ConvASREncoder.from_config_dict(DictConfig(encoder_dict))
-        assert isinstance(encoder_instance, ConvASREncoder)
-        encoder_instance.export(output='encoder.onnx')
+        with tempfile.TemporaryDirectory() as tmpdir:
+            encoder_instance = ConvASREncoder.from_config_dict(DictConfig(encoder_dict))
+            assert isinstance(encoder_instance, ConvASREncoder)
+            filename = os.path.join(tmpdir, 'qn_encoder.onnx')
+            encoder_instance.export(output=filename)
+            # TODO: how to assert that this is a proper .onnx file
+            assert os.path.exists(filename)

--- a/tests/core/test_typecheck.py
+++ b/tests/core/test_typecheck.py
@@ -15,7 +15,7 @@
 import pytest
 import torch
 
-from nemo.core import NeuralModule, Typing, typecheck
+from nemo.core import Typing, typecheck
 from nemo.core.neural_types import *
 
 


### PR DESCRIPTION
This PR: 
* Introduces Exportable interface which could be inherited by modules or (in future) models.
* Implements Exportable for ConvASREncoder and adds unit-test of it

The Exportable.export() is a generic function with implementation. However, the idea is that Exportable will be added to modules on module-by-module basis because there are often module-specific steps such as: prepare_for_export  (see ConvASREncoder.prepare_for_export implementation) which are necessary in practice