### PR TITLE
Add MatchboxNet support for Subset Classification task

### DIFF
--- a/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
@@ -1,20 +1,24 @@
 name: &name "MatchboxNet-3x1x64-v1"
-sample_rate: &sample_rate 16000
 
 model:
-  timesteps: &timesteps 128
-  repeat: &repeat 1
-  dropout: &dropout 0.0
-  kernel_size_factor: &kfactor 1.0
+  sample_rate: 16000
+  timesteps: 128
+  repeat: 1
+  dropout: 0.0
+  kernel_size_factor: 1.0
 
-  labels: &labels ['bed', 'bird', 'cat', 'dog', 'down', 'eight', 'five', 'four', 'go', 'happy', 'house', 'left', 'marvin',
-                   'nine', 'no', 'off', 'on', 'one', 'right', 'seven', 'sheila', 'six', 'stop', 'three', 'tree', 'two', 'up',
-                   'wow', 'yes', 'zero']
+  labels_full: ['bed', 'bird', 'cat', 'dog', 'down', 'eight', 'five', 'four', 'go', 'happy', 'house', 'left', 'marvin',
+           'nine', 'no', 'off', 'on', 'one', 'right', 'seven', 'sheila', 'six', 'stop', 'three', 'tree', 'two', 'up',
+           'wow', 'yes', 'zero']
+
+  labels_subset: ["yes", "no", "up", "down", "left", "right", "on", "off", "stop", "go", "unknown", "silence"]
+
+  labels: ${model.labels_full}
 
   train_ds:
     manifest_filepath: ???
-    sample_rate: *sample_rate
-    labels: *labels
+    sample_rate: ${model.sample_rate}
+    labels: ${model.labels}
     batch_size: 128
     shuffle: True
     augmentor:
@@ -29,16 +33,16 @@ model:
 
   validation_ds:
     manifest_filepath: ???
-    sample_rate: *sample_rate
-    labels: *labels
+    sample_rate: ${model.sample_rate}
+    labels: ${model.labels}
     batch_size: 128
     shuffle: False
     val_loss_idx: 0
 
   test_ds:
     manifest_filepath: null
-    sample_rate: *sample_rate
-    labels: *labels
+    sample_rate: ${model.sample_rate}
+    labels: ${model.labels}
     batch_size: 128
     shuffle: False
     test_loss_idx: 0
@@ -67,7 +71,7 @@ model:
   crop_or_pad_augment:
     cls: nemo.collections.asr.modules.CropOrPadSpectrogramAugmentation
     params:
-      audio_length: *timesteps
+      audio_length: ${model.timesteps}
 
   encoder:
     cls: nemo.collections.asr.modules.ConvASREncoder
@@ -82,57 +86,57 @@ model:
           kernel: [11]
           stride: [1]
           dilation: [1]
-          dropout: *dropout
+          dropout: ${model.dropout}
           residual: false
           separable: true
-          kernel_size_factor: *kfactor
+          kernel_size_factor: ${model.kernel_size_factor}
 
         - filters: 64
-          repeat: *repeat
+          repeat: ${model.repeat}
           kernel: [13]
           stride: [1]
           dilation: [1]
-          dropout: *dropout
+          dropout: ${model.dropout}
           residual: true
           separable: true
-          kernel_size_factor: *kfactor
+          kernel_size_factor: ${model.kernel_size_factor}
 
         - filters: 64
-          repeat: *repeat
+          repeat: ${model.repeat}
           kernel: [15]
           stride: [1]
           dilation: [1]
-          dropout: *dropout
+          dropout: ${model.dropout}
           residual: true
           separable: true
-          kernel_size_factor: *kfactor
+          kernel_size_factor: ${model.kernel_size_factor}
 
         - filters: 64
-          repeat: *repeat
+          repeat: ${model.repeat}
           kernel: [17]
           stride: [1]
           dilation: [1]
-          dropout: *dropout
+          dropout: ${model.dropout}
           residual: true
           separable: true
-          kernel_size_factor: *kfactor
+          kernel_size_factor: ${model.kernel_size_factor}
 
         - filters: 128
           repeat: 1
           kernel: [29]
           stride: [1]
           dilation: [2]
-          dropout: *dropout
+          dropout: ${model.dropout}
           residual: false
           separable: true
-          kernel_size_factor: *kfactor
+          kernel_size_factor: ${model.kernel_size_factor}
 
         - filters: &enc_final_filters 128
           repeat: 1
           kernel: [1]
           stride: [1]
           dilation: [1]
-          dropout: *dropout
+          dropout: ${model.dropout}
           residual: false
 
   decoder:

--- a/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
@@ -1,21 +1,24 @@
 name: &name "MatchboxNet-3x1x64-v2"
 
 model:
-  sample_rate: &sample_rate 16000
+  sample_rate: 16000
+  timesteps: 128
+  repeat: 1
+  dropout: 0.0
+  kernel_size_factor: 1.0
 
-  timesteps: &timesteps 128
-  repeat: &repeat 1
-  dropout: &dropout 0.0
-  kernel_size_factor: &kfactor 1.0
+  labels_full: ['visual', 'wow', 'learn', 'backward', 'dog', 'two', 'left', 'happy', 'nine', 'go', 'up', 'bed', 'stop',
+           'one', 'zero', 'tree', 'seven', 'on', 'four', 'bird', 'right', 'eight', 'no', 'six', 'forward', 'house',
+           'marvin', 'sheila', 'five', 'off', 'three', 'down', 'cat', 'follow', 'yes']
 
-  labels: &labels ['visual', 'wow', 'learn', 'backward', 'dog', 'two', 'left', 'happy', 'nine', 'go', 'up', 'bed', 'stop',
-                   'one', 'zero', 'tree', 'seven', 'on', 'four', 'bird', 'right', 'eight', 'no', 'six', 'forward', 'house',
-                   'marvin', 'sheila', 'five', 'off', 'three', 'down', 'cat', 'follow', 'yes']
+  labels_subset: ["yes", "no", "up", "down", "left", "right", "on", "off", "stop", "go", "unknown", "silence"]
+
+  labels: ${model.labels_full}
 
   train_ds:
     manifest_filepath: ???
-    sample_rate: *sample_rate
-    labels: *labels
+    sample_rate: ${model.sample_rate}
+    labels: ${model.labels}
     batch_size: 128
     shuffle: True
     augmentor:
@@ -30,16 +33,16 @@ model:
 
   validation_ds:
     manifest_filepath: ???
-    sample_rate: *sample_rate
-    labels: *labels
+    sample_rate: ${model.sample_rate}
+    labels: ${model.labels}
     batch_size: 128
     shuffle: False
     val_loss_idx: 0
 
   test_ds:
     manifest_filepath: null
-    sample_rate: *sample_rate
-    labels: *labels
+    sample_rate: ${model.sample_rate}
+    labels: ${model.labels}
     batch_size: 128
     shuffle: False
     test_loss_idx: 0
@@ -68,7 +71,7 @@ model:
   crop_or_pad_augment:
     cls: nemo.collections.asr.modules.CropOrPadSpectrogramAugmentation
     params:
-      audio_length: *timesteps
+      audio_length: ${model.timesteps}
 
   encoder:
     cls: nemo.collections.asr.modules.ConvASREncoder
@@ -83,57 +86,57 @@ model:
           kernel: [11]
           stride: [1]
           dilation: [1]
-          dropout: *dropout
+          dropout: ${model.dropout}
           residual: false
           separable: true
-          kernel_size_factor: *kfactor
+          kernel_size_factor: ${model.kernel_size_factor}
 
         - filters: 64
-          repeat: *repeat
+          repeat: ${model.repeat}
           kernel: [13]
           stride: [1]
           dilation: [1]
-          dropout: *dropout
+          dropout: ${model.dropout}
           residual: true
           separable: true
-          kernel_size_factor: *kfactor
+          kernel_size_factor: ${model.kernel_size_factor}
 
         - filters: 64
-          repeat: *repeat
+          repeat: ${model.repeat}
           kernel: [15]
           stride: [1]
           dilation: [1]
-          dropout: *dropout
+          dropout: ${model.dropout}
           residual: true
           separable: true
-          kernel_size_factor: *kfactor
+          kernel_size_factor: ${model.kernel_size_factor}
 
         - filters: 64
-          repeat: *repeat
+          repeat: ${model.repeat}
           kernel: [17]
           stride: [1]
           dilation: [1]
-          dropout: *dropout
+          dropout: ${model.dropout}
           residual: true
           separable: true
-          kernel_size_factor: *kfactor
+          kernel_size_factor: ${model.kernel_size_factor}
 
         - filters: 128
           repeat: 1
           kernel: [29]
           stride: [1]
           dilation: [2]
-          dropout: *dropout
+          dropout: ${model.dropout}
           residual: false
           separable: true
-          kernel_size_factor: *kfactor
+          kernel_size_factor: ${model.kernel_size_factor}
 
         - filters: &enc_final_filters 128
           repeat: 1
           kernel: [1]
           stride: [1]
           dilation: [1]
-          dropout: *dropout
+          dropout: ${model.dropout}
           residual: false
 
   decoder:

--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -148,6 +148,14 @@ class EncDecClassificationModel(ASRModel):
             "which obtains 97.29% accuracy on test set.",
         )
         result.append(model)
+
+        model = PretrainedModelInfo(
+            pretrained_model_name="MatchboxNet-3x1x64-v2-subset-task",
+            location="https://nemo-public.s3.us-east-2.amazonaws.com/nemo-1.0.0alpha-tests/MatchboxNet-3x2x64-v2-subset-task.nemo",
+            description="MatchboxNet model trained on Google Speech Commands dataset (v2, 10+2 classes) "
+                        "which obtains 98.4% accuracy on test set.",
+        )
+        result.append(model)
         return result
 
     @property

--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -153,7 +153,7 @@ class EncDecClassificationModel(ASRModel):
             pretrained_model_name="MatchboxNet-3x1x64-v2-subset-task",
             location="https://nemo-public.s3.us-east-2.amazonaws.com/nemo-1.0.0alpha-tests/MatchboxNet-3x2x64-v2-subset-task.nemo",
             description="MatchboxNet model trained on Google Speech Commands dataset (v2, 10+2 classes) "
-                        "which obtains 98.4% accuracy on test set.",
+            "which obtains 98.4% accuracy on test set.",
         )
         result.append(model)
         return result

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -758,17 +758,17 @@ class ModelPT(LightningModule, Model):
 
         # Replace ddp multi-gpu until PTL has a fix
         DDP_WARN = """\n\nDuring testing, it is currently advisable to construct a new Trainer "
-                    "with single GPU and no DDP to obtain accurate results.\n"
-                    "Following pattern should be used: \n"
-                    "gpu = 1 if cfg.trainer.gpus != 0 else 0\n"
-                    "trainer = Trainer(gpus=gpu)\n"
-                    "if model.prepare_test(trainer):\n"
+                    "with single GPU and no DDP to obtain accurate results.
+                    "Following pattern should be used: "
+                    "gpu = 1 if cfg.trainer.gpus != 0 else 0"
+                    "trainer = Trainer(gpus=gpu)"
+                    "if model.prepare_test(trainer):"
                     "  trainer.test(model)\n\n"""
 
         if trainer is not None:
             if trainer.num_gpus > 1:
                 logging.warning(DDP_WARN)
-                return True
+                return False
 
         # Assign trainer to the model
         self.set_trainer(trainer)
@@ -786,6 +786,15 @@ class ModelPT(LightningModule, Model):
     @property
     def num_weights(self):
         return sum(p.numel() for p in self.parameters() if p.requires_grad)
+
+    @property
+    def cfg(self):
+        return self._cfg
+
+    @cfg.setter
+    def cfg(self, cfg):
+        self._cfg = cfg
+        self._set_hparams(cfg)
 
     @staticmethod
     def __make_nemo_file_from_folder(filename, source_dir):


### PR DESCRIPTION
# Changelog
- Adds support for MBN subset task inside yaml + pretrained model
- Adds fix for testing with DDP
- Adds config preservation property + setter to safely update config. This is needed so that both .nemo format and PTL checkpoint can be restored properly after update of config, then save + restore