### PR TITLE
Fix multi dataloader and ASR logging + patch asr wer calculation

### DIFF
--- a/examples/asr/conf/quartznet_15x5.yaml
+++ b/examples/asr/conf/quartznet_15x5.yaml
@@ -262,6 +262,9 @@ exp_manager:
   name: *name
   create_tensorboard_logger: True
   create_checkpoint_callback: True
+  checkpoint_callback_params:
+    monitor: "val_wer"
+    mode: "min"
   create_wandb_logger: False
   wandb_logger_kwargs:
     name: null

--- a/examples/asr/conf/quartznet_15x5_zh.yaml
+++ b/examples/asr/conf/quartznet_15x5_zh.yaml
@@ -471,6 +471,9 @@ exp_manager:
   name: *name
   create_tensorboard_logger: True
   create_checkpoint_callback: True
+  checkpoint_callback_params:
+    monitor: "val_wer"
+    mode: "min"
   create_wandb_logger: False
   wandb_logger_kwargs:
     name: null

--- a/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_2x_stride.yaml
+++ b/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_2x_stride.yaml
@@ -369,6 +369,9 @@ exp_manager:
   name: *name
   create_tensorboard_logger: true
   create_checkpoint_callback: true
+  checkpoint_callback_params:
+    monitor: "val_wer"
+    mode: "min"
   create_wandb_logger: false
   wandb_logger_kwargs:
     name: null

--- a/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_4x_stride.yaml
+++ b/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_4x_stride.yaml
@@ -369,6 +369,9 @@ exp_manager:
   name: *name
   create_tensorboard_logger: true
   create_checkpoint_callback: true
+  checkpoint_callback_params:
+    monitor: "val_wer"
+    mode: "min"
   create_wandb_logger: false
   wandb_logger_kwargs:
     name: null

--- a/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_8x_stride.yaml
+++ b/examples/asr/experimental/configs/contextnet_bpe/contextnet_192_8x_stride.yaml
@@ -369,6 +369,9 @@ exp_manager:
   name: *name
   create_tensorboard_logger: true
   create_checkpoint_callback: true
+  checkpoint_callback_params:
+    monitor: "val_wer"
+    mode: "min"
   create_wandb_logger: false
   wandb_logger_kwargs:
     name: null

--- a/nemo/collections/asr/metrics/wer.py
+++ b/nemo/collections/asr/metrics/wer.py
@@ -171,8 +171,8 @@ class WER(Metric):
             # Compute Levenstein's distance
             scores += editdistance.eval(h_list, r_list)
 
-        self.scores += torch.tensor(scores, device=self.scores.device, dtype=self.scores.dtype)
-        self.words += torch.tensor(words, device=self.words.device, dtype=self.words.dtype)
+        self.scores = torch.tensor(scores, device=self.scores.device, dtype=self.scores.dtype)
+        self.words = torch.tensor(words, device=self.words.device, dtype=self.words.dtype)
         # return torch.tensor([scores, words]).to(predictions.device)
 
     def compute(self):

--- a/nemo/collections/asr/metrics/wer.py
+++ b/nemo/collections/asr/metrics/wer.py
@@ -103,7 +103,7 @@ class WER(Metric):
         log_prediction=True,
         dist_sync_on_step=False,
     ):
-        super().__init__(dist_sync_on_step=dist_sync_on_step)
+        super().__init__(dist_sync_on_step=dist_sync_on_step, compute_on_step=False)
         self.batch_dim_index = batch_dim_index
         self.blank_id = len(vocabulary)
         self.labels_map = dict([(i, vocabulary[i]) for i in range(len(vocabulary))])
@@ -171,9 +171,11 @@ class WER(Metric):
             # Compute Levenstein's distance
             scores += editdistance.eval(h_list, r_list)
 
-        self.scores = torch.tensor(scores).to(predictions.device)
-        self.words = torch.tensor(words).to(predictions.device)
+        self.scores += torch.tensor(scores, device=self.scores.device, dtype=self.scores.dtype)
+        self.words += torch.tensor(words, device=self.words.device, dtype=self.words.dtype)
         # return torch.tensor([scores, words]).to(predictions.device)
 
     def compute(self):
-        return self.scores / self.words
+        scores = self.scores.detach().float()
+        words = self.words.detach().float()
+        return scores / words, scores, words

--- a/nemo/collections/asr/metrics/wer_bpe.py
+++ b/nemo/collections/asr/metrics/wer_bpe.py
@@ -134,8 +134,8 @@ class WERBPE(Metric):
             # Compute Levenstein's distance
             scores += editdistance.eval(h_list, r_list)
 
-        self.scores += torch.tensor(scores, device=self.scores.device, dtype=self.scores.dtype)
-        self.words += torch.tensor(words, device=self.words.device, dtype=self.words.dtype)
+        self.scores = torch.tensor(scores, device=self.scores.device, dtype=self.scores.dtype)
+        self.words = torch.tensor(words, device=self.words.device, dtype=self.words.dtype)
         # return torch.tensor([scores, words]).to(predictions.device)
 
     def compute(self):

--- a/nemo/collections/asr/metrics/wer_bpe.py
+++ b/nemo/collections/asr/metrics/wer_bpe.py
@@ -66,7 +66,7 @@ class WERBPE(Metric):
         log_prediction=True,
         dist_sync_on_step=False,
     ):
-        super().__init__(dist_sync_on_step=dist_sync_on_step)
+        super().__init__(dist_sync_on_step=dist_sync_on_step, compute_on_step=False)
         self.tokenizer = tokenizer
         self.batch_dim_index = batch_dim_index
         self.blank_id = tokenizer.tokenizer.vocab_size
@@ -134,9 +134,11 @@ class WERBPE(Metric):
             # Compute Levenstein's distance
             scores += editdistance.eval(h_list, r_list)
 
-        self.scores = torch.tensor(scores).to(predictions.device)
-        self.words = torch.tensor(words).to(predictions.device)
+        self.scores += torch.tensor(scores, device=self.scores.device, dtype=self.scores.dtype)
+        self.words += torch.tensor(words, device=self.words.device, dtype=self.words.dtype)
         # return torch.tensor([scores, words]).to(predictions.device)
 
     def compute(self):
-        return self.scores / self.words
+        scores = self.scores.detach().float()
+        words = self.words.detach().float()
+        return scores / words, scores, words

--- a/nemo/collections/asr/models/asr_model.py
+++ b/nemo/collections/asr/models/asr_model.py
@@ -38,7 +38,7 @@ class ASRModel(ModelPT, ABC):
         val_loss_mean = torch.stack([x['val_loss'] for x in outputs]).mean()
         wer_num = torch.stack([x['val_wer_num'] for x in outputs]).sum()
         wer_denom = torch.stack([x['val_wer_denom'] for x in outputs]).sum()
-        tensorboard_logs = {'validation_loss': val_loss_mean, 'validation_wer': wer_num / wer_denom}
+        tensorboard_logs = {'val_loss': val_loss_mean, 'val_wer': wer_num / wer_denom}
         return {'val_loss': val_loss_mean, 'log': tensorboard_logs}
 
     def multi_test_epoch_end(self, outputs, dataloader_idx: int = 0):

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -378,7 +378,7 @@ class EncDecCTCModel(ASRModel, Exportable):
             log_every_n_steps = 1
 
         if (batch_nb + 1) % log_every_n_steps == 0:
-            self._wer(predictions, transcript, transcript_len)
+            self._wer.update(predictions, transcript, transcript_len)
             wer, _, _ = self._wer.compute()
             tensorboard_logs.update({'training_batch_wer': wer})
 
@@ -392,7 +392,7 @@ class EncDecCTCModel(ASRModel, Exportable):
         loss_value = self.loss(
             log_probs=log_probs, targets=transcript, input_lengths=encoded_len, target_lengths=transcript_len
         )
-        self._wer(predictions, transcript, transcript_len)
+        self._wer.update(predictions, transcript, transcript_len)
         wer, wer_num, wer_denom = self._wer.compute()
         return {
             'val_loss': loss_value,

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -378,7 +378,8 @@ class EncDecCTCModel(ASRModel, Exportable):
             log_every_n_steps = 1
 
         if (batch_nb + 1) % log_every_n_steps == 0:
-            wer = self._wer(predictions, transcript, transcript_len)
+            self._wer(predictions, transcript, transcript_len)
+            wer, _, _ = self._wer.compute()
             tensorboard_logs.update({'training_batch_wer': wer})
 
         return {'loss': loss_value, 'log': tensorboard_logs}
@@ -391,8 +392,8 @@ class EncDecCTCModel(ASRModel, Exportable):
         loss_value = self.loss(
             log_probs=log_probs, targets=transcript, input_lengths=encoded_len, target_lengths=transcript_len
         )
-        wer = self._wer(predictions, transcript, transcript_len)
-        wer_num, wer_denom = self._wer.scores, self._wer.words
+        self._wer(predictions, transcript, transcript_len)
+        wer, wer_num, wer_denom = self._wer.compute()
         return {
             'val_loss': loss_value,
             'val_wer_num': wer_num,

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -124,6 +124,9 @@ class ModelPT(LightningModule, Model):
                     f"Test config : \n{OmegaConf.to_yaml(self._cfg.test_ds)}"
                 )
 
+        # ModelPT wrappers over subclass implementations
+        self.training_step = model_utils.wrap_training_step(self.training_step)
+
     def register_artifact(self, config_path: str, src: str):
         """
         Register model artifacts with this function. These artifacts (files) will be included inside .nemo file
@@ -404,7 +407,7 @@ class ModelPT(LightningModule, Model):
             val_data_layer_config: validation data layer parameters.
         """
         # Set some placeholder overriden by helper method
-        self._validation_loss_idx = 0
+        self._validation_dl_idx = 0
         self._validation_names = None
         self._validation_dl = None  # type: torch.utils.data.DataLoader
 
@@ -429,7 +432,7 @@ class ModelPT(LightningModule, Model):
             test_data_layer_config: test data layer parameters.
         """
         # Set some placeholder overriden by helper method
-        self._test_loss_idx = 0
+        self._test_dl_idx = 0
         self._test_names = None
         self._test_dl = None  # type: torch.utils.data.DataLoader
 
@@ -640,7 +643,7 @@ class ModelPT(LightningModule, Model):
         Note:
             If more than one data loader exists, and they all provide `val_loss`,
             only the `val_loss` of the first data loader will be used by default.
-            This default can be changed by passing the special key `val_loss_idx: int`
+            This default can be changed by passing the special key `val_dl_idx: int`
             inside the `validation_ds` config.
 
         Args:
@@ -656,7 +659,12 @@ class ModelPT(LightningModule, Model):
 
         # Case where we provide exactly 1 data loader
         if type(outputs[0]) == dict:
-            return self.multi_validation_epoch_end(outputs, dataloader_idx=0)
+            output_dict = self.multi_validation_epoch_end(outputs, dataloader_idx=0)
+
+            if output_dict is not None and 'log' in output_dict:
+                self.log_dict(output_dict.pop('log'), on_epoch=True)
+
+            return output_dict
 
         else:  # Case where we provide more than 1 data loader
             output_dict = {'log': {}}
@@ -672,7 +680,7 @@ class ModelPT(LightningModule, Model):
 
                 # Perform `val_loss` resolution first (if provided outside logs)
                 if 'val_loss' in dataloader_logs:
-                    if 'val_loss' not in output_dict and dataloader_idx == self._validation_loss_idx:
+                    if 'val_loss' not in output_dict and dataloader_idx == self._validation_dl_idx:
                         output_dict['val_loss'] = dataloader_logs['val_loss']
 
                 # For every item in the result dictionary
@@ -683,23 +691,14 @@ class ModelPT(LightningModule, Model):
                         log_dict = {}
 
                         for k_log, v_log in v.items():
-                            # If we are logging the loss, but dont provide it at result level,
+                            # If we are logging the metric, but dont provide it at result level,
                             # store it twice - once in log and once in result level.
                             # Also mark log with prefix name to avoid log level clash with other data loaders
-                            if (
-                                k_log == 'val_loss'
-                                and 'val_loss' not in output_dict['log']
-                                and dataloader_idx == self._validation_loss_idx
-                            ):
-                                new_k_log = 'val_loss'
+                            if k_log not in output_dict['log'] and dataloader_idx == self._validation_dl_idx:
+                                new_k_log = k_log
 
                                 # Also insert duplicate key with prefix for ease of comparison / avoid name clash
                                 log_dict[dataloader_prefix + k_log] = v_log
-
-                            elif k_log == 'val_loss' and dataloader_idx != self._validation_loss_idx:
-                                # replace all other "val_loss" with <prefix> + loss
-                                # this avoid duplication of the word <prefix> + "val_loss" which causes confusion
-                                new_k_log = dataloader_prefix + 'loss'
 
                             else:
                                 # Simply prepend prefix to key and save
@@ -720,7 +719,12 @@ class ModelPT(LightningModule, Model):
                         new_k = dataloader_prefix + k
                         output_dict[new_k] = v
 
-            return output_dict
+            if 'log' in output_dict:
+                self.log_dict(output_dict.pop('log'), on_epoch=True)
+
+            # log everything else
+            if len(output_dict) > 0:
+                self.log_dict(output_dict, on_epoch=True)
 
     def test_epoch_end(
         self, outputs: Union[List[Dict[str, torch.Tensor]], List[List[Dict[str, torch.Tensor]]]]
@@ -735,7 +739,7 @@ class ModelPT(LightningModule, Model):
         Note:
             If more than one data loader exists, and they all provide `test_loss`,
             only the `test_loss` of the first data loader will be used by default.
-            This default can be changed by passing the special key `test_loss_idx: int`
+            This default can be changed by passing the special key `test_dl_idx: int`
             inside the `test_ds` config.
 
         Args:
@@ -751,7 +755,12 @@ class ModelPT(LightningModule, Model):
 
         # Case where we provide exactly 1 data loader
         if type(outputs[0]) == dict:
-            return self.multi_test_epoch_end(outputs, dataloader_idx=0)
+            output_dict = self.multi_test_epoch_end(outputs, dataloader_idx=0)
+
+            if output_dict is not None and 'log' in output_dict:
+                self.log_dict(output_dict.pop('log'), on_epoch=True)
+
+            return output_dict
 
         else:  # Case where we provide more than 1 data loader
             output_dict = {'log': {}}
@@ -767,7 +776,7 @@ class ModelPT(LightningModule, Model):
 
                 # Perform `test_loss` resolution first (if provided outside logs)
                 if 'test_loss' in dataloader_logs:
-                    if 'test_loss' not in output_dict and dataloader_idx == self._test_loss_idx:
+                    if 'test_loss' not in output_dict and dataloader_idx == self._test_dl_idx:
                         output_dict['test_loss'] = dataloader_logs['test_loss']
 
                 # For every item in the result dictionary
@@ -780,20 +789,11 @@ class ModelPT(LightningModule, Model):
                             # If we are logging the loss, but dont provide it at result level,
                             # store it twice - once in log and once in result level.
                             # Also mark log with prefix name to avoid log level clash with other data loaders
-                            if (
-                                k_log == 'test_loss'
-                                and 'test_loss' not in output_dict['log']
-                                and dataloader_idx == self._test_loss_idx
-                            ):
-                                new_k_log = 'test_loss'
+                            if k_log not in output_dict['log'] and dataloader_idx == self._test_dl_idx:
+                                new_k_log = k_log
 
-                                # Also insert duplicate key with prefix for ease of comparison
+                                # Also insert duplicate key with prefix for ease of comparison / avoid name clash
                                 log_dict[dataloader_prefix + k_log] = v_log
-
-                            elif k_log == 'test_loss' and dataloader_idx != self._test_loss_idx:
-                                # replace all other "test_loss" with <prefix> + loss
-                                # this avoid duplication of the word <prefix> + "test_loss" which causes confusion
-                                new_k_log = dataloader_prefix + 'loss'
 
                             else:
                                 # Simply prepend prefix to key and save
@@ -813,7 +813,11 @@ class ModelPT(LightningModule, Model):
                         new_k = dataloader_prefix + k
                         output_dict[new_k] = v
 
-            return output_dict
+            if 'log' in output_dict:
+                self.log_dict(output_dict.pop('log'), on_epoch=True)
+
+            if len(output_dict) > 0:
+                self.log_dict(output_dict, on_epoch=True)
 
     def multi_validation_epoch_end(
         self, outputs: List[Dict[str, torch.Tensor]], dataloader_idx: int = 0

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -407,7 +407,7 @@ class ModelPT(LightningModule, Model):
             val_data_layer_config: validation data layer parameters.
         """
         # Set some placeholder overriden by helper method
-        self._validation_dl_idx = 0
+        self._val_dl_idx = 0
         self._validation_names = None
         self._validation_dl = None  # type: torch.utils.data.DataLoader
 
@@ -680,7 +680,7 @@ class ModelPT(LightningModule, Model):
 
                 # Perform `val_loss` resolution first (if provided outside logs)
                 if 'val_loss' in dataloader_logs:
-                    if 'val_loss' not in output_dict and dataloader_idx == self._validation_dl_idx:
+                    if 'val_loss' not in output_dict and dataloader_idx == self._val_dl_idx:
                         output_dict['val_loss'] = dataloader_logs['val_loss']
 
                 # For every item in the result dictionary
@@ -694,7 +694,7 @@ class ModelPT(LightningModule, Model):
                             # If we are logging the metric, but dont provide it at result level,
                             # store it twice - once in log and once in result level.
                             # Also mark log with prefix name to avoid log level clash with other data loaders
-                            if k_log not in output_dict['log'] and dataloader_idx == self._validation_dl_idx:
+                            if k_log not in output_dict['log'] and dataloader_idx == self._val_dl_idx:
                                 new_k_log = k_log
 
                                 # Also insert duplicate key with prefix for ease of comparison / avoid name clash

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -722,9 +722,8 @@ class ModelPT(LightningModule, Model):
             if 'log' in output_dict:
                 self.log_dict(output_dict.pop('log'), on_epoch=True)
 
-            # log everything else
-            if len(output_dict) > 0:
-                self.log_dict(output_dict, on_epoch=True)
+            # return everything else
+            return output_dict
 
     def test_epoch_end(
         self, outputs: Union[List[Dict[str, torch.Tensor]], List[List[Dict[str, torch.Tensor]]]]
@@ -816,8 +815,8 @@ class ModelPT(LightningModule, Model):
             if 'log' in output_dict:
                 self.log_dict(output_dict.pop('log'), on_epoch=True)
 
-            if len(output_dict) > 0:
-                self.log_dict(output_dict, on_epoch=True)
+            # return everything else
+            return output_dict
 
     def multi_validation_epoch_end(
         self, outputs: List[Dict[str, torch.Tensor]], dataloader_idx: int = 0

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -207,7 +207,7 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
         val_dl_idx = 0
 
     # Set val_loss_idx
-    model._validation_dl_idx = val_dl_idx
+    model._val_dl_idx = val_dl_idx
 
     ds_key = resolve_dataset_name_from_cfg(cfg.validation_ds)
 

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -17,6 +17,8 @@ import os
 from pathlib import Path
 from typing import List, Optional
 
+import pytorch_lightning as pl
+import wrapt
 from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from nemo.utils import logging
@@ -197,15 +199,15 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
     dataloaders = []
 
     # process val_loss_idx
-    if 'val_loss_idx' in cfg.validation_ds:
+    if 'val_dl_idx' in cfg.validation_ds:
         cfg = OmegaConf.to_container(cfg)
-        val_loss_idx = cfg['validation_ds'].pop('val_loss_idx')
+        val_dl_idx = cfg['validation_ds'].pop('val_dl_idx')
         cfg = OmegaConf.create(cfg)
     else:
-        val_loss_idx = 0
+        val_dl_idx = 0
 
     # Set val_loss_idx
-    model._validation_loss_idx = val_loss_idx
+    model._validation_dl_idx = val_dl_idx
 
     ds_key = resolve_dataset_name_from_cfg(cfg.validation_ds)
 
@@ -266,15 +268,15 @@ def resolve_test_dataloaders(model: 'ModelPT'):
     dataloaders = []
 
     # process test_loss_idx
-    if 'test_loss_idx' in cfg.test_ds:
+    if 'test_dl_idx' in cfg.test_ds:
         cfg = OmegaConf.to_container(cfg)
-        test_loss_idx = cfg['test_ds'].pop('test_loss_idx')
+        test_dl_idx = cfg['test_ds'].pop('test_dl_idx')
         cfg = OmegaConf.create(cfg)
     else:
-        test_loss_idx = 0
+        test_dl_idx = 0
 
     # Set val_loss_idx
-    model._test_loss_idx = test_loss_idx
+    model._test_dl_idx = test_dl_idx
 
     ds_key = resolve_dataset_name_from_cfg(cfg.test_ds)
 
@@ -307,3 +309,14 @@ def resolve_test_dataloaders(model: 'ModelPT'):
         model._test_names = [parse_dataset_as_name(ds_values)]
 
         unique_names_check(name_list=model._test_names)
+
+
+@wrapt.decorator
+def wrap_training_step(wrapped, instance: pl.LightningModule, args, kwargs):
+    output_dict = wrapped(*args, **kwargs)
+
+    if 'log' in output_dict:
+        log_dict = output_dict.pop('log')
+        instance.log_dict(log_dict, on_step=True)
+
+    return output_dict

--- a/tests/collections/asr/test_asr_metrics.py
+++ b/tests/collections/asr/test_asr_metrics.py
@@ -80,15 +80,13 @@ class TestWordErrorRate:
         return torch.Tensor(string_in_id_form).unsqueeze(0)
 
     def get_wer(self, wer, prediction: str, reference: str):
-        res = (
-            wer(
-                predictions=self.__string_to_ctc_tensor(prediction),
-                targets=self.__reference_string_to_tensor(reference),
-                target_lengths=torch.tensor([len(reference)]),
-            )
-            .detach()
-            .cpu()
+        wer(
+            predictions=self.__string_to_ctc_tensor(prediction),
+            targets=self.__reference_string_to_tensor(reference),
+            target_lengths=torch.tensor([len(reference)]),
         )
+        res, _, _ = wer.compute()
+        res = res.detach().cpu()
         # return res[0] / res[1]
         return res.item()
 


### PR DESCRIPTION
# Changelog
- Patch multidataloader to add all of the keys from the validation / test steps.
- Add the default `val/test` log results, where default is designated by `val_dl_idx` or `test_dl_idx` (optional keys in the *_ds configs which default to the 0th dataloader).
- Patch ASR wer computation. 
  - It was computing wer two times, which impacts execution time and causes logs to be printed twice.
- Patch all subclasses of `training_step` to automatically remove all log dicts and simply use the new logging api in place.

Signed-off-by: smajumdar <titu1994@gmail.com>