### PR TITLE
Replacing "BRANCH" to "main" re. new pip install.

### DIFF
--- a/tutorials/nlp/Token_Classification-BioMegatron.ipynb
+++ b/tutorials/nlp/Token_Classification-BioMegatron.ipynb
@@ -323,7 +323,7 @@
     "os.makedirs(config_dir, exist_ok=True)\n",
     "if not os.path.exists(config_dir + MODEL_CONFIG):\n",
     "    print('Downloading config file...')\n",
-    "    wget.download('https://raw.githubusercontent.com/NVIDIA/NeMo/' + BRANCH + '/examples/nlp/token_classification/conf/' + MODEL_CONFIG, config_dir)\n",
+    "    wget.download('https://raw.githubusercontent.com/NVIDIA/NeMo/main/examples/nlp/token_classification/conf/' + MODEL_CONFIG, config_dir)\n",
     "else:\n",
     "    print ('config file is already exists')"
    ]


### PR DESCRIPTION
We made a minor change in the first cell, removing "BRANCH".
Realize that "BRANCH" was still there in a later cell - removing that and replacing with "main".