### PR TITLE
Patch to test_asr_metrics

### DIFF
--- a/tests/collections/asr/test_asr_metrics.py
+++ b/tests/collections/asr/test_asr_metrics.py
@@ -124,7 +124,9 @@ class TestWordErrorRate:
             n2 = random.randint(1, 512)
             s1 = __randomString(n1)
             s2 = __randomString(n2)
-            assert (
-                abs(self.get_wer(wer, prediction=s1, reference=s2) - word_error_rate(hypotheses=[s1], references=[s2]))
-                < 1e-6
-            )
+            # skip empty strings as reference
+            if s2.strip():
+                assert (
+                    abs(self.get_wer(wer, prediction=s1, reference=s2) - word_error_rate(hypotheses=[s1], references=[s2]))
+                    < 1e-6
+                )

--- a/tests/collections/asr/test_asr_metrics.py
+++ b/tests/collections/asr/test_asr_metrics.py
@@ -127,6 +127,9 @@ class TestWordErrorRate:
             # skip empty strings as reference
             if s2.strip():
                 assert (
-                    abs(self.get_wer(wer, prediction=s1, reference=s2) - word_error_rate(hypotheses=[s1], references=[s2]))
+                    abs(
+                        self.get_wer(wer, prediction=s1, reference=s2)
+                        - word_error_rate(hypotheses=[s1], references=[s2])
+                    )
                     < 1e-6
                 )


### PR DESCRIPTION
Skip assert when reference is empty since empty reference does not make sense for WER.