### PR TITLE
Convert ModelPT to optionally load datasets

### DIFF
--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -86,14 +86,14 @@ class ModelPT(LightningModule, Model):
                     self.setup_training_data(self._cfg.train_ds)
 
             except Exception as e:
+                logging.debug("Original exception >>> \n" f"{traceback.format_exception(type(e), e, e.__traceback__)}")
+
                 logging.warning(
                     "Unable to load the train data loader with the provided config \n"
                     f"{self._cfg.train_ds}\n"
                     f"Please call the ModelPT.setup_training_data() method "
                     f"and provide a valid configuration file."
                 )
-
-                logging.debug("Original exception >>> \n" f"{traceback.format_exception(type(e), e, e.__traceback__)}")
 
             if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
                 self.setup_multiple_validation_data(val_data_config=None)
@@ -259,14 +259,14 @@ class ModelPT(LightningModule, Model):
                     self._validation_names = ['val_{}_'.format(idx) for idx in range(len(self._validation_dl))]
 
         except Exception as e:
+            logging.debug("Original exception >>> \n" f"{traceback.format_exception(type(e), e, e.__traceback__)}")
+
             logging.warning(
                 "Unable to load the validation data loader(s) with the provided config \n"
                 f"{self._cfg.validation_ds}\n"
                 f"Please call the ModelPT.setup_validation_data() or ModelPT.setup_multiple_validation_data() method "
                 f"and provide a valid configuration file."
             )
-
-            logging.debug("Original exception >>> \n" f"{traceback.format_exception(type(e), e, e.__traceback__)}")
 
     def setup_multiple_test_data(self, test_data_config: Union[DictConfig, Dict]):
         """
@@ -294,14 +294,14 @@ class ModelPT(LightningModule, Model):
                     self._test_names = ['test_{}_'.format(idx) for idx in range(len(self._test_dl))]
 
         except Exception as e:
+            logging.debug("Original exception >>> \n" f"{traceback.format_exception(type(e), e, e.__traceback__)}")
+
             logging.warning(
                 "Unable to load the test data loader(s) with the provided config \n"
                 f"{self._cfg.test_ds}\n"
                 f"Please call the ModelPT.setup_test_data() or ModelPT.setup_multiple_test_data() method "
                 f"and provide a valid configuration file."
             )
-
-            logging.debug("Original exception >>> \n" f"{traceback.format_exception(type(e), e, e.__traceback__)}")
 
     def setup_optimization(self, optim_config: Optional[Union[DictConfig, Dict]] = None):
         """

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import tarfile
 import tempfile
+import traceback
 from abc import abstractmethod
 from os import path
 from typing import Dict, List, Optional, Union
@@ -84,13 +85,15 @@ class ModelPT(LightningModule, Model):
                 if 'train_ds' in self._cfg and self._cfg.train_ds is not None:
                     self.setup_training_data(self._cfg.train_ds)
 
-            except Exception:
+            except Exception as e:
                 logging.warning(
                     "Unable to load the train data loader with the provided config \n"
                     f"{self._cfg.train_ds}\n"
                     f"Please call the ModelPT.setup_training_data() method "
                     f"and provide a valid configuration file."
                 )
+
+                logging.debug("Original exception >>> \n" f"{traceback.format_exception(type(e), e, e.__traceback__)}")
 
             if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
                 self.setup_multiple_validation_data(val_data_config=None)
@@ -255,13 +258,15 @@ class ModelPT(LightningModule, Model):
                 if self._validation_dl is not None and type(self._validation_dl) in [list, tuple]:
                     self._validation_names = ['val_{}_'.format(idx) for idx in range(len(self._validation_dl))]
 
-        except Exception:
+        except Exception as e:
             logging.warning(
                 "Unable to load the validation data loader(s) with the provided config \n"
                 f"{self._cfg.validation_ds}\n"
-                f"Please call the ModelPT.setup_multiple_validation_data() method "
+                f"Please call the ModelPT.setup_validation_data() or ModelPT.setup_multiple_validation_data() method "
                 f"and provide a valid configuration file."
             )
+
+            logging.debug("Original exception >>> \n" f"{traceback.format_exception(type(e), e, e.__traceback__)}")
 
     def setup_multiple_test_data(self, test_data_config: Union[DictConfig, Dict]):
         """
@@ -288,13 +293,15 @@ class ModelPT(LightningModule, Model):
                 if self._test_dl is not None and type(self._test_dl) in [list, tuple]:
                     self._test_names = ['test_{}_'.format(idx) for idx in range(len(self._test_dl))]
 
-        except Exception:
+        except Exception as e:
             logging.warning(
                 "Unable to load the test data loader(s) with the provided config \n"
                 f"{self._cfg.test_ds}\n"
-                f"Please call the ModelPT.setup_multiple_test_data() method "
+                f"Please call the ModelPT.setup_test_data() or ModelPT.setup_multiple_test_data() method "
                 f"and provide a valid configuration file."
             )
+
+            logging.debug("Original exception >>> \n" f"{traceback.format_exception(type(e), e, e.__traceback__)}")
 
     def setup_optimization(self, optim_config: Optional[Union[DictConfig, Dict]] = None):
         """

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -85,10 +85,12 @@ class ModelPT(LightningModule, Model):
                     self.setup_training_data(self._cfg.train_ds)
 
             except Exception:
-                logging.warning("Unable to load the train data loader with the provided config \n"
-                                f"{self._cfg.train_ds}\n"
-                                f"Please call the ModelPT.setup_training_data() method "
-                                f"and provide a valid configuration file.")
+                logging.warning(
+                    "Unable to load the train data loader with the provided config \n"
+                    f"{self._cfg.train_ds}\n"
+                    f"Please call the ModelPT.setup_training_data() method "
+                    f"and provide a valid configuration file."
+                )
 
             if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
                 self.prepare_validation_data()
@@ -254,10 +256,12 @@ class ModelPT(LightningModule, Model):
                     self._validation_names = ['val_{}_'.format(idx) for idx in range(len(self._validation_dl))]
 
         except Exception:
-            logging.warning("Unable to load the validation data loader(s) with the provided config \n"
-                            f"{self._cfg.validation_ds}\n"
-                            f"Please call the ModelPT.prepare_validation_data() method "
-                            f"and provide a valid configuration file.")
+            logging.warning(
+                "Unable to load the validation data loader(s) with the provided config \n"
+                f"{self._cfg.validation_ds}\n"
+                f"Please call the ModelPT.prepare_validation_data() method "
+                f"and provide a valid configuration file."
+            )
 
     def prepare_test_data(self, test_data_config: Union[DictConfig, Dict]):
         """
@@ -285,10 +289,12 @@ class ModelPT(LightningModule, Model):
                     self._test_names = ['test_{}_'.format(idx) for idx in range(len(self._test_dl))]
 
         except Exception:
-            logging.warning("Unable to load the test data loader(s) with the provided config \n"
-                            f"{self._cfg.test_ds}\n"
-                            f"Please call the ModelPT.prepare_test_data() method "
-                            f"and provide a valid configuration file.")
+            logging.warning(
+                "Unable to load the test data loader(s) with the provided config \n"
+                f"{self._cfg.test_ds}\n"
+                f"Please call the ModelPT.prepare_test_data() method "
+                f"and provide a valid configuration file."
+            )
 
     def setup_optimization(self, optim_config: Optional[Union[DictConfig, Dict]] = None):
         """

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -93,10 +93,10 @@ class ModelPT(LightningModule, Model):
                 )
 
             if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
-                self.prepare_validation_data()
+                self.prepare_validation_data(val_data_config=None)
 
             if 'test_ds' in self._cfg and self._cfg.test_ds is not None:
-                self.prepare_test_data()
+                self.prepare_test_data(test_data_config=None)
 
     def register_artifact(self, config_path: str, src: str):
         """

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -80,32 +80,21 @@ class ModelPT(LightningModule, Model):
         self._trainer = trainer
 
         if self._cfg is not None:  # TODO: This check is redundant since we know cfg is an instance of DictConfig
-            if 'train_ds' in self._cfg and self._cfg.train_ds is not None:
-                self.setup_training_data(self._cfg.train_ds)
+            try:
+                if 'train_ds' in self._cfg and self._cfg.train_ds is not None:
+                    self.setup_training_data(self._cfg.train_ds)
+
+            except Exception:
+                logging.warning("Unable to load the train data loader with the provided config \n"
+                                f"{self._cfg.train_ds}\n"
+                                f"Please call the ModelPT.setup_training_data() method "
+                                f"and provide a valid configuration file.")
 
             if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
-                # Set some placeholder overriden by helper method
-                self._validation_loss_idx = 0
-                self._validation_names = None
-                self._validation_dl = None  # type: torch.utils.data.DataLoader
-
-                model_utils.resolve_validation_dataloaders(model=self)
-
-                if self._validation_names is None:
-                    if self._validation_dl is not None and type(self._validation_dl) in [list, tuple]:
-                        self._validation_names = ['val_{}_'.format(idx) for idx in range(len(self._validation_dl))]
+                self.prepare_validation_data()
 
             if 'test_ds' in self._cfg and self._cfg.test_ds is not None:
-                # Set some placeholder overriden by helper method
-                self._test_loss_idx = 0
-                self._test_names = None
-                self._test_dl = None  # type: torch.utils.data.DataLoader
-
-                model_utils.resolve_test_dataloaders(model=self)
-
-                if self._test_names is None:
-                    if self._test_dl is not None and type(self._test_dl) in [list, tuple]:
-                        self._test_names = ['test_{}_'.format(idx) for idx in range(len(self._test_dl))]
+                self.prepare_test_data()
 
     def register_artifact(self, config_path: str, src: str):
         """
@@ -238,6 +227,68 @@ class ModelPT(LightningModule, Model):
 
         """
         raise NotImplementedError()
+
+    def prepare_validation_data(self, val_data_config: Union[DictConfig, Dict]):
+        """
+        (Optionally) Setups data loader to be used in validation, with support for multiple data loaders.
+
+        Args:
+            val_data_layer_config: validation data layer parameters.
+        """
+        try:
+            # Set some placeholder overriden by helper method
+            self._validation_loss_idx = 0
+            self._validation_names = None
+            self._validation_dl = None  # type: torch.utils.data.DataLoader
+
+            if val_data_config is not None:
+                if isinstance(val_data_config, dict):
+                    val_data_config = DictConfig(val_data_config)
+
+                self._cfg.validation_ds = val_data_config
+
+            model_utils.resolve_validation_dataloaders(model=self)
+
+            if self._validation_names is None:
+                if self._validation_dl is not None and type(self._validation_dl) in [list, tuple]:
+                    self._validation_names = ['val_{}_'.format(idx) for idx in range(len(self._validation_dl))]
+
+        except Exception:
+            logging.warning("Unable to load the validation data loader(s) with the provided config \n"
+                            f"{self._cfg.validation_ds}\n"
+                            f"Please call the ModelPT.prepare_validation_data() method "
+                            f"and provide a valid configuration file.")
+
+    def prepare_test_data(self, test_data_config: Union[DictConfig, Dict]):
+        """
+        (Optionally) Setups data loader to be used in test, with support for multiple data loaders.
+
+        Args:
+            test_data_layer_config: test data layer parameters.
+        """
+        try:
+            # Set some placeholder overriden by helper method
+            self._test_loss_idx = 0
+            self._test_names = None
+            self._test_dl = None  # type: torch.utils.data.DataLoader
+
+            if test_data_config is not None:
+                if isinstance(test_data_config, dict):
+                    test_data_config = DictConfig(test_data_config)
+
+                self._cfg.test_ds = test_data_config
+
+            model_utils.resolve_test_dataloaders(model=self)
+
+            if self._test_names is None:
+                if self._test_dl is not None and type(self._test_dl) in [list, tuple]:
+                    self._test_names = ['test_{}_'.format(idx) for idx in range(len(self._test_dl))]
+
+        except Exception:
+            logging.warning("Unable to load the test data loader(s) with the provided config \n"
+                            f"{self._cfg.test_ds}\n"
+                            f"Please call the ModelPT.prepare_test_data() method "
+                            f"and provide a valid configuration file.")
 
     def setup_optimization(self, optim_config: Optional[Union[DictConfig, Dict]] = None):
         """

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -93,10 +93,10 @@ class ModelPT(LightningModule, Model):
                 )
 
             if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
-                self.prepare_validation_data(val_data_config=None)
+                self.setup_multiple_validation_data(val_data_config=None)
 
             if 'test_ds' in self._cfg and self._cfg.test_ds is not None:
-                self.prepare_test_data(test_data_config=None)
+                self.setup_multiple_test_data(test_data_config=None)
 
     def register_artifact(self, config_path: str, src: str):
         """
@@ -230,7 +230,7 @@ class ModelPT(LightningModule, Model):
         """
         raise NotImplementedError()
 
-    def prepare_validation_data(self, val_data_config: Union[DictConfig, Dict]):
+    def setup_multiple_validation_data(self, val_data_config: Union[DictConfig, Dict]):
         """
         (Optionally) Setups data loader to be used in validation, with support for multiple data loaders.
 
@@ -259,11 +259,11 @@ class ModelPT(LightningModule, Model):
             logging.warning(
                 "Unable to load the validation data loader(s) with the provided config \n"
                 f"{self._cfg.validation_ds}\n"
-                f"Please call the ModelPT.prepare_validation_data() method "
+                f"Please call the ModelPT.setup_multiple_validation_data() method "
                 f"and provide a valid configuration file."
             )
 
-    def prepare_test_data(self, test_data_config: Union[DictConfig, Dict]):
+    def setup_multiple_test_data(self, test_data_config: Union[DictConfig, Dict]):
         """
         (Optionally) Setups data loader to be used in test, with support for multiple data loaders.
 
@@ -292,7 +292,7 @@ class ModelPT(LightningModule, Model):
             logging.warning(
                 "Unable to load the test data loader(s) with the provided config \n"
                 f"{self._cfg.test_ds}\n"
-                f"Please call the ModelPT.prepare_test_data() method "
+                f"Please call the ModelPT.setup_multiple_test_data() method "
                 f"and provide a valid configuration file."
             )
 


### PR DESCRIPTION
# Bugfix
- ModelPT tries to load train, val and test data loaders without safety checks.
- This causes an issue upon deserialization via ModelPT.restore_from(), which holds old paths to manifest/datasets etc which are invalid on a new system.
- This patch optionally attempts to instantiate the data loaders, which failing and logging a warning with guidance to user to prepare data loaders explicitly via some methods.

# Caveats
- Due to the automatic multi data loader support for validation and test ds, and since subclasses override `setup_validation_data` and `setup_test_data`, it is not possibly to re-perform the multi-dataloader logic by using just the setup* calls.
- To get around this, there are 2 ways.
  - Use another method (here called `prepare_*` methods with same signature to perform maintenance work
  - Use a meta class to wrap all subclass overrides of `setup_validation_data` and `setup_test_data` with this maintenance work. In doing so, user can continue calling `setup_*` methods and be unaware that we are doing multi loader maintenance.
- This PR takes approach 1 to avoid over complicated book keeping, but approach 2 is more stream lined and in principle reduces burdon on users. 

Signed-off-by: smajumdar <titu1994@gmail.com>