### PR TITLE
ASR BPE Patches

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,6 +160,21 @@ pipeline {
           }
         }
       }
+
+      stage('Speech to Text WPE') {
+        steps {
+            sh 'python examples/asr/speech_to_text_bpe.py \
+            --config-path="experimental/configs/" --config-name="config_bpe" \
+            model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json \
+            model.validation_ds.manifest_filepath=/home/TestData/an4_dataset/an4_val.json \
+            model.tokenizer.dir="/home/TestData/asr_tokenizers/an4_wpe_128/" \
+            model.tokenizer.type="wpe" \
+            trainer.gpus=[1] \
+            +trainer.fast_dev_run=True \
+            exp_manager.root_dir=examples/asr/speech_to_text_wpe_results'
+            sh 'rm -rf examples/asr/speech_to_text_wpe_results'
+          }
+      }
     }
 
     stage('L2: ASR Multi-dataloader dev run') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -159,18 +159,9 @@ pipeline {
             sh 'rm -rf examples/speaker_recognition/speaker_recognition_results'
           }
         }
-      }
-    }
 
-    stage('L2: Speech to Text WPE') {
-        when {
-            anyOf{
-              branch 'candidate'
-              changeRequest target: 'candidate'
-            }
-        }
-        failFast true
-        steps {
+        stage('L2: Speech to Text WPE') {
+          steps {
             sh 'python examples/asr/speech_to_text_bpe.py \
             --config-path="experimental/configs/" --config-name="config_bpe" \
             model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json \
@@ -182,7 +173,11 @@ pipeline {
             exp_manager.root_dir=examples/asr/speech_to_text_wpe_results'
             sh 'rm -rf examples/asr/speech_to_text_wpe_results'
           }
-     }
+        }
+      }
+    }
+
+
 
     stage('L2: ASR Multi-dataloader dev run') {
       when {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,7 +162,7 @@ pipeline {
       }
     }
 
-    stage('Speech to Text WPE') {
+    stage('L2: Speech to Text WPE') {
         when {
             anyOf{
               branch 'candidate'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -160,8 +160,16 @@ pipeline {
           }
         }
       }
+    }
 
-      stage('Speech to Text WPE') {
+    stage('Speech to Text WPE') {
+        when {
+            anyOf{
+              branch 'candidate'
+              changeRequest target: 'candidate'
+            }
+        }
+        failFast true
         steps {
             sh 'python examples/asr/speech_to_text_bpe.py \
             --config-path="experimental/configs/" --config-name="config_bpe" \
@@ -174,8 +182,7 @@ pipeline {
             exp_manager.root_dir=examples/asr/speech_to_text_wpe_results'
             sh 'rm -rf examples/asr/speech_to_text_wpe_results'
           }
-      }
-    }
+     }
 
     stage('L2: ASR Multi-dataloader dev run') {
       when {

--- a/nemo/collections/asr/metrics/wer_bpe.py
+++ b/nemo/collections/asr/metrics/wer_bpe.py
@@ -63,7 +63,7 @@ class WERBPE(TensorMetric):
         self.use_cer = use_cer
         self.ctc_decode = ctc_decode
 
-    def __ctc_decoder_predictions_tensor(self, predictions: torch.Tensor) -> List[str]:
+    def ctc_decoder_predictions_tensor(self, predictions: torch.Tensor) -> List[str]:
         """
         Decodes a sequence of labels to words
         """

--- a/nemo/collections/asr/metrics/wer_bpe.py
+++ b/nemo/collections/asr/metrics/wer_bpe.py
@@ -100,7 +100,7 @@ class WERBPE(TensorMetric):
                 reference = self.tokenizer.ids_to_text(target)
                 references.append(reference)
             if self.ctc_decode:
-                hypotheses = self.__ctc_decoder_predictions_tensor(predictions)
+                hypotheses = self.ctc_decoder_predictions_tensor(predictions)
             else:
                 raise NotImplementedError("Implement me if you need non-CTC decode on predictions")
 

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -43,6 +43,9 @@ class EncDecCTCModelBPE(EncDecCTCModel):
         self.tokenizer_dir = self.tokenizer_cfg.pop('dir')  # Remove tokenizer directory
         self.tokenizer_type = self.tokenizer_cfg.pop('type').lower()  # Remove tokenizer_type
 
+        # Store the model + vocab dir
+        self.tokenizer_dir = self.register_artifact('tokenizer.dir', self.tokenizer_dir)
+
         if self.tokenizer_type not in ['bpe', 'wpe']:
             raise ValueError(
                 "`tokenizer.type` must be either `bpe` for SentencePiece tokenizer or "

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -17,12 +17,11 @@ from dataclasses import dataclass
 from typing import Dict, List, Optional
 
 import torch
-from omegaconf import MISSING, DictConfig, ListConfig, OmegaConf
+from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from nemo.collections.asr.data.audio_to_text import AudioToBPEDataset
 from nemo.collections.asr.metrics.wer_bpe import WERBPE
 from nemo.collections.asr.models.ctc_models import EncDecCTCModel
-from nemo.collections.asr.parts.features import WaveformFeaturizer
 from nemo.collections.asr.parts.perturb import process_augmentations
 from nemo.collections.common import tokenizers
 from nemo.core.neural_types import *
@@ -122,14 +121,12 @@ class EncDecCTCModelBPE(EncDecCTCModel):
         else:
             augmentor = None
 
-        featurizer = WaveformFeaturizer(
-            sample_rate=config['sample_rate'], int_values=config.get('int_values', False), augmentor=augmentor
-        )
-
         dataset = AudioToBPEDataset(
             manifest_filepath=config['manifest_filepath'],
             tokenizer=self.tokenizer,
-            featurizer=featurizer,
+            sample_rate=config['sample_rate'],
+            int_values=config.get('int_values', False),
+            augmentor=augmentor,
             max_duration=config.get('max_duration', None),
             min_duration=config.get('min_duration', None),
             max_utts=config.get('max_utts', 0),

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -215,6 +215,32 @@ class EncDecCTCModelBPE(EncDecCTCModel):
             "greedy_predictions": NeuralType(('B', 'T'), LabelsType()),
         }
 
+    def _setup_transcribe_dataloader(self, config: Dict) -> 'torch.utils.data.DataLoader':
+        """
+        Setup function for a temporary data loader which wraps the provided audio file.
+
+        Args:
+            config: A python dictionary which contains the following keys:
+            paths2audio_files: (a list) of paths to audio files. The files should be relatively short fragments. \
+                Recommended length per file is between 5 and 25 seconds.
+            batch_size: (int) batch size to use during inference. \
+                Bigger will result in better throughput performance but would use more memory.
+            temp_dir: (str) A temporary directory where the audio manifest is temporarily
+                stored.
+
+        Returns:
+            A pytorch DataLoader for the given audio file(s).
+        """
+        dl_config = {
+            'manifest_filepath': os.path.join(config['temp_dir'], 'manifest.json'),
+            'sample_rate': self.preprocessor._sample_rate,
+            'batch_size': min(config['batch_size'], len(config['paths2audio_files'])),
+            'shuffle': False,
+        }
+
+        temporary_datalayer = self._setup_dataloader_from_config(config=DictConfig(dl_config))
+        return temporary_datalayer
+
 
 @experimental
 class JasperNetBPE(EncDecCTCModelBPE):

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -12,10 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import os
-import tempfile
-from typing import Dict, List, Optional
+from typing import Dict, Optional
 
 import torch
 from omegaconf import DictConfig, ListConfig, OmegaConf

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -90,11 +90,6 @@ class EncDecCTCModelBPE(EncDecCTCModel):
         # Initialize a dummy vocabulary
         vocabulary = self.tokenizer.tokenizer.get_vocab()
 
-        # Remove special tokens
-        for special_token in self.tokenizer.tokenizer.all_special_tokens:
-            if special_token in vocabulary:
-                vocabulary.pop(special_token)
-
         # Set the new vocabulary
         cfg.decoder.params.vocabulary = ListConfig(list(vocabulary.values()))
 

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
-from dataclasses import dataclass
+import tempfile
 from typing import Dict, List, Optional
 
 import torch
@@ -117,7 +118,54 @@ class EncDecCTCModelBPE(EncDecCTCModel):
         self._wer = WERBPE(tokenizer=self.tokenizer, batch_dim_index=0, use_cer=False, ctc_decode=True)
 
     def transcribe(self, paths2audio_files: List[str], batch_size: int = 4) -> List[str]:
-        pass
+        """
+        Uses greedy decoding to transcribe audio files. Use this method for debugging and prototyping.
+
+        Args:
+
+            paths2audio_files: (a list) of paths to audio files. The files should be relatively short fragments. \
+        Recommended length per file is between 5 and 25 seconds.
+            batch_size: (int) batch size to use during inference. \
+        Bigger will result in better throughput performance but would use more memory.
+
+        Returns:
+
+            A list of transcriptions in the same order as paths2audio_files
+        """
+        if paths2audio_files is None or len(paths2audio_files) == 0:
+            return {}
+        # We will store transcriptions here
+        hypotheses = []
+        # Model's mode and device
+        mode = self.training
+        device = next(self.parameters()).device
+        try:
+            # Switch model to evaluation mode
+            self.eval()
+            # Work in tmp directory - will store manifest file there
+            with tempfile.TemporaryDirectory() as tmpdir:
+                with open(os.path.join(tmpdir, 'manifest.json'), 'w') as fp:
+                    for audio_file in paths2audio_files:
+                        entry = {'audio_filepath': audio_file, 'duration': 100000, 'text': 'nothing'}
+                        fp.write(json.dumps(entry) + '\n')
+
+                dl_config = {
+                    'manifest_filepath': os.path.join(tmpdir, 'manifest.json'),
+                    'sample_rate': self.preprocessor._sample_rate,
+                    'batch_size': min(batch_size, len(paths2audio_files)),
+                    'shuffle': False,
+                }
+                temporary_datalayer = self._setup_dataloader_from_config(config=DictConfig(dl_config))
+                for test_batch in temporary_datalayer:
+                    _, _, greedy_predictions = self.forward(
+                        input_signal=test_batch[0].to(device), input_signal_length=test_batch[1].to(device)
+                    )
+                    hypotheses += self._wer.ctc_decoder_predictions_tensor(greedy_predictions)
+                    del test_batch
+        finally:
+            # set mode back to its original value
+            self.train(mode=mode)
+        return hypotheses
 
     def _setup_dataloader_from_config(self, config: Optional[Dict]):
         if 'augmentor' in config:

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -162,7 +162,7 @@ class EncDecCTCModel(ASRModel):
         shuffle = config['shuffle']
 
         # Instantiate tarred dataset loader or normal dataset loader
-        if config.get('is_tarred', False):
+        if 'is_tarred' in config and config.get('is_tarred', False):
             dataset = TarredAudioToCharDataset(
                 audio_tar_filepaths=config['tarred_audio_filepaths'],
                 manifest_filepath=config['manifest_filepath'],
@@ -170,7 +170,7 @@ class EncDecCTCModel(ASRModel):
                 sample_rate=config['sample_rate'],
                 int_values=config.get('int_values', False),
                 augmentor=augmentor,
-                shuffle_n=50,
+                shuffle_n=config.get('shuffle_n', 50),
                 max_duration=config.get('max_duration', None),
                 min_duration=config.get('min_duration', None),
                 max_utts=config.get('max_utts', 0),
@@ -220,7 +220,7 @@ class EncDecCTCModel(ASRModel):
         # Need to set this because if using an IterableDataset, the length of the dataloader is the total number
         # of samples rather than the number of batches, and this messes up the tqdm progress bar.
         # So we set the number of steps manually (to the correct number) to fix this.
-        if train_data_config['is_tarred']:
+        if 'is_tarred' in train_data_config and train_data_config['is_tarred']:
             # We also need to check if limit_train_batches is already set.
             # If it's an int, we assume that the user has set it to something sane, i.e. <= # training batches,
             # and don't change it. Otherwise, adjust batches accordingly if it's a float (including 1.0).

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -191,9 +191,7 @@ class ModelPT(LightningModule, Model):
         with tempfile.TemporaryDirectory() as tmpdir:
             try:
                 cls.__unpack_nemo_file(path2file=restore_path, out_folder=tmpdir)
-
                 os.chdir(tmpdir)
-
                 config_yaml = path.join(tmpdir, _MODEL_CONFIG_YAML)
                 model_weights = path.join(tmpdir, _MODEL_WEIGHTS)
                 conf = OmegaConf.load(config_yaml)

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -186,14 +186,24 @@ class ModelPT(LightningModule, Model):
         if not path.exists(restore_path):
             raise FileExistsError(f"Can't find {restore_path}")
 
+        cwd = os.getcwd()
+
         with tempfile.TemporaryDirectory() as tmpdir:
-            cls.__unpack_nemo_file(path2file=restore_path, out_folder=tmpdir)
-            config_yaml = path.join(tmpdir, _MODEL_CONFIG_YAML)
-            model_weights = path.join(tmpdir, _MODEL_WEIGHTS)
-            conf = OmegaConf.load(config_yaml)
-            OmegaConf.set_struct(conf, True)
-            instance = cls.from_config_dict(config=conf)
-            instance.load_state_dict(torch.load(model_weights))
+            try:
+                cls.__unpack_nemo_file(path2file=restore_path, out_folder=tmpdir)
+
+                os.chdir(tmpdir)
+
+                config_yaml = path.join(tmpdir, _MODEL_CONFIG_YAML)
+                model_weights = path.join(tmpdir, _MODEL_WEIGHTS)
+                conf = OmegaConf.load(config_yaml)
+                OmegaConf.set_struct(conf, True)
+                instance = cls.from_config_dict(config=conf)
+                instance.load_state_dict(torch.load(model_weights))
+
+            finally:
+                os.chdir(cwd)
+
         return instance
 
     @abstractmethod

--- a/tests/collections/asr/test_asr_ctc_encoder_model_bpe.py
+++ b/tests/collections/asr/test_asr_ctc_encoder_model_bpe.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import copy
+
+import pytest
+from omegaconf import DictConfig
+
+from nemo.collections.asr.models.ctc_bpe_models import EncDecCTCModelBPE
+
+
+@pytest.fixture()
+def asr_model():
+    preprocessor = {'cls': 'nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor', 'params': dict({})}
+    encoder = {
+        'cls': 'nemo.collections.asr.modules.ConvASREncoder',
+        'params': {
+            'feat_in': 64,
+            'activation': 'relu',
+            'conv_mask': True,
+            'jasper': [
+                {
+                    'filters': 1024,
+                    'repeat': 1,
+                    'kernel': [1],
+                    'stride': [1],
+                    'dilation': [1],
+                    'dropout': 0.0,
+                    'residual': False,
+                    'separable': True,
+                    'se': True,
+                    'se_context_size': -1,
+                }
+            ],
+        },
+    }
+
+    decoder = {
+        'cls': 'nemo.collections.asr.modules.ConvASRDecoder',
+        'params': {
+            'feat_in': 1024,
+            'num_classes': -1,
+            'vocabulary': None
+        },
+    }
+
+    tokenizer = {
+        'dir': '',
+        'type': 'wpe'
+    }
+
+    modelConfig = DictConfig(
+        {'preprocessor': DictConfig(preprocessor), 'encoder': DictConfig(encoder), 'decoder': DictConfig(decoder),
+         'tokenizer': DictConfig(tokenizer)}
+    )
+
+    model_instance = EncDecCTCModelBPE(cfg=modelConfig)
+    return model_instance
+
+
+class TestEncDecCTCModel:
+    @pytest.mark.unit
+    def test_constructor(self, asr_model):
+        asr_model.train()
+        # TODO: make proper config and assert correct number of weights
+        # Check to/from config_dict:
+        confdict = asr_model.to_config_dict()
+        instance2 = EncDecCTCModelBPE.from_config_dict(confdict)
+        assert isinstance(instance2, EncDecCTCModelBPE)
+
+    @pytest.mark.unit
+    def test_vocab_change(self, asr_model):
+        old_vocab = copy.deepcopy(asr_model.decoder.vocabulary)
+        nw1 = asr_model.num_weights
+        asr_model.change_vocabulary(new_vocabulary=old_vocab)
+        # No change
+        assert nw1 == asr_model.num_weights
+        new_vocab = copy.deepcopy(old_vocab)
+        new_vocab.append('!')
+        new_vocab.append('$')
+        new_vocab.append('@')
+        asr_model.change_vocabulary(new_vocabulary=new_vocab)
+        # fully connected + bias
+        assert asr_model.num_weights == nw1 + 3 * (asr_model.decoder._feat_in + 1)

--- a/tests/collections/asr/test_asr_ctc_encoder_model_bpe.py
+++ b/tests/collections/asr/test_asr_ctc_encoder_model_bpe.py
@@ -48,21 +48,18 @@ def asr_model(test_data_dir):
 
     decoder = {
         'cls': 'nemo.collections.asr.modules.ConvASRDecoder',
-        'params': {
-            'feat_in': 1024,
-            'num_classes': -1,
-            'vocabulary': None
-        },
+        'params': {'feat_in': 1024, 'num_classes': -1, 'vocabulary': None},
     }
 
-    tokenizer = {
-        'dir': os.path.join(test_data_dir, "asr", "tokenizers", "an4_wpe_128"),
-        'type': 'wpe'
-    }
+    tokenizer = {'dir': os.path.join(test_data_dir, "asr", "tokenizers", "an4_wpe_128"), 'type': 'wpe'}
 
     modelConfig = DictConfig(
-        {'preprocessor': DictConfig(preprocessor), 'encoder': DictConfig(encoder), 'decoder': DictConfig(decoder),
-         'tokenizer': DictConfig(tokenizer)}
+        {
+            'preprocessor': DictConfig(preprocessor),
+            'encoder': DictConfig(encoder),
+            'decoder': DictConfig(decoder),
+            'tokenizer': DictConfig(tokenizer),
+        }
     )
 
     model_instance = EncDecCTCModelBPE(cfg=modelConfig)

--- a/tests/collections/asr/test_asr_ctc_encoder_model_bpe.py
+++ b/tests/collections/asr/test_asr_ctc_encoder_model_bpe.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import copy
+import os
 
 import pytest
 from omegaconf import DictConfig
@@ -20,7 +21,7 @@ from nemo.collections.asr.models.ctc_bpe_models import EncDecCTCModelBPE
 
 
 @pytest.fixture()
-def asr_model():
+def asr_model(test_data_dir):
     preprocessor = {'cls': 'nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor', 'params': dict({})}
     encoder = {
         'cls': 'nemo.collections.asr.modules.ConvASREncoder',
@@ -55,7 +56,7 @@ def asr_model():
     }
 
     tokenizer = {
-        'dir': '',
+        'dir': os.path.join(test_data_dir, "asr", "tokenizers", "an4_wpe_128"),
         'type': 'wpe'
     }
 


### PR DESCRIPTION
# Changelog
- Patches signature change in ASR data preprocessor
- Patches WPE signature to allow transcription
- Registers the tokenizer objects (vocab and potentially the .model file) for restoration from .nemo object
- Patches an issue with how number of tokens were calculated (and passed) to the CTC model. Now special tokens will be added to the vocabulary of the model
- Add concrete transcript function based on base ASR model
- Refactors restore_from() so that it changes directory to the temp directory. This is necessary for artifact restoration from .nemo files.
- Add basic instantiation and serialization/deserialization from .nemo tests for BPE models