### PR TITLE
Candidate patches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,6 +136,7 @@ pipeline {
             sh 'python examples/asr/speech_to_label.py \
             model.train_ds.manifest_filepath=/home/TestData/speech_commands/train_manifest.json \
             model.validation_ds.manifest_filepath=/home/TestData/speech_commands/test_manifest.json \
+            model.test_ds.manifest_filepath=/home/TestData/speech_commands/test_manifest.json \
             trainer.gpus=[1] \
             +trainer.fast_dev_run=True \
             model.preprocessor.cls=nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor \

--- a/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
@@ -35,13 +35,13 @@ model:
     shuffle: False
     val_loss_idx: 0
 
-#  test_ds:
-#    manifest_filepath: ???
-#    sample_rate: *sample_rate
-#    labels: *labels
-#    batch_size: 128
-#    shuffle: False
-#    test_loss_idx: 0
+  test_ds:
+    manifest_filepath: null
+    sample_rate: *sample_rate
+    labels: *labels
+    batch_size: 128
+    shuffle: False
+    test_loss_idx: 0
 
   preprocessor:
     cls: nemo.collections.asr.modules.AudioToMFCCPreprocessor

--- a/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
@@ -35,13 +35,13 @@ model:
     shuffle: False
     val_loss_idx: 0
 
-#  test_ds:
-#    manifest_filepath: ???
-#    sample_rate: *sample_rate
-#    labels: *labels
-#    batch_size: 128
-#    shuffle: False
-#    test_loss_idx: 0
+  test_ds:
+    manifest_filepath: null
+    sample_rate: *sample_rate
+    labels: *labels
+    batch_size: 128
+    shuffle: False
+    test_loss_idx: 0
 
   preprocessor:
     cls: nemo.collections.asr.modules.AudioToMFCCPreprocessor

--- a/examples/asr/speech_to_label.py
+++ b/examples/asr/speech_to_label.py
@@ -39,6 +39,11 @@ def main(cfg):
 
     trainer.fit(asr_model)
 
+    if hasattr(cfg.model, 'test_ds') and cfg.model.test_ds.manifest_filepath is not None:
+        trainer = pl.Trainer()
+        if asr_model.prepare_test(trainer):
+            trainer.test(asr_model)
+
 
 if __name__ == '__main__':
     main()  # noqa pylint: disable=no-value-for-parameter

--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -49,10 +49,8 @@ class EncDecClassificationModel(ASRModel):
             self.crop_or_pad = EncDecClassificationModel.from_config_dict(self._cfg.crop_or_pad_augment)
         else:
             self.crop_or_pad = None
-        # Optimizer setup needs to happen after all model weights are ready
-        self.setup_optimization()
-        # Setup metric objects
 
+        # Setup metric objects
         self._accuracy = TopKClassificationAccuracy()
 
     def transcribe(self, path2audio_file: str) -> str:

--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -59,6 +59,9 @@ class EncDecClassificationModel(ASRModel):
         raise NotImplementedError("Classification models do not transcribe audio.")
 
     def _setup_dataloader_from_config(self, config: Optional[Dict]):
+        if config.get('manifest_filepath') is None:
+            return
+
         if 'augmentor' in config:
             augmentor = process_augmentations(config['augmentor'])
         else:

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -55,8 +55,7 @@ class EncDecCTCModel(ASRModel):
             self.spec_augmentation = EncDecCTCModel.from_config_dict(self._cfg.spec_augment)
         else:
             self.spec_augmentation = None
-        # Optimizer setup needs to happen after all model weights are ready
-        self.setup_optimization()
+
         # Setup metric objects
         self._wer = WER(vocabulary=self.decoder.vocabulary, batch_dim_index=0, use_cer=False, ctc_decode=True)
 

--- a/nemo/collections/asr/models/label_models.py
+++ b/nemo/collections/asr/models/label_models.py
@@ -53,8 +53,6 @@ class EncDecSpeakerLabelModel(ModelPT):
         self.encoder = EncDecSpeakerLabelModel.from_config_dict(cfg.encoder)
         self.decoder = EncDecSpeakerLabelModel.from_config_dict(cfg.decoder)
         self.loss = CELoss()
-        # Optimizer setup needs to happen after all model weights are ready
-        self.setup_optimization()
 
     def __setup_dataloader_from_config(self, config: Optional[Dict]):
         featurizer = WaveformFeaturizer(sample_rate=config['sample_rate'], int_values=config.get('int_values', False))

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -380,7 +380,11 @@ class AudioToMFCCPreprocessor(AudioPreprocessor):
         )
 
     def get_features(self, input_signal, length):
-        return self.featurizer(input_signal)
+        features = self.featurizer(input_signal)
+        seq_len = torch.ceil(length.to(torch.float32) / self.hop_length).to(dtype=torch.long)
+        return features, seq_len
+
+
 
 
 class SpectrogramAugmentation(NeuralModule):

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -385,8 +385,6 @@ class AudioToMFCCPreprocessor(AudioPreprocessor):
         return features, seq_len
 
 
-
-
 class SpectrogramAugmentation(NeuralModule):
     """
     Performs time and freq cuts in one of two ways.

--- a/nemo/collections/nlp/models/qa_model.py
+++ b/nemo/collections/nlp/models/qa_model.py
@@ -76,9 +76,6 @@ class QAModel(ModelPT):
 
         self.loss = SpanningLoss()
 
-        # Optimizer setup needs to happen after all model weights are ready
-        self.setup_optimization(cfg.optim)
-
     @typecheck()
     def forward(self, input_ids, token_type_ids, attention_mask):
         hidden_states = self.bert(input_ids=input_ids, token_type_ids=token_type_ids, attention_mask=attention_mask)

--- a/nemo/collections/nlp/models/text_classification/text_classification_model.py
+++ b/nemo/collections/nlp/models/text_classification/text_classification_model.py
@@ -91,9 +91,6 @@ class TextClassificationModel(ModelPT):
         # setup to track metrics
         self.classification_report = ClassificationReport(self.data_desc.num_classes)
 
-        # Optimizer setup needs to happen after all model weights are ready
-        self.setup_optimization(cfg.optim)
-
     @typecheck()
     def forward(self, input_ids, token_type_ids, attention_mask):
         """

--- a/nemo/collections/nlp/models/token_classification/ner_model.py
+++ b/nemo/collections/nlp/models/token_classification/ner_model.py
@@ -97,8 +97,6 @@ class NERModel(ModelPT):
         self.classification_report = ClassificationReport(
             self.data_desc.num_classes, label_ids=self.data_desc.label_ids
         )
-        # Optimizer setup needs to happen after all model weights are ready
-        self.setup_optimization(self._cfg.optim)
 
     @typecheck()
     def forward(self, input_ids, token_type_ids, attention_mask):

--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
@@ -96,9 +96,6 @@ class PunctuationCapitalizationModel(ModelPT):
         self.punct_class_report = ClassificationReport(len(self.punct_label_ids), label_ids=self.punct_label_ids)
         self.capit_class_report = ClassificationReport(len(self.capit_label_ids), label_ids=self.capit_label_ids)
 
-        # Optimizer setup needs to happen after all model weights are ready
-        self.setup_optimization(cfg.optim)
-
     @typecheck()
     def forward(self, input_ids, attention_mask, token_type_ids=None):
         """

--- a/nemo/collections/tts/models/tacotron2.py
+++ b/nemo/collections/tts/models/tacotron2.py
@@ -85,9 +85,6 @@ class Tacotron2Model(ModelPT):
         self.postnet = Tacotron2Model.from_config_dict(self._cfg.postnet)
         self.loss = Tacotron2Loss()
 
-        # After defining all torch.modules, create optimizer and scheduler
-        self.setup_optimization()
-
     @property
     def input_types(self):
         return {

--- a/nemo/collections/tts/models/waveglow.py
+++ b/nemo/collections/tts/models/waveglow.py
@@ -79,8 +79,6 @@ class WaveGlowModel(ModelPT):
         self.mode = OperationMode.infer
         self.loss = WaveGlowLoss()
 
-        self.setup_optimization()
-
     @property
     def input_types(self):
         return {

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -583,12 +583,24 @@ class ModelPT(LightningModule, Model):
     def multi_validation_epoch_end(
         self, outputs: List[Dict[str, torch.Tensor]], dataloader_idx: int = 0
     ) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
-        raise NotImplementedError()
+        logging.warning(
+            "Multi data loader support has been enabled, but "
+            "`multi_validation_epoch_end(outputs, dataloader_idx) has not been implemented.\n"
+            "If you require multi data loader support for validation sets, please override this method.\n"
+            "If you do not require multi data loader support, please instead override "
+            "`validation_epoch_end(outputs)."
+        )
 
     def multi_test_epoch_end(
         self, outputs: List[Dict[str, torch.Tensor]], dataloader_idx: int = 0
     ) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
-        raise NotImplementedError()
+        logging.warning(
+            "Multi data loader support has been enabled, but "
+            "`multi_test_epoch_end(outputs, dataloader_idx) has not been implemented.\n"
+            "If you require multi data loader support for validation sets, please override this method.\n"
+            "If you do not require multi data loader support, please instead override "
+            "`test_epoch_end(outputs)."
+        )
 
     def get_validation_dataloader_prefix(self, dataloader_idx=0):
         return self._validation_names[dataloader_idx]

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -516,7 +516,7 @@ class ModelPT(LightningModule, Model):
 
         # Case where we provide exactly 1 data loader
         if type(outputs[0]) == dict:
-            return self.multi_validation_epoch_end(outputs, dataloader_idx=0)
+            return self.multi_test_epoch_end(outputs, dataloader_idx=0)
 
         else:  # Case where we provide more than 1 data loader
             output_dict = {'log': {}}

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -623,7 +623,7 @@ class ModelPT(LightningModule, Model):
             return False to guide the user.
         """
         if not hasattr(self._cfg, 'test_ds'):
-            logging.info("No `test_ds` config found within the manifest. " "No modifications are required.")
+            logging.info("No `test_ds` config found within the manifest.")
             return False
 
         # Recompute optimizers if AMP is being used

--- a/nemo/core/config/optimizers.py
+++ b/nemo/core/config/optimizers.py
@@ -16,6 +16,8 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any, Dict, Optional, Tuple
 
+from omegaconf import OmegaConf
+
 __all__ = [
     'OptimizerParams',
     'AdamParams',
@@ -238,6 +240,11 @@ def get_optimizer_config(name: str, **kwargs: Optional[Dict[str, Any]]) -> Optim
         )
 
     scheduler_params = AVAILABLE_OPTIMIZER_PARAMS[name]
+
+    if kwargs is not None and len(kwargs) != 0:
+        kwargs = OmegaConf.create(kwargs)
+        OmegaConf.merge(scheduler_params(), kwargs)
+
     scheduler_params = partial(scheduler_params, **kwargs)
     return scheduler_params
 

--- a/nemo/core/config/schedulers.py
+++ b/nemo/core/config/schedulers.py
@@ -87,7 +87,7 @@ class WarmupAnnealingParams(WarmupSchedulerParams):
     It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
     """
 
-    warmup_ratio: 0.1
+    warmup_ratio: 0.0
 
 
 @dataclass

--- a/nemo/core/optim/__init__.py
+++ b/nemo/core/optim/__init__.py
@@ -26,4 +26,3 @@ from nemo.core.optim.lr_scheduler import (
 )
 from nemo.core.optim.novograd import Novograd
 from nemo.core.optim.optimizers import get_optimizer, parse_optimizer_args, register_optimizer
-from nemo.utils.arguments import add_optimizer_args

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -40,7 +40,7 @@ class WarmupPolicy(_LRScheduler):
             infinite training
     """
 
-    def __init__(self, optimizer, *, warmup_steps=None, warmup_ratio=None, max_steps=None, last_epoch=-1):
+    def __init__(self, optimizer, *, warmup_steps=None, warmup_ratio=None, max_steps=None, min_lr=0.0, last_epoch=-1):
         assert not (
             warmup_steps is not None and warmup_ratio is not None
         ), "Either use particular number of step or ratio"
@@ -55,6 +55,8 @@ class WarmupPolicy(_LRScheduler):
             self.warmup_steps = int(warmup_ratio * max_steps)
         else:
             self.warmup_steps = 0
+
+        self.min_lr = min_lr
         super().__init__(optimizer, last_epoch)
 
     def get_lr(self):
@@ -70,7 +72,7 @@ class WarmupPolicy(_LRScheduler):
             return [initial_lr * lr_val for initial_lr in self.base_lrs]
 
         if step > self.max_steps:
-            return [0.0 for _ in self.base_lrs]
+            return [self.min_lr for _ in self.base_lrs]
 
         return self._get_lr(step)
 
@@ -106,7 +108,7 @@ class WarmupHoldPolicy(WarmupPolicy):
         assert not (hold_steps is not None and hold_ratio is not None), "Either use particular number of step or ratio"
         assert hold_ratio is None or max_steps is not None, "If there is a ratio, there should be a total steps"
 
-        self._min_lr = min_lr
+        self.min_lr = min_lr
         self._last_warmup_lr = 0.0
 
         # Necessary to duplicate as class attributes are hidden in inner class
@@ -131,6 +133,7 @@ class WarmupHoldPolicy(WarmupPolicy):
             warmup_ratio=warmup_ratio,
             max_steps=max_steps,
             last_epoch=last_epoch,
+            min_lr=min_lr,
         )
 
     def get_lr(self):
@@ -151,7 +154,7 @@ class WarmupHoldPolicy(WarmupPolicy):
             return self.base_lrs
 
         if step > self.max_steps:
-            return [0.0 for _ in self.base_lrs]
+            return [self.min_lr for _ in self.base_lrs]
 
         return self._get_lr(step)
 
@@ -190,9 +193,7 @@ def _poly_decay(initial_lr, step, decay_steps, power, min_lr, cycle):
 
 class SquareAnnealing(WarmupPolicy):
     def __init__(self, optimizer, *, max_steps, min_lr=1e-5, last_epoch=-1, **kwargs):
-        self.min_lr = min_lr
-
-        super().__init__(optimizer=optimizer, max_steps=max_steps, last_epoch=last_epoch, **kwargs)
+        super().__init__(optimizer=optimizer, max_steps=max_steps, last_epoch=last_epoch, min_lr=min_lr, **kwargs)
 
     def _get_lr(self, step):
         new_lrs = [
@@ -209,9 +210,7 @@ class SquareAnnealing(WarmupPolicy):
 
 class SquareRootAnnealing(WarmupPolicy):
     def __init__(self, optimizer, *, max_steps, min_lr=0, last_epoch=-1, **kwargs):
-        self.min_lr = min_lr
-
-        super().__init__(optimizer=optimizer, max_steps=max_steps, last_epoch=last_epoch, **kwargs)
+        super().__init__(optimizer=optimizer, max_steps=max_steps, last_epoch=last_epoch, min_lr=min_lr, **kwargs)
 
     def _get_lr(self, step):
         new_lrs = [
@@ -223,9 +222,7 @@ class SquareRootAnnealing(WarmupPolicy):
 
 class CosineAnnealing(WarmupPolicy):
     def __init__(self, optimizer, *, max_steps, min_lr=0, last_epoch=-1, **kwargs):
-        self.min_lr = min_lr
-
-        super().__init__(optimizer=optimizer, max_steps=max_steps, last_epoch=last_epoch, **kwargs)
+        super().__init__(optimizer=optimizer, max_steps=max_steps, last_epoch=last_epoch, min_lr=min_lr, **kwargs)
 
     def _get_lr(self, step):
         for initial_lr in self.base_lrs:
@@ -247,8 +244,8 @@ class CosineAnnealing(WarmupPolicy):
 
 
 class WarmupAnnealing(WarmupPolicy):
-    def __init__(self, optimizer, *, max_steps, last_epoch=-1, **kwargs):
-        super().__init__(optimizer=optimizer, max_steps=max_steps, last_epoch=last_epoch, **kwargs)
+    def __init__(self, optimizer, *, max_steps, last_epoch=-1, min_lr=0.0, **kwargs):
+        super().__init__(optimizer=optimizer, max_steps=max_steps, last_epoch=last_epoch, min_lr=min_lr, **kwargs)
 
     def _get_lr(self, step):
         progress = float(step / self.max_steps)
@@ -261,8 +258,8 @@ class WarmupAnnealing(WarmupPolicy):
 
 
 class InverseSquareRootAnnealing(WarmupPolicy):
-    def __init__(self, optimizer, *, max_steps, last_epoch=-1, **kwargs):
-        super().__init__(optimizer=optimizer, max_steps=max_steps, **kwargs, last_epoch=last_epoch)
+    def __init__(self, optimizer, *, max_steps, last_epoch=-1, min_lr=0.0, **kwargs):
+        super().__init__(optimizer=optimizer, max_steps=max_steps, **kwargs, last_epoch=last_epoch, min_lr=min_lr)
 
     def _get_lr(self, step):
         denom = ((step + 1) / (self.warmup_steps + 1)) ** 0.5
@@ -272,11 +269,10 @@ class InverseSquareRootAnnealing(WarmupPolicy):
 
 class PolynomialDecayAnnealing(WarmupPolicy):
     def __init__(self, optimizer, *, max_steps, min_lr=0.0, power=1.0, cycle=False, last_epoch=-1, **kwargs):
-        self.min_lr = min_lr
         self.power = power
         self.cycle = cycle
 
-        super().__init__(optimizer=optimizer, max_steps=max_steps, last_epoch=last_epoch, **kwargs)
+        super().__init__(optimizer=optimizer, max_steps=max_steps, last_epoch=last_epoch, min_lr=min_lr, **kwargs)
 
     def _get_lr(self, step):
         new_lrs = [
@@ -307,7 +303,7 @@ class PolynomialHoldDecayAnnealing(WarmupHoldPolicy):
                 step=step - self.hold_steps,
                 decay_steps=self.max_steps - max(self.warmup_steps, self.hold_steps),
                 power=self.power,
-                min_lr=self._min_lr,
+                min_lr=self.min_lr,
                 cycle=self.cycle,
             )
             for initial_lr in self.base_lrs
@@ -503,10 +499,12 @@ def prepare_lr_scheduler(
         max_steps = round(num_samples * iters_per_batch / float(batch_size))
 
     else:
-        raise ValueError(
+        logging.warning(
             "Neither `max_steps` nor `iters_per_batch` were provided to `optim.sched`, "
-            "cannot compute effective `max_steps` !"
+            "cannot compute effective `max_steps` !\n"
+            "Scheduler will not be instantiated !"
         )
+        return None
 
     # Inject max_steps (effective or provided) into the scheduler config
     scheduler_args['max_steps'] = max_steps

--- a/tests/core/test_optimizers_schedulers.py
+++ b/tests/core/test_optimizers_schedulers.py
@@ -1,0 +1,633 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import omegaconf
+import pytest
+import torch
+import torch.optim
+
+from nemo.core import config, optim
+from nemo.core.optim.lr_scheduler import AVAILABLE_SCHEDULERS
+from nemo.core.optim.optimizers import AVAILABLE_OPTIMIZERS
+
+
+class TempModel(torch.nn.Module):
+    def __init__(self):
+        super(TempModel, self).__init__()
+        self.layer = torch.nn.Linear(5, 1)
+
+    def forward(self, x):
+        x = self.layer(x)
+        return x
+
+
+class TestOptimizersSchedulers:
+    INITIAL_LR = 0.1
+    MIN_LR = 1e-3
+    MAX_STEPS = 10
+
+    @pytest.mark.unit
+    def test_get_optimizer(self):
+        model = TempModel()
+
+        for opt_name in AVAILABLE_OPTIMIZERS.keys():
+            opt_cls = optim.get_optimizer(opt_name)
+            opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+            assert isinstance(opt, AVAILABLE_OPTIMIZERS[opt_name])
+
+    @pytest.mark.unit
+    def test_register_optimizer(self):
+        class TempOpt(torch.optim.SGD):
+            pass
+
+        class TempOptParams(config.optimizers.SGDParams):
+            pass
+
+        optim.register_optimizer('TempOpt', TempOpt, TempOptParams)
+
+        model = TempModel()
+        opt_cls = optim.get_optimizer('TempOpt')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+        assert isinstance(opt, TempOpt)
+
+    def test_optim_config_parse_bypass(self):
+        basic_optim_config = {'weight_decay': 0.001, 'betas': [0.8, 0.5]}
+        parsed_params = optim.parse_optimizer_args('novograd', basic_optim_config)
+        assert parsed_params['weight_decay'] == basic_optim_config['weight_decay']
+        assert parsed_params['betas'][0] == basic_optim_config['betas'][0]
+        assert parsed_params['betas'][1] == basic_optim_config['betas'][1]
+
+        dict_config = omegaconf.OmegaConf.create(basic_optim_config)
+        parsed_params = optim.parse_optimizer_args('novograd', dict_config)
+        assert parsed_params['weight_decay'] == dict_config['weight_decay']
+        assert parsed_params['betas'][0] == dict_config['betas'][0]
+        assert parsed_params['betas'][1] == dict_config['betas'][1]
+
+    def test_optim_config_parse_arg_by_name(self):
+        basic_optim_config = {'name': 'auto', 'weight_decay': 0.001, 'betas': [0.8, 0.5]}
+        parsed_params = optim.parse_optimizer_args('novograd', basic_optim_config)
+        assert parsed_params['weight_decay'] == basic_optim_config['weight_decay']
+        assert parsed_params['betas'][0] == basic_optim_config['betas'][0]
+        assert parsed_params['betas'][1] == basic_optim_config['betas'][1]
+
+        dict_config = omegaconf.OmegaConf.create(basic_optim_config)
+        parsed_params = optim.parse_optimizer_args('novograd', dict_config)
+        assert parsed_params['weight_decay'] == dict_config['weight_decay']
+        assert parsed_params['betas'][0] == dict_config['betas'][0]
+        assert parsed_params['betas'][1] == dict_config['betas'][1]
+
+        with pytest.raises(omegaconf.errors.ConfigKeyError):
+            optim.parse_optimizer_args('sgd', dict_config)
+
+    def test_optim_config_parse_arg_by_target(self):
+        basic_optim_config = {
+            'target': 'nemo.core.config.NovogradParams',
+            'params': {'weight_decay': 0.001, 'betas': [0.8, 0.5]},
+        }
+        basic_optim_config = omegaconf.OmegaConf.create(basic_optim_config)
+        parsed_params = optim.parse_optimizer_args('novograd', basic_optim_config)
+        assert parsed_params['weight_decay'] == basic_optim_config['params']['weight_decay']
+        assert parsed_params['betas'][0] == basic_optim_config['params']['betas'][0]
+        assert parsed_params['betas'][1] == basic_optim_config['params']['betas'][1]
+
+        dict_config = omegaconf.OmegaConf.create(basic_optim_config)
+        parsed_params = optim.parse_optimizer_args('novograd', dict_config)
+        assert parsed_params['weight_decay'] == dict_config['params']['weight_decay']
+        assert parsed_params['betas'][0] == dict_config['params']['betas'][0]
+        assert parsed_params['betas'][1] == dict_config['params']['betas'][1]
+
+        # Names are ignored when passing class path
+        # This will be captured during optimizer instantiation
+        output_config = optim.parse_optimizer_args('sgd', dict_config)
+        sgd_config = vars(config.SGDParams())
+        novograd_config = vars(config.NovogradParams())
+
+        assert set(output_config.keys()) != set(sgd_config.keys())
+        assert set(output_config.keys()) == set(novograd_config)
+
+    def test_get_scheduler(self):
+        model = TempModel()
+        optimizer = optim.Novograd(model.parameters(), lr=self.INITIAL_LR)
+
+        for sched_name in AVAILABLE_SCHEDULERS.keys():
+            sched_cls = optim.lr_scheduler.get_scheduler(sched_name)
+
+            try:
+                sched = sched_cls(optimizer)
+                assert isinstance(sched, AVAILABLE_SCHEDULERS[sched_name])
+                continue
+            except Exception:
+                pass
+
+            try:
+                sched = sched_cls(optimizer, max_steps=self.MAX_STEPS)
+                assert isinstance(sched, AVAILABLE_SCHEDULERS[sched_name])
+                continue
+            except Exception:
+                pass
+
+    @pytest.mark.unit
+    def test_register_scheduler(self):
+        class TempSched(optim.lr_scheduler.CosineAnnealing):
+            pass
+
+        class TempSchedParams(config.schedulers.CosineAnnealingParams):
+            pass
+
+        optim.lr_scheduler.register_scheduler('TempSched', TempSched, TempSchedParams)
+
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+        sched_cls = optim.lr_scheduler.get_scheduler('TempSched')
+        sched = sched_cls(opt, max_steps=self.MAX_STEPS)
+
+        assert isinstance(sched, TempSched)
+
+    def test_sched_config_parse_simple(self):
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+        basic_sched_config = {'name': 'CosineAnnealing', 'max_steps': 10}
+        scheduler_setup = optim.lr_scheduler.prepare_lr_scheduler(opt, basic_sched_config)
+        assert isinstance(scheduler_setup['scheduler'], optim.lr_scheduler.CosineAnnealing)
+
+        dict_config = omegaconf.OmegaConf.create(basic_sched_config)
+        scheduler_setup = optim.lr_scheduler.prepare_lr_scheduler(opt, dict_config)
+        assert isinstance(scheduler_setup['scheduler'], optim.lr_scheduler.CosineAnnealing)
+
+    def test_sched_config_parse_from_cls(self):
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+        basic_sched_config = {
+            'target': 'nemo.core.config.CosineAnnealingParams',
+            'params': {'min_lr': 0.1},
+            'max_steps': self.MAX_STEPS,
+        }
+        scheduler_setup = optim.lr_scheduler.prepare_lr_scheduler(opt, basic_sched_config)
+        assert isinstance(scheduler_setup['scheduler'], optim.lr_scheduler.CosineAnnealing)
+
+        dict_config = omegaconf.OmegaConf.create(basic_sched_config)
+        scheduler_setup = optim.lr_scheduler.prepare_lr_scheduler(opt, dict_config)
+        assert isinstance(scheduler_setup['scheduler'], optim.lr_scheduler.CosineAnnealing)
+
+    def test_WarmupPolicy(self):
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+        # No warmup case
+        policy = optim.lr_scheduler.WarmupPolicy(opt, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR)
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr == self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            assert policy.get_last_lr()[0] == self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+        # Warmup steps available
+        policy = optim.lr_scheduler.WarmupPolicy(opt, warmup_steps=5, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR)
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr < self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            if i <= 4:
+                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            else:
+                assert policy.get_last_lr()[0] == self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+    def test_WarmupHoldPolicy(self):
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+        # No warmup case
+        policy = optim.lr_scheduler.WarmupHoldPolicy(opt, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR)
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr == self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            assert policy.get_last_lr()[0] == self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+        # Warmup steps available
+        policy = optim.lr_scheduler.WarmupHoldPolicy(opt, warmup_steps=5, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR)
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr < self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            if i <= 4:
+                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            else:
+                assert policy.get_last_lr()[0] == self.INITIAL_LR
+
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+        # Warmup + Hold steps available
+        policy = optim.lr_scheduler.WarmupHoldPolicy(
+            opt, warmup_steps=5, hold_steps=3, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR
+        )
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr < self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            if i <= 4:
+                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            else:
+                assert policy.get_last_lr()[0] == self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+    def test_WarmupAnnealing(self):
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+        # No warmup case
+        policy = optim.lr_scheduler.WarmupAnnealing(opt, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR)
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr == self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+        # Warmup steps available
+        policy = optim.lr_scheduler.WarmupAnnealing(opt, warmup_steps=5, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR)
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr < self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            if i <= 5:
+                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            else:
+                assert policy.get_last_lr()[0] < self.INITIAL_LR
+
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+        # Warmup + Hold steps available
+        policy = optim.lr_scheduler.WarmupHoldPolicy(
+            opt, warmup_steps=5, hold_steps=3, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR
+        )
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr < self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            if i <= 4:
+                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            else:
+                assert policy.get_last_lr()[0] == self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+    def test_SquareAnnealing(self):
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+        # No warmup case
+        policy = optim.lr_scheduler.SquareAnnealing(opt, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR)
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr == self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+        # Warmup steps available
+        policy = optim.lr_scheduler.SquareAnnealing(opt, warmup_steps=5, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR)
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr < self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            if i <= 5:
+                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            else:
+                assert policy.get_last_lr()[0] < self.INITIAL_LR
+
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+    def test_SquareRootAnnealing(self):
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+        # No warmup case
+        policy = optim.lr_scheduler.SquareRootAnnealing(opt, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR)
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr == self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+        # Warmup steps available
+        policy = optim.lr_scheduler.SquareRootAnnealing(
+            opt, warmup_steps=5, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR
+        )
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr < self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            if i <= 5:
+                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            else:
+                assert policy.get_last_lr()[0] < self.INITIAL_LR
+
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+    def test_CosineAnnealing(self):
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+        # No warmup case
+        policy = optim.lr_scheduler.CosineAnnealing(opt, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR)
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr == self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+        # Warmup steps available
+        policy = optim.lr_scheduler.CosineAnnealing(opt, warmup_steps=5, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR)
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr < self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            if i <= 5:
+                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            else:
+                assert policy.get_last_lr()[0] < self.INITIAL_LR
+
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+    def test_PolynomialDecayAnnealing(self):
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+        # No warmup case
+        policy = optim.lr_scheduler.PolynomialDecayAnnealing(
+            opt, power=2, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR
+        )
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr == self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+        # Warmup steps available
+        policy = optim.lr_scheduler.PolynomialDecayAnnealing(
+            opt, warmup_steps=5, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR
+        )
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr < self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            if i <= 5:
+                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            else:
+                assert policy.get_last_lr()[0] < self.INITIAL_LR
+
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+    def test_PolynomialDecayAnnealing(self):
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+        # No warmup case
+        policy = optim.lr_scheduler.PolynomialHoldDecayAnnealing(
+            opt, power=2, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR
+        )
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr == self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+        # Warmup steps available
+        policy = optim.lr_scheduler.PolynomialHoldDecayAnnealing(
+            opt, power=2, warmup_steps=5, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR
+        )
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr < self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            if i <= 5:
+                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            else:
+                assert policy.get_last_lr()[0] < self.INITIAL_LR
+
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+        # Warmup + Hold steps available
+        policy = optim.lr_scheduler.PolynomialHoldDecayAnnealing(
+            opt, warmup_steps=5, hold_steps=3, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR, power=2
+        )
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr < self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            if i <= 4:
+                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            elif i <= 8:
+                assert policy.get_last_lr()[0] == self.INITIAL_LR
+            else:
+                assert policy.get_last_lr()[0] < self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+    def test_InverseSquareRootAnnealing(self):
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+
+        # No warmup case
+        policy = optim.lr_scheduler.InverseSquareRootAnnealing(opt, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR)
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr == self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR
+
+        # Warmup steps available
+        policy = optim.lr_scheduler.InverseSquareRootAnnealing(
+            opt, warmup_steps=5, max_steps=self.MAX_STEPS, min_lr=self.MIN_LR
+        )
+        initial_lr = policy.get_last_lr()[0]
+
+        assert initial_lr < self.INITIAL_LR
+
+        for i in range(self.MAX_STEPS):
+            if i <= 5:
+                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+            else:
+                assert policy.get_last_lr()[0] < self.INITIAL_LR
+
+            opt.step()
+            policy.step()
+
+        policy.step()
+        final_lr = policy.get_last_lr()[0]
+
+        assert final_lr == self.MIN_LR


### PR DESCRIPTION
# Bugfixes
- Correctly call `multi_test_epoch_end()` when performing `trainer.test()`.
- Raise warning per call instead of raising NotImplementedError() when `multi_*` methods are not implemented but subclass also does not override `validation_epoch_end()` and `test_epoch_end()`. This is an uncertain state between unknowingly supporting multi data loaders but not overriding any of the required methods.
- Add min_lr to all NeMo schedulers so that min_lr is properly preserved for all schedulers.
- Patch schedulers to properly support target / cls instead of `name`. 
- Schedulers now fail with warning that they were not initialized instead of raising ValueError. This is necessary when re-instantiating models from configs but data loaders are not available to compute effective `max_steps`.
- Optimizers now preserve the config passed to them via deepcopy.

# Improvements
- Add helper method to correctly test a model on the test set.
- Config check when optimizer parameters are passed via their Param classes.
- Add full test suite for Optimizers and Schedulers