### PR TITLE
Patch to Model Parallelism after PTL 1.0.3 Upgrade

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -463,36 +463,36 @@ pipeline {
         }
       }
     }
-    // TODO: Adding this back after upgrade
-    // stage('L2: Text Classification with Model Parallel Size 2 Megatron BERT') {
-    //   when {
-    //     anyOf{
-    //       branch 'main'
-    //       changeRequest target: 'main'
-    //     }
-    //   }
-    //   failFast true
-    //   steps{
-    //     sh 'cd examples/nlp/text_classification && \
-    //     python text_classification_with_bert.py \
-    //     exp_manager.create_checkpoint_callback=false \
-    //     exp_manager.exp_dir=exp_mp_2_megatron_bert \
-    //     trainer.gpus=[0,1] \
-    //     trainer.num_nodes=1 \
-    //     trainer.precision=16 \
-    //     ~trainer.amp_level \
-    //     +trainer.replace_sampler_ddp=false \
-    //     +trainer.fast_dev_run=true \
-    //     model.dataset.num_classes=6 \
-    //     model.train_ds.file_path=/home/TestData/nlp/retail_text_classification/train.tsv \
-    //     model.train_ds.batch_size=4 \
-    //     model.language_model.pretrained_model_name=megatron-bert-uncased \
-    //     model.language_model.config_file=/home/TestData/nlp/mp_2_bert_toy/config.json \
-    //     model.language_model.lm_checkpoint=/home/TestData/nlp/mp_2_bert_toy/iter_2000000 \
-    //     '
-    //     sh 'rm -rf examples/nlp/text_classification/exp_mp_2_megatron_bert'
-    //   }
-    // }
+    stage('L2: Text Classification with Model Parallel Size 2 Megatron BERT') {
+      when {
+        anyOf{
+          branch 'main'
+          changeRequest target: 'main'
+        }
+      }
+      failFast true
+      steps{
+        sh 'cd examples/nlp/text_classification && \
+        python text_classification_with_bert.py \
+        exp_manager.create_checkpoint_callback=false \
+        exp_manager.exp_dir=exp_mp_2_megatron_bert \
+        trainer.gpus=[0,1] \
+        trainer.num_nodes=1 \
+        trainer.precision=16 \
+        trainer.gradient_clip_val=1.0 \
+        ~trainer.amp_level \
+        +trainer.replace_sampler_ddp=false \
+        +trainer.fast_dev_run=true \
+        model.dataset.num_classes=6 \
+        model.train_ds.file_path=/home/TestData/nlp/retail_text_classification/train.tsv \
+        model.train_ds.batch_size=4 \
+        model.language_model.pretrained_model_name=megatron-bert-uncased \
+        model.language_model.config_file=/home/TestData/nlp/mp_2_bert_toy/config.json \
+        model.language_model.lm_checkpoint=/home/TestData/nlp/mp_2_bert_toy/iter_2000000 \
+        '
+        sh 'rm -rf examples/nlp/text_classification/exp_mp_2_megatron_bert'
+      }
+    }
 
     stage('L2: Parallel NLP Examples 2') {
       when {

--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -104,8 +104,12 @@ class NLPModel(ModelPT):
             app_state = AppState()
 
             if app_state.model_parallel_size is not None:
+
                 if app_state.model_parallel_group is None:
                     self.init_model_parallel(app_state.global_rank, app_state.world_size)
+
+                self._trainer.accelerator_backend.ddp_plugin.configure_ddp = self.configure_ddp
+
                 if isinstance(self.bert_model, MegatronBertEncoder):
                     logging.info(f"restoring model parallel checkpoint: {self.bert_model._restore_path}")
                     # model parallel checkpoints need to be restored after torch.distributed is initialized

--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo.utils import app_state
 from typing import List
 
 import torch
@@ -25,7 +24,7 @@ from torch.nn.parallel import DistributedDataParallel
 
 from nemo.collections.nlp.modules import MegatronBertEncoder
 from nemo.core.classes import ModelPT
-from nemo.utils import AppState, logging
+from nemo.utils import AppState, app_state, logging
 
 __all__ = ['NLPModel']
 
@@ -38,7 +37,7 @@ class NLPModel(ModelPT):
         super().__init__(cfg, trainer)
         self.bert_model = None  # Pretrained BERT encoder
         self.set_world_size(trainer)
-    
+
     def init_model_parallel(self, global_rank: int, world_size: int) -> None:
         """ Override for LightningModule DDP initialization.
             Initializes Megatron-LM model parallel if using model parallelism.
@@ -53,13 +52,13 @@ class NLPModel(ModelPT):
         # we initialize megatron-lm model parallel and data parallel groups
         # after initializing DDP with PTL.
         if app_state.model_parallel_size is not None:
-                mpu.initialize_model_parallel(app_state.model_parallel_size)
-                app_state.model_parallel_group = mpu.get_model_parallel_group()
-                app_state.data_parallel_group = mpu.get_data_parallel_group()
-                app_state.model_parallel_rank = torch.distributed.get_rank(group=app_state.model_parallel_group)
-                app_state.data_parallel_rank = torch.distributed.get_rank(group=app_state.data_parallel_group)
-                logging.info(f'mp_rank: {app_state.model_parallel_rank}')
-                logging.info(f'dp_rank: {app_state.data_parallel_rank}')
+            mpu.initialize_model_parallel(app_state.model_parallel_size)
+            app_state.model_parallel_group = mpu.get_model_parallel_group()
+            app_state.data_parallel_group = mpu.get_data_parallel_group()
+            app_state.model_parallel_rank = torch.distributed.get_rank(group=app_state.model_parallel_group)
+            app_state.data_parallel_rank = torch.distributed.get_rank(group=app_state.data_parallel_group)
+            logging.info(f'mp_rank: {app_state.model_parallel_rank}')
+            logging.info(f'dp_rank: {app_state.data_parallel_rank}')
 
     def configure_ddp(self, model: LightningModule, device_ids: List[int]) -> DistributedDataParallel:
         """ Override LightningModule ddp if using model parallel.

--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -108,6 +108,7 @@ class NLPModel(ModelPT):
                 if app_state.model_parallel_group is None:
                     self.init_model_parallel(app_state.global_rank, app_state.world_size)
 
+                # Update PTL trainer to use our configure_ddp
                 self._trainer.accelerator_backend.ddp_plugin.configure_ddp = self.configure_ddp
 
                 if isinstance(self.bert_model, MegatronBertEncoder):

--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -108,7 +108,7 @@ class NLPModel(ModelPT):
                     self.init_model_parallel(app_state.global_rank, app_state.world_size)
 
                 # Update PTL trainer to use our configure_ddp
-                self._trainer.accelerator_backend.ddp_plugin.configure_ddp = self.configure_ddp
+                self._trainer.accelerator_backend.configure_ddp = self.configure_ddp
 
                 if isinstance(self.bert_model, MegatronBertEncoder):
                     logging.info(f"restoring model parallel checkpoint: {self.bert_model._restore_path}")

--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -24,7 +24,7 @@ from torch.nn.parallel import DistributedDataParallel
 
 from nemo.collections.nlp.modules import MegatronBertEncoder
 from nemo.core.classes import ModelPT
-from nemo.utils import AppState, app_state, logging
+from nemo.utils import AppState, logging
 
 __all__ = ['NLPModel']
 

--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -113,7 +113,7 @@ class NLPModel(ModelPT):
                     logging.info("replacing sampler with model parallel sampler")
                     mp_sampler = torch.utils.data.distributed.DistributedSampler(
                         self._train_dl.dataset,
-                        num_replicas=app_state.model_parallel_size,
+                        num_replicas=app_state.data_parallel_size,
                         rank=app_state.data_parallel_rank,
                     )
                     mp_dl = self._trainer.replace_sampler(self._train_dl, mp_sampler)

--- a/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
@@ -20,7 +20,7 @@ import torch
 from megatron import get_args, initialize_megatron
 from megatron.model import get_language_model
 from megatron.model.bert_model import bert_attention_mask_func, bert_extended_attention_mask, bert_position_ids
-from megatron.mpu import get_model_parallel_group
+from megatron.mpu import get_model_parallel_group, model_parallel_is_initialized
 from omegaconf import OmegaConf
 
 from nemo.collections.nlp.modules.common.bert_module import BertModule
@@ -145,7 +145,7 @@ class MegatronBertEncoder(BertModule):
             logging.info(f"weights restored from {restore_path}")
         elif os.path.isdir(restore_path):
             # need model parallel groups to restore model parallel checkpoints
-            if torch.distributed.is_initialized():
+            if model_parallel_is_initialized():
                 model_parallel_rank = torch.distributed.get_rank(group=get_model_parallel_group())
                 mp_restore_path = f'{restore_path}/mp_rank_{model_parallel_rank:02d}/model_optim_rng.pt'
                 logging.info(f'Restoring model parallel checkpoint from: {mp_restore_path}')


### PR DESCRIPTION
Hooks that we were previously using are now gone.

We were able to initialize model parallel and configure ddp from `setup` hook.