### PR TITLE
Fine-tuning Model Parallel Megatron: Load checkpoint and start training

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
@@ -20,7 +20,8 @@ import torch
 from megatron import get_args, initialize_megatron
 from megatron.model import get_language_model
 from megatron.model.bert_model import bert_attention_mask_func, bert_extended_attention_mask, bert_position_ids
-from megatron.mpu import get_model_parallel_rank
+#from megatron.mpu import get_model_parallel_rank
+from megatron.mpu import get_model_parallel_group
 
 from nemo.collections.nlp.modules.common.bert_module import BertModule
 from nemo.core.classes import typecheck
@@ -46,6 +47,9 @@ class MegatronBertEncoder(BertModule):
 
         super().__init__()
 
+        self._model_parallel_size = None
+        self._restore_path = None
+
         if not os.path.exists(vocab_file):
             raise ValueError(f'Vocab file not found at {vocab_file}')
 
@@ -57,13 +61,25 @@ class MegatronBertEncoder(BertModule):
 
         config['onnx_safe'] = True
 
+        # config['hidden_size'] = 1024 
+        # config['num_attention_heads'] = 16 
+        # config['num_layers'] = 24
+        # config['max_position_embeddings'] = 512
+
+        os.environ["WORLD_SIZE"] = "2"
+
+        def _update_model_parallel_arg(parser):
+            parser.set_defaults(model_parallel_size=2)
+            return parser
+        extra_args_provider = _update_model_parallel_arg
+
         # Initialize part of Megatron global state that is needed for its constructor.
         # We set 'lazy_mpu_init' flag on to make Megatron do only the initialization that does not depend
         # on ddp be initialized yet (and we don't want Megatron to initialize DDP itself either)
         # and to return a hook for us to call after PTL has torch.distributed initialized
         # (that would be on our first forward() call).
         self._lazy_init_fn = initialize_megatron(
-            extra_args_provider=None, args_defaults=config, ignore_unknown_args=True
+            extra_args_provider=extra_args_provider, args_defaults=config, ignore_unknown_args=True
         )
 
         # read Megatron arguments back
@@ -89,7 +105,11 @@ class MegatronBertEncoder(BertModule):
     @typecheck()
     def forward(self, input_ids, attention_mask, token_type_ids):
         if self._lazy_init_fn is not None:
+            logging.info(f'Finishing megatron mpu init.')
             self._lazy_init_fn()
+            # model parallel checkpoints need to be restored after torch.distributed is initialized
+            if self._model_parallel_size is not None:
+                self.restore_weights(self._restore_path)
             self._lazy_init_fn = None
 
         extended_attention_mask = bert_extended_attention_mask(
@@ -113,6 +133,7 @@ class MegatronBertEncoder(BertModule):
         Args:
             restore_path (str): restore_path should a file or a directory if using model parallel
         """
+        self._restore_path = restore_path
         if os.path.isfile(restore_path):
             logging.info(
                 f'restore_path: {restore_path} is a file. Assuming no megatron model parallelism'
@@ -126,6 +147,7 @@ class MegatronBertEncoder(BertModule):
             logging.info(f"weights restored from {restore_path}")
         elif os.path.isdir(restore_path):
             model_parallel_size = len(os.listdir(restore_path))
+            self._model_parallel_size = model_parallel_size
             logging.info(
                 (
                     f'restore_path: {restore_path} is a directory. '
@@ -134,10 +156,19 @@ class MegatronBertEncoder(BertModule):
                 )
             )
             # need model parallel groups to restore
-            if torch.distributed.is_initialized() and get_model_parallel_rank():
-                mp_restore_path = f'{restore_path}/mp_rank_{get_model_parallel_rank():02d}/model_optim_rng.pt'
+            if torch.distributed.is_initialized():
+                model_parallel_rank = torch.distributed.get_rank(group=get_model_parallel_group())
+                #mp_restore_path = f'{restore_path}/mp_rank_{get_model_parallel_rank():02d}/model_optim_rng.pt'
+                mp_restore_path = f'{restore_path}/mp_rank_{model_parallel_rank:02d}/model_optim_rng.pt'
                 logging.info(f'Restoring model parallel checkpoint from: {mp_restore_path}')
-                self.restore_weights(mp_restore_path)
+                state_dict = torch.load(mp_restore_path)
+                # to load from Megatron pretrained checkpoint
+                if 'model' in state_dict:
+                    self.language_model.load_state_dict(state_dict['model'][self._language_model_key])
+                else:
+                    self.load_state_dict(state_dict)
+            else:
+                logging.info(f'torch.distributed not initialized yet. Will not restore model parallel checkpoint')
         else:
             logging.error(f'restore_path: {restore_path} must be a file or directory.')
 

--- a/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
@@ -85,7 +85,9 @@ class MegatronBertEncoder(BertModule):
         # and to return a hook for us to call after PTL has torch.distributed initialized
         # (that would be on our first forward() call).
         self._lazy_init_fn = initialize_megatron(
-            extra_args_provider=extra_args_provider, args_defaults=config, ignore_unknown_args=True
+            extra_args_provider=extra_args_provider,
+            args_defaults=config,
+            ignore_unknown_args=True
         )
 
         # read Megatron arguments back

--- a/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
@@ -85,9 +85,7 @@ class MegatronBertEncoder(BertModule):
         # and to return a hook for us to call after PTL has torch.distributed initialized
         # (that would be on our first forward() call).
         self._lazy_init_fn = initialize_megatron(
-            extra_args_provider=extra_args_provider,
-            args_defaults=config,
-            ignore_unknown_args=True
+            extra_args_provider=extra_args_provider, args_defaults=config, ignore_unknown_args=True
         )
 
         # read Megatron arguments back

--- a/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
@@ -20,7 +20,8 @@ import torch
 from megatron import get_args, initialize_megatron
 from megatron.model import get_language_model
 from megatron.model.bert_model import bert_attention_mask_func, bert_extended_attention_mask, bert_position_ids
-#from megatron.mpu import get_model_parallel_rank
+
+# from megatron.mpu import get_model_parallel_rank
 from megatron.mpu import get_model_parallel_group
 
 from nemo.collections.nlp.modules.common.bert_module import BertModule
@@ -62,7 +63,7 @@ class MegatronBertEncoder(BertModule):
 
         config['onnx_safe'] = True
 
-        #if 'model_parallel_size' in config:
+        # if 'model_parallel_size' in config:
         if self._model_parallel_size is not None:
             app_state = AppState()
 
@@ -73,6 +74,7 @@ class MegatronBertEncoder(BertModule):
             def _update_model_parallel_arg(parser):
                 parser.set_defaults(model_parallel_size=self._model_parallel_size)
                 return parser
+
             extra_args_provider = _update_model_parallel_arg
         else:
             extra_args_provider = None
@@ -140,9 +142,7 @@ class MegatronBertEncoder(BertModule):
         """
         self._restore_path = restore_path
         if os.path.isfile(restore_path):
-            logging.info(
-                f'restore_path: {restore_path} is a file. Assuming no megatron model parallelism'
-            )
+            logging.info(f'restore_path: {restore_path} is a file. Assuming no megatron model parallelism')
             state_dict = torch.load(restore_path)
             # to load from Megatron pretrained checkpoint
             if 'model' in state_dict:
@@ -166,5 +166,3 @@ class MegatronBertEncoder(BertModule):
                 logging.info(f'torch.distributed not initialized yet. Will not restore model parallel checkpoint')
         else:
             logging.error(f'restore_path: {restore_path} must be a file or directory.')
-
-

--- a/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
@@ -71,7 +71,7 @@ class MegatronBertEncoder(BertModule):
 
             # used to set model_parallel_size in megatron-lm argparser
             def _update_model_parallel_arg(parser):
-                parser.set_defaults(model_parallel_size=config['model_parallel_size'])
+                parser.set_defaults(model_parallel_size=self._model_parallel_size)
                 return parser
             extra_args_provider = _update_model_parallel_arg
         else:

--- a/nemo/collections/nlp/modules/common/megatron/megatron_utils.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_utils.py
@@ -93,6 +93,8 @@ def get_megatron_lm_model(
             fixed_config = {}
             for key in config.keys():
                 fixed_key = key.replace("-", "_")
+                if fixed_key == 'max_seq_length':
+                    fixed_key = 'max_position_embeddings'
                 fixed_config[fixed_key] = config[key]
             config = fixed_config
     elif config_dict:

--- a/nemo/collections/nlp/modules/common/megatron/megatron_utils.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_utils.py
@@ -90,22 +90,11 @@ def get_megatron_lm_model(
         with open(config_file) as f:
             config = json.load(f)
             # replace dashes with underscores in config keys
-            keys_to_pop = []
+            fixed_config = {}
             for key in config.keys():
-                fixed = False
-                fixed_key = ""
-                for char in key:
-                    if char == '-':
-                        new_char = '_'
-                        fixed_key += new_char
-                        fixed = True
-                    else:
-                        fixed_key += char
-                if fixed:
-                    config[fixed_key] = config[key]
-                    keys_to_pop.append(key)
-            for key in keys_to_pop:
-                config.pop(key)
+                fixed_key = key.replace("-", "_")
+                fixed_config[fixed_key] = config[key]
+            config = fixed_config
     elif config_dict:
         config = config_dict
     elif pretrained_model_name in get_megatron_lm_models_list():

--- a/nemo/collections/nlp/modules/common/megatron/megatron_utils.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_utils.py
@@ -96,6 +96,9 @@ def get_megatron_lm_model(
                 if fixed_key == 'max_seq_length':
                     fixed_key = 'max_position_embeddings'
                 fixed_config[fixed_key] = config[key]
+            # 'vocab_size" no longer used.
+            if 'vocab_size' in fixed_config:
+                fixed_config.pop('vocab_size')
             config = fixed_config
     elif config_dict:
         config = config_dict

--- a/nemo/collections/nlp/modules/common/megatron/megatron_utils.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_utils.py
@@ -139,12 +139,8 @@ def get_megatron_lm_model(
     else:
         model_parallel_size = None
 
-    
     model = MegatronBertEncoder(
-        model_name=pretrained_model_name,
-        config=config,
-        vocab_file=vocab,
-        model_parallel_size=model_parallel_size
+        model_name=pretrained_model_name, config=config, vocab_file=vocab, model_parallel_size=model_parallel_size
     )
 
     return model, checkpoint_file

--- a/nemo/collections/nlp/modules/common/megatron/megatron_utils.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_utils.py
@@ -89,7 +89,22 @@ def get_megatron_lm_model(
     if config_file:
         with open(config_file) as f:
             config = json.load(f)
-            #configf = json.load(f)
+            # replace dashes with underscores in config keys
+            keys_to_pop = []
+            for key in config.keys():
+                fixed = False
+                fixed_key = key
+                for i, x in enumerate(key):
+                    if x == '-':
+                        fixed_key[i] = '_'
+                        fixed = True
+                if fixed:
+                    config[fixed_key] = config[key]
+                    keys_to_pop.append(key)
+            for key in keys_to_pop:
+                config.pop(key)
+
+            # configf = json.load(f)
             # config = {
             #     "hidden_size": configf['hidden-size'],
             #     "num_attention_heads": configf['num-attention-heads'],

--- a/nemo/collections/nlp/modules/common/megatron/megatron_utils.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_utils.py
@@ -93,24 +93,19 @@ def get_megatron_lm_model(
             keys_to_pop = []
             for key in config.keys():
                 fixed = False
-                fixed_key = key
-                for i, x in enumerate(key):
-                    if x == '-':
-                        fixed_key[i] = '_'
+                fixed_key = ""
+                for char in key:
+                    if char == '-':
+                        new_char = '_'
+                        fixed_key += new_char
                         fixed = True
+                    else:
+                        fixed_key += char
                 if fixed:
                     config[fixed_key] = config[key]
                     keys_to_pop.append(key)
             for key in keys_to_pop:
                 config.pop(key)
-
-            # configf = json.load(f)
-            # config = {
-            #     "hidden_size": configf['hidden-size'],
-            #     "num_attention_heads": configf['num-attention-heads'],
-            #     "num_layers": configf['num-layers'],
-            #     "max_position_embeddings": configf['max-seq-length'],
-            # }
     elif config_dict:
         config = config_dict
     elif pretrained_model_name in get_megatron_lm_models_list():

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -31,6 +31,7 @@ from nemo.core import optim
 from nemo.core.classes.common import Model
 from nemo.core.optim import prepare_lr_scheduler
 from nemo.utils import logging, model_utils
+from nemo.utils.app_state import AppState
 
 __all__ = ['ModelPT']
 
@@ -85,6 +86,11 @@ class ModelPT(LightningModule, Model):
         self._optimizer = None
         self._scheduler = None
         self._trainer = trainer
+
+        # Update AppState with world information from trainer
+        app_state = AppState()
+        app_state.world_size = self._trainer.num_gpus * self._trainer.num_nodes
+
 
         if self._cfg is not None and not self.__is_model_being_restored():
             if 'train_ds' in self._cfg and self._cfg.train_ds is not None:

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -91,7 +91,6 @@ class ModelPT(LightningModule, Model):
         app_state = AppState()
         app_state.world_size = self._trainer.num_gpus * self._trainer.num_nodes
 
-
         if self._cfg is not None and not self.__is_model_being_restored():
             if 'train_ds' in self._cfg and self._cfg.train_ds is not None:
                 self.setup_training_data(self._cfg.train_ds)

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -89,7 +89,8 @@ class ModelPT(LightningModule, Model):
 
         # Update AppState with world information from trainer
         app_state = AppState()
-        app_state.world_size = self._trainer.num_gpus * self._trainer.num_nodes
+        if self._trainer.num_gpus and self._trainer.num_nodes:
+            app_state.world_size = self._trainer.num_gpus * self._trainer.num_nodes
 
         if self._cfg is not None and not self.__is_model_being_restored():
             if 'train_ds' in self._cfg and self._cfg.train_ds is not None:

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -89,8 +89,9 @@ class ModelPT(LightningModule, Model):
 
         # Update AppState with world information from trainer
         app_state = AppState()
-        if self._trainer.num_gpus and self._trainer.num_nodes:
-            app_state.world_size = self._trainer.num_gpus * self._trainer.num_nodes
+        if isinstance(self._trainer, Trainer):
+            if self._trainer.num_gpus and self._trainer.num_nodes:
+                app_state.world_size = self._trainer.num_gpus * self._trainer.num_nodes
 
         if self._cfg is not None and not self.__is_model_being_restored():
             if 'train_ds' in self._cfg and self._cfg.train_ds is not None:

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -1,0 +1,191 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemo.utils.metaclasses import Singleton
+
+class AppState(metaclass=Singleton):
+    def __init__(self):
+        # World info
+        self._local_rank = None
+        self._global_rank = None
+        self._model_parallel_rank = None
+        self._data_parallel_rank = None
+
+        self._world_size = None
+        self._model_parallel_size = None
+        self._model_parallel_group = None
+        self._data_parallel_size = None
+        self._data_parallel_group = None
+
+        self._random_seed = None
+
+    @property
+    def world_size(self):
+        """ Property returns the total number of GPUs.
+            Returns:
+                Total number of GPUs.
+        """
+        return self._world_size
+
+    @world_size.setter
+    def world_size(self, size):
+        """ Property sets the total number of GPUs.
+            Args:
+                size (int):  Total number of GPUs.
+        """
+        self._world_size = size
+
+    @property
+    def model_parallel_size(self):
+        """ Property returns the number of GPUs in each model parallel group.
+            Returns:
+                Number of GPUs in each model parallel group.
+        """
+        return self._model_parallel_size
+
+    @model_parallel_size.setter
+    def model_parallel_size(self, size):
+        """ Property sets the number of GPUs in each model parallel group.
+            Args:
+                size (int):  Number of GPUs in each model parallel group.
+        """
+        self._model_parallel_size = size
+
+    @property
+    def data_parallel_size(self):
+        """ Property returns the number of GPUs in each data parallel group.
+            Returns:
+                Number of GPUs in each data parallel group.
+        """
+        return self._data_parallel_size
+
+    @data_parallel_size.setter
+    def data_parallel_size(self, size):
+        """ Property sets the number of GPUs in each data parallel group.
+            Args:
+                size (int):  Number of GPUs in each data parallel group.
+        """
+        self._data_parallel_size = size
+
+    @property
+    def local_rank(self):
+        """ Property returns the local rank.
+            Returns:
+                Local rank.
+        """
+        return self._local_rank
+
+    @local_rank.setter
+    def local_rank(self, rank):
+        """ Property sets the local rank.
+            Args:
+                rank (int):  Local rank.
+        """
+        self._local_rank = rank
+
+    @property
+    def global_rank(self):
+        """ Property returns the global rank.
+            Returns:
+                Global rank.
+        """
+        return self._global_rank
+
+    @global_rank.setter
+    def global_rank(self, rank):
+        """ Property sets the global rank.
+            Args:
+                rank (int):  Global rank.
+        """
+        self._global_rank = rank
+
+    @property
+    def model_parallel_rank(self):
+        """ Property returns the model parallel rank.
+            Returns:
+                Model parallel rank.
+        """
+        return self._model_parallel_rank
+
+    @model_parallel_rank.setter
+    def model_parallel_rank(self, rank):
+        """ Property sets the model parallel rank.
+            Args:
+                rank (int):  Model parallel rank.
+        """
+        self._model_parallel_rank = rank
+
+    @property
+    def model_parallel_group(self):
+        """ Property returns the model parallel group.
+            Returns:
+                Model parallel group.
+        """
+        return self._model_parallel_group
+
+    @model_parallel_group.setter
+    def model_parallel_group(self, group):
+        """ Property sets the model parallel group.
+            Args:
+                group:  Model parallel group.
+        """
+        self._model_parallel_group = group
+
+    @property
+    def data_parallel_rank(self):
+        """ Property returns the data parallel rank.
+            Returns:
+                Data parallel rank.
+        """
+        return self._data_parallel_rank
+
+    @data_parallel_rank.setter
+    def data_parallel_rank(self, rank):
+        """ Property sets the data parallel rank.
+            Args:
+                rank (int):  Data parallel rank.
+        """
+        self._data_parallel_rank = rank
+
+    @property
+    def data_parallel_group(self):
+        """ Property returns the data parallel group.
+            Returns:
+                Data parallel group.
+        """
+        return self._data_parallel_group
+
+    @data_parallel_group.setter
+    def data_parallel_group(self, group):
+        """ Property sets the data parallel group.
+            Args:
+                group:  Data parallel group.
+        """
+        self._data_parallel_group = group
+
+    @property
+    def random_seed(self):
+        """ Property returns the random seed.
+            Returns:
+                Random seed.
+        """
+        return self._random_seed
+
+    @random_seed.setter
+    def random_seed(self, seed):
+        """ Property sets the random seed.
+            Args:
+                seed (int):  Random seed.
+        """
+        self._random_seed = seed

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -16,6 +16,10 @@ from nemo.utils.metaclasses import Singleton
 
 class AppState(metaclass=Singleton):
     def __init__(self):
+
+        # TODO: should we store global config in hydra_runner?
+        self._app_cfg = None
+
         # World info
         self._local_rank = None
         self._global_rank = None

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -14,6 +14,7 @@
 
 from nemo.utils.metaclasses import Singleton
 
+
 class AppState(metaclass=Singleton):
     def __init__(self):
 


### PR DESCRIPTION
In order to use model parallel for fine-tuning in NeMo, the user only has to pass the path to the model parallel checkpoints. Since model parallel checkpoints require a specific directory structure, NeMo will infer the model parallel size before instantiating the Megatron BERT encoder.

Note this PR does NOT guarantee convergence, that will come in future PRs when we add model parallel gradient clipping, sampling, etc.

# Usage
This should work for any NLP example script that uses a BERT encoder.
```
#!/bin/bash
export NEMO_TESTING=true

python token_classification.py \
    trainer.gpus=[2,3] \
    trainer.num_nodes=1 \
    model.dataset.data_dir=/raid/data/token_classification/data \
    model.train_ds.batch_size=4 \
    model.language_model.pretrained_model_name=megatron-bert-uncased \
    model.language_model.lm_checkpoint=/raid/results/1194279-2/iter_2000000 \
    model.language_model.config_file=/raid/megatron_checkpoints/mp_bert_345M/config.json 
```
# Changes to NeMo, implementation details
The crucial thing to understand is that Megatron-LM requires torch.distributed to be initialized in order to instantiate Megatron BERT encoders. This poses a challenge as PyTorch Lightning only initializes torch.distributed after calling trainer.fit().

@borisfom figured out that we can lazily initialize megatron-lm, and only fully instantiate the megatron-lm bert encoder after pytorch lightning has initialized torch.distributed by finishing megatron-lm initialization in the first forward pass. 

This is why we lazily load model parallel checkpoints in the first forward pass, because we need the model parallel groups to have been initialized, and to do that we need torch.distributed to be initialized.

Another interesting point, is that in order to instantiate megatron-lm model parallel encoders, we need to know not just the model parallel size but also the world size. See https://github.com/NVIDIA/Megatron-LM/blob/46a536cc888dcd4899c3f74d048ec29b9d93a412/megatron/mpu/initialize.py#L59 .

To get the world size, we need to know num_gpus and num_nodes, note this information is not available from torch.distributed as it hasn't been initialized yet. So we get this information from trainer, and store it in AppState() (app_state.py). This is done in the ModelPT constructor. @tkornuta-nvidia has some ideas on simply extracting that information from the config rather than passing the trainer to ModelPT.

Finally, to correctly pass model_parallel_size to megatron-lm we have to use the ```extra_args_provider``` since we can't pass the arguments with argparser in NeMo (we are using Hydra for configuration).