### PR TITLE
Ensure `onnx_opset_version` consistency.

### DIFF
--- a/nemo/utils/export_utils.py
+++ b/nemo/utils/export_utils.py
@@ -227,6 +227,6 @@ def attach_onnx_to_onnx(model1: onnx.ModelProto, model2: onnx.ModelProto, prefix
     graph.value_info.extend(model2.graph.value_info)
     if model1.graph.doc_string:
         graph.doc_string = model1.graph.doc_string
-    output_model = onnx.helper.make_model(graph)
+    output_model = onnx.helper.make_model(graph, opset_imports=model1.opset_import)
     onnx.checker.check_model(output_model, full_check=True)
     return output_model


### PR DESCRIPTION
The `attach_onnx_to_onnx` method merges two onnx graphs. It uses
`onnx.helper.make_model`. That has an `opset_import` optional argument.
If this is not set, it will use whatever the default for your onnx
version is.

I found this playing around with exporting `quartznet` in the `main` branch on the `nvcr.io/nvidia/pytorch:20.09-py3` container. While the `encoder` and `decoder` `.onnx` models were opset version 12 (as specified in the `export` method), the single model `.onnx` was opset version 13. This change causes it to use the same opset version as model1.
For example: https://github.com/NVIDIA/NeMo/blob/d061dfd7970b95790d713b24f7874511129833e5/nemo/collections/asr/models/ctc_models.py#L503

I think, given the context, it is safe to assume that `model1` and `model2` will have the same opset version?