### PR TITLE
Correct hasattr check in DictConfig

### DIFF
--- a/nemo/collections/asr/parts/jasper.py
+++ b/nemo/collections/asr/parts/jasper.py
@@ -156,7 +156,7 @@ class MaskedConv1d(nn.Module):
     def get_seq_len(self, lens):
         return (
             lens + 2 * self.conv.padding[0] - self.conv.dilation[0] * (self.conv.kernel_size[0] - 1) - 1
-        ) / self.conv.stride[0] + 1
+        ) // self.conv.stride[0] + 1
 
     def forward(self, x, lens):
         if self.use_mask:

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -189,6 +189,7 @@ class ModelPT(LightningModule, Model):
             config_yaml = path.join(tmpdir, _MODEL_CONFIG_YAML)
             model_weights = path.join(tmpdir, _MODEL_WEIGHTS)
             conf = OmegaConf.load(config_yaml)
+            OmegaConf.set_struct(conf, True)
             instance = cls.from_config_dict(config=conf)
             instance.load_state_dict(torch.load(model_weights))
         return instance

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -83,10 +83,10 @@ def resolve_dataset_name_from_cfg(cfg: DictConfig) -> str:
         A str representing the `key` of the config which hosts the filepath(s),
         or None in case path could not be resolved.
     """
-    if hasattr(cfg, _VAL_TEST_FASTPATH_KEY) and cfg[_VAL_TEST_FASTPATH_KEY] is not None:
+    if _VAL_TEST_FASTPATH_KEY in cfg and cfg[_VAL_TEST_FASTPATH_KEY] is not None:
         fastpath_key = cfg[_VAL_TEST_FASTPATH_KEY]
 
-        if isinstance(fastpath_key, str) and hasattr(cfg, fastpath_key):
+        if isinstance(fastpath_key, str) and fastpath_key in cfg:
             return cfg[fastpath_key]
         else:
             return _VAL_TEST_FASTPATH_KEY
@@ -171,7 +171,7 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
     dataloaders = []
 
     # process val_loss_idx
-    if hasattr(cfg.validation_ds, 'val_loss_idx'):
+    if 'val_loss_idx' in cfg.validation_ds:
         cfg = OmegaConf.to_container(cfg)
         val_loss_idx = cfg['validation_ds'].pop('val_loss_idx')
         cfg = OmegaConf.create(cfg)
@@ -242,7 +242,7 @@ def resolve_test_dataloaders(model: 'ModelPT'):
     dataloaders = []
 
     # process test_loss_idx
-    if hasattr(cfg.test_ds, 'test_loss_idx'):
+    if 'test_loss_idx' in cfg.test_ds:
         cfg = OmegaConf.to_container(cfg)
         test_loss_idx = cfg['test_ds'].pop('test_loss_idx')
         cfg = OmegaConf.create(cfg)


### PR DESCRIPTION
Note: `hasattr(DictConfig, <key>)` is an incorrect check for key existence inside DictConfig. This patch fixes that.

Signed-off-by: smajumdar <titu1994@gmail.com>