### PR TITLE
Improve CTC and CTC BPE Models

### DIFF
--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -85,6 +85,7 @@ class EncDecClassificationModel(ASRModel):
             drop_last=config.get('drop_last', False),
             shuffle=config['shuffle'],
             num_workers=config.get('num_workers', 0),
+            pin_memory=config.get('pin_memory', False),
         )
 
     def setup_training_data(self, train_data_config: Optional[Union[DictConfig, Dict]]):

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -183,6 +183,7 @@ class EncDecCTCModelBPE(EncDecCTCModel):
             drop_last=config.get('drop_last', False),
             shuffle=shuffle,
             num_workers=config.get('num_workers', 0),
+            pin_memory=config.get('pin_memory', False),
         )
 
     @property

--- a/nemo/collections/asr/models/label_models.py
+++ b/nemo/collections/asr/models/label_models.py
@@ -90,6 +90,7 @@ class EncDecSpeakerLabelModel(ModelPT):
             drop_last=config.get('drop_last', False),
             shuffle=config['shuffle'],
             num_workers=config.get('num_workers', 2),
+            pin_memory=config.get('pin_memory', False),
         )
 
     def setup_training_data(self, train_data_layer_config: Optional[Union[DictConfig, Dict]]):

--- a/scripts/convert_to_tarred_audio_dataset.py
+++ b/scripts/convert_to_tarred_audio_dataset.py
@@ -1,4 +1,4 @@
-# Copyright 2020 NVIDIA. All Rights Reserved.
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/scripts/convert_to_tarred_audio_dataset.py
+++ b/scripts/convert_to_tarred_audio_dataset.py
@@ -1,0 +1,132 @@
+# Copyright 2020 NVIDIA. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This script converts an existing audio dataset with a manifest to
+# a tarred and sharded audio dataset that can be read by the
+# TarredAudioToTextDataLayer.
+
+import argparse
+import json
+import os
+import random
+import tarfile
+
+parser = argparse.ArgumentParser(
+    description="Convert an existing ASR dataset to tarballs compatible with TarredAudioToTextDataLayer."
+)
+parser.add_argument(
+    "--manifest_path", default=None, type=str, required=True, help="Path to the existing dataset's manifest."
+)
+
+# Optional arguments
+parser.add_argument(
+    "--target_dir",
+    default='./tarred',
+    type=str,
+    help="Target directory for resulting tarballs and manifest. Defaults to `./tarred`. Creates the path if ncessary.",
+)
+parser.add_argument(
+    "--num_shards",
+    default=1,
+    type=int,
+    help="Number of shards (tarballs) to create. Used for partitioning data among workers.",
+)
+parser.add_argument(
+    '--max_duration',
+    default=None,
+    type=float,
+    help='Maximum duration of audio clip in the dataset. By default, it is None and will not filter files.',
+)
+parser.add_argument(
+    "--shuffle",
+    action='store_true',
+    help="Whether or not to randomly shuffle the samples in the manifest before tarring/sharding.",
+)
+args = parser.parse_args()
+
+
+def create_shard(entries, target_dir, new_entries, shard_id):
+    """Creates a tarball containing the audio files from `entries`.
+    """
+    tar = tarfile.open(os.path.join(target_dir, f'audio_{shard_id}.tar'), mode='w')
+
+    for entry in entries:
+        # We squash the filename since we do not preserve directory structure of audio files in the tarball.
+        base, ext = os.path.splitext(entry['audio_filepath'])
+        base = base.replace('/', '_')
+        # Need the following replacement as long as WebDataset splits on first period
+        base = base.replace('.', '_')
+        squashed_filename = f'{base}{ext}'
+        tar.add(entry['audio_filepath'], arcname=squashed_filename)
+
+        new_entry = {
+            'audio_filepath': squashed_filename,
+            'duration': entry['duration'],
+            'text': entry['text'],
+            'shard_id': shard_id,  # Keep shard ID for recordkeeping
+        }
+        new_entries.append(new_entry)
+
+    tar.close()
+
+
+def main():
+    manifest_path = args.manifest_path
+    target_dir = args.target_dir
+    num_shards = args.num_shards
+    max_duration = args.max_duration
+    shuffle = args.shuffle
+
+    if not os.path.exists(target_dir):
+        os.makedirs(target_dir)
+
+    # Read the existing manifest
+    entries = []
+    filtered_entries = 0
+    with open(manifest_path, 'r') as m:
+        for line in m:
+            entry = json.loads(line)
+            if max_duration is not None and entry['duration'] < max_duration:
+                entries.append(entry)
+            else:
+                filtered_entries += 1
+
+    if filtered_entries > 0:
+        print(f"Filtered {filtered_entries} files with maximum duration > {max_duration} seconds.")
+
+    if shuffle:
+        print("Shuffling...")
+        random.shuffle(entries)
+
+    # Create shards and updated manifest entries
+    new_entries = []
+    for i in range(num_shards):
+        start_idx = (len(entries) // num_shards) * i
+        end_idx = start_idx + (len(entries) // num_shards)
+        if i == num_shards - 1:
+            end_idx = len(entries)  # Last shard gets the leftovers.
+        print(f"Shard {i} will have {end_idx - start_idx} entries.")
+
+        create_shard(entries[start_idx:end_idx], target_dir, new_entries, i)
+
+    # Write manifest
+    new_manifest_path = os.path.join(target_dir, 'tarred_audio_manifest.json')
+    with open(new_manifest_path, 'w') as m2:
+        for entry in new_entries:
+            json.dump(entry, m2)
+            m2.write('\n')
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_librispeech_data.py
+++ b/scripts/get_librispeech_data.py
@@ -1,0 +1,135 @@
+# Copyright (c) 2019 NVIDIA Corporation
+#
+# USAGE: python get_librispeech_data.py --data_root=<where to put data>
+#        --data_set=<datasets_to_download>
+# where <datasets_to_download> can be: dev_clean, dev_other, test_clean,
+# test_other, train_clean_100, train_clean_360, train_other_500 or ALL
+# You can also put more than one data_set comma-separated:
+# --data_set=dev_clean,train_clean_100
+import argparse
+import fnmatch
+import json
+import logging
+import os
+import subprocess
+import tarfile
+import urllib.request
+
+from sox import Transformer
+from tqdm import tqdm
+
+parser = argparse.ArgumentParser(description='LibriSpeech Data download')
+parser.add_argument("--data_root", required=True, default=None, type=str)
+parser.add_argument("--data_sets", default="dev_clean", type=str)
+args = parser.parse_args()
+
+URLS = {
+    'TRAIN_CLEAN_100': ("http://www.openslr.org/resources/12/train-clean-100.tar.gz"),
+    'TRAIN_CLEAN_360': ("http://www.openslr.org/resources/12/train-clean-360.tar.gz"),
+    'TRAIN_OTHER_500': ("http://www.openslr.org/resources/12/train-other-500.tar.gz"),
+    'DEV_CLEAN': "http://www.openslr.org/resources/12/dev-clean.tar.gz",
+    'DEV_OTHER': "http://www.openslr.org/resources/12/dev-other.tar.gz",
+    'TEST_CLEAN': "http://www.openslr.org/resources/12/test-clean.tar.gz",
+    'TEST_OTHER': "http://www.openslr.org/resources/12/test-other.tar.gz",
+}
+
+
+def __maybe_download_file(destination: str, source: str):
+    """
+    Downloads source to destination if it doesn't exist.
+    If exists, skips download
+    Args:
+        destination: local filepath
+        source: url of resource
+    Returns:
+    """
+    source = URLS[source]
+    if not os.path.exists(destination):
+        logging.info("{0} does not exist. Downloading ...".format(destination))
+        urllib.request.urlretrieve(source, filename=destination + '.tmp')
+        os.rename(destination + '.tmp', destination)
+        logging.info("Downloaded {0}.".format(destination))
+    else:
+        logging.info("Destination {0} exists. Skipping.".format(destination))
+    return destination
+
+
+def __extract_file(filepath: str, data_dir: str):
+    try:
+        tar = tarfile.open(filepath)
+        tar.extractall(data_dir)
+        tar.close()
+    except Exception:
+        logging.info('Not extracting. Maybe already there?')
+
+
+def __process_data(data_folder: str, dst_folder: str, manifest_file: str):
+    """
+    Converts flac to wav and build manifests's json
+    Args:
+        data_folder: source with flac files
+        dst_folder: where wav files will be stored
+        manifest_file: where to store manifest
+    Returns:
+    """
+
+    if not os.path.exists(dst_folder):
+        os.makedirs(dst_folder)
+
+    files = []
+    entries = []
+
+    for root, dirnames, filenames in os.walk(data_folder):
+        for filename in fnmatch.filter(filenames, '*.trans.txt'):
+            files.append((os.path.join(root, filename), root))
+
+    for transcripts_file, root in tqdm(files):
+        with open(transcripts_file, encoding="utf-8") as fin:
+            for line in fin:
+                id, text = line[: line.index(" ")], line[line.index(" ") + 1 :]
+                transcript_text = text.lower().strip()
+
+                # Convert FLAC file to WAV
+                flac_file = os.path.join(root, id + ".flac")
+                wav_file = os.path.join(dst_folder, id + ".wav")
+                if not os.path.exists(wav_file):
+                    Transformer().build(flac_file, wav_file)
+                # check duration
+                duration = subprocess.check_output("soxi -D {0}".format(wav_file), shell=True)
+
+                entry = {}
+                entry['audio_filepath'] = os.path.abspath(wav_file)
+                entry['duration'] = float(duration)
+                entry['text'] = transcript_text
+                entries.append(entry)
+
+    with open(manifest_file, 'w') as fout:
+        for m in entries:
+            fout.write(json.dumps(m) + '\n')
+
+
+def main():
+    data_root = args.data_root
+    data_sets = args.data_sets
+
+    if data_sets == "ALL":
+        data_sets = "dev_clean,dev_other,train_clean_100,train_clean_360,train_other_500,test_clean,test_other"
+
+    for data_set in data_sets.split(','):
+        logging.info("\n\nWorking on: {0}".format(data_set))
+        filepath = os.path.join(data_root, data_set + ".tar.gz")
+        logging.info("Getting {0}".format(data_set))
+        __maybe_download_file(filepath, data_set.upper())
+        logging.info("Extracting {0}".format(data_set))
+        __extract_file(filepath, data_root)
+        logging.info("Processing {0}".format(data_set))
+        __process_data(
+            os.path.join(os.path.join(data_root, "LibriSpeech"), data_set.replace("_", "-"),),
+            os.path.join(os.path.join(data_root, "LibriSpeech"), data_set.replace("_", "-"),) + "-processed",
+            os.path.join(data_root, data_set + ".json"),
+        )
+    logging.info('Done!')
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/get_librispeech_data.py
+++ b/scripts/get_librispeech_data.py
@@ -1,4 +1,16 @@
-# Copyright (c) 2019 NVIDIA Corporation
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # USAGE: python get_librispeech_data.py --data_root=<where to put data>
 #        --data_set=<datasets_to_download>


### PR DESCRIPTION
# Changelog
- Add `pin_memory` support to CTC and CTC BPE models.
- Add `zero_infinity` support for CTC BPE models.
- Add WER logging at trainer.row_log_interval intervals. If trainer is not available (not set after restore, default to logging every step).
- Add scripts/convert_to_tarred_audio_dataset.py
  - Add support for filtering out samples with length > max_duration directly from script to avoid double work.
- Add scripts/get_librispeech_data.py for Librispeech preprocessing


Signed-off-by: smajumdar <titu1994@gmail.com>