### PR TITLE
Improve usability of NeuralModule + Typing

### DIFF
--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -274,16 +274,14 @@ class Serialization(ABC):
 
 
 class FileIO(ABC):
-    @abstractmethod
     def save_to(self, save_path: str):
         """Saves module/model with weights"""
-        pass
+        raise NotImplementedError()
 
     @classmethod
-    @abstractmethod
     def restore_from(cls, restore_path: str, override_config_path: Optional[str] = None):
         """Restores module/model with weights"""
-        pass
+        raise NotImplementedError()
 
     @classmethod
     def from_config_file(cls, path2yaml_file: str):

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -248,6 +248,9 @@ class Serialization(ABC):
         if ('cls' in config or 'target' in config) and 'params' in config:
             # regular hydra-based instantiation
             instance = hydra.utils.instantiate(config=config)
+        elif '_target_' in config:
+            # regular hydra-based instantiation
+            instance = hydra.utils.instantiate(config=config)
         else:
             # models are handled differently for now
             instance = cls(cfg=config)

--- a/nemo/core/neural_types/neural_type.py
+++ b/nemo/core/neural_types/neural_type.py
@@ -122,7 +122,7 @@ class NeuralType(object):
         if isinstance(other, NeuralType):
             return self.compare(other)
 
-        return NeuralTypeComparisonResult.INCOMPATIBLE
+        return False
 
     @staticmethod
     def __check_sanity(axes):

--- a/nemo/core/neural_types/neural_type.py
+++ b/nemo/core/neural_types/neural_type.py
@@ -118,6 +118,12 @@ class NeuralType(object):
                 parent_type_name, port_name, str(self), str(second_object.ntype), type_comatibility
             )
 
+    def __eq__(self, other):
+        if isinstance(other, NeuralType):
+            return self.compare(other)
+
+        return NeuralTypeComparisonResult.INCOMPATIBLE
+
     @staticmethod
     def __check_sanity(axes):
         # check that list come before any tensor dimension


### PR DESCRIPTION
# Changelog
- Make FileIO concrete with empty implementations
- Add proper `_target_` support for serialization and deserialization
- Implement `__eq__` for NeuralType comparison.

Signed-off-by: smajumdar <titu1994@gmail.com>