### PR TITLE
Test flag: --use_local_test_data

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,20 @@ __TEST_DATA_SUBDIR = ".data"
 
 
 def pytest_addoption(parser):
-    """ Additional command-line arguments passed to pytest. For now: --cpu """
-    parser.addoption('--cpu', action='store_true', help="pass that argument to use CPU during testing (default: GPU)")
+    """
+    Additional command-line arguments passed to pytest.
+    For now: 
+        --cpu: use CPU during testing (DEFAULT: GPU)
+        --use_local_test_data: use local test data/skip downloading from URL/GitHub (DEFAULT: False)
+    """
+    parser.addoption(
+        '--cpu', action='store_true', help="pass that argument to use CPU during testing (DEFAULT: False = GPU)"
+    )
+    parser.addoption(
+        '--use_local_test_data',
+        action='store_true',
+        help="pass that argument to use local test data/skip downloading from URL/GitHub (DEFAULT: False)",
+    )
 
 
 @pytest.fixture
@@ -78,6 +90,17 @@ def pytest_configure(config):
     except:
         # File does not exist.
         test_data_local_size = -1
+
+    if config.option.use_local_test_data:
+        if test_data_local_size == -1:
+            pytest.exit("Test data `{}` is not present in the system".format(test_data_archive))
+        else:
+            print(
+                "Using the local `{}` test archive ({}B) found in the `{}` folder.".format(
+                    __TEST_DATA_FILENAME, test_data_local_size, test_dir
+                )
+            )
+            return
 
     # Get size of remote test_data archive.
     try:


### PR DESCRIPTION
This PR adds new test flag: --use_local_test_data

When one will call:
```
pytest -m unit --use_local_test_data
```
if will force to skip the checking of consistency/downloading the test data from URL (github Release) and use the local data found in the `/tests/.data folder`.

If local test archive is not found - will return an error and stop tests.