### PR TITLE
Refactor model restoration to bypass data loaders + minor fixes 

### DIFF
--- a/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_2x_stride.yaml
+++ b/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_2x_stride.yaml
@@ -289,7 +289,7 @@ model:
 
         - filters: 384
           repeat: ${model.model_defaults.repeat}
-          kernel: [51
+          kernel: [51]
           stride: [1]
           dilation: [1]
           dropout: ${model.model_defaults.dropout}

--- a/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_4x_stride.yaml
+++ b/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_4x_stride.yaml
@@ -289,7 +289,7 @@ model:
 
         - filters: 384
           repeat: ${model.model_defaults.repeat}
-          kernel: [51
+          kernel: [51]
           stride: [1]
           dilation: [1]
           dropout: ${model.model_defaults.dropout}

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -167,7 +167,7 @@ class EncDecCTCModel(ASRModel):
             if ('tarred_audio_filepaths' in config and config['tarred_audio_filepaths'] is None) or (
                 'manifest_filepath' in config and config['manifest_filepath'] is None
             ):
-                logging.info(
+                logging.warning(
                     "Could not load dataset as `manifest_filepath` was None or "
                     f"`tarred_audio_filepaths` is None. Provided config : {config}"
                 )

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -197,7 +197,7 @@ class EncDecCTCModel(ASRModel):
             shuffle = False
         else:
             if 'manifest_filepath' in config and config['manifest_filepath'] is None:
-                logging.info(f"Could not load dataset as `manifest_filepath` was None. Provided config : {config}")
+                logging.warning(f"Could not load dataset as `manifest_filepath` was None. Provided config : {config}")
                 return None
 
             dataset = AudioToCharDataset(

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -164,6 +164,15 @@ class EncDecCTCModel(ASRModel):
 
         # Instantiate tarred dataset loader or normal dataset loader
         if config.get('is_tarred', False):
+            if ('tarred_audio_filepaths' in config and config['tarred_audio_filepaths'] is None) or (
+                'manifest_filepath' in config and config['manifest_filepath'] is None
+            ):
+                logging.info(
+                    "Could not load dataset as `manifest_filepath` was None or "
+                    f"`tarred_audio_filepaths` is None. Provided config : {config}"
+                )
+                return None
+
             shuffle_n = config.get('shuffle_n', 4 * config['batch_size'])
             dataset = TarredAudioToCharDataset(
                 audio_tar_filepaths=config['tarred_audio_filepaths'],
@@ -187,6 +196,10 @@ class EncDecCTCModel(ASRModel):
             )
             shuffle = False
         else:
+            if 'manifest_filepath' in config and config['manifest_filepath'] is None:
+                logging.info(f"Could not load dataset as `manifest_filepath` was None. Provided config : {config}")
+                return None
+
             dataset = AudioToCharDataset(
                 manifest_filepath=config['manifest_filepath'],
                 labels=config['labels'],

--- a/nemo/collections/tts/models/glow_tts.py
+++ b/nemo/collections/tts/models/glow_tts.py
@@ -207,7 +207,7 @@ class GlowTTSModel(ModelPT):
     def _setup_dataloader_from_config(self, cfg: DictConfig):
 
         if 'manifest_filepath' in cfg and cfg['manifest_filepath'] is None:
-            logging.info(f"Could not load dataset as `manifest_filepath` was None. Provided config : {cfg}")
+            logging.warning(f"Could not load dataset as `manifest_filepath` was None. Provided config : {cfg}")
             return None
 
         if 'augmentor' in cfg:

--- a/nemo/collections/tts/models/glow_tts.py
+++ b/nemo/collections/tts/models/glow_tts.py
@@ -27,6 +27,7 @@ from nemo.collections.tts.helpers.helpers import log_audio_to_tb, plot_alignment
 from nemo.collections.tts.losses.glow_tts_loss import GlowTTSLoss
 from nemo.collections.tts.modules.glow_tts import GlowTTSModule
 from nemo.core.classes import ModelPT
+from nemo.utils import logging
 from nemo.utils.decorators import experimental
 
 
@@ -204,6 +205,10 @@ class GlowTTSModel(ModelPT):
         return {'val_loss': avg_loss, 'log': tensorboard_logs}
 
     def _setup_dataloader_from_config(self, cfg: DictConfig):
+
+        if 'manifest_filepath' in cfg and cfg['manifest_filepath'] is None:
+            logging.info(f"Could not load dataset as `manifest_filepath` was None. Provided config : {cfg}")
+            return None
 
         if 'augmentor' in cfg:
             augmentor = process_augmentations(cfg['augmentor'])

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -18,7 +18,6 @@ import os
 import shutil
 import tarfile
 import tempfile
-import traceback
 from abc import abstractmethod
 from os import path
 from typing import Dict, List, Optional, Union

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -687,7 +687,7 @@ class ModelPT(LightningModule, Model):
             "`test_epoch_end(outputs)."
         )
 
-    def get_validation_dataloader_prefix(self, dataloader_idx=0) -> str:
+    def get_validation_dataloader_prefix(self, dataloader_idx: int = 0) -> str:
         """
         Get the name of one or more data loaders, which will be prepended to all logs.
 
@@ -699,7 +699,7 @@ class ModelPT(LightningModule, Model):
         """
         return self._validation_names[dataloader_idx]
 
-    def get_test_dataloader_prefix(self, dataloader_idx=0):
+    def get_test_dataloader_prefix(self, dataloader_idx: int = 0) -> str:
         """
         Get the name of one or more data loaders, which will be prepended to all logs.
 

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -98,21 +98,21 @@ class ModelPT(LightningModule, Model):
 
         else:
             if 'train_ds' in self._cfg and self._cfg.train_ds is not None:
-                logging.info(
+                logging.warning(
                     f"Please call the ModelPT.setup_training_data() method "
                     f"and provide a valid configuration file to setup the train data loader.\n"
                     f"Train config : \n{self._cfg.train_ds}"
                 )
 
             if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
-                logging.info(
+                logging.warning(
                     f"Please call the ModelPT.setup_validation_data() or ModelPT.setup_multiple_validation_data() method "
                     f"and provide a valid configuration file to setup the validation data loader(s). \n"
                     f"Validation config : \n{self._cfg.validation_ds}"
                 )
 
             if 'test_ds' in self._cfg and self._cfg.test_ds is not None:
-                logging.info(
+                logging.warning(
                     f"Please call the ModelPT.setup_test_data() or ModelPT.setup_multiple_test_data() method "
                     f"and provide a valid configuration file to setup the test data loader(s).\n"
                     f"Test config : \n{self._cfg.test_ds}"

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -37,6 +37,7 @@ __all__ = ['ModelPT']
 
 _MODEL_CONFIG_YAML = "model_config.yaml"
 _MODEL_WEIGHTS = "model_weights.ckpt"
+_MODEL_IS_RESTORED = False
 
 
 class ModelPT(LightningModule, Model):
@@ -80,27 +81,37 @@ class ModelPT(LightningModule, Model):
         self._scheduler = None
         self._trainer = trainer
 
-        if self._cfg is not None:  # TODO: This check is redundant since we know cfg is an instance of DictConfig
-            try:
-                if 'train_ds' in self._cfg and self._cfg.train_ds is not None:
-                    self.setup_training_data(self._cfg.train_ds)
-
-            except Exception as e:
-                debug_error = "".join(traceback.format_exception(type(e), e, e.__traceback__))
-                logging.debug("Original exception >>> \n" f"{debug_error}")
-
-                logging.warning(
-                    "Unable to load the train data loader with the provided config \n"
-                    f"{self._cfg.train_ds}\n"
-                    f"Please call the ModelPT.setup_training_data() method "
-                    f"and provide a valid configuration file."
-                )
+        if self._cfg is not None and not self.__is_model_being_restored():
+            if 'train_ds' in self._cfg and self._cfg.train_ds is not None:
+                self.setup_training_data(self._cfg.train_ds)
 
             if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
                 self.setup_multiple_validation_data(val_data_config=None)
 
             if 'test_ds' in self._cfg and self._cfg.test_ds is not None:
                 self.setup_multiple_test_data(test_data_config=None)
+
+        else:
+            if 'train_ds' in self._cfg and self._cfg.train_ds is not None:
+                logging.info(
+                    f"Please call the ModelPT.setup_training_data() method "
+                    f"and provide a valid configuration file to setup the train data loader.\n"
+                    f"Train config : \n{self._cfg.train_ds}"
+                )
+
+            if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
+                logging.info(
+                    f"Please call the ModelPT.setup_validation_data() or ModelPT.setup_multiple_validation_data() method "
+                    f"and provide a valid configuration file to setup the validation data loader(s). \n"
+                    f"Validation config : \n{self._cfg.validation_ds}"
+                )
+
+            if 'test_ds' in self._cfg and self._cfg.test_ds is not None:
+                logging.info(
+                    f"Please call the ModelPT.setup_test_data() or ModelPT.setup_multiple_test_data() method "
+                    f"and provide a valid configuration file to setup the test data loader(s).\n"
+                    f"Test config : \n{self._cfg.test_ds}"
+                )
 
     def register_artifact(self, config_path: str, src: str):
         """
@@ -185,6 +196,7 @@ class ModelPT(LightningModule, Model):
 
         with tempfile.TemporaryDirectory() as tmpdir:
             try:
+                cls.__set_model_restore_state(is_being_restored=True)
                 cls.__unpack_nemo_file(path2file=restore_path, out_folder=tmpdir)
                 os.chdir(tmpdir)
                 config_yaml = path.join(tmpdir, _MODEL_CONFIG_YAML)
@@ -197,6 +209,7 @@ class ModelPT(LightningModule, Model):
 
                 logging.info(f'Model {cls.__name__} was successfully restored from {restore_path}.')
             finally:
+                cls.__set_model_restore_state(is_being_restored=False)
                 os.chdir(cwd)
 
         return instance
@@ -256,34 +269,22 @@ class ModelPT(LightningModule, Model):
         Args:
             val_data_layer_config: validation data layer parameters.
         """
-        try:
-            # Set some placeholder overriden by helper method
-            self._validation_loss_idx = 0
-            self._validation_names = None
-            self._validation_dl = None  # type: torch.utils.data.DataLoader
+        # Set some placeholder overriden by helper method
+        self._validation_loss_idx = 0
+        self._validation_names = None
+        self._validation_dl = None  # type: torch.utils.data.DataLoader
 
-            if val_data_config is not None:
-                if isinstance(val_data_config, dict):
-                    val_data_config = DictConfig(val_data_config)
+        if val_data_config is not None:
+            if isinstance(val_data_config, dict):
+                val_data_config = DictConfig(val_data_config)
 
-                self._cfg.validation_ds = val_data_config
+            self._cfg.validation_ds = val_data_config
 
-            model_utils.resolve_validation_dataloaders(model=self)
+        model_utils.resolve_validation_dataloaders(model=self)
 
-            if self._validation_names is None:
-                if self._validation_dl is not None and type(self._validation_dl) in [list, tuple]:
-                    self._validation_names = ['val_{}_'.format(idx) for idx in range(len(self._validation_dl))]
-
-        except Exception as e:
-            debug_error = "".join(traceback.format_exception(type(e), e, e.__traceback__))
-            logging.debug("Original exception >>> \n" f"{debug_error}")
-
-            logging.warning(
-                "Unable to load the validation data loader(s) with the provided config \n"
-                f"{self._cfg.validation_ds}\n"
-                f"Please call the ModelPT.setup_validation_data() or ModelPT.setup_multiple_validation_data() method "
-                f"and provide a valid configuration file."
-            )
+        if self._validation_names is None:
+            if self._validation_dl is not None and type(self._validation_dl) in [list, tuple]:
+                self._validation_names = ['val_{}_'.format(idx) for idx in range(len(self._validation_dl))]
 
     def setup_multiple_test_data(self, test_data_config: Union[DictConfig, Dict]):
         """
@@ -292,34 +293,22 @@ class ModelPT(LightningModule, Model):
         Args:
             test_data_layer_config: test data layer parameters.
         """
-        try:
-            # Set some placeholder overriden by helper method
-            self._test_loss_idx = 0
-            self._test_names = None
-            self._test_dl = None  # type: torch.utils.data.DataLoader
+        # Set some placeholder overriden by helper method
+        self._test_loss_idx = 0
+        self._test_names = None
+        self._test_dl = None  # type: torch.utils.data.DataLoader
 
-            if test_data_config is not None:
-                if isinstance(test_data_config, dict):
-                    test_data_config = DictConfig(test_data_config)
+        if test_data_config is not None:
+            if isinstance(test_data_config, dict):
+                test_data_config = DictConfig(test_data_config)
 
-                self._cfg.test_ds = test_data_config
+            self._cfg.test_ds = test_data_config
 
-            model_utils.resolve_test_dataloaders(model=self)
+        model_utils.resolve_test_dataloaders(model=self)
 
-            if self._test_names is None:
-                if self._test_dl is not None and type(self._test_dl) in [list, tuple]:
-                    self._test_names = ['test_{}_'.format(idx) for idx in range(len(self._test_dl))]
-
-        except Exception as e:
-            debug_error = "".join(traceback.format_exception(type(e), e, e.__traceback__))
-            logging.debug("Original exception >>> \n" f"{debug_error}")
-
-            logging.warning(
-                "Unable to load the test data loader(s) with the provided config \n"
-                f"{self._cfg.test_ds}\n"
-                f"Please call the ModelPT.setup_test_data() or ModelPT.setup_multiple_test_data() method "
-                f"and provide a valid configuration file."
-            )
+        if self._test_names is None:
+            if self._test_dl is not None and type(self._test_dl) in [list, tuple]:
+                self._test_names = ['test_{}_'.format(idx) for idx in range(len(self._test_dl))]
 
     def setup_optimization(self, optim_config: Optional[Union[DictConfig, Dict]] = None):
         """
@@ -698,10 +687,28 @@ class ModelPT(LightningModule, Model):
             "`test_epoch_end(outputs)."
         )
 
-    def get_validation_dataloader_prefix(self, dataloader_idx=0):
+    def get_validation_dataloader_prefix(self, dataloader_idx=0) -> str:
+        """
+        Get the name of one or more data loaders, which will be prepended to all logs.
+
+        Args:
+            dataloader_idx: Index of the data loader.
+
+        Returns:
+            str name of the data loader at index provided.
+        """
         return self._validation_names[dataloader_idx]
 
     def get_test_dataloader_prefix(self, dataloader_idx=0):
+        """
+        Get the name of one or more data loaders, which will be prepended to all logs.
+
+        Args:
+            dataloader_idx: Index of the data loader.
+
+        Returns:
+            str name of the data loader at index provided.
+        """
         return self._test_names[dataloader_idx]
 
     def prepare_test(self, trainer: 'Trainer') -> bool:
@@ -737,6 +744,15 @@ class ModelPT(LightningModule, Model):
 
         return True
 
+    def set_trainer(self, trainer: 'Trainer'):
+        """
+        Set an instance of Trainer object.
+
+        Args:
+            trainer: PyTorch Lightning Trainer object.
+        """
+        self._trainer = trainer
+
     @property
     def num_weights(self):
         return sum(p.numel() for p in self.parameters() if p.requires_grad)
@@ -755,3 +771,13 @@ class ModelPT(LightningModule, Model):
         tar.extractall(path=out_folder)
         tar.close()
         return out_folder
+
+    @staticmethod
+    def __is_model_being_restored() -> bool:
+        global _MODEL_IS_RESTORED
+        return _MODEL_IS_RESTORED
+
+    @staticmethod
+    def __set_model_restore_state(is_being_restored: bool):
+        global _MODEL_IS_RESTORED
+        _MODEL_IS_RESTORED = is_being_restored

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -71,7 +71,13 @@ class ModelPT(LightningModule, Model):
             OmegaConf.set_struct(cfg, False)
             cfg.target = "{0}.{1}".format(self.__class__.__module__, self.__class__.__name__)
             OmegaConf.set_struct(cfg, True)
-        self._cfg = cfg
+
+        config = OmegaConf.to_container(cfg, resolve=True)
+        config = OmegaConf.create(config)
+        OmegaConf.set_struct(config, True)
+
+        self._cfg = config
+
         self.save_hyperparameters(self._cfg)
         self._train_dl = None
         self._validation_dl = None

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -158,7 +158,7 @@ def unique_names_check(name_list: Optional[List[str]]):
         return
 
     # Name uniqueness checks
-    names = {}
+    names = set()
     for name in name_list:
         if name in names:
             logging.warning(
@@ -168,7 +168,7 @@ def unique_names_check(name_list: Optional[List[str]]):
                 f"Resolved name : {name}"
             )
         else:
-            names[name] = True  # we need just hash key check, value is just a placeholder
+            names.add(name)  # we need just hash key check, value is just a placeholder
 
 
 def resolve_validation_dataloaders(model: 'ModelPT'):

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -15,6 +15,7 @@
 import copy
 import os
 from pathlib import Path
+from typing import List, Optional
 
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
@@ -145,6 +146,31 @@ def parse_dataset_as_name(name: str) -> str:
     return name
 
 
+def unique_names_check(name_list: Optional[List[str]]):
+    """
+    Performs a uniqueness check on the name list resolved, so that it can warn users
+    about non-unique keys.
+
+    Args:
+        name_list: List of strings resolved for data loaders.
+    """
+    if name_list is None:
+        return
+
+    # Name uniqueness checks
+    names = {}
+    for name in name_list:
+        if name in names:
+            logging.warning(
+                "Name resolution has found more than one data loader having the same name !\n"
+                "In such cases, logs will nor be properly generated. "
+                "Please rename the item to have unique names.\n"
+                f"Resolved name : {name}"
+            )
+        else:
+            names[name] = True  # we need just hash key check, value is just a placeholder
+
+
 def resolve_validation_dataloaders(model: 'ModelPT'):
     """
     Helper method that operates on the ModelPT class to automatically support
@@ -204,6 +230,8 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
         model._validation_dl = dataloaders
         model._validation_names = [parse_dataset_as_name(ds) for ds in ds_values]
 
+        unique_names_check(name_list=model._validation_names)
+
         # In fast-dev-run, only one data loader is used
         if hasattr(model, '_trainer') and model._trainer.fast_dev_run:
             model._validation_dl = model._validation_dl[:1]
@@ -214,6 +242,8 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
     else:
         model.setup_validation_data(cfg.validation_ds)
         model._validation_names = [parse_dataset_as_name(ds_values)]
+
+        unique_names_check(name_list=model._validation_names)
 
 
 def resolve_test_dataloaders(model: 'ModelPT'):
@@ -275,6 +305,8 @@ def resolve_test_dataloaders(model: 'ModelPT'):
         model._test_dl = dataloaders
         model._test_names = [parse_dataset_as_name(ds) for ds in ds_values]
 
+        unique_names_check(name_list=model._test_names)
+
         # In fast-dev-run, only one data loader is used
         if hasattr(model, '_trainer') and model._trainer.fast_dev_run:
             model._test_dl = model._test_dl[:1]
@@ -283,3 +315,5 @@ def resolve_test_dataloaders(model: 'ModelPT'):
     else:
         model.setup_test_data(cfg.test_ds)
         model._test_names = [parse_dataset_as_name(ds_values)]
+
+        unique_names_check(name_list=model._test_names)

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -205,7 +205,7 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
         model._validation_names = [parse_dataset_as_name(ds) for ds in ds_values]
 
         # In fast-dev-run, only one data loader is used
-        if model._trainer.fast_dev_run:
+        if hasattr(model, '_trainer') and model._trainer.fast_dev_run:
             model._validation_dl = model._validation_dl[:1]
             model._validation_names = model._validation_names[:1]
 
@@ -276,7 +276,7 @@ def resolve_test_dataloaders(model: 'ModelPT'):
         model._test_names = [parse_dataset_as_name(ds) for ds in ds_values]
 
         # In fast-dev-run, only one data loader is used
-        if model._trainer.fast_dev_run:
+        if hasattr(model, '_trainer') and model._trainer.fast_dev_run:
             model._test_dl = model._test_dl[:1]
             model._test_names = model._test_names[:1]
 

--- a/scripts/process_asr_text_tokenizer.py
+++ b/scripts/process_asr_text_tokenizer.py
@@ -110,7 +110,7 @@ def __process_data(text_path: str, dst_folder: str, vocab_size: int, tokenizer_t
         tokenizer = tokenizers.BertWordPieceTokenizer(lowercase=True)
 
         tokenizer.train(text_path, vocab_size=vocab_size)
-        tokenizer.save(tokenizer_dir)
+        tokenizer.save(os.path.join(tokenizer_dir, 'vocab.txt'))
 
     return tokenizer_dir
 

--- a/scripts/process_asr_text_tokenizer.py
+++ b/scripts/process_asr_text_tokenizer.py
@@ -25,7 +25,6 @@ import json
 import logging
 import os
 
-import sentencepiece
 import tokenizers
 
 from nemo.collections.common.tokenizers.sentencepiece_tokenizer import create_spt_model
@@ -87,7 +86,7 @@ def __process_data(text_path: str, dst_folder: str, vocab_size: int, tokenizer_t
         tokenizer_type: type of tokenization to perform - bpe or wpe
     Returns:
     """
-    tokenizer_dir = os.path.join(dst_folder, 'librispeech_tokenizer_{}_v{}').format(tokenizer_type, vocab_size)
+    tokenizer_dir = os.path.join(dst_folder, 'tokenizer_{}_v{}').format(tokenizer_type, vocab_size)
 
     if not os.path.exists(tokenizer_dir):
         os.makedirs(tokenizer_dir)
@@ -110,7 +109,7 @@ def __process_data(text_path: str, dst_folder: str, vocab_size: int, tokenizer_t
         tokenizer = tokenizers.BertWordPieceTokenizer(lowercase=True)
 
         tokenizer.train(text_path, vocab_size=vocab_size)
-        tokenizer.save(os.path.join(tokenizer_dir, 'vocab.txt'))
+        tokenizer.save_model(tokenizer_dir)
 
     return tokenizer_dir
 
@@ -120,8 +119,6 @@ def main():
     manifests = args.manifest
     vocab_size = args.vocab_size
     tokenizer = args.tokenizer
-
-    data_root = os.path.join(data_root, 'LibriSpeechTokenizer')
 
     if not os.path.exists(data_root):
         os.makedirs(data_root)


### PR DESCRIPTION
## Core changes
- Defers and logs data loaders when model is being restored. 
- Adds a patch for checks for availability of `_trainer` inside model_utils.
- Adds a utility warning if unique names are not found in resolved names for multi data loader.

## Support changes
- asr and tts models must check for valid existence of manifest path prior to initializing dataset. 
- correct tokenization preprocessing for wpe on latest version of tokenizers library
- add missing brackets from config file
- correct tokenizer generation with WPE for 3.0+

Signed-off-by: smajumdar <titu1994@gmail.com>