### PR TITLE
Improves test support of ASR domain, updation of vocabulary and various fixes

### DIFF
--- a/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_2x_stride.yaml
+++ b/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_2x_stride.yaml
@@ -19,6 +19,12 @@ model:
     batch_size: 32
     shuffle: false
 
+  test_ds:
+    manifest_filepath: null
+    sample_rate: 16000
+    batch_size: 32
+    shuffle: false
+
   model_defaults:
     repeat: 5
     dropout: 0.0

--- a/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_4x_stride.yaml
+++ b/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_4x_stride.yaml
@@ -19,6 +19,12 @@ model:
     batch_size: 32
     shuffle: false
 
+  test_ds:
+    manifest_filepath: null
+    sample_rate: 16000
+    batch_size: 32
+    shuffle: false
+
   model_defaults:
     repeat: 5
     dropout: 0.0

--- a/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_8x_stride.yaml
+++ b/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_8x_stride.yaml
@@ -19,6 +19,12 @@ model:
     batch_size: 32
     shuffle: false
 
+  test_ds:
+    manifest_filepath: null
+    sample_rate: 16000
+    batch_size: 32
+    shuffle: false
+
   model_defaults:
     repeat: 5
     dropout: 0.0

--- a/examples/asr/speech_to_text_bpe.py
+++ b/examples/asr/speech_to_text_bpe.py
@@ -63,6 +63,12 @@ def main(cfg):
 
     trainer.fit(asr_model)
 
+    if hasattr(cfg.model, 'test_ds') and cfg.model.test_ds.manifest_filepath is not None:
+        gpu = 1 if cfg.trainer.gpus != 0 else 0
+        trainer = pl.Trainer(gpus=gpu)
+        if asr_model.prepare_test(trainer):
+            trainer.test(asr_model)
+
 
 if __name__ == '__main__':
     main()

--- a/nemo/collections/asr/models/asr_model.py
+++ b/nemo/collections/asr/models/asr_model.py
@@ -40,3 +40,10 @@ class ASRModel(ModelPT, ABC):
         wer_denom = torch.stack([x['val_wer_denom'] for x in outputs]).sum()
         tensorboard_logs = {'validation_loss': val_loss_mean, 'validation_wer': wer_num / wer_denom}
         return {'val_loss': val_loss_mean, 'log': tensorboard_logs}
+
+    def multi_test_epoch_end(self, outputs, dataloader_idx: int = 0):
+        val_loss_mean = torch.stack([x['test_loss'] for x in outputs]).mean()
+        wer_num = torch.stack([x['test_wer_num'] for x in outputs]).sum()
+        wer_denom = torch.stack([x['test_wer_denom'] for x in outputs]).sum()
+        tensorboard_logs = {'test_loss': val_loss_mean, 'test_wer': wer_num / wer_denom}
+        return {'test_loss': val_loss_mean, 'log': tensorboard_logs}

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -315,6 +315,15 @@ class EncDecCTCModel(ASRModel):
         wer_num, wer_denom = self._wer(predictions, transcript, transcript_len)
         return {'val_loss': loss_value, 'val_wer_num': wer_num, 'val_wer_denom': wer_denom}
 
+    def test_step(self, batch, batch_idx, dataloader_idx=0):
+        logs = self.validation_step(batch, batch_idx, dataloader_idx=dataloader_idx)
+        test_logs = {
+            'test_loss': logs['val_loss'],
+            'test_wer_num': logs['val_wer_num'],
+            'test_wer_denom': logs['val_wer_denom'],
+        }
+        return test_logs
+
     def test_dataloader(self):
         if self._test_dl is not None:
             return self._test_dl

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -622,7 +622,7 @@ class ModelPT(LightningModule, Model):
 
                 # Perform `test_loss` resolution first (if provided outside logs)
                 if 'test_loss' in dataloader_logs:
-                    if 'test_loss' not in output_dict and dataloader_idx == self._validation_loss_idx:
+                    if 'test_loss' not in output_dict and dataloader_idx == self._test_loss_idx:
                         output_dict['test_loss'] = dataloader_logs['test_loss']
 
                 # For every item in the result dictionary
@@ -748,6 +748,8 @@ class ModelPT(LightningModule, Model):
                 logging.warning(DDP_WARN)
                 return False
 
+        # Assign trainer to the model
+        self.set_trainer(trainer)
         return True
 
     def set_trainer(self, trainer: 'Trainer'):

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -496,14 +496,22 @@ def prepare_lr_scheduler(
     elif 'iters_per_batch' in scheduler_config:
         # Compute effective max_steps if iters_per_batch is provided
         if train_dataloader is None:
-            raise ValueError(
-                'As `iters_per_batch` is provided, it is required to pass the train dataloader in order '
-                'to compute effective maximum number of steps'
+            logging.warning(
+                'As `iters_per_batch` is provided/computed, it is required to pass the train dataloader in order\n'
+                'to compute effective maximum number of steps.\n'
+                'Scheduler will not be instantiated !'
             )
+            return None
 
         # Raise exception if neither `max_steps` nor `iters_per_batch` is provided
         if scheduler_config.get('iters_per_batch', None) is None:
-            raise ValueError("`iters_per_batch` cannot be None when `max_steps` is not not provided.")
+            logging.warning(
+                "`iters_per_batch` cannot be None when `max_steps` is not not provided.\n"
+                "This can occur when `train dataloader` is not available to correctly "
+                "prepare the scheduler.\n"
+                "Scheduler will not be instantiated !"
+            )
+            return None
 
         # Get iters_per_batch
         iters_per_batch = scheduler_config.get('iters_per_batch')

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -233,9 +233,10 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
         unique_names_check(name_list=model._validation_names)
 
         # In fast-dev-run, only one data loader is used
-        if hasattr(model, '_trainer') and model._trainer.fast_dev_run:
-            model._validation_dl = model._validation_dl[:1]
-            model._validation_names = model._validation_names[:1]
+        if hasattr(model, '_trainer') and model._trainer is not None:
+            if hasattr(model._trainer, 'fast_dev_run') and model._trainer.fast_dev_run:
+                model._validation_dl = model._validation_dl[:1]
+                model._validation_names = model._validation_names[:1]
 
         return
 
@@ -308,9 +309,10 @@ def resolve_test_dataloaders(model: 'ModelPT'):
         unique_names_check(name_list=model._test_names)
 
         # In fast-dev-run, only one data loader is used
-        if hasattr(model, '_trainer') and model._trainer.fast_dev_run:
-            model._test_dl = model._test_dl[:1]
-            model._test_names = model._test_names[:1]
+        if hasattr(model, '_trainer') and model._trainer is not None:
+            if hasattr(model._trainer, 'fast_dev_run') and model._trainer.fast_dev_run:
+                model._test_dl = model._test_dl[:1]
+                model._test_names = model._test_names[:1]
 
     else:
         model.setup_test_data(cfg.test_ds)

--- a/tests/collections/asr/test_asr_classification_model.py
+++ b/tests/collections/asr/test_asr_classification_model.py
@@ -12,49 +12,57 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
+
 import pytest
-from omegaconf import DictConfig
+from omegaconf import DictConfig, ListConfig
 
 from nemo.collections.asr.models import EncDecClassificationModel
 
 
+@pytest.fixture()
+def speech_classification_model():
+    preprocessor = {'cls': 'nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor', 'params': dict({})}
+    encoder = {
+        'cls': 'nemo.collections.asr.modules.ConvASREncoder',
+        'params': {
+            'feat_in': 64,
+            'activation': 'relu',
+            'conv_mask': True,
+            'jasper': [
+                {
+                    'filters': 32,
+                    'repeat': 1,
+                    'kernel': [1],
+                    'stride': [1],
+                    'dilation': [1],
+                    'dropout': 0.0,
+                    'residual': False,
+                    'separable': True,
+                    'se': True,
+                    'se_context_size': -1,
+                }
+            ],
+        },
+    }
+
+    decoder = {
+        'cls': 'nemo.collections.asr.modules.ConvASRDecoderClassification',
+        'params': {'feat_in': 32, 'num_classes': 30, },
+    }
+
+    modelConfig = DictConfig(
+        {'preprocessor': DictConfig(preprocessor), 'encoder': DictConfig(encoder), 'decoder': DictConfig(decoder),
+         'labels': ListConfig(["dummy_cls_{}".format(i + 1) for i in range(30)])}
+    )
+    model = EncDecClassificationModel(cfg=modelConfig)
+    return model
+
+
 class TestEncDecClassificationModel:
     @pytest.mark.unit
-    def test_constructor(self):
-        preprocessor = {'cls': 'nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor', 'params': dict({})}
-        encoder = {
-            'cls': 'nemo.collections.asr.modules.ConvASREncoder',
-            'params': {
-                'feat_in': 64,
-                'activation': 'relu',
-                'conv_mask': True,
-                'jasper': [
-                    {
-                        'filters': 32,
-                        'repeat': 1,
-                        'kernel': [1],
-                        'stride': [1],
-                        'dilation': [1],
-                        'dropout': 0.0,
-                        'residual': False,
-                        'separable': True,
-                        'se': True,
-                        'se_context_size': -1,
-                    }
-                ],
-            },
-        }
-
-        decoder = {
-            'cls': 'nemo.collections.asr.modules.ConvASRDecoderClassification',
-            'params': {'feat_in': 32, 'num_classes': 30,},
-        }
-
-        modelConfig = DictConfig(
-            {'preprocessor': DictConfig(preprocessor), 'encoder': DictConfig(encoder), 'decoder': DictConfig(decoder)}
-        )
-        asr_model = EncDecClassificationModel(cfg=modelConfig)
-        asr_model.train()
+    def test_constructor(self, speech_classification_model):
+        asr_model = speech_classification_model.train()
 
         conv_cnt = (64 * 32 * 1 + 32) + (64 * 1 * 1 + 32)  # separable kernel + bias + pointwise kernel + bias
         bn_cnt = (4 * 32) * 2  # 2 * moving averages
@@ -68,3 +76,20 @@ class TestEncDecClassificationModel:
         instance2 = EncDecClassificationModel.from_config_dict(confdict)
 
         assert isinstance(instance2, EncDecClassificationModel)
+
+    @pytest.mark.unit
+    def test_vocab_change(self, speech_classification_model):
+        asr_model = speech_classification_model.train()
+
+        old_labels = copy.deepcopy(asr_model._cfg.labels)
+        nw1 = asr_model.num_weights
+        asr_model.change_labels(new_labels=old_labels)
+        # No change
+        assert nw1 == asr_model.num_weights
+        new_labels = copy.deepcopy(old_labels)
+        new_labels.append('dummy_cls_31')
+        new_labels.append('dummy_cls_32')
+        new_labels.append('dummy_cls_33')
+        asr_model.change_labels(new_labels=new_labels)
+        # fully connected + bias
+        assert asr_model.num_weights == nw1 + 3 * (asr_model.decoder._feat_in + 1)

--- a/tests/collections/asr/test_asr_classification_model.py
+++ b/tests/collections/asr/test_asr_classification_model.py
@@ -48,12 +48,16 @@ def speech_classification_model():
 
     decoder = {
         'cls': 'nemo.collections.asr.modules.ConvASRDecoderClassification',
-        'params': {'feat_in': 32, 'num_classes': 30, },
+        'params': {'feat_in': 32, 'num_classes': 30,},
     }
 
     modelConfig = DictConfig(
-        {'preprocessor': DictConfig(preprocessor), 'encoder': DictConfig(encoder), 'decoder': DictConfig(decoder),
-         'labels': ListConfig(["dummy_cls_{}".format(i + 1) for i in range(30)])}
+        {
+            'preprocessor': DictConfig(preprocessor),
+            'encoder': DictConfig(encoder),
+            'decoder': DictConfig(decoder),
+            'labels': ListConfig(["dummy_cls_{}".format(i + 1) for i in range(30)]),
+        }
     )
     model = EncDecClassificationModel(cfg=modelConfig)
     return model


### PR DESCRIPTION
# Changelog
- Adds `test_ds` support for all experimental model configs
- Adds `trainer.test` support for CTC and CTC BPE models.
  - Attaches trainer to "ready" model that has been validated for `trainer.test()`
- Adds ASRModel level support for multi dataset test set evaluation
- Adds support for changing label set for ASR Classification models vis `change_labels(new_labels)`
- Refactor Tokenizer setup for BPE models
- Adds support for changing tokenizer for ASR BPE models via `change_vocabulary(new_tokenizer_dir, new_tokenizer_type)`
  - Signature mismatch with base class. Options are to 
  - 1) override base class method, raise not implemented and direct to use another method
  - 2) continue with the signature mismatch in place (not a pythonic solution).
- Adds tests for new functions

# Bugfixes
- Corrects an issue in ModelPT.py where self._validation_loss_idx is used for multi test set evaluation
- Replaces Value Error for scheduler setup - required during test step (without attaching any train dataset).
  - Schedulers will now log a warning instead
- `model_utils` will now do a two step check - once to check if _trainer is available, and if _trainer.fast_dev_run is set.
  - Avoids a crash where any one of the 4 cases is None or false or does not exist in the dictionary at all.

## Reason for warning instead of raising error in scheduler setup
Trainer.test() calls optimizer + scheduler setup (it calls the internal fit call with different parameters). Since the fit call has the configure_optimizers() call, the scheduler is attempted to be built.

If the model is tested right after training, then there's no issues as the train ds is in place and can be used to recreate the scheduler even if it's not used.

But if you restore and immediately use trainer.test(), then the train ds does not exist (even though the user has already setup test_ds). This will then raise the above error. In order to avoid raising an error in a valid use case - testing without setting up a training dataset from restoration, this needs to be a warning instead of an error.