### PR TITLE
Integration scripts

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,4 +12,5 @@ wrapt
 ruamel.yaml
 scikit-learn
 scipy
+frozendict
 

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -9,3 +9,4 @@ sphinx
 sphinxcontrib-bibtex
 wrapt
 wget
+frozendict

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -9,4 +9,3 @@ sphinx
 sphinxcontrib-bibtex
 wrapt
 wget
-frozendict

--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,19 @@
+# ! /usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 NVIDIA. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+from scripts.integration import *

--- a/scripts/integration/__init__.py
+++ b/scripts/integration/__init__.py
@@ -1,0 +1,21 @@
+# ! /usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright 2020 NVIDIA. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# =============================================================================
+
+from scripts.integration.get_collections import get_collections
+from scripts.integration.get_modules import get_modules
+from scripts.integration.get_module_ports import get_module_ports

--- a/scripts/integration/__init__.py
+++ b/scripts/integration/__init__.py
@@ -17,5 +17,5 @@
 # =============================================================================
 
 from scripts.integration.get_collections import get_collections
-from scripts.integration.get_modules import get_modules
 from scripts.integration.get_module_ports import get_module_ports
+from scripts.integration.get_modules import get_modules

--- a/scripts/integration/get_collections.py
+++ b/scripts/integration/get_collections.py
@@ -15,8 +15,11 @@
 
 """ Script responsible for generation of a JSON file with list of NeMo collections.
 
+Exemplary call:
+    nemo-get-collections
+
 Returns:
-    Format of the output JSON file (indicated  as --output_filename):
+    Format of the output JSON file (indicated  as -o, --output_filename):
 
 [
     {

--- a/scripts/integration/get_collections.py
+++ b/scripts/integration/get_collections.py
@@ -40,7 +40,7 @@ def process_collection(id, col):
     }
 
 
-def main():
+def get_collections():
     """ Main function generating a JSON file with list of NeMo collections. """
     # Parse arguments.
     parser = argparse.ArgumentParser()
@@ -93,4 +93,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    get_collections()

--- a/scripts/integration/get_collections.py
+++ b/scripts/integration/get_collections.py
@@ -13,7 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Script responsible for generation of a JSON file with list of NeMo collections. """
+""" Script responsible for generation of a JSON file with list of NeMo collections.
+
+Returns:
+    Format of the output JSON file (indicated  as --output_filename):
+
+[
+    {
+        "name": "nlp",
+        "id": "nemo.collections.nlp",
+        "description": "Natural Language Processing collection",
+        "version": "0.11.0",
+        "author": "NVIDIA Corporation"
+    },
+...
+]
+"""
 
 import argparse
 import importlib
@@ -43,8 +58,8 @@ def process_collection(id, col):
 def get_collections():
     """ Main function generating a JSON file with list of NeMo collections. """
     # Parse arguments.
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--output_filename', help='Name of the output JSON file', type=str, default="collections.json")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--output_filename', help='Name of the output JSON file (DEFAULT: collections.json)', type=str, default="collections.json")
     args = parser.parse_args()
 
     # Get collections directory.

--- a/scripts/integration/get_collections.py
+++ b/scripts/integration/get_collections.py
@@ -59,7 +59,13 @@ def get_collections():
     """ Main function generating a JSON file with list of NeMo collections. """
     # Parse arguments.
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--output_filename', help='Name of the output JSON file (DEFAULT: collections.json)', type=str, default="collections.json")
+    parser.add_argument(
+        '--output_filename',
+        '-o',
+        help='Name of the output JSON file (DEFAULT: collections.json)',
+        type=str,
+        default="collections.json",
+    )
     args = parser.parse_args()
 
     # Get collections directory.
@@ -100,11 +106,9 @@ def get_collections():
         json.dump(output_list, outfile)
 
     logging.info("=" * 80)
-    logging.info(
-        'Finshed the analysis, found {} collections, results exported to `{}`.'.format(
-            len(output_list), args.output_filename
-        )
-    )
+    outputs = "".join("* {} \n".format(o) for o in output_list)
+    logging.info("Finshed the analysis, found {} collections:\n{}".format(len(output_list), outputs))
+    logging.info("Results exported to `{}`.".format(args.output_filename))
 
 
 if __name__ == '__main__':

--- a/scripts/integration/get_module_outputs.py
+++ b/scripts/integration/get_module_outputs.py
@@ -51,7 +51,6 @@ Returns:
 """
 
 import argparse
-import importlib
 import json
 
 import torch

--- a/scripts/integration/get_module_outputs.py
+++ b/scripts/integration/get_module_outputs.py
@@ -16,8 +16,11 @@
 
 """ Script responsible for processing of module inputs and generating outputs.
 
+Exemplary call:
+    nemo-get-module-outputs -i module_def_inputs.json
+
 Args:
-    Format of the input JSON file (passed as --input_filename):
+    Format of the input JSON file (passed as -i, --input_filename):
     {
         "name": "my_lenet",
         "id": "nemo.collections.cv.modules.trainables.feed_forward_network.FeedForwardNetwork",
@@ -44,7 +47,7 @@ Args:
 Required fields: "id", "name", "arguments", "inputs"
 
 Returns:
-    Format of the output JSON file (indicated  as --output_filename):
+    Format of the output JSON file (indicated  as -o, --output_filename):
     [
         {"name": "outputs", "value": [1.3470189571380615, 0.06865233182907104], "type": "Tensor"}
     ]

--- a/scripts/integration/get_module_outputs.py
+++ b/scripts/integration/get_module_outputs.py
@@ -1,0 +1,139 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+""" Script responsible for processing of module inputs and generating outputs.
+
+Args:
+    Format of the input JSON file (passed as --input_filename):
+    {
+        "name": "my_lenet",
+        "id": "nemo.collections.cv.modules.trainables.feed_forward_network.FeedForwardNetwork",
+        "module_type": "trainable",
+        "arguments": [
+            {
+                "name": "input_size",
+                "value": 10
+            },
+            {
+                "name": "output_size",
+                "value": 2
+            }
+        ],
+        "inputs": [
+            {
+                "name": "inputs",
+                "value": [1, 1, 1, 1, 1, 1, 1, 1, 1, 1],
+                "type": "Tensor"
+            }
+        ]
+    }
+
+Required fields: "id", "name", "arguments", "inputs"
+
+Returns:
+    Format of the output JSON file (indicated  as --output_filename):
+    [
+        {"name": "outputs", "value": [1.3470189571380615, 0.06865233182907104], "type": "Tensor"}
+    ]
+"""
+
+import argparse
+import importlib
+import json
+
+import torch
+from scripts.integration.get_module_ports import instantiate_module
+
+import nemo
+from nemo.utils import logging
+
+
+def get_module_outputs():
+    """ Main function processing of module inputs and generating outputs """
+    # Parse filename.
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        '--input_filename',
+        '-i',
+        help='Name of the input JSON file containing module description and arguments',
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        '--output_filename',
+        '-o',
+        help='Name of the output JSON file containing port definitions (DEFAULT: module_outputs.json)',
+        type=str,
+        default="module_outputs.json",
+    )
+    args = parser.parse_args()
+
+    # Open the file and retrieve the input_dict.
+    try:
+        with open(args.input_filename) as f:
+            input_dict = json.load(f)
+        logging.info('Processing the `{}` input file'.format(args.input_filename))
+    except FileNotFoundError:
+        logging.error("Failed to open the `{}` file".format(args.input_filename))
+        exit(-1)
+
+    # Instantiate Neural Factory - on CPU.
+    _ = nemo.core.NeuralModuleFactory(placement=nemo.core.DeviceType.CPU)
+
+    # Instantiate module.
+    module = instantiate_module(input_dict)
+
+    # Process inputs.
+    inputs = {}
+    for inp in input_dict["inputs"]:
+        # Special case: Tensor.
+        if inp["type"] == "Tensor":
+            inputs[inp["name"]] = torch.FloatTensor(inp["value"])
+        else:
+            inputs[inp["name"]] = inp["value"]
+
+    with torch.no_grad():
+        outputs = module(force_pt=True, inputs=inputs["inputs"])
+
+    # Process outputs
+    output_dict = []
+    for key, val in zip(module.output_ports.keys(), outputs):
+        t = type(val).__name__
+        # Special case: Tensor.
+        if t == "Tensor":
+            v = val.numpy().tolist()
+        else:
+            v = val
+
+        output_dict.append({"name": key, "value": v, "type": t})
+
+    # Generate output filename - for default add prefix based on module name.
+    output_filename = (
+        args.output_filename
+        if args.output_filename != "module_outputs.json"
+        else input_dict["name"].lower() + "_outputs.json"
+    )
+    # Export to JSON.
+    with open(output_filename, 'w') as outfile:
+        json.dump(output_dict, outfile)
+
+    logging.info("=" * 80)
+    logging.info("Finished processing of inputs/outputs the `{}` module: \n{}".format(input_dict["name"], output_dict))
+    logging.info("Results exported to `{}`.".format(output_filename))
+
+
+if __name__ == '__main__':
+    get_module_outputs()

--- a/scripts/integration/get_module_ports.py
+++ b/scripts/integration/get_module_ports.py
@@ -43,8 +43,6 @@ Required fields: "id", "name", "arguments"
 Returns:
     Format of the output JSON file (indicated  as --output_filename):
     {
-        "name": "my_image_encoder",
-        "id": "nemo.collections.cv.modules.trainables.image_encoder.ImageEncoder",
         "input_ports": {
             "inputs": "axes: (batch, dimension:3, height:224, width:224); elements_type: ImageValue"
         },
@@ -99,7 +97,7 @@ def instantiate_module(module_dict):
 
 
 def get_module_ports():
-    """ Main function analysing the indicated NeMo collection and generating a JSON file with module descriptions. """
+    """ Main function retrieving module input/output ports. """
     # Parse filename.
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -138,8 +136,8 @@ def get_module_ports():
     output_ports = {k: str(v) for k, v in module.output_ports.items()}
 
     output_dict = {
-        "name": input_dict["name"],
-        "id": input_dict["id"],
+        # "name": input_dict["name"],
+        # "id": input_dict["id"],
         "input_ports": input_ports,
         "output_ports": output_ports,
     }

--- a/scripts/integration/get_module_ports.py
+++ b/scripts/integration/get_module_ports.py
@@ -23,7 +23,7 @@ import nemo
 from nemo.utils import logging
 
 
-def main():
+def get_module_ports():
     """ Main function analysing the indicated NeMo collection and generating a JSON file with module descriptions. """
     # Parse filename.
     parser = argparse.ArgumentParser()
@@ -109,4 +109,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    get_module_ports()

--- a/scripts/integration/get_module_ports.py
+++ b/scripts/integration/get_module_ports.py
@@ -16,8 +16,11 @@
 
 """ Script responsible for retrieving module input/output ports.
 
+Exemplary call:
+    nemo-get-module-ports -i module_def.json
+
 Args:
-    Format of the input JSON file (passed as --input_filename):
+    Format of the input JSON file (passed as -i, --input_filename):
     {
         "name": "my_image_encoder",
         "id": "nemo.collections.cv.modules.trainables.image_encoder.ImageEncoder",
@@ -41,7 +44,7 @@ Args:
 Required fields: "id", "name", "arguments"
 
 Returns:
-    Format of the output JSON file (indicated  as --output_filename):
+    Format of the output JSON file (indicated  as -o, --output_filename):
     {
         "input_ports": {
             "inputs": "axes: (batch, dimension:3, height:224, width:224); elements_type: ImageValue"

--- a/scripts/integration/get_modules.py
+++ b/scripts/integration/get_modules.py
@@ -155,7 +155,7 @@ def process_member(module_name, obj, module_list) -> bool:
 
 
 def import_submodules(package, recursive=True):
-    """ Import all submodules of a module, recursively, including subpackages
+    """ Import all submodules of a module, recursively, including subpackages.
 
     Args:
         package: package (name or actual module) (str | module)

--- a/scripts/integration/get_modules.py
+++ b/scripts/integration/get_modules.py
@@ -13,7 +13,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-""" Script responsible for generation of a JSON file containing list of modules of a given collection. """
+""" Script responsible for generation of a JSON file containing list of modules of a given collection. 
+
+Args:
+    Name of the collection (--c, --collection)
+
+Returns:
+    Format of the output JSON file (indicated  as --output_filename):
+
+[
+    {
+        "name": "CIFAR100DataLayer",
+        "id": "nemo.collections.cv.modules.data_layers.cifar100_datalayer.CIFAR100DataLayer",
+        "module_type": "datalayer",
+        "arguments": [
+            {
+                "name": "height",
+                "default": 32,
+                "annotation": "int"
+            },
+            {
+                "name": "width",
+                "default": 32,
+                "annotation": "int"
+            },
+    ...
+    },
+    {
+        "name": "CIFAR10DataLayer",
+        "id": "nemo.collections.cv.modules.data_layers.cifar10_datalayer.CIFAR10DataLayer",
+    ...
+    },
+...
+]
+"""
+
 
 import argparse
 import importlib
@@ -156,9 +190,9 @@ def import_submodules(package, recursive=True):
 def get_modules():
     """ Main function analysing the indicated NeMo collection and generating a JSON file with module descriptions. """
     # Parse arguments.
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--collection', help='ID of the collection', type=str, required=True)
-    parser.add_argument('--output_filename', help='Name of the output JSON file', type=str, default="modules.json")
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--collection','-c', help='ID of the collection', type=str, required=True)
+    parser.add_argument('--output_filename','-o', help='Name of the output JSON file (DEFAULT: modules.json)', type=str, default="modules.json")
     args = parser.parse_args()
 
     # Get collections directory.

--- a/scripts/integration/get_modules.py
+++ b/scripts/integration/get_modules.py
@@ -15,11 +15,14 @@
 
 """ Script responsible for generation of a JSON file containing list of modules of a given collection. 
 
+Exemplary call:
+    nemo-get-modules -c cv
+
 Args:
-    Name of the collection (--c, --collection)
+    Name of the collection (-c, --collection)
 
 Returns:
-    Format of the output JSON file (indicated  as --output_filename):
+    Format of the output JSON file (indicated  as -o, --output_filename):
 
 [
     {

--- a/scripts/integration/get_modules.py
+++ b/scripts/integration/get_modules.py
@@ -153,7 +153,7 @@ def import_submodules(package, recursive=True):
     return results
 
 
-def main():
+def get_modules():
     """ Main function analysing the indicated NeMo collection and generating a JSON file with module descriptions. """
     # Parse arguments.
     parser = argparse.ArgumentParser()
@@ -242,4 +242,4 @@ def main():
 
 
 if __name__ == '__main__':
-    main()
+    get_modules()

--- a/scripts/integration/get_modules.py
+++ b/scripts/integration/get_modules.py
@@ -191,8 +191,14 @@ def get_modules():
     """ Main function analysing the indicated NeMo collection and generating a JSON file with module descriptions. """
     # Parse arguments.
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--collection','-c', help='ID of the collection', type=str, required=True)
-    parser.add_argument('--output_filename','-o', help='Name of the output JSON file (DEFAULT: modules.json)', type=str, default="modules.json")
+    parser.add_argument('--collection', '-c', help='ID of the collection', type=str, required=True)
+    parser.add_argument(
+        '--output_filename',
+        '-o',
+        help='Name of the output JSON file (DEFAULT: modules.json)',
+        type=str,
+        default="modules.json",
+    )
     args = parser.parse_args()
 
     # Get collections directory.
@@ -268,11 +274,13 @@ def get_modules():
         json.dump(module_list, outfile)
 
     logging.info("=" * 80)
+    modules = "".join("* {}\n".format(o) for o in module_list)
     logging.info(
-        'Finished analysis of the `{}` collection, found {} modules, results exported to `{}`.'.format(
-            args.collection, total_counter, output_filename
+        "Finished analysis of the `{}` collection, found {} modules: \n{}".format(
+            args.collection, total_counter, modules
         )
     )
+    logging.info('Results exported to `{}`.'.format(output_filename))
 
 
 if __name__ == '__main__':

--- a/scripts/integration/validate_connections.py
+++ b/scripts/integration/validate_connections.py
@@ -71,7 +71,6 @@ Returns:
 """
 
 import argparse
-import importlib
 import json
 
 from scripts.integration.get_module_ports import instantiate_module

--- a/scripts/integration/validate_connections.py
+++ b/scripts/integration/validate_connections.py
@@ -15,8 +15,11 @@
 
 """ Script responsible for analysis the provided graph (modules and connections) and returning their status. 
 
+Exemplary call:
+    nemo-validate-connections --i connections_input.json
+
 Args:
-    Format of the input JSON file (passed as --input_filename):
+    Format of the input JSON file (passed as -i, --input_filename):
     {
         "modules": [
             {
@@ -63,7 +66,7 @@ Args:
 Required fields: "modules", "connections"
 
 Returns:
-    Format of the output JSON file (indicated  as --output_filename):
+    Format of the output JSON file (indicated  as -o, --output_filename):
     {
         "cifar100_dl.images->my_image_encoder.inputs": "NeuralTypeComparisonResult.SAME",
         "cifar100_dl.coarse_labels->my_image_encoder.inputs": "NeuralTypeComparisonResult.INCOMPATIBLE"

--- a/scripts/integration/validate_connections.py
+++ b/scripts/integration/validate_connections.py
@@ -1,0 +1,175 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+""" Script responsible for analysis the provided graph (modules and connections) and returning their status. 
+
+Args:
+    Format of the input JSON file (passed as --input_filename):
+    {
+        "modules": [
+            {
+                "name": "cifar100_dl",
+                "id": "nemo.collections.cv.modules.data_layers.cifar100_datalayer.CIFAR100DataLayer",
+                "module_type": "datalayer",
+                "arguments": [
+                    {
+                        "name": "height",
+                        "value": 224
+                    },
+                    {
+                        "name": "width",
+                        "value": 224
+                    }
+                ]
+            },
+            {
+                "name": "my_image_encoder",
+                "id": "nemo.collections.cv.modules.trainables.image_encoder.ImageEncoder",
+                "module_type": "trainable",
+                "arguments": [
+                    {
+                        "name": "model_type",
+                        "value": "resnet50"
+                    },
+                    {
+                        "name": "output_size",
+                        "value": 10
+                    },
+                    {
+                        "name": "return_feature_maps",
+                        "value": false
+                    }
+                ]
+            }
+        ],
+        "connections": [
+            "cifar100_dl.images->my_image_encoder.inputs",
+            "cifar100_dl.coarse_labels->my_image_encoder.inputs"
+        ]
+    }
+
+Required fields: "modules", "connections"
+
+Returns:
+    Format of the output JSON file (indicated  as --output_filename):
+    {
+        "cifar100_dl.images->my_image_encoder.inputs": "NeuralTypeComparisonResult.SAME",
+        "cifar100_dl.coarse_labels->my_image_encoder.inputs": "NeuralTypeComparisonResult.INCOMPATIBLE"
+    }
+"""
+
+import argparse
+import importlib
+import json
+
+from scripts.integration.get_module_ports import instantiate_module
+
+import nemo
+from nemo.utils import logging
+
+def get_module_port(module_str: str):
+    """ Function returns module name and port. """
+    lst = module_str.split(".")
+    # Handle two cases.
+    if len(lst) == 2:
+        # Handle module.port case.
+        # E.g. "audiotomelspectrogrampreprocessor0.processed_signal"
+        module_name = lst[0]
+        module_port = lst[1]
+    elif len(lst) == 3:
+        # Handle step.module.port case.
+        # E.g. "0.audiotomelspectrogrampreprocessor0.processed_signal"
+        module_name = lst[1]
+        module_port = lst[2]
+    else:
+        raise KeyError("Connection `{}` has improper format".format(connection_str))
+    return module_name, module_port
+
+
+def validate_connections():
+    """ Main function analysing the provided graph (modules and connections) and returning their status. """
+    # Parse filename.
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--input_filename',
+        '-i',
+        help='Name of the input JSON file containing graph definition (modules and connections) to be validated',
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        '--output_filename',
+        '-o',
+        help='Name of the output JSON file containing statuses (DEFAULT: statuses.json)',
+        type=str,
+        default="statuses.json",
+    )
+    args = parser.parse_args()
+
+    # Open the file and retrieve the input_dict.
+    try:
+        with open(args.input_filename) as f:
+            input_dict = json.load(f)
+        logging.info('Processing the `{}` input file'.format(args.input_filename))
+    except FileNotFoundError:
+        logging.error("Failed to open the `{}` file".format(args.input_filename))
+        exit(-1)
+
+    # Instantiate Neural Factory - on CPU.
+    _ = nemo.core.NeuralModuleFactory(placement=nemo.core.DeviceType.CPU)
+
+    # Check the required keys.
+    for key in ["modules", "connections"]:
+        if not key in input_dict.keys():
+            logging.error("Loaded file doesn't contain the required `{}` key".format(key))
+            exit(-2)
+
+    # Instantiate modules.
+    modules = {}
+    for module_dict in input_dict["modules"]:
+        modules[module_dict["name"]] = instantiate_module(module_dict)
+
+    # Analyse the connections.
+    output_dict = {}
+    for con_dict in input_dict["connections"]:
+        # Split connection.
+        producer, consumer = con_dict.split("->")
+        prod_name, prod_port = get_module_port(producer)
+        cons_name, cons_port = get_module_port(consumer)
+
+        print(prod_name, " : ", prod_port,  " -> ", cons_name,  " : ", cons_port)
+
+        # Compare definitions.
+        prod_type = modules[prod_name].output_ports[prod_port]
+        cons_type = modules[cons_name].input_ports[cons_port]
+        status = prod_type.compare(cons_type)
+
+        output_dict[con_dict] = str(status)
+
+    # Output filename.
+    output_filename = args.output_filename
+
+    # Export to JSON.
+    with open(output_filename, 'w') as outfile:
+        json.dump(output_dict, outfile)
+
+    logging.info("=" * 80)
+    outputs = "".join("* {}: {}\n".format(k, v) for k,v in output_dict.items())
+    logging.info('Finished analysis of {} connections:\n{}'.format(len(input_dict["connections"]), outputs))
+    logging.info('Results exported to `{}`.'.format(output_filename))
+
+
+if __name__ == '__main__':
+    validate_connections()

--- a/scripts/integration/validate_connections.py
+++ b/scripts/integration/validate_connections.py
@@ -79,6 +79,7 @@ from scripts.integration.get_module_ports import instantiate_module
 import nemo
 from nemo.utils import logging
 
+
 def get_module_port(module_str: str):
     """ Function returns module name and port. """
     lst = module_str.split(".")
@@ -149,7 +150,7 @@ def validate_connections():
         prod_name, prod_port = get_module_port(producer)
         cons_name, cons_port = get_module_port(consumer)
 
-        print(prod_name, " : ", prod_port,  " -> ", cons_name,  " : ", cons_port)
+        print(prod_name, " : ", prod_port, " -> ", cons_name, " : ", cons_port)
 
         # Compare definitions.
         prod_type = modules[prod_name].output_ports[prod_port]
@@ -166,7 +167,7 @@ def validate_connections():
         json.dump(output_dict, outfile)
 
     logging.info("=" * 80)
-    outputs = "".join("* {}: {}\n".format(k, v) for k,v in output_dict.items())
+    outputs = "".join("* {}: {}\n".format(k, v) for k, v in output_dict.items())
     logging.info('Finished analysis of {} connections:\n{}'.format(len(input_dict["connections"]), outputs))
     logging.info('Results exported to `{}`.'.format(output_filename))
 

--- a/setup.py
+++ b/setup.py
@@ -257,6 +257,7 @@ setuptools.setup(
         'console_scripts': [
             'nemo-get-collections=scripts.integration.get_collections:get_collections',
             'nemo-get-modules=scripts.integration.get_modules:get_modules',
+            'nemo-get-module-outputs=scripts.integration.get_module_outputs:get_module_outputs',
             'nemo-get-module-ports=scripts.integration.get_module_ports:get_module_ports',
             'nemo-validate-connections=scripts.integration.validate_connections:validate_connections',
         ]

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,8 @@ from itertools import chain
 
 import setuptools
 
+import scripts
+
 
 def is_build_action():
     if len(sys.argv) <= 1:
@@ -250,4 +252,12 @@ setuptools.setup(
     keywords=__keywords__,
     # Custom commands.
     cmdclass={'style': StyleCommand},
+    # Console commands.
+    entry_points={
+         'console_scripts': [
+             'nemo-get-collections=scripts.integration.get_collections:get_collections',
+             'nemo-get-modules=scripts.integration.get_modules:get_modules',
+             'nemo-get-module-ports=scripts.integration.get_module_ports:get_module_ports',
+         ]
+     },    
 )

--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,6 @@ from itertools import chain
 
 import setuptools
 
-import scripts
-
 
 def is_build_action():
     if len(sys.argv) <= 1:

--- a/setup.py
+++ b/setup.py
@@ -254,10 +254,11 @@ setuptools.setup(
     cmdclass={'style': StyleCommand},
     # Console commands.
     entry_points={
-         'console_scripts': [
-             'nemo-get-collections=scripts.integration.get_collections:get_collections',
-             'nemo-get-modules=scripts.integration.get_modules:get_modules',
-             'nemo-get-module-ports=scripts.integration.get_module_ports:get_module_ports',
-         ]
-     },    
+        'console_scripts': [
+            'nemo-get-collections=scripts.integration.get_collections:get_collections',
+            'nemo-get-modules=scripts.integration.get_modules:get_modules',
+            'nemo-get-module-ports=scripts.integration.get_module_ports:get_module_ports',
+            'nemo-validate-connections=scripts.integration.validate_connections:validate_connections',
+        ]
+    },
 )


### PR DESCRIPTION
This PR introduces two new scripts for integration of NeMo with external editor
 - [x] validate_connections.py
 - [x]  get_module_outputs.py

Moreover, the PR updates the setup.py so running it will install scripts enabling the user to run them from command line/any folder, e.g.:
```
nemo-get-module-outputs --i cv_inputs.json
```

Minor update of the remaining integration scripts
 - [x] added shorter arguments (-i, -o, -c)
 - [x] updated description of files/scripts, added input/output examples
 - [x] description now appearing with help (-h)
