### PR TITLE
add container device command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ We recommend using NVIDIA's PyTorch container version 20.08-py3 with NeMo's main
 
     docker run --gpus all -it --rm -v <nemo_github_folder>:/NeMo --shm-size=8g \
     -p 8888:8888 -p 6006:6006 --ulimit memlock=-1 --ulimit \
-    stack=67108864 nvcr.io/nvidia/pytorch:20.08-py3
+    stack=67108864 --device=/dev/snd nvcr.io/nvidia/pytorch:20.08-py3
 
 
 Installation


### PR DESCRIPTION
Add --device=/dev/snd when runing container. for Invalid output device (no default output device) bug.


Signed-off-by: fayejf <fayejf07@gmail.com>