### PR TITLE
Add support for replicated shard strategy for tarred datasets

### DIFF
--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -17,7 +17,7 @@ model:
     shuffle: True
     is_tarred: False
     tarred_audio_filepaths: null
-    shard_strategy: "scatter"
+    tarred_shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -17,6 +17,7 @@ model:
     shuffle: True
     is_tarred: False
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/jasper_10x5dr.yaml
+++ b/examples/asr/conf/jasper_10x5dr.yaml
@@ -15,7 +15,7 @@ model:
     shuffle: True
     is_tarred: False
     tarred_audio_filepaths: null
-    shard_strategy: "scatter"
+    tarred_shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/jasper_10x5dr.yaml
+++ b/examples/asr/conf/jasper_10x5dr.yaml
@@ -15,6 +15,7 @@ model:
     shuffle: True
     is_tarred: False
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/quartznet_15x5.yaml
+++ b/examples/asr/conf/quartznet_15x5.yaml
@@ -18,7 +18,7 @@ model:
     shuffle: True
     is_tarred: False
     tarred_audio_filepaths: null
-    shard_strategy: "scatter"
+    tarred_shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/quartznet_15x5.yaml
+++ b/examples/asr/conf/quartznet_15x5.yaml
@@ -18,6 +18,7 @@ model:
     shuffle: True
     is_tarred: False
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/quartznet_15x5_zh.yaml
+++ b/examples/asr/conf/quartznet_15x5_zh.yaml
@@ -226,6 +226,7 @@ model:
     shuffle: True
     is_tarred: False
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/quartznet_15x5_zh.yaml
+++ b/examples/asr/conf/quartznet_15x5_zh.yaml
@@ -226,7 +226,7 @@ model:
     shuffle: True
     is_tarred: False
     tarred_audio_filepaths: null
-    shard_strategy: "scatter"
+    tarred_shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/citrinet/citrinet_192_2x_stride.yaml
+++ b/examples/asr/experimental/citrinet/citrinet_192_2x_stride.yaml
@@ -12,7 +12,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
-    shard_strategy: "scatter"
+    tarred_shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/citrinet/citrinet_192_2x_stride.yaml
+++ b/examples/asr/experimental/citrinet/citrinet_192_2x_stride.yaml
@@ -12,6 +12,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/citrinet/citrinet_192_4x_stride.yaml
+++ b/examples/asr/experimental/citrinet/citrinet_192_4x_stride.yaml
@@ -12,7 +12,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
-    shard_strategy: "scatter"
+    tarred_shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/citrinet/citrinet_192_4x_stride.yaml
+++ b/examples/asr/experimental/citrinet/citrinet_192_4x_stride.yaml
@@ -12,6 +12,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/citrinet/citrinet_192_8x_stride.yaml
+++ b/examples/asr/experimental/citrinet/citrinet_192_8x_stride.yaml
@@ -12,7 +12,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
-    shard_strategy: "scatter"
+    tarred_shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/citrinet/citrinet_192_8x_stride.yaml
+++ b/examples/asr/experimental/citrinet/citrinet_192_8x_stride.yaml
@@ -12,6 +12,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/citrinet/config_bpe.yaml
+++ b/examples/asr/experimental/citrinet/config_bpe.yaml
@@ -14,6 +14,7 @@ model:
     shuffle: True
     is_tarred: False
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/configs/quartznet_15x5_aug.yaml
+++ b/examples/asr/experimental/configs/quartznet_15x5_aug.yaml
@@ -18,6 +18,7 @@ model:
     shuffle: True
     is_tarred: False
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
     augmentor:
       rir_noise_aug:
         prob: 0.5

--- a/examples/asr/experimental/configs/quartznet_15x5_aug.yaml
+++ b/examples/asr/experimental/configs/quartznet_15x5_aug.yaml
@@ -18,7 +18,7 @@ model:
     shuffle: True
     is_tarred: False
     tarred_audio_filepaths: null
-    shard_strategy: "scatter"
+    tarred_shard_strategy: "scatter"
     augmentor:
       rir_noise_aug:
         prob: 0.5

--- a/examples/asr/experimental/conformer/conformer_bpe.yaml
+++ b/examples/asr/experimental/conformer/conformer_bpe.yaml
@@ -16,7 +16,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
-    shard_strategy: "scatter"
+    tarred_shard_strategy: "scatter"
     num_workers: 4
     pin_memory: false
     use_start_end_token: true

--- a/examples/asr/experimental/conformer/conformer_bpe.yaml
+++ b/examples/asr/experimental/conformer/conformer_bpe.yaml
@@ -16,6 +16,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
     num_workers: 4
     pin_memory: false
     use_start_end_token: true

--- a/examples/asr/experimental/conformer/conformer_char.yaml
+++ b/examples/asr/experimental/conformer/conformer_char.yaml
@@ -19,7 +19,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
-    shard_strategy: "scatter"
+    tarred_shard_strategy: "scatter"
     num_workers: 4
     pin_memory: true
 

--- a/examples/asr/experimental/conformer/conformer_char.yaml
+++ b/examples/asr/experimental/conformer/conformer_char.yaml
@@ -19,6 +19,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
     num_workers: 4
     pin_memory: true
 

--- a/examples/asr/experimental/contextnet_rnnt/config_rnnt.yaml
+++ b/examples/asr/experimental/contextnet_rnnt/config_rnnt.yaml
@@ -17,7 +17,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
-    shard_strategy: "scatter"
+    tarred_shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/contextnet_rnnt/config_rnnt.yaml
+++ b/examples/asr/experimental/contextnet_rnnt/config_rnnt.yaml
@@ -17,6 +17,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/contextnet_rnnt/config_rnnt_bpe.yaml
+++ b/examples/asr/experimental/contextnet_rnnt/config_rnnt_bpe.yaml
@@ -18,6 +18,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
+    shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/contextnet_rnnt/config_rnnt_bpe.yaml
+++ b/examples/asr/experimental/contextnet_rnnt/config_rnnt_bpe.yaml
@@ -18,7 +18,7 @@ model:
     shuffle: true
     is_tarred: false
     tarred_audio_filepaths: null
-    shard_strategy: "scatter"
+    tarred_shard_strategy: "scatter"
 
   validation_ds:
     manifest_filepath: ???

--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -675,6 +675,18 @@ class _TarredAudioToTextDataset(IterableDataset):
         pad_id (id): Token used to pad when collating samples in batches.
             If this is None, pads using 0s.
             Defaults to None.
+        shard_strategy (str): Tarred dataset shard distribution strategy chosen as a str value during ddp.
+            -   `scatter`: The default shard strategy applied by WebDataset, where each node gets
+                a unique set of shards, which are permanently pre-allocated and never changed at runtime.
+            -   `replicate`: Optional shard strategy, where each node gets all of the set of shards
+                available in the tarred dataset, which are permanently pre-allocated and never changed at runtime.
+                The benefit of replication is that it allows each node to sample data points from the entire
+                dataset independently of other nodes, and reduces dependence on value of `shuffle_n`.
+
+                Note: Replicated strategy allows every node to sample the entire set of available tarfiles,
+                and therefore more than one node may sample the same tarfile, and even sample the same
+                data points! As such, there is no assured guarantee that all samples in the dataset will be
+                sampled at least once during 1 epoch.
         global_rank (int): Worker rank, used for partitioning shards. Defaults to 0.
         world_size (int): Total number of processes, used for partitioning shards. Defaults to 0.
     """
@@ -696,6 +708,7 @@ class _TarredAudioToTextDataset(IterableDataset):
         eos_id: Optional[int] = None,
         add_misc: bool = False,
         pad_id: int = 0,
+        shard_strategy: str = "scatter",
         global_rank: int = 0,
         world_size: int = 0,
     ):
@@ -714,6 +727,10 @@ class _TarredAudioToTextDataset(IterableDataset):
         self.bos_id = bos_id
         self.pad_id = pad_id
         self._add_misc = add_misc
+
+        valid_shard_strategies = ['scatter', 'replicate']
+        if shard_strategy not in valid_shard_strategies:
+            raise ValueError(f"`shard_strategy` must be one of {valid_shard_strategies}")
 
         if isinstance(audio_tar_filepaths, str):
             # Replace '(' and '[' with '{'
@@ -734,18 +751,27 @@ class _TarredAudioToTextDataset(IterableDataset):
                 # Brace expand
                 audio_tar_filepaths = list(braceexpand.braceexpand(audio_tar_filepaths))
 
-            if len(audio_tar_filepaths) % world_size != 0:
-                logging.warning(
-                    f"Number of shards in tarred dataset ({len(audio_tar_filepaths)}) is not divisible "
-                    f"by number of distributed workers ({world_size})."
+            if shard_strategy == 'scatter':
+                logging.info("All tarred dataset shards will be scattered evenly across all nodes.")
+
+                if len(audio_tar_filepaths) % world_size != 0:
+                    logging.warning(
+                        f"Number of shards in tarred dataset ({len(audio_tar_filepaths)}) is not divisible "
+                        f"by number of distributed workers ({world_size})."
+                    )
+
+                begin_idx = (len(audio_tar_filepaths) // world_size) * global_rank
+                end_idx = begin_idx + (len(audio_tar_filepaths) // world_size)
+                audio_tar_filepaths = audio_tar_filepaths[begin_idx:end_idx]
+                logging.info(
+                    "Partitioning tarred dataset: process (%d) taking shards [%d, %d)", global_rank, begin_idx, end_idx
                 )
 
-            begin_idx = (len(audio_tar_filepaths) // world_size) * global_rank
-            end_idx = begin_idx + (len(audio_tar_filepaths) // world_size)
-            audio_tar_filepaths = audio_tar_filepaths[begin_idx:end_idx]
-            logging.info(
-                "Partitioning tarred dataset: process (%d) taking shards [%d, %d)", global_rank, begin_idx, end_idx
-            )
+            elif shard_strategy == 'replicate':
+                logging.info("All tarred dataset shards will be replicated across all nodes.")
+
+            else:
+                raise ValueError(f"Invalid shard strategy ! Allowed values are : {valid_shard_strategies}")
 
         # Put together WebDataset
         self._dataset = (
@@ -899,6 +925,18 @@ class TarredAudioToCharDataset(_TarredAudioToTextDataset):
         pad_id (id): Token used to pad when collating samples in batches.
             If this is None, pads using 0s.
             Defaults to None.
+        shard_strategy (str): Tarred dataset shard distribution strategy chosen as a str value during ddp.
+            -   `scatter`: The default shard strategy applied by WebDataset, where each node gets
+                a unique set of shards, which are permanently pre-allocated and never changed at runtime.
+            -   `replicate`: Optional shard strategy, where each node gets all of the set of shards
+                available in the tarred dataset, which are permanently pre-allocated and never changed at runtime.
+                The benefit of replication is that it allows each node to sample data points from the entire
+                dataset independently of other nodes, and reduces dependence on value of `shuffle_n`.
+
+                Note: Replicated strategy allows every node to sample the entire set of available tarfiles,
+                and therefore more than one node may sample the same tarfile, and even sample the same
+                data points! As such, there is no assured guarantee that all samples in the dataset will be
+                sampled at least once during 1 epoch.
         global_rank (int): Worker rank, used for partitioning shards. Defaults to 0.
         world_size (int): Total number of processes, used for partitioning shards. Defaults to 0.
     """
@@ -924,6 +962,7 @@ class TarredAudioToCharDataset(_TarredAudioToTextDataset):
         parser: Optional[str] = 'en',
         add_misc: bool = False,
         pad_id: int = 0,
+        shard_strategy: str = "scatter",
         global_rank: int = 0,
         world_size: int = 0,
     ):
@@ -949,6 +988,7 @@ class TarredAudioToCharDataset(_TarredAudioToTextDataset):
             eos_id=eos_id,
             add_misc=add_misc,
             pad_id=pad_id,
+            shard_strategy=shard_strategy,
             global_rank=global_rank,
             world_size=world_size,
         )
@@ -1010,6 +1050,18 @@ class TarredAudioToBPEDataset(_TarredAudioToTextDataset):
         pad_id (id): Token used to pad when collating samples in batches.
             If this is None, pads using 0s.
             Defaults to None.
+        shard_strategy (str): Tarred dataset shard distribution strategy chosen as a str value during ddp.
+            -   `scatter`: The default shard strategy applied by WebDataset, where each node gets
+                a unique set of shards, which are permanently pre-allocated and never changed at runtime.
+            -   `replicate`: Optional shard strategy, where each node gets all of the set of shards
+                available in the tarred dataset, which are permanently pre-allocated and never changed at runtime.
+                The benefit of replication is that it allows each node to sample data points from the entire
+                dataset independently of other nodes, and reduces dependence on value of `shuffle_n`.
+
+                Note: Replicated strategy allows every node to sample the entire set of available tarfiles,
+                and therefore more than one node may sample the same tarfile, and even sample the same
+                data points! As such, there is no assured guarantee that all samples in the dataset will be
+                sampled at least once during 1 epoch.
         global_rank (int): Worker rank, used for partitioning shards. Defaults to 0.
         world_size (int): Total number of processes, used for partitioning shards. Defaults to 0.
     """
@@ -1028,9 +1080,10 @@ class TarredAudioToBPEDataset(_TarredAudioToTextDataset):
         max_utts: int = 0,
         trim: bool = False,
         add_misc: bool = False,
+        use_start_end_token: bool = True,
+        shard_strategy: str = "scatter",
         global_rank: int = 0,
         world_size: int = 0,
-        use_start_end_token: bool = True,
     ):
         if use_start_end_token and hasattr(tokenizer, 'bos_token'):
             bos_id = tokenizer.bos_id
@@ -1071,6 +1124,7 @@ class TarredAudioToBPEDataset(_TarredAudioToTextDataset):
             eos_id=eos_id,
             add_misc=add_misc,
             pad_id=pad_id,
+            shard_strategy=shard_strategy,
             global_rank=global_rank,
             world_size=world_size,
         )

--- a/nemo/collections/asr/data/audio_to_text_dataset.py
+++ b/nemo/collections/asr/data/audio_to_text_dataset.py
@@ -116,6 +116,7 @@ def get_tarred_char_dataset(
         trim=config.get('trim_silence', True),
         parser=config.get('parser', 'en'),
         add_misc=config.get('add_misc', False),
+        shard_strategy=config.get('shard_strategy', 'scatter'),
         global_rank=global_rank,
         world_size=world_size,
     )
@@ -159,6 +160,7 @@ def get_tarred_bpe_dataset(
         trim=config.get('trim_silence', True),
         add_misc=config.get('add_misc', False),
         use_start_end_token=config.get('use_start_end_token', True),
+        shard_strategy=config.get('shard_strategy', 'scatter'),
         global_rank=global_rank,
         world_size=world_size,
     )

--- a/nemo/collections/asr/data/audio_to_text_dataset.py
+++ b/nemo/collections/asr/data/audio_to_text_dataset.py
@@ -116,7 +116,7 @@ def get_tarred_char_dataset(
         trim=config.get('trim_silence', True),
         parser=config.get('parser', 'en'),
         add_misc=config.get('add_misc', False),
-        shard_strategy=config.get('shard_strategy', 'scatter'),
+        shard_strategy=config.get('tarred_shard_strategy', 'scatter'),
         global_rank=global_rank,
         world_size=world_size,
     )
@@ -160,7 +160,7 @@ def get_tarred_bpe_dataset(
         trim=config.get('trim_silence', True),
         add_misc=config.get('add_misc', False),
         use_start_end_token=config.get('use_start_end_token', True),
-        shard_strategy=config.get('shard_strategy', 'scatter'),
+        shard_strategy=config.get('tarred_shard_strategy', 'scatter'),
         global_rank=global_rank,
         world_size=world_size,
     )


### PR DESCRIPTION
# Changelog
- Support `replicate` strategy for sharding of tarfiles under ddp for Tarred WebDataset.
- Add config line to all ASR models

Signed-off-by: smajumdar <titu1994@gmail.com>