### PR TITLE
Add ability to globally disable @typecheck

### DIFF
--- a/nemo/core/classes/__init__.py
+++ b/nemo/core/classes/__init__.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-from nemo.core.classes.common import FileIO, Model, Serialization, Typing, typecheck
+from nemo.core.classes.common import FileIO, Model, Serialization, Typing, is_typecheck_enabled, typecheck
 from nemo.core.classes.dataset import Dataset, IterableDataset
 from nemo.core.classes.loss import Loss
 from nemo.core.classes.modelPT import ModelPT

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -26,6 +26,16 @@ from nemo.core.neural_types import NeuralType, NeuralTypeComparisonResult
 __all__ = ['Typing', 'FileIO', 'Model', 'Serialization', 'typecheck']
 
 
+_TYPECHECK_ENABLED = True
+
+
+def is_typecheck_enabled():
+    """
+    Getter method for typechecking state.
+    """
+    return _TYPECHECK_ENABLED
+
+
 class Typing(ABC):
     """
     An interface which endows module with neural types
@@ -303,7 +313,7 @@ class typecheck:
 
         """
 
-    @wrapt.decorator
+    @wrapt.decorator(enabled=is_typecheck_enabled)
     def __call__(self, wrapped, instance: Typing, args, kwargs):
         if instance is None:
             raise RuntimeError("Only classes which inherit nemo.core.Typing can use this decorator !")
@@ -334,3 +344,8 @@ class typecheck:
         instance._attach_and_validate_output_types(outputs)
 
         return outputs
+
+    @classmethod
+    def set_typecheck_enabled(cls, enabled: bool = True):
+        global _TYPECHECK_ENABLED
+        _TYPECHECK_ENABLED = enabled

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -345,7 +345,7 @@ class typecheck:
 
         return outputs
 
-    @classmethod
-    def set_typecheck_enabled(cls, enabled: bool = True):
+    @staticmethod
+    def set_typecheck_enabled(enabled: bool = True):
         global _TYPECHECK_ENABLED
         _TYPECHECK_ENABLED = enabled


### PR DESCRIPTION
# API

To enable / disable typechecks - 

```python
from nemo.core.classes import typecheck

typecheck.set_typecheck_enabled(enabled=True)  # or False
```

To inspect current state of whether typecheck is enabled or disabled

```python
from nemo.core.classes import is_typecheck_enabled

print(is_typecheck_enabled())
```

Signed-off-by: smajumdar <titu1994@gmail.com>