### PR TITLE
Speech Commands - update number of classes automatically

### DIFF
--- a/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v1.yaml
@@ -143,7 +143,6 @@ model:
     cls: nemo.collections.asr.modules.ConvASRDecoderClassification
     params:
       feat_in: *enc_final_filters
-      num_classes: 30
       return_logits: true
       pooling_type: 'avg'
 

--- a/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_v2.yaml
@@ -143,7 +143,6 @@ model:
     cls: nemo.collections.asr.modules.ConvASRDecoderClassification
     params:
       feat_in: *enc_final_filters
-      num_classes: 35
       return_logits: true
       pooling_type: 'avg'
 

--- a/examples/asr/conf/matchboxnet_3x1x64_vad.yaml
+++ b/examples/asr/conf/matchboxnet_3x1x64_vad.yaml
@@ -132,7 +132,6 @@ model:
     cls: nemo.collections.asr.modules.ConvASRDecoderClassification
     params:
       feat_in: *enc_final_filters
-      num_classes: 2
       return_logits: true
       pooling_type: 'avg'
 

--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -298,14 +298,14 @@ class EncDecClassificationModel(ASRModel):
             if new_labels is None or len(new_labels) == 0:
                 raise ValueError(f'New labels must be non-empty list of labels. But I got: {new_labels}')
 
+            # Update config
+            self._cfg.labels = new_labels
+
             decoder_config = self.decoder.to_config_dict()
             new_decoder_config = copy.deepcopy(decoder_config)
             self._update_decoder_config(new_decoder_config)
             del self.decoder
             self.decoder = EncDecClassificationModel.from_config_dict(new_decoder_config)
-
-            # Update config
-            self._cfg.labels = new_labels
 
             OmegaConf.set_struct(self._cfg.decoder, False)
             self._cfg.decoder = new_decoder_config


### PR DESCRIPTION
# Changelog
- Update number of classes in the decoder automatically based on len(cfg.labels). 
- Update configs related to these models. Should be backward compatible. 

Signed-off-by: smajumdar <titu1994@gmail.com>