### PR TITLE
Add check for manifest filepath prior to load dataset for BPE

### DIFF
--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -129,6 +129,15 @@ class EncDecCTCModelBPE(EncDecCTCModel):
 
         # Instantiate tarred dataset loader or normal dataset loader
         if config.get('is_tarred', False):
+            if ('tarred_audio_filepaths' in config and config['tarred_audio_filepaths'] is None) or (
+                'manifest_filepath' in config and config['manifest_filepath'] is None
+            ):
+                logging.warning(
+                    "Could not load dataset as `manifest_filepath` was None or "
+                    f"`tarred_audio_filepaths` is None. Provided config : {config}"
+                )
+                return None
+
             shuffle_n = config.get('shuffle_n', 4 * config['batch_size'])
             dataset = TarredAudioToBPEDataset(
                 audio_tar_filepaths=config['tarred_audio_filepaths'],
@@ -148,6 +157,10 @@ class EncDecCTCModelBPE(EncDecCTCModel):
             )
             shuffle = False
         else:
+            if 'manifest_filepath' in config and config['manifest_filepath'] is None:
+                logging.warning(f"Could not load dataset as `manifest_filepath` was None. Provided config : {config}")
+                return None
+
             dataset = AudioToBPEDataset(
                 manifest_filepath=config['manifest_filepath'],
                 tokenizer=self.tokenizer,


### PR DESCRIPTION
# Changelog
- Adds the patch to check for correct manifest in filepath from CTC to CTC BPE models

Signed-off-by: smajumdar <titu1994@gmail.com>