### PR TITLE
Add CTC BPE Model pretrained checkpoint

### DIFF
--- a/nemo/collections/asr/models/__init__.py
+++ b/nemo/collections/asr/models/__init__.py
@@ -14,5 +14,6 @@
 
 from nemo.collections.asr.models.asr_model import ASRModel
 from nemo.collections.asr.models.classification_models import EncDecClassificationModel
+from nemo.collections.asr.models.ctc_bpe_models import EncDecCTCModelBPE
 from nemo.collections.asr.models.ctc_models import EncDecCTCModel
 from nemo.collections.asr.models.label_models import EncDecSpeakerLabelModel, ExtractSpeakerEmbeddingsModel

--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -108,7 +108,7 @@ class EncDecClassificationModel(ASRModel):
             return self._test_dl
 
     @classmethod
-    def list_available_models(cls) -> Optional[PretrainedModelInfo]:
+    def list_available_models(cls) -> Optional[List[PretrainedModelInfo]]:
         """
         This method returns a list of pre-trained model which can be instantiated directly from NVIDIA's NGC cloud.
 
@@ -150,9 +150,26 @@ class EncDecClassificationModel(ASRModel):
 
         model = PretrainedModelInfo(
             pretrained_model_name="MatchboxNet-3x1x64-v2-subset-task",
+            location="https://nemo-public.s3.us-east-2.amazonaws.com/nemo-1.0.0alpha-tests/MatchboxNet-3x1x64-v2-subset-task.nemo",
+            description="MatchboxNet model trained on Google Speech Commands dataset (v2, 10+2 classes) "
+            "which obtains 98.2% accuracy on test set.",
+        )
+        result.append(model)
+
+        model = PretrainedModelInfo(
+            pretrained_model_name="MatchboxNet-3x2x64-v2-subset-task",
             location="https://nemo-public.s3.us-east-2.amazonaws.com/nemo-1.0.0alpha-tests/MatchboxNet-3x2x64-v2-subset-task.nemo",
             description="MatchboxNet model trained on Google Speech Commands dataset (v2, 10+2 classes) "
             "which obtains 98.4% accuracy on test set.",
+        )
+        result.append(model)
+
+        model = PretrainedModelInfo(
+            pretrained_model_name="MatchboxNet-VAD-3x2",
+            location="https://nemo-public.s3.us-east-2.amazonaws.com/nemo-1.0.0alpha-tests/MatchboxNet_VAD_3x2.nemo",
+            description="MatchboxNet VAD model trained on google speech command (v2) and freesound background data, "
+            "which obtains 0.992 accuracy on testset from same source and 0.852 TPR for FPR=0.315 "
+            "on testset (ALL) of AVA movie data",
         )
         result.append(model)
         return result

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -24,15 +24,32 @@ from nemo.collections.asr.metrics.wer_bpe import WERBPE
 from nemo.collections.asr.models.ctc_models import EncDecCTCModel
 from nemo.collections.asr.parts.perturb import process_augmentations
 from nemo.collections.common import tokenizers
+from nemo.core.classes.common import PretrainedModelInfo
 from nemo.core.neural_types import *
 from nemo.utils import logging
-from nemo.utils.decorators import experimental
 
 __all__ = ['EncDecCTCModelBPE', 'JasperNetBPE', 'QuartzNetBPE']
 
 
 class EncDecCTCModelBPE(EncDecCTCModel):
     """Encoder decoder CTC-based models with Byte Pair Encoding."""
+
+    @classmethod
+    def list_available_models(cls) -> Optional[PretrainedModelInfo]:
+        """
+        This method returns a list of pre-trained model which can be instantiated directly from NVIDIA's NGC cloud.
+
+        Returns:
+            List of available pre-trained models.
+        """
+        result = []
+        model = PretrainedModelInfo(
+            pretrained_model_name="ContextNet-192-WPE-1024-8x-Stride",
+            location="https://nemo-public.s3.us-east-2.amazonaws.com/nemo-1.0.0alpha-tests/ContextNet-192-WPE-1024-8x-Stride.nemo",
+            description="The model is trained on the Librispeech corpus and achieves a WER of 10.09% on test-other and 10.11% on dev-other.",
+        )
+        result.append(model)
+        return result
 
     def __init__(self, cfg: DictConfig, trainer=None):
         if 'tokenizer' not in cfg:
@@ -288,11 +305,9 @@ class EncDecCTCModelBPE(EncDecCTCModel):
         logging.info(f"Changed tokenizer to {self.decoder.vocabulary} vocabulary.")
 
 
-@experimental
 class JasperNetBPE(EncDecCTCModelBPE):
     pass
 
 
-@experimental
 class QuartzNetBPE(EncDecCTCModelBPE):
     pass


### PR DESCRIPTION
# Changelog
- Add CTC BPE models to init
- Add Pretrained models for MBN subset task, VAD and EncDec WPE models

Signed-off-by: smajumdar <titu1994@gmail.com>