### PR TITLE
Add testing support alongside training script across all models

### DIFF
--- a/examples/nlp/intent_slot_classification/intent_slot_classification.py
+++ b/examples/nlp/intent_slot_classification/intent_slot_classification.py
@@ -57,7 +57,6 @@ def main(cfg: DictConfig) -> None:
 
         # we will reinitialize the trainer with a single GPU and no distributed backend for the evaluation
         # we need to call the next line also to overcome an issue with a trainer reinitialization in PT
-        os.environ.pop('PL_TRAINER_GPUS')
         cfg.trainer.gpus = 1 if cfg.trainer.gpus != 0 else 0
         cfg.trainer.distributed_backend = None
         eval_trainer = pl.Trainer(**cfg.trainer)

--- a/examples/nlp/text_classification/text_classification_with_bert.py
+++ b/examples/nlp/text_classification/text_classification_with_bert.py
@@ -151,7 +151,6 @@ def main(cfg: DictConfig) -> None:
         # the same script, and it can be a problem with multi-GPU training.
         # We also need to reset the environment variable PL_TRAINER_GPUS to prevent PT from initializing ddp.
         # When evaluation and training scripts are in separate files, no need for this resetting.
-        os.environ.pop('PL_TRAINER_GPUS')
         eval_trainer_cfg.gpus = 1 if torch.cuda.is_available() else 0
         eval_trainer_cfg.distributed_backend = None
         eval_trainer = pl.Trainer(**eval_trainer_cfg)


### PR DESCRIPTION
# Bugfix
- Allows use of the following schema for testing and training on the same script across all domains
- Bugfix identified and resolved by @VahidooX @vladgets 

```python
    model= SomeModel(cfg=cfg.model, trainer=trainer)

    trainer.fit(model)

    if hasattr(cfg.model, 'test_ds') and cfg.model.test_ds.manifest_filepath is not None:
        gpu = 1 if cfg.trainer.gpus != 0 else 0
        trainer = pl.Trainer(gpus=gpu)
        if model.prepare_test(trainer):
            trainer.test(model)
```
Signed-off-by: smajumdar <titu1994@gmail.com>