### PR TITLE
Add BPE support for Tarred Datasets

### DIFF
--- a/examples/asr/conf/quartznet_15x5.yaml
+++ b/examples/asr/conf/quartznet_15x5.yaml
@@ -15,6 +15,8 @@ model:
     trim_silence: True
     max_duration: 16.7
     shuffle: True
+    is_tarred: False
+    tarred_audio_filepaths: null
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/configs/config_bpe.yaml
+++ b/examples/asr/experimental/configs/config_bpe.yaml
@@ -12,6 +12,8 @@ model:
     trim_silence: True
     max_duration: 16.7
     shuffle: True
+    is_tarred: False
+    tarred_audio_filepaths: null
 
   validation_ds:
     manifest_filepath: ???

--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -748,7 +748,9 @@ class TarredAudioToCharDataset(_TarredAudioToTextDataset):
     ):
         self.labels = labels
 
-        parser = parsers.make_parser(labels=labels, name=parser, unk_id=unk_index, blank_id=blank_index, do_normalize=normalize)
+        parser = parsers.make_parser(
+            labels=labels, name=parser, unk_id=unk_index, blank_id=blank_index, do_normalize=normalize
+        )
 
         super().__init__(
             audio_tar_filepaths=audio_tar_filepaths,

--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -26,7 +26,13 @@ from nemo.core.neural_types import *
 from nemo.utils import logging
 from nemo.utils.decorators import experimental
 
-__all__ = ['AudioToCharDataset', 'AudioToBPEDataset', 'AudioLabelDataset', 'TarredAudioToCharDataset']
+__all__ = [
+    'AudioToCharDataset',
+    'AudioToBPEDataset',
+    'AudioLabelDataset',
+    'TarredAudioToCharDataset',
+    'TarredAudioToBPEDataset',
+]
 
 
 def _speech_collate_fn(batch, pad_id):
@@ -239,7 +245,7 @@ class AudioToCharDataset(_AudioTextDataset):
     def __init__(
         self,
         manifest_filepath: str,
-        labels: List[str],
+        labels: Union[str, List[str]],
         sample_rate: int,
         int_values: bool = False,
         augmentor: 'nemo.collections.asr.parts.perturb.AudioAugmentor' = None,
@@ -441,11 +447,11 @@ class AudioLabelDataset(Dataset):
 
 
 @experimental
-class TarredAudioToCharDataset(IterableDataset):
+class _TarredAudioToTextDataset(IterableDataset):
     """
-    A similar Dataset to the AudioToCharDataset, but which loads tarred audio files.
+    A similar Dataset to the AudioToCharDataset/AudioToBPEDataset, but which loads tarred audio files.
 
-    Accepts a single comma-separated JSON manifest file (in the same style as for the AudioToCharDataset),
+    Accepts a single comma-separated JSON manifest file (in the same style as for the AudioToCharDataset/AudioToBPEDataset),
     as well as the path(s) to the tarball(s) containing the wav files. Each line of the manifest should
     contain the information for one audio file, including at least the transcript and name of the audio
     file within the tarball.
@@ -471,9 +477,7 @@ class TarredAudioToCharDataset(IterableDataset):
         audio_tar_filepaths: Either a list of audio tarball filepaths, or a
             string (can be brace-expandable).
         manifest_filepath (str): Path to the manifest.
-        labels (list): List of characters that can be output by the ASR model.
-            For Jasper, this is the 28 character set {a-z '}. The CTC blank
-            symbol is automatically added later for models using ctc.
+        parser (callable): A callable which is used to pre-process the text output.
         sample_rate (int): Sample rate to resample loaded audio to
         int_values (bool): If true, load samples as 32-bit integers. Defauts to False.
         augmentor (nemo.collections.asr.parts.perturb.AudioAugmentor): An AudioAugmentor
@@ -512,51 +516,29 @@ class TarredAudioToCharDataset(IterableDataset):
         world_size (int): Total number of processes, used for partitioning shards. Defaults to 0.
     """
 
-    @property
-    def output_types(self) -> Optional[Dict[str, NeuralType]]:
-        """Returns definitions of module output ports.
-        """
-        return {
-            'audio_signal': NeuralType(
-                ('B', 'T'),
-                AudioSignal(freq=self._sample_rate)
-                if self is not None and hasattr(self, '_sample_rate')
-                else AudioSignal(),
-            ),
-            'a_sig_length': NeuralType(tuple('B'), LengthsType()),
-            'transcripts': NeuralType(('B', 'T'), LabelsType()),
-            'transcript_length': NeuralType(tuple('B'), LengthsType()),
-        }
-
     def __init__(
         self,
-        audio_tar_filepaths,
-        manifest_filepath,
-        labels,
-        sample_rate,
-        int_values=False,
-        augmentor=None,
-        shuffle_n=0,
-        min_duration=None,
-        max_duration=None,
-        max_utts=0,
-        blank_index=-1,
-        unk_index=-1,
-        normalize=True,
-        trim=False,
-        bos_id=None,
-        eos_id=None,
-        parser='en',
-        add_misc=False,
-        pad_id=0,
-        global_rank=0,
-        world_size=0,
+        audio_tar_filepaths: Union[str, List[str]],
+        manifest_filepath: str,
+        parser: Callable,
+        sample_rate: int,
+        int_values: bool = False,
+        augmentor: Optional['nemo.collections.asr.parts.perturb.AudioAugmentor'] = None,
+        shuffle_n: int = 0,
+        min_duration: Optional[float] = None,
+        max_duration: Optional[float] = None,
+        max_utts: int = 0,
+        trim: bool = False,
+        bos_id: Optional[int] = None,
+        eos_id: Optional[int] = None,
+        add_misc: bool = False,
+        pad_id: int = 0,
+        global_rank: int = 0,
+        world_size: int = 0,
     ):
         self.collection = collections.ASRAudioText(
             manifests_files=manifest_filepath.split(','),
-            parser=parsers.make_parser(
-                labels=labels, name=parser, unk_id=unk_index, blank_id=blank_index, do_normalize=normalize
-            ),
+            parser=parser,
             min_duration=min_duration,
             max_duration=max_duration,
             max_number=max_utts,
@@ -666,3 +648,245 @@ class TarredAudioToCharDataset(IterableDataset):
 
     def __len__(self):
         return len(self.collection)
+
+
+@experimental
+class TarredAudioToCharDataset(_TarredAudioToTextDataset):
+    """
+    A similar Dataset to the AudioToCharDataset, but which loads tarred audio files.
+
+    Accepts a single comma-separated JSON manifest file (in the same style as for the AudioToCharDataset),
+    as well as the path(s) to the tarball(s) containing the wav files. Each line of the manifest should
+    contain the information for one audio file, including at least the transcript and name of the audio
+    file within the tarball.
+
+    Valid formats for the audio_tar_filepaths argument include:
+    (1) a single string that can be brace-expanded, e.g. 'path/to/audio.tar' or 'path/to/audio_{1..100}.tar.gz', or
+    (2) a list of file paths that will not be brace-expanded, e.g. ['audio_1.tar', 'audio_2.tar', ...].
+
+    See the WebDataset documentation for more information about accepted data and input formats.
+
+    If using multiple processes the number of shards should be divisible by the number of workers to ensure an
+    even split among workers. If it is not divisible, logging will give a warning but training will proceed.
+    In addition, if using mutiprocessing, each shard MUST HAVE THE SAME NUMBER OF ENTRIES after filtering
+    is applied. We currently do not check for this, but your program may hang if the shards are uneven!
+
+    Notice that a few arguments are different from the AudioToCharDataset; for example, shuffle (bool) has been
+    replaced by shuffle_n (int).
+
+    Additionally, please note that the len() of this DataLayer is assumed to be the length of the manifest
+    after filtering. An incorrect manifest length may lead to some DataLoader issues down the line.
+
+    Args:
+        audio_tar_filepaths: Either a list of audio tarball filepaths, or a
+            string (can be brace-expandable).
+        manifest_filepath (str): Path to the manifest.
+        labels (list): List of characters that can be output by the ASR model.
+            For Jasper, this is the 28 character set {a-z '}. The CTC blank
+            symbol is automatically added later for models using ctc.
+        sample_rate (int): Sample rate to resample loaded audio to
+        int_values (bool): If true, load samples as 32-bit integers. Defauts to False.
+        augmentor (nemo.collections.asr.parts.perturb.AudioAugmentor): An AudioAugmentor
+            object used to augment loaded audio
+        shuffle_n (int): How many samples to look ahead and load to be shuffled.
+            See WebDataset documentation for more details.
+            Defaults to 0.
+        min_duration (float): Dataset parameter.
+            All training files which have a duration less than min_duration
+            are dropped. Note: Duration is read from the manifest JSON.
+            Defaults to 0.1.
+        max_duration (float): Dataset parameter.
+            All training files which have a duration more than max_duration
+            are dropped. Note: Duration is read from the manifest JSON.
+            Defaults to None.
+        max_utts (int): Limit number of utterances. 0 means no maximum.
+        blank_index (int): Blank character index, defaults to -1.
+        unk_index (int): Unknown character index, defaults to -1.
+        normalize (bool): Dataset parameter.
+            Whether to use automatic text cleaning.
+            It is highly recommended to manually clean text for best results.
+            Defaults to True.
+        trim (bool): Whether to use trim silence from beginning and end
+            of audio signal using librosa.effects.trim().
+            Defaults to False.
+        bos_id (id): Dataset parameter.
+            Beginning of string symbol id used for seq2seq models.
+            Defaults to None.
+        eos_id (id): Dataset parameter.
+            End of string symbol id used for seq2seq models.
+            Defaults to None.
+        pad_id (id): Token used to pad when collating samples in batches.
+            If this is None, pads using 0s.
+            Defaults to None.
+        global_rank (int): Worker rank, used for partitioning shards. Defaults to 0.
+        world_size (int): Total number of processes, used for partitioning shards. Defaults to 0.
+    """
+
+    def __init__(
+        self,
+        audio_tar_filepaths: Union[str, List[str]],
+        manifest_filepath: str,
+        labels: List[str],
+        sample_rate: int,
+        int_values: bool = False,
+        augmentor: Optional['nemo.collections.asr.parts.perturb.AudioAugmentor'] = None,
+        shuffle_n: int = 0,
+        min_duration: Optional[float] = None,
+        max_duration: Optional[float] = None,
+        max_utts: int = 0,
+        blank_index: int = -1,
+        unk_index: int = -1,
+        normalize: bool = True,
+        trim: bool = False,
+        bos_id: Optional[int] = None,
+        eos_id: Optional[int] = None,
+        parser: Optional[str] = 'en',
+        add_misc: bool = False,
+        pad_id: int = 0,
+        global_rank: int = 0,
+        world_size: int = 0,
+    ):
+        self.labels = labels
+
+        parser = parsers.make_parser(labels=labels, name=parser, unk_id=unk_index, blank_id=blank_index, do_normalize=normalize)
+
+        super().__init__(
+            audio_tar_filepaths=audio_tar_filepaths,
+            manifest_filepath=manifest_filepath,
+            parser=parser,
+            sample_rate=sample_rate,
+            int_values=int_values,
+            augmentor=augmentor,
+            shuffle_n=shuffle_n,
+            min_duration=min_duration,
+            max_duration=max_duration,
+            max_utts=max_utts,
+            trim=trim,
+            bos_id=bos_id,
+            eos_id=eos_id,
+            add_misc=add_misc,
+            pad_id=pad_id,
+            global_rank=global_rank,
+            world_size=world_size,
+        )
+
+
+@experimental
+class TarredAudioToBPEDataset(_TarredAudioToTextDataset):
+    """
+    A similar Dataset to the AudioToBPEDataset, but which loads tarred audio files.
+
+    Accepts a single comma-separated JSON manifest file (in the same style as for the AudioToBPEDataset),
+    as well as the path(s) to the tarball(s) containing the wav files. Each line of the manifest should
+    contain the information for one audio file, including at least the transcript and name of the audio
+    file within the tarball.
+
+    Valid formats for the audio_tar_filepaths argument include:
+    (1) a single string that can be brace-expanded, e.g. 'path/to/audio.tar' or 'path/to/audio_{1..100}.tar.gz', or
+    (2) a list of file paths that will not be brace-expanded, e.g. ['audio_1.tar', 'audio_2.tar', ...].
+
+    See the WebDataset documentation for more information about accepted data and input formats.
+
+    If using multiple processes the number of shards should be divisible by the number of workers to ensure an
+    even split among workers. If it is not divisible, logging will give a warning but training will proceed.
+    In addition, if using mutiprocessing, each shard MUST HAVE THE SAME NUMBER OF ENTRIES after filtering
+    is applied. We currently do not check for this, but your program may hang if the shards are uneven!
+
+    Notice that a few arguments are different from the AudioToBPEDataset; for example, shuffle (bool) has been
+    replaced by shuffle_n (int).
+
+    Additionally, please note that the len() of this DataLayer is assumed to be the length of the manifest
+    after filtering. An incorrect manifest length may lead to some DataLoader issues down the line.
+
+    Args:
+        audio_tar_filepaths: Either a list of audio tarball filepaths, or a
+            string (can be brace-expandable).
+        manifest_filepath (str): Path to the manifest.
+        tokenizer (TokenizerSpec): Either a Word Piece Encoding tokenizer (BERT),
+            or a Sentence Piece Encoding tokenizer (BPE). The CTC blank
+            symbol is automatically added later for models using ctc.
+        sample_rate (int): Sample rate to resample loaded audio to
+        int_values (bool): If true, load samples as 32-bit integers. Defauts to False.
+        augmentor (nemo.collections.asr.parts.perturb.AudioAugmentor): An AudioAugmentor
+            object used to augment loaded audio
+        shuffle_n (int): How many samples to look ahead and load to be shuffled.
+            See WebDataset documentation for more details.
+            Defaults to 0.
+        min_duration (float): Dataset parameter.
+            All training files which have a duration less than min_duration
+            are dropped. Note: Duration is read from the manifest JSON.
+            Defaults to 0.1.
+        max_duration (float): Dataset parameter.
+            All training files which have a duration more than max_duration
+            are dropped. Note: Duration is read from the manifest JSON.
+            Defaults to None.
+        max_utts (int): Limit number of utterances. 0 means no maximum.
+        trim (bool): Whether to use trim silence from beginning and end
+            of audio signal using librosa.effects.trim().
+            Defaults to False.
+        pad_id (id): Token used to pad when collating samples in batches.
+            If this is None, pads using 0s.
+            Defaults to None.
+        global_rank (int): Worker rank, used for partitioning shards. Defaults to 0.
+        world_size (int): Total number of processes, used for partitioning shards. Defaults to 0.
+    """
+
+    def __init__(
+        self,
+        audio_tar_filepaths: Union[str, List[str]],
+        manifest_filepath: str,
+        tokenizer: 'nemo.collections.common.tokenizers.TokenizerSpec',
+        sample_rate: int,
+        int_values: bool = False,
+        augmentor: Optional['nemo.collections.asr.parts.perturb.AudioAugmentor'] = None,
+        shuffle_n: int = 0,
+        min_duration: Optional[float] = None,
+        max_duration: Optional[float] = None,
+        max_utts: int = 0,
+        trim: bool = False,
+        add_misc: bool = False,
+        global_rank: int = 0,
+        world_size: int = 0,
+    ):
+        if hasattr(tokenizer, 'bos_token'):
+            bos_id = tokenizer.bos_id
+        else:
+            bos_id = None
+
+        if hasattr(tokenizer, 'eos_token'):
+            eos_id = tokenizer.eos_id
+        else:
+            eos_id = None
+
+        if hasattr(tokenizer, 'pad_token'):
+            pad_id = tokenizer.pad_id
+        else:
+            pad_id = 0
+
+        class TokenizerWrapper:
+            def __init__(self, tokenizer):
+                self._tokenizer = tokenizer
+
+            def __call__(self, text):
+                t = self._tokenizer.text_to_ids(text)
+                return t
+
+        super().__init__(
+            audio_tar_filepaths=audio_tar_filepaths,
+            manifest_filepath=manifest_filepath,
+            parser=TokenizerWrapper(tokenizer),
+            sample_rate=sample_rate,
+            int_values=int_values,
+            augmentor=augmentor,
+            shuffle_n=shuffle_n,
+            min_duration=min_duration,
+            max_duration=max_duration,
+            max_utts=max_utts,
+            trim=trim,
+            bos_id=bos_id,
+            eos_id=eos_id,
+            add_misc=add_misc,
+            pad_id=pad_id,
+            global_rank=global_rank,
+            world_size=world_size,
+        )

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -125,6 +125,7 @@ class EncDecCTCModelBPE(EncDecCTCModel):
 
         # Instantiate tarred dataset loader or normal dataset loader
         if 'is_tarred' in config and config.get('is_tarred', False):
+            shuffle_n = config.get('shuffle_n', 4 * config['batch_size'])
             dataset = TarredAudioToBPEDataset(
                 audio_tar_filepaths=config['tarred_audio_filepaths'],
                 manifest_filepath=config['manifest_filepath'],
@@ -132,7 +133,7 @@ class EncDecCTCModelBPE(EncDecCTCModel):
                 sample_rate=config['sample_rate'],
                 int_values=config.get('int_values', False),
                 augmentor=augmentor,
-                shuffle_n=config.get('shuffle_n', 50),
+                shuffle_n=shuffle_n,
                 max_duration=config.get('max_duration', None),
                 min_duration=config.get('min_duration', None),
                 max_utts=config.get('max_utts', 0),

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -124,7 +124,7 @@ class EncDecCTCModelBPE(EncDecCTCModel):
         shuffle = config['shuffle']
 
         # Instantiate tarred dataset loader or normal dataset loader
-        if 'is_tarred' in config and config.get('is_tarred', False):
+        if config.get('is_tarred', False):
             shuffle_n = config.get('shuffle_n', 4 * config['batch_size'])
             dataset = TarredAudioToBPEDataset(
                 audio_tar_filepaths=config['tarred_audio_filepaths'],

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -18,7 +18,7 @@ from typing import Dict, Optional
 import torch
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
-from nemo.collections.asr.data.audio_to_text import AudioToBPEDataset
+from nemo.collections.asr.data.audio_to_text import AudioToBPEDataset, TarredAudioToBPEDataset
 from nemo.collections.asr.metrics.wer_bpe import WERBPE
 from nemo.collections.asr.models.ctc_models import EncDecCTCModel
 from nemo.collections.asr.parts.perturb import process_augmentations
@@ -121,26 +121,48 @@ class EncDecCTCModelBPE(EncDecCTCModel):
         else:
             augmentor = None
 
-        dataset = AudioToBPEDataset(
-            manifest_filepath=config['manifest_filepath'],
-            tokenizer=self.tokenizer,
-            sample_rate=config['sample_rate'],
-            int_values=config.get('int_values', False),
-            augmentor=augmentor,
-            max_duration=config.get('max_duration', None),
-            min_duration=config.get('min_duration', None),
-            max_utts=config.get('max_utts', 0),
-            trim=config.get('trim_silence', True),
-            load_audio=config.get('load_audio', True),
-            add_misc=config.get('add_misc', False),
-        )
+        shuffle = config['shuffle']
+
+        # Instantiate tarred dataset loader or normal dataset loader
+        if 'is_tarred' in config and config.get('is_tarred', False):
+            dataset = TarredAudioToBPEDataset(
+                audio_tar_filepaths=config['tarred_audio_filepaths'],
+                manifest_filepath=config['manifest_filepath'],
+                tokenizer=self.tokenizer,
+                sample_rate=config['sample_rate'],
+                int_values=config.get('int_values', False),
+                augmentor=augmentor,
+                shuffle_n=config.get('shuffle_n', 50),
+                max_duration=config.get('max_duration', None),
+                min_duration=config.get('min_duration', None),
+                max_utts=config.get('max_utts', 0),
+                trim=config.get('trim_silence', True),
+                add_misc=config.get('add_misc', False),
+                global_rank=self.global_rank,
+                world_size=self.world_size,
+            )
+            shuffle = False
+        else:
+            dataset = AudioToBPEDataset(
+                manifest_filepath=config['manifest_filepath'],
+                tokenizer=self.tokenizer,
+                sample_rate=config['sample_rate'],
+                int_values=config.get('int_values', False),
+                augmentor=augmentor,
+                max_duration=config.get('max_duration', None),
+                min_duration=config.get('min_duration', None),
+                max_utts=config.get('max_utts', 0),
+                trim=config.get('trim_silence', True),
+                load_audio=config.get('load_audio', True),
+                add_misc=config.get('add_misc', False),
+            )
 
         return torch.utils.data.DataLoader(
             dataset=dataset,
             batch_size=config['batch_size'],
             collate_fn=dataset.collate_fn,
             drop_last=config.get('drop_last', False),
-            shuffle=config['shuffle'],
+            shuffle=shuffle,
             num_workers=config.get('num_workers', 0),
         )
 

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -162,7 +162,8 @@ class EncDecCTCModel(ASRModel):
         shuffle = config['shuffle']
 
         # Instantiate tarred dataset loader or normal dataset loader
-        if 'is_tarred' in config and config.get('is_tarred', False):
+        if config.get('is_tarred', False):
+            shuffle_n = config.get('shuffle_n', 4 * config['batch_size'])
             dataset = TarredAudioToCharDataset(
                 audio_tar_filepaths=config['tarred_audio_filepaths'],
                 manifest_filepath=config['manifest_filepath'],
@@ -170,7 +171,7 @@ class EncDecCTCModel(ASRModel):
                 sample_rate=config['sample_rate'],
                 int_values=config.get('int_values', False),
                 augmentor=augmentor,
-                shuffle_n=config.get('shuffle_n', 50),
+                shuffle_n=shuffle_n,
                 max_duration=config.get('max_duration', None),
                 min_duration=config.get('min_duration', None),
                 max_utts=config.get('max_utts', 0),

--- a/tests/collections/asr/test_asr_datasets.py
+++ b/tests/collections/asr/test_asr_datasets.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+
 import pytest
 import torch
 

--- a/tests/collections/asr/test_asr_datasets.py
+++ b/tests/collections/asr/test_asr_datasets.py
@@ -56,10 +56,7 @@ class TestASRDatasets:
 
     @pytest.mark.unit
     def test_tarred_dataset(self, test_data_dir):
-        batch_size = 4
         manifest_path = os.path.abspath(os.path.join(test_data_dir, 'asr/tarred_an4/tarred_audio_manifest.json'))
-
-        featurizer = WaveformFeaturizer()
 
         # Test braceexpand loading
         tarpath = os.path.abspath(os.path.join(test_data_dir, 'asr/tarred_an4/audio_{0..1}.tar'))
@@ -84,10 +81,7 @@ class TestASRDatasets:
 
     @pytest.mark.unit
     def test_tarred_bpe_dataset(self, test_data_dir):
-        batch_size = 4
         manifest_path = os.path.abspath(os.path.join(test_data_dir, 'asr/tarred_an4/tarred_audio_manifest.json'))
-
-        featurizer = WaveformFeaturizer()
 
         tokenizer_path = os.path.join(test_data_dir, "asr", "tokenizers", "an4_wpe_128", 'vocab.txt')
         tokenizer = tokenizers.NemoBertTokenizer(vocab_file=tokenizer_path)

--- a/tests/collections/asr/test_asr_datasets.py
+++ b/tests/collections/asr/test_asr_datasets.py
@@ -78,7 +78,7 @@ class TestASRDatasets:
             audio_tar_filepaths=tarpath, manifest_filepath=manifest_path, labels=self.labels, sample_rate=16000
         )
         count = 0
-        for _ in ds_braceexpand:
+        for _ in ds_list_load:
             count += 1
         assert count == 32
 
@@ -109,6 +109,6 @@ class TestASRDatasets:
             audio_tar_filepaths=tarpath, manifest_filepath=manifest_path, tokenizer=tokenizer, sample_rate=16000
         )
         count = 0
-        for _ in ds_braceexpand:
+        for _ in ds_list_load:
             count += 1
         assert count == 32

--- a/tests/collections/asr/test_asr_datasets.py
+++ b/tests/collections/asr/test_asr_datasets.py
@@ -17,8 +17,9 @@ import os
 import pytest
 import torch
 
-from nemo.collections.asr.data.audio_to_text import TarredAudioToCharDataset
+from nemo.collections.asr.data.audio_to_text import TarredAudioToBPEDataset, TarredAudioToCharDataset
 from nemo.collections.asr.parts.features import WaveformFeaturizer
+from nemo.collections.common import tokenizers
 
 
 class TestASRDatasets:
@@ -75,6 +76,37 @@ class TestASRDatasets:
         tarpath = [os.path.abspath(os.path.join(test_data_dir, f'asr/tarred_an4/audio_{i}.tar')) for i in range(2)]
         ds_list_load = TarredAudioToCharDataset(
             audio_tar_filepaths=tarpath, manifest_filepath=manifest_path, labels=self.labels, sample_rate=16000
+        )
+        count = 0
+        for _ in ds_braceexpand:
+            count += 1
+        assert count == 32
+
+    @pytest.mark.unit
+    def test_tarred_bpe_dataset(self, test_data_dir):
+        batch_size = 4
+        manifest_path = os.path.abspath(os.path.join(test_data_dir, 'asr/tarred_an4/tarred_audio_manifest.json'))
+
+        featurizer = WaveformFeaturizer()
+
+        tokenizer_path = os.path.join(test_data_dir, "asr", "tokenizers", "an4_wpe_128", 'vocab.txt')
+        tokenizer = tokenizers.NemoBertTokenizer(vocab_file=tokenizer_path)
+
+        # Test braceexpand loading
+        tarpath = os.path.abspath(os.path.join(test_data_dir, 'asr/tarred_an4/audio_{0..1}.tar'))
+        ds_braceexpand = TarredAudioToBPEDataset(
+            audio_tar_filepaths=tarpath, manifest_filepath=manifest_path, tokenizer=tokenizer, sample_rate=16000
+        )
+        assert len(ds_braceexpand) == 32
+        count = 0
+        for _ in ds_braceexpand:
+            count += 1
+        assert count == 32
+
+        # Test loading via list
+        tarpath = [os.path.abspath(os.path.join(test_data_dir, f'asr/tarred_an4/audio_{i}.tar')) for i in range(2)]
+        ds_list_load = TarredAudioToBPEDataset(
+            audio_tar_filepaths=tarpath, manifest_filepath=manifest_path, tokenizer=tokenizer, sample_rate=16000
         )
         count = 0
         for _ in ds_braceexpand:


### PR DESCRIPTION
# Changelog
- Adds BPE support to TarredDataset
- Adds respective tests for tarred bpe support
- Refactor TarredDataset to support both cases equivalently
- Add type annotations to TarredDatasets
- Add Tarred dataset support to SpeechToTextBPE models
