### PR TITLE
Use context manager to locally turn off @typecheck

### DIFF
--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -16,6 +16,7 @@
 """Interfaces common to all Neural Modules and Models."""
 from abc import ABC, abstractmethod
 from collections import namedtuple
+from contextlib import contextmanager
 from enum import Enum
 from typing import Dict, Optional, Union
 
@@ -476,3 +477,12 @@ class typecheck:
     def set_typecheck_enabled(enabled: bool = True):
         global _TYPECHECK_ENABLED
         _TYPECHECK_ENABLED = enabled
+
+    @staticmethod
+    @contextmanager
+    def disable_checks():
+        typecheck.set_typecheck_enabled(enabled=False)
+        try:
+            yield
+        finally:
+            typecheck.set_typecheck_enabled(enabled=True)

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -295,11 +295,10 @@ class PolynomialDecayAnnealing(WarmupPolicy):
 
 class PolynomialHoldDecayAnnealing(WarmupHoldPolicy):
     def __init__(self, optimizer, *, max_steps, min_lr=0.0, power=1.0, cycle=False, last_epoch=-1, **kwargs):
-        self.min_lr = min_lr
         self.power = power
         self.cycle = cycle
 
-        super().__init__(optimizer=optimizer, max_steps=max_steps, last_epoch=last_epoch, **kwargs)
+        super().__init__(optimizer=optimizer, max_steps=max_steps, last_epoch=last_epoch, min_lr=min_lr, **kwargs)
 
     def _get_lr(self, step):
         new_lrs = [

--- a/tests/core/test_typecheck.py
+++ b/tests/core/test_typecheck.py
@@ -645,21 +645,17 @@ class TestNeuralTypeCheckSystem:
                 return x
 
         # Disable typecheck tests
-        typecheck.set_typecheck_enabled(enabled=False)
+        with typecheck.disable_checks():
+            obj = InputOutputTypes()
 
-        obj = InputOutputTypes()
+            # Execute function without kwarg
+            result = obj(torch.zeros(10))
 
-        # Execute function without kwarg
-        result = obj(torch.zeros(10))
+            assert result.sum() == torch.tensor(10.0)
+            assert hasattr(result, 'neural_type') is False
 
-        assert result.sum() == torch.tensor(10.0)
-        assert hasattr(result, 'neural_type') is False
-
-        # Test passing wrong key for input
-        _ = obj(a=torch.zeros(10), x=torch.zeros(5))
-
-        # Re-enable type checking
-        typecheck.set_typecheck_enabled(enabled=True)
+            # Test passing wrong key for input
+            _ = obj(a=torch.zeros(10), x=torch.zeros(5))
 
     @pytest.mark.pleasefixme
     @pytest.mark.unit


### PR DESCRIPTION
# Changelog
- If typecheck needs to be disabled globally, continue to disable `typecheck.set_typecheck_enabled(enabled=<value>)`.
- If typecheck needs to be disabled locally (inside a function), use the below decorator

```python
with typecheck.disable_checks():
    ...
```

Also includes a fix to pass the `min_lr` value correctly to certain schedulers

Signed-off-by: smajumdar <titu1994@gmail.com>