### PR TITLE
Updated ambiguous placeholder text

### DIFF
--- a/examples/nlp/glue_benchmark/glue_benchmark.py
+++ b/examples/nlp/glue_benchmark/glue_benchmark.py
@@ -26,7 +26,7 @@ To train GLUEModel with the default config file, run:
     model.dataset.data_dir=<PATH_TO_DATA_DIR>  \
     model.task_name=TASK_NAME \
     trainer.max_epochs=<NUM_EPOCHS> \
-    trainer.gpus="[<CHANGE_TO_GPU_YOU_WANT_TO_USE>]
+    trainer.gpus="[<CHANGE_TO_NUMBER_OF_GPUS_TO_USE>]
 
 Supported task names:
 ["cola", "sst-2", "mrpc", "sts-b", "qqp", "mnli", "qnli", "rte", "wnli"]


### PR DESCRIPTION
Line 29 in `examples/nlp/glue_benchmark` says `trainer.gpus="[<CHANGE_TO_GPU_YOU_WANT_TO_USE>]` which is not correct since this parameter sets the number of GPUs to use during training. 

I have updated the placeholder text accordingly to say `trainer.gpus="[<CHANGE_TO_NUMBER_OF_GPUS_TO_USE>]`.