### PR TITLE
Test data dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,6 +150,9 @@ dmypy.json
 cifar-10-batches-py
 *.tar.gz
 
+# Test data.
+tests/.data
+
 # outputs folder
 examples/*/outputs
 examples/*/wandb

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,9 +63,10 @@ def test_dir():
 
 def pytest_configure(config):
     """
-    Allows plugins and conftest files to perform initial configuration.
-    This hook is called for every plugin and initial conftest
-    file after command line options have been parsed.
+    Initial configuration of conftest.
+    The function checks if test_data.tar.gz is present in tests/.data.
+    If so, compares its size with github's test_data.tar.gz.
+    If file absent or sizes not equal, function downloads the archive from github and unpacks it.
     """
     # Test dir and archive filepath.
     test_dir = join(dirname(__file__), __TEST_DATA_SUBDIR)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,15 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from os import mkdir
-from os.path import dirname, join, getsize, exists
-from  shutil import rmtree
-import urllib.request
 import tarfile
+import urllib.request
+from os import mkdir
+from os.path import dirname, exists, getsize, join
+from shutil import rmtree
 
 import pytest
 
-# Those variables should go to main NeMo configuration file (config.yaml).
+# Those variables probably should go to main NeMo configuration file (config.yaml).
 __TEST_DATA_FILENAME = "test_data.tar.gz"
 __TEST_DATA_URL = "https://github.com/NVIDIA/NeMo/releases/download/v0.11.0/"
 __TEST_DATA_SUBDIR = ".data"
@@ -74,11 +74,9 @@ def pytest_configure(config):
     # Get size of local test_data archive.
     try:
         test_data_local_size = getsize(test_data_archive)
-    except: 
+    except:
         # File does not exist.
         test_data_local_size = -1
-
-    #print("! test_data_local_size: ", test_data_local_size)
 
     # Get size of remote test_data archive.
     url = __TEST_DATA_URL + __TEST_DATA_FILENAME
@@ -87,11 +85,11 @@ def pytest_configure(config):
     meta = u.info()
     test_data_remote_size = int(meta["Content-Length"])
 
-    #print("! test_data_remote_size:", test_data_remote_size)
-
     # Compare sizes.
     if test_data_local_size != test_data_remote_size:
-        print("Downloading the `{}` test archive from `{}`, please wait...".format(__TEST_DATA_FILENAME, __TEST_DATA_URL))
+        print(
+            "Downloading the `{}` test archive from `{}`, please wait...".format(__TEST_DATA_FILENAME, __TEST_DATA_URL)
+        )
         # Remove .data folder.
         if exists(test_dir):
             rmtree(test_dir)
@@ -103,7 +101,10 @@ def pytest_configure(config):
         print("Extracting the `{}` test archive, please wait...".format(test_data_archive))
         tar = tarfile.open(test_data_archive)
         tar.extractall(path=test_dir)
-        tar.close()        
+        tar.close()
     else:
-        print("A valid `{}` test archive ({}B) found in the `{}` folder.".format(__TEST_DATA_FILENAME, test_data_local_size, test_dir))
-
+        print(
+            "A valid `{}` test archive ({}B) found in the `{}` folder.".format(
+                __TEST_DATA_FILENAME, test_data_local_size, test_dir
+            )
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,11 +54,11 @@ def pytest_configure(config):
 
 
 @pytest.fixture()
-def test_dir():
-    """ Fixture returns test_dir. """
+def test_data_dir():
+    """ Fixture returns test_data_dir. """
     # Test dir.
-    test_data_dir = join(dirname(__file__), __TEST_DATA_SUBDIR)
-    return test_data_dir
+    test_data_dir_ = join(dirname(__file__), __TEST_DATA_SUBDIR)
+    return test_data_dir_
 
 
 def pytest_configure(config):

--- a/tests/test_data_dir.py
+++ b/tests/test_data_dir.py
@@ -18,10 +18,10 @@ from os.path import exists, join
 import pytest
 
 
-class TestDir:
+class TestDataDir:
     @pytest.mark.unit
-    def test_test_dir(self, test_dir):
-        """" Just a dummy tests showing how to use the test_dir fixture. """
-        # test_dir contains the absolute path to nemo -> tests/.data
-        assert exists(test_dir)
-        assert exists(join(test_dir, "test_data.tar.gz"))
+    def test_test_data_dir(self, test_data_dir):
+        """" Just a dummy tests showing how to use the test_data_dir fixture. """
+        # test_data_dir contains the absolute path to nemo -> tests/.data
+        assert exists(test_data_dir)
+        assert exists(join(test_data_dir, "test_data.tar.gz"))

--- a/tests/test_test_data.py
+++ b/tests/test_test_data.py
@@ -18,9 +18,9 @@ from os.path import exists, join
 import pytest
 
 
-class TestData:
+class TestDir:
     @pytest.mark.unit
-    def test_test_data_download(self, test_dir):
+    def test_test_dir(self, test_dir):
         """" Just a dummy tests showing how to use the test_dir fixture. """
         # test_dir contains the absolute path to nemo -> tests/.data
         assert exists(test_dir)

--- a/tests/test_test_data.py
+++ b/tests/test_test_data.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from os.path import join, exists
+
+import pytest
+
+class TestData:
+    @pytest.mark.unit
+    def test_test_data_download(self, test_dir):
+        """" Just a dummy tests showing how to use the test_dir fixture. """
+        # test_dir contains the absolute path to nemo -> tests/.data
+        assert exists(test_dir)
+        assert exists(join(test_dir, "test_data.tar.gz"))
+        

--- a/tests/test_test_data.py
+++ b/tests/test_test_data.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 
-from os.path import join, exists
+from os.path import exists, join
 
 import pytest
+
 
 class TestData:
     @pytest.mark.unit
@@ -24,4 +25,3 @@ class TestData:
         # test_dir contains the absolute path to nemo -> tests/.data
         assert exists(test_dir)
         assert exists(join(test_dir, "test_data.tar.gz"))
-        


### PR DESCRIPTION
The PR aims at the problem of storing test (binary) data in NeMo soure code.

The solution involves:
 - [x] storing binary data as part of nemo release files, currently set to:
https://github.com/NVIDIA/NeMo/releases/tag/v0.11.0 -> `test_data.tar.gz`
 - [x] pytest_configure() method which:
    * checks if `test_data.tar.gz` is present in `tests/.data`
      * if so, compares its size with github's `test_data.tar.gz`
    * if absent or sizes not equal - downloads the archive from github and unpacks it
 - [x] new `test_data_dir` fixture providing the absolute path to the test data
 - [x] `test_test_data_dir` unit test testing the presence of test data/showing how to use the `test_data_dir` fixture

Currently all the variables are "hardcoded in `conftest.py`:
```
# Those variables probably should go to main NeMo configuration file (config.yaml).
__TEST_DATA_FILENAME = "test_data.tar.gz"
__TEST_DATA_URL = "https://github.com/NVIDIA/NeMo/releases/download/v0.11.0/"
__TEST_DATA_SUBDIR = ".data"
```
