### PR TITLE
Add support for Tarred dataset for Transformer LM

### DIFF
--- a/nemo/collections/nlp/data/__init__.py
+++ b/nemo/collections/nlp/data/__init__.py
@@ -16,7 +16,10 @@ from nemo.collections.nlp.data.data_utils import *
 from nemo.collections.nlp.data.information_retrieval.information_retrieval_dataset import (
     BertInformationRetrievalDataset,
 )
-from nemo.collections.nlp.data.language_modeling.l2r_lm_dataset import L2RLanguageModelingDataset
+from nemo.collections.nlp.data.language_modeling.l2r_lm_dataset import (
+    L2RLanguageModelingDataset,
+    TarredL2RLanguageModelingDataset,
+)
 from nemo.collections.nlp.data.language_modeling.lm_bert_dataset import (
     BertPretrainingDataset,
     BertPretrainingPreprocessedDataloader,

--- a/nemo/collections/nlp/data/data_utils/data_preprocessing.py
+++ b/nemo/collections/nlp/data/data_utils/data_preprocessing.py
@@ -20,9 +20,9 @@ import random
 import re
 import string
 from collections import Counter
-from tqdm.auto import tqdm
 
 import numpy as np
+from tqdm.auto import tqdm
 
 from nemo.utils import logging
 

--- a/nemo/collections/nlp/data/data_utils/data_preprocessing.py
+++ b/nemo/collections/nlp/data/data_utils/data_preprocessing.py
@@ -20,6 +20,7 @@ import random
 import re
 import string
 from collections import Counter
+from tqdm.auto import tqdm
 
 import numpy as np
 
@@ -372,7 +373,7 @@ def dataset_to_ids(dataset, tokenizer, cache_ids=False, add_bos_eos=True):
         logging.info("Tokenizing dataset ...")
         data = open(dataset, "rb").readlines()
         ids = []
-        for sentence in data:
+        for sentence in tqdm(data, desc='Tokenizing sentence'):
             sent_ids = tokenizer.text_to_ids(sentence.decode("utf-8"))
             if add_bos_eos:
                 sent_ids = [tokenizer.bos_id] + sent_ids + [tokenizer.eos_id]

--- a/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
@@ -39,6 +39,9 @@ class L2RLanguageModelingDataset(Dataset):
         batch_step: distance (in tokens) between two successive sequences of
             the text. By default, it is equal to max_seq_length which corresponds
             to splitting text into disjoint segments covering full dataset
+        cache_ids: bool value, defaults to False. Determines whether the preprocessed,
+            tokenized dataset should be cached into a pickle file. If true, cache is saved
+            at the path provided in `dataset`.
     """
 
     def __init__(

--- a/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
+import json
+import pickle
 from typing import Optional
 
 import numpy as np
-import json
 import webdataset as wd
-import io
-import pickle
 from torch.utils.data import Dataset, IterableDataset
 
 from nemo.collections.common.tokenizers.tokenizer_spec import TokenizerSpec
@@ -47,7 +47,7 @@ class L2RLanguageModelingDataset(Dataset):
         dataset: str,
         max_seq_length: Optional[int] = 512,
         batch_step: Optional[int] = None,
-        cache_ids: bool = False
+        cache_ids: bool = False,
     ):
         self.tokenizer = tokenizer
         self.max_seq_length = max_seq_length

--- a/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
@@ -19,7 +19,7 @@ import json
 import webdataset as wd
 import io
 import pickle
-from torch.utils.data import Dataset,IterableDataset
+from torch.utils.data import Dataset, IterableDataset
 
 from nemo.collections.common.tokenizers.tokenizer_spec import TokenizerSpec
 from nemo.collections.nlp.data.data_utils import dataset_to_ids
@@ -105,7 +105,7 @@ class TarredL2RLanguageModelingDataset(IterableDataset):
 
         # Put together WebDataset
         self._dataset = (
-            wd.Dataset(tarpath)
+            wd.Dataset(tarpath, shard_selection=lambda urls: urls)
             .shuffle(shuffle_n)
             .rename(npy='npy', key='__key__')
             .to_tuple('npy', 'key')
@@ -119,7 +119,7 @@ class TarredL2RLanguageModelingDataset(IterableDataset):
         npy.close()
 
         # flatten data
-        idx = np.random.randint(0, (len(data) - self.max_seq_length) // self.batch_step + 1)
+        idx = np.random.randint(0, (len(data) - self.max_seq_length) // self.batch_step)
 
         # random slice of data
         left = idx * self.batch_step

--- a/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
@@ -38,7 +38,7 @@ class L2RLanguageModelingDataset(Dataset):
         batch_step: distance (in tokens) between two successive sequences of
             the text. By default, it is equal to max_seq_length which corresponds
             to splitting text into disjoint segments covering full dataset
-        cache_ids: bool value, defaults to False. Determines whether the preprocessed,
+        use_cache: bool value, defaults to False. Determines whether the preprocessed,
             tokenized dataset should be cached into a pickle file. If true, cache is saved
             at the path provided in `dataset`.
     """
@@ -49,12 +49,12 @@ class L2RLanguageModelingDataset(Dataset):
         dataset: str,
         max_seq_length: Optional[int] = 512,
         batch_step: Optional[int] = None,
-        cache_ids: bool = False,
+        use_cache: bool = False,
     ):
         self.tokenizer = tokenizer
         self.max_seq_length = max_seq_length
         self.batch_step = batch_step or self.max_seq_length
-        ids = dataset_to_ids(dataset, tokenizer, cache_ids=cache_ids, add_bos_eos=False)
+        ids = dataset_to_ids(dataset, tokenizer, cache_ids=use_cache, add_bos_eos=False)
         self.ids = np.array([j for i in ids for j in i])
 
     def __len__(self):

--- a/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
@@ -105,7 +105,7 @@ class TarredL2RLanguageModelingDataset(IterableDataset):
 
         # Put together WebDataset
         self._dataset = (
-            wd.Dataset(tarpath, shard_selection=lambda urls: urls)
+            wd.Dataset(tarpath)
             .shuffle(shuffle_n)
             .rename(npy='npy', key='__key__')
             .to_tuple('npy', 'key')
@@ -131,7 +131,14 @@ class TarredL2RLanguageModelingDataset(IterableDataset):
         return src_ids, src_mask, labels
 
     def __iter__(self):
-        return self._dataset.__iter__()
+        dl_iter = iter(self._dataset)
+        while True:
+            try:
+                batch = next(dl_iter)
+                yield batch
+            except StopIteration:
+                dl_iter = iter(self._dataset)
+                continue
 
     def __len__(self):
         return (self.metadata['num_text'] - self.max_seq_length) // self.batch_step

--- a/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
@@ -147,13 +147,13 @@ class TarredL2RLanguageModelingDataset(IterableDataset):
         self.metadata = metadata
 
         if isinstance(text_tar_filepaths, str):
-            # Replace '(' and '[' with '{'
+            # Replace '(', '[', '<' and '_OP_' with '{'
             brace_keys_open = ['(', '[', '<', '_OP_']
             for bkey in brace_keys_open:
                 if bkey in text_tar_filepaths:
                     text_tar_filepaths = text_tar_filepaths.replace(bkey, "{")
 
-            # Replace ')' and ']' with '}'
+            # Replace ')', ']', '>' and '_CL_' with '}'
             brace_keys_close = [')', ']', '>', '_CL_']
             for bkey in brace_keys_close:
                 if bkey in text_tar_filepaths:

--- a/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
@@ -14,7 +14,6 @@
 
 import io
 import json
-import pickle
 from typing import Optional
 
 import numpy as np
@@ -77,7 +76,7 @@ class TarredL2RLanguageModelingDataset(IterableDataset):
     The manifest should contain information such as the number of shards, the number of tokens in the corpus,
     and the number of tokens contained within each shard of the tarfile(s).
 
-    Valid formats for the audio_tar_filepaths argument include:
+    Valid formats for the text_tar_filepaths argument include:
     (1) a single string that can be brace-expanded, e.g. 'path/to/text.tar' or 'path/to/text_{1..100}.tar.gz', or
     (2) a list of file paths that will not be brace-expanded, e.g. ['text_1.tar', 'text_2.tar', ...].
 
@@ -173,7 +172,7 @@ class TarredL2RLanguageModelingDataset(IterableDataset):
 
             begin_idx = (len(text_tar_filepaths) // world_size) * global_rank
             end_idx = begin_idx + (len(text_tar_filepaths) // world_size)
-            audio_tar_filepaths = text_tar_filepaths[begin_idx:end_idx]
+            text_tar_filepaths = text_tar_filepaths[begin_idx:end_idx]
             logging.info(
                 "Partitioning tarred dataset: process (%d) taking shards [%d, %d)", global_rank, begin_idx, end_idx
             )

--- a/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
@@ -68,14 +68,68 @@ class L2RLanguageModelingDataset(Dataset):
 
 
 class TarredL2RLanguageModelingDataset(IterableDataset):
+    """
+    A similar Dataset to the L2RLanguageModelingDataset, but which loads tarred tokenized numpy files.
+    Accepts a single JSON metadata manifest file as well as the path(s) to the tarball(s) containing the wav files. 
+    The manifest should contain information such as the number of shards, the number of tokens in the corpus,
+    and the number of tokens contained within each shard of the tarfile(s).
+
+    Valid formats for the audio_tar_filepaths argument include:
+    (1) a single string that can be brace-expanded, e.g. 'path/to/text.tar' or 'path/to/text_{1..100}.tar.gz', or
+    (2) a list of file paths that will not be brace-expanded, e.g. ['text_1.tar', 'text_2.tar', ...].
+
+    Note: For brace expansion in (1), there may be cases where `{x..y}` syntax cannot be used due to shell interference.
+    This occurs most commonly inside SLURM scripts. Therefore we provide a few equivalent replacements.
+    Supported opening braces - { <=> (, [, < and the special tag _OP_.
+    Supported closing braces - } <=> ), ], > and the special tag _CL_.
+    For SLURM based tasks, we suggest the use of the special tags for ease of use.
+    See the WebDataset documentation for more information about accepted data and input formats.
+
+    If using multiple processes the number of shards should be divisible by the number of workers to ensure an
+    even split among workers. If it is not divisible, logging will give a warning but training will proceed.
+
+    Additionally, please note that the len() of this DataLayer is assumed to be the number of tokens
+    of the text data. An incorrect manifest length may lead to some DataLoader issues down the line.
+
+    Args:
+        text_tar_filepaths: Either a list of tokenized text tarball filepaths, or a
+            string (can be brace-expandable).
+        metadata_path (str): Path to the metadata manifest.
+        tokenizer: tokenizer, such as WordTokenizer or CharTokenizer
+        dataset: path to data
+        max_seq_length: maximum sequence length (in tokens) of input tensors
+        batch_step: distance (in tokens) between two successive sequences of
+            the text. By default, it is equal to max_seq_length which corresponds
+            to splitting text into disjoint segments covering full dataset
+        shuffle_n (int): How many samples to look ahead and load to be shuffled.
+            See WebDataset documentation for more details.
+            Defaults to 0.
+        shard_strategy (str): Tarred dataset shard distribution strategy chosen as a str value during ddp.
+            -   `scatter`: The default shard strategy applied by WebDataset, where each node gets
+                a unique set of shards, which are permanently pre-allocated and never changed at runtime.
+            -   `replicate`: Optional shard strategy, where each node gets all of the set of shards
+                available in the tarred dataset, which are permanently pre-allocated and never changed at runtime.
+                The benefit of replication is that it allows each node to sample data points from the entire
+                dataset independently of other nodes, and reduces dependence on value of `shuffle_n`.
+                Note: Replicated strategy allows every node to sample the entire set of available tarfiles,
+                and therefore more than one node may sample the same tarfile, and even sample the same
+                data points! As such, there is no assured guarantee that all samples in the dataset will be
+                sampled at least once during 1 epoch.
+        global_rank (int): Worker rank, used for partitioning shards. Defaults to 0.
+        world_size (int): Total number of processes, used for partitioning shards. Defaults to 0.
+    """
+
     def __init__(
         self,
-        tarpath: str,
+        text_tar_filepaths: str,
         metadata_path: str,
         tokenizer,
-        shuffle_n: int = 64,
         max_seq_length: int = 512,
         batch_step: int = None,
+        shuffle_n: int = 1,
+        shard_strategy: str = "scatter",
+        global_rank: int = 0,
+        world_size: int = 0,
     ):
         super(TarredL2RLanguageModelingDataset, self).__init__()
 
@@ -83,29 +137,55 @@ class TarredL2RLanguageModelingDataset(IterableDataset):
         self.max_seq_length = max_seq_length
         self.batch_step = batch_step or self.max_seq_length
 
+        valid_shard_strategies = ['scatter', 'replicate']
+        if shard_strategy not in valid_shard_strategies:
+            raise ValueError(f"`shard_strategy` must be one of {valid_shard_strategies}")
+
         with open(metadata_path, 'r') as f:
             metadata = json.load(f)
 
         self.metadata = metadata
 
-        if isinstance(tarpath, str):
+        if isinstance(text_tar_filepaths, str):
             # Replace '(' and '[' with '{'
             brace_keys_open = ['(', '[', '<', '_OP_']
             for bkey in brace_keys_open:
-                if bkey in tarpath:
-                    tarpath = tarpath.replace(bkey, "{")
+                if bkey in text_tar_filepaths:
+                    text_tar_filepaths = text_tar_filepaths.replace(bkey, "{")
 
             # Replace ')' and ']' with '}'
             brace_keys_close = [')', ']', '>', '_CL_']
             for bkey in brace_keys_close:
-                if bkey in tarpath:
-                    tarpath = tarpath.replace(bkey, "}")
+                if bkey in text_tar_filepaths:
+                    text_tar_filepaths = text_tar_filepaths.replace(bkey, "}")
 
-        self.tarpath = tarpath
+        if shard_strategy == 'scatter':
+            logging.info("All tarred dataset shards will be scattered evenly across all nodes.")
+
+            if len(text_tar_filepaths) % world_size != 0:
+                logging.warning(
+                    f"Number of shards in tarred dataset ({len(text_tar_filepaths)}) is not divisible "
+                    f"by number of distributed workers ({world_size})."
+                )
+
+            begin_idx = (len(text_tar_filepaths) // world_size) * global_rank
+            end_idx = begin_idx + (len(text_tar_filepaths) // world_size)
+            audio_tar_filepaths = text_tar_filepaths[begin_idx:end_idx]
+            logging.info(
+                "Partitioning tarred dataset: process (%d) taking shards [%d, %d)", global_rank, begin_idx, end_idx
+            )
+
+        elif shard_strategy == 'replicate':
+            logging.info("All tarred dataset shards will be replicated across all nodes.")
+
+        else:
+            raise ValueError(f"Invalid shard strategy ! Allowed values are : {valid_shard_strategies}")
+
+        self.tarpath = text_tar_filepaths
 
         # Put together WebDataset
         self._dataset = (
-            wd.Dataset(tarpath)
+            wd.Dataset(text_tar_filepaths)
             .shuffle(shuffle_n)
             .rename(npy='npy', key='__key__')
             .to_tuple('npy', 'key')
@@ -116,7 +196,7 @@ class TarredL2RLanguageModelingDataset(IterableDataset):
         # Load file
         npy, filepath = tup
         npy = io.BytesIO(npy)
-        data = np.load(npy)
+        data = np.load(npy)  # loads np.int64 vector
         npy.close()
 
         # Select random contiguous subsegment
@@ -125,7 +205,7 @@ class TarredL2RLanguageModelingDataset(IterableDataset):
         # Slice of data chunk
         left = idx * self.batch_step
         right = left + self.max_seq_length
-        data = data[left:right + 1]
+        data = data[left : right + 1]
 
         # Create batch
         src_ids = data[:-1]

--- a/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
@@ -15,12 +15,17 @@
 from typing import Optional
 
 import numpy as np
-from torch.utils.data import Dataset
+import json
+import webdataset as wd
+import io
+import pickle
+from torch.utils.data import Dataset,IterableDataset
 
 from nemo.collections.common.tokenizers.tokenizer_spec import TokenizerSpec
 from nemo.collections.nlp.data.data_utils import dataset_to_ids
+from nemo.utils import logging
 
-__all__ = ['L2RLanguageModelingDataset']
+__all__ = ['L2RLanguageModelingDataset', 'TarredL2RLanguageModelingDataset']
 
 
 class L2RLanguageModelingDataset(Dataset):
@@ -60,3 +65,73 @@ class L2RLanguageModelingDataset(Dataset):
         labels = self.ids[left + 1 : right + 1]
         src_mask = (src_ids != self.tokenizer.pad_id).astype(np.float32)
         return src_ids, src_mask, labels
+
+
+class TarredL2RLanguageModelingDataset(IterableDataset):
+    def __init__(
+        self,
+        tarpath: str,
+        metadata_path: str,
+        tokenizer,
+        shuffle_n: int = 512,
+        max_seq_length: int = 512,
+        batch_step: int = None,
+    ):
+        super(TarredL2RLanguageModelingDataset, self).__init__()
+
+        self.tokenizer = tokenizer
+        self.max_seq_length = max_seq_length
+        self.batch_step = batch_step or self.max_seq_length
+
+        with open(metadata_path, 'r') as f:
+            metadata = json.load(f)
+
+        self.metadata = metadata
+
+        if isinstance(tarpath, str):
+            # Replace '(' and '[' with '{'
+            brace_keys_open = ['(', '[', '<', '_OP_']
+            for bkey in brace_keys_open:
+                if bkey in tarpath:
+                    tarpath = tarpath.replace(bkey, "{")
+
+            # Replace ')' and ']' with '}'
+            brace_keys_close = [')', ']', '>', '_CL_']
+            for bkey in brace_keys_close:
+                if bkey in tarpath:
+                    tarpath = tarpath.replace(bkey, "}")
+
+        self.tarpath = tarpath
+
+        # Put together WebDataset
+        self._dataset = (
+            wd.Dataset(tarpath)
+            .shuffle(shuffle_n)
+            .rename(npy='npy', key='__key__')
+            .to_tuple('npy', 'key')
+            .map(f=self._build_sample)
+        )
+
+    def _build_sample(self, tup):
+        npy, filepath = tup
+        npy = io.BytesIO(npy)
+        data = np.load(npy)
+        npy.close()
+
+        # flatten data
+        idx = np.random.randint(0, (len(data) - self.max_seq_length) // self.batch_step + 1)
+
+        # random slice of data
+        left = idx * self.batch_step
+        right = left + self.max_seq_length
+        data = data[left:right + 1]
+        src_ids = data[:-1]
+        labels = data[1:]
+        src_mask = (src_ids != self.tokenizer.pad_id).astype(np.float32)
+        return src_ids, src_mask, labels
+
+    def __iter__(self):
+        return self._dataset.__iter__()
+
+    def __len__(self):
+        return (self.metadata['num_text'] - self.max_seq_length) // self.batch_step

--- a/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/l2r_lm_dataset.py
@@ -42,11 +42,12 @@ class L2RLanguageModelingDataset(Dataset):
         dataset: str,
         max_seq_length: Optional[int] = 512,
         batch_step: Optional[int] = None,
+        cache_ids: bool = False
     ):
         self.tokenizer = tokenizer
         self.max_seq_length = max_seq_length
         self.batch_step = batch_step or self.max_seq_length
-        ids = dataset_to_ids(dataset, tokenizer, add_bos_eos=False)
+        ids = dataset_to_ids(dataset, tokenizer, cache_ids=cache_ids, add_bos_eos=False)
         self.ids = np.array([j for i in ids for j in i])
 
     def __len__(self):

--- a/nemo/collections/nlp/models/language_modeling/transformer_lm_model.py
+++ b/nemo/collections/nlp/models/language_modeling/transformer_lm_model.py
@@ -184,7 +184,7 @@ class TransformerLMModel(ModelPT):
         )
 
     def _setup_dataloader_from_config(self, cfg: DictConfig, predict_last_k=0):
-        if cfg.get('cache_ids', False):
+        if cfg.get('use_cache', False):
             logging.info("Constructing tokenized dataset cache...")
 
         shuffle = cfg.shuffle
@@ -220,7 +220,7 @@ class TransformerLMModel(ModelPT):
                 dataset=cfg.file_name,
                 max_seq_length=self.dataset_cfg.max_seq_length,
                 batch_step=predict_last_k,
-                cache_ids=cfg.get('cache_ids', False),
+                use_cache=cfg.get('use_cache', False),
             )
 
         return torch.utils.data.DataLoader(

--- a/nemo/collections/nlp/models/language_modeling/transformer_lm_model.py
+++ b/nemo/collections/nlp/models/language_modeling/transformer_lm_model.py
@@ -209,7 +209,7 @@ class TransformerLMModel(ModelPT):
                 shuffle_n=shuffle_n,
                 shard_strategy=cfg.get("tarred_shard_strategy", "scatter"),
                 global_rank=self.global_rank,
-                world_size=self.world_size
+                world_size=self.world_size,
             )
 
             shuffle = False
@@ -220,7 +220,7 @@ class TransformerLMModel(ModelPT):
                 dataset=cfg.file_name,
                 max_seq_length=self.dataset_cfg.max_seq_length,
                 batch_step=predict_last_k,
-                cache_ids=cfg.get('cache_ids', False)
+                cache_ids=cfg.get('cache_ids', False),
             )
 
         return torch.utils.data.DataLoader(

--- a/nemo/collections/nlp/models/language_modeling/transformer_lm_model.py
+++ b/nemo/collections/nlp/models/language_modeling/transformer_lm_model.py
@@ -28,6 +28,7 @@ from nemo.collections.nlp.modules.common.tokenizer_utils import get_tokenizer
 from nemo.collections.nlp.modules.common.transformer import TransformerEmbedding, TransformerEncoder
 from nemo.core.classes.common import typecheck
 from nemo.core.classes.modelPT import ModelPT
+from nemo.utils import logging
 
 __all__ = ["TransformerLMModel"]
 
@@ -163,11 +164,15 @@ class TransformerLMModel(ModelPT):
         )
 
     def _setup_dataloader_from_config(self, cfg: DictConfig, predict_last_k=0):
+        if cfg.get('cache_ids', False):
+            logging.info("Constructing tokenized dataset cache...")
+
         dataset = L2RLanguageModelingDataset(
             tokenizer=self.tokenizer,
             dataset=cfg.file_name,
             max_seq_length=self.dataset_cfg.max_seq_length,
             batch_step=predict_last_k,
+            cache_ids=cfg.get('cache_ids', False)
         )
         return torch.utils.data.DataLoader(
             dataset=dataset,

--- a/scripts/create_tarred_tokenized_text_lm_dataset.py
+++ b/scripts/create_tarred_tokenized_text_lm_dataset.py
@@ -145,7 +145,6 @@ def __tokenize_text(data, tokenizer, tokenized_cachedir, chunk_size=8192, write_
 
             # Update counters
             chunk_idx += 1
-            global_chunk_idx += 1
 
             if (chunk_idx == write_buffer) or (idx + chunk_size) >= dataset_len:
                 # write the chunks into disk after parallel tokenization
@@ -161,6 +160,8 @@ def __tokenize_text(data, tokenizer, tokenized_cachedir, chunk_size=8192, write_
 
                     chunk_paths.append(fp)
                     chunk_lens.append(len(chunk))
+
+                    global_chunk_idx += 1
 
                 logging.info(f"Wrote a buffer size of {chunk_idx} chunks to file...")
 

--- a/scripts/create_tarred_tokenized_text_lm_dataset.py
+++ b/scripts/create_tarred_tokenized_text_lm_dataset.py
@@ -60,6 +60,9 @@ parser.add_argument('--log', action='store_true')
 
 # Tokenizer arguments
 parser.add_argument('--tokenizer_name', required=False, default=None, type=str, help='Tokenizer name for resolution')
+parser.add_argument(
+    '--tokenizer_model', required=False, default=None, type=str, help='Path to tokenizer model for sentencepiece'
+)
 parser.add_argument('--tokenizer_vocab_file', required=False, type=str, default=None, help='Path to a vocab file')
 parser.add_argument(
     '--tokenizer_special_tokens', default=None, type=str, nargs='+', help='List of special tokens for the tokenizer'
@@ -265,6 +268,7 @@ def main():
 
         tokenizer = get_tokenizer(
             tokenizer_name=args.tokenizer_name,
+            tokenizer_model=args.tokenizer_model,
             vocab_file=args.tokenizer_vocab_file,
             special_tokens=args.tokenizer_special_tokens,
         )

--- a/scripts/create_tarred_tokenized_text_lm_dataset.py
+++ b/scripts/create_tarred_tokenized_text_lm_dataset.py
@@ -1,0 +1,299 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Execution :
+
+python create_tarred_tokenized_text_lm_dataset.py \
+    --data_root="/media/smajumdar/data/Datasets/Librispeech_LM/tokenized_dataset/" \
+    --text_path="/media/smajumdar/data/Datasets/Librispeech_LM/librispeech-lm-norm.txt" \
+    --tokenizer_name="bert-base-cased" \
+    --tokenizer_vocab_file="/home/smajumdar/PycharmProjects/nemo-eval/nemo_eval/librispeech/manifests/full/LibriSpeechTokenizer/librispeech_tokenizer_wpe_v1024/vocab.txt" \
+    --num_shards=64 \
+    --chunk_size=8192 \
+    --chunk_write_buffer=512 \
+    --lower_case \
+    --log
+"""
+
+
+import argparse
+import json
+import tarfile
+import logging
+import os
+import numpy as np
+import joblib
+import glob
+from pathlib import Path
+
+from tqdm import tqdm
+
+from nemo.collections.nlp.modules.common.tokenizer_utils import get_tokenizer
+
+parser = argparse.ArgumentParser(description='Tarred Tokenized dataset for text language modelling')
+
+# Data path arguments
+parser.add_argument('--text_path', required=True, default=None, type=str, help='Text paths, seperated by commas')
+parser.add_argument('--data_root', required=True, default=None, type=str, help='Output directory')
+
+# General arguments
+parser.add_argument(
+    '--chunk_write_buffer',
+    default=128,
+    type=int,
+    help='Number of chunks of `chunk_size` to buffer for parallel tokenization and serial write to disk',
+)
+parser.add_argument('--lower_case', action='store_true', help='Whether to lower case the corpus')
+parser.add_argument('--log', action='store_true')
+
+# Tokenizer arguments
+parser.add_argument('--tokenizer_name', required=False, default=None, type=str, help='Tokenizer name for resolution')
+parser.add_argument('--tokenizer_vocab_file', required=False, type=str, default=None, help='Path to a vocab file')
+parser.add_argument(
+    '--tokenizer_special_tokens', default=None, type=str, nargs='+', help='List of special tokens for the tokenizer'
+)
+
+# Tarred dataset arguments
+parser.add_argument('--num_shards', default=1, type=int, help='Number of shards for the tarfile')
+parser.add_argument('--chunk_size', default=8192, type=int, help='Number of rows of data concatenated into a vector')
+
+parser.set_defaults(log=False, lower_case=False)
+args = parser.parse_args()
+
+
+def __build_dataset_from_text(texts: str, lower_case: bool):
+    if ',' in texts:
+        texts = texts.split(',')
+    else:
+        texts = [texts]
+
+    num_lines = 0
+    text_dataset = []
+
+    for text in texts:
+        with open(text, 'r') as in_reader:
+            reader = tqdm(iter(lambda: in_reader.readline(), ''), desc="Read 0 lines", unit=' lines')
+
+            for i, line in enumerate(reader):
+                # Clean text line
+                line = line.replace("\n", "").strip()
+
+                if lower_case:
+                    line = line.lower()
+
+                if line:
+                    text_dataset.append(line)
+
+                    num_lines += 1
+                    if num_lines % 100000 == 0:
+                        reader.set_description(f"Read {num_lines} lines")
+
+            logging.info(f"Finished extracting manifest : {text}")
+
+        logging.info("Finished extracting all manifests ! Number of sentences : {}".format(num_lines))
+
+    return text_dataset
+
+
+def __tokenize_str(texts, tokenizer):
+    tokenized_text = []
+    for text in texts:
+        tok_text = tokenizer.text_to_ids(text)
+        tokenized_text.extend(tok_text)
+    return tokenized_text
+
+
+def __tokenize_text(data, tokenizer, tokenized_cachedir, chunk_size=8192, write_buffer: int = -1):
+    dataset_len = len(data)
+    logging.info(
+        f"Chunking {dataset_len} rows into {dataset_len // chunk_size} tasks (each chunk contains {chunk_size} elements)"
+    )
+
+    if write_buffer < 1:
+        write_buffer = max(os.cpu_count() - write_buffer, 1)
+
+    logging.info(f"Using chunk write buffer of size {write_buffer}")
+
+    if not os.path.exists(tokenized_cachedir):
+        os.makedirs(tokenized_cachedir)
+
+    # global parameters
+    global_chunk_idx = 0
+    chunk_paths = []
+    chunk_lens = []
+
+    # buffer parameters
+    data_cache = []
+    chunk_idx = 0
+
+    with joblib.Parallel(n_jobs=-2, verbose=10) as parallel:
+
+        for idx in range(0, dataset_len, chunk_size):
+            data_cache.append(data[idx : idx + chunk_size])
+
+            # Update counters
+            chunk_idx += 1
+            global_chunk_idx += 1
+
+            if (chunk_idx == write_buffer) or (idx + chunk_size) >= dataset_len:
+                # write the chunks into disk after parallel tokenization
+                tokenized_data_list = parallel(
+                    joblib.delayed(__tokenize_str)(chunk, tokenizer) for chunk in data_cache
+                )
+
+                # Sequential write cache
+                for chunk in tokenized_data_list:
+                    fp = os.path.join(tokenized_cachedir, f"chunk_{global_chunk_idx}.npy")
+                    chunk = np.asarray(chunk, dtype=np.int64)
+                    np.save(fp, chunk, allow_pickle=False)
+
+                    chunk_paths.append(fp)
+                    chunk_lens.append(len(chunk))
+
+                logging.info(f"Wrote a buffer size of {chunk_idx} chunks to file...")
+
+                # reset caches
+                data_cache.clear()
+                del data_cache
+
+                data_cache = []
+                chunk_idx = 0
+
+    return chunk_paths, chunk_lens
+
+
+def __create_chunk(data_root, chunk_path, shard_id, compute_metrics=False):
+    """Creates a tarball containing the audio files from `entries`.
+       """
+    tar = tarfile.open(os.path.join(data_root, f'text_{shard_id}.tar'), mode='a')
+
+    # We squash the filename since we do not preserve directory structure of audio files in the tarball.
+    base, ext = os.path.splitext(chunk_path)
+    base = base.replace(os.pathsep, '_')
+    # Need the following replacement as long as WebDataset splits on first period
+    base = base.replace('.', '_')
+    squashed_filename = f'{base}{ext}'
+    tar.add(chunk_path, arcname=squashed_filename)
+
+    tar.close()
+
+    if compute_metrics:
+        data = np.load(chunk_path, allow_pickle=False)
+        chunk_len = len(data)
+        return (chunk_len,)
+    else:
+        return None
+
+
+def __write_tarred_tokenized_text_dataset(data_root, num_shards, chunk_paths, chunk_lens):
+    num_chunks = len(chunk_paths)
+
+    if chunk_lens is not None:
+        num_text = sum(chunk_lens)
+        shard_counts = {chunk_id: chunk_len for chunk_id, chunk_len in enumerate(chunk_lens)}
+        compute_metrics = False
+
+    else:
+        num_text = 0
+        shard_counts = {}
+        compute_metrics = True
+
+    for chunk_id, chunk_path in enumerate(tqdm(chunk_paths, desc='Writing chunk ', unit=' chunks')):
+        shard_id = chunk_id % num_shards
+        metrics = __create_chunk(data_root, chunk_path, shard_id, compute_metrics=compute_metrics)
+
+        if metrics is not None:
+            num_text += metrics[0]
+            shard_counts[chunk_id] = metrics[0]
+
+    # write metadata
+    metadata_path = os.path.join(data_root, 'metadata.json')
+    with open(metadata_path, 'w') as f:
+        metadata = {'num_chunks': num_chunks, 'num_text': num_text, 'shard_count': shard_counts}
+        json.dump(metadata, f, indent=4)
+        logging.info("Metadata writen..")
+
+
+def main():
+    text_path = args.text_path
+    data_root = args.data_root
+
+    if args.log:
+        logging.basicConfig(level=logging.INFO)
+
+    if os.path.exists(data_root):
+        logging.warning(
+            f'Data root {data_root} already potentially contains files. In such a case,'
+            f'please be aware that the tarfiles will be **appended** instead of overridden!'
+        )
+
+    if not os.path.exists(data_root):
+        os.makedirs(data_root)
+
+    tokenized_cachedir = os.path.join(data_root, '_tokenized_dataset_cachedir')
+
+    chunk_paths = None
+    chunk_lens = None
+
+    if os.path.exists(tokenized_cachedir):
+        paths = glob.glob(os.path.join(tokenized_cachedir, "*.npy"))
+        if len(paths) > 0:
+            logging.info("Cached tokenized numpy files found, skipping re-tokenization of dataset")
+
+            chunk_paths = paths
+            chunk_lens = None
+
+    if chunk_paths is None:
+        if args.tokenizer_name is None:
+            raise ValueError("`tokenizer_name` name is required when tokenizing the dataset for the first time.")
+
+        if args.tokenizer_vocab_file is None:
+            raise ValueError("`tokenizer_vocab_file` is required when constructing the tokenized dataset")
+
+        tokenizer = get_tokenizer(
+            tokenizer_name=args.tokenizer_name,
+            vocab_file=args.tokenizer_vocab_file,
+            special_tokens=args.tokenizer_special_tokens,
+        )
+
+        logging.info("Built tokenizer")
+
+        # load the text into memory
+        text_dataset = __build_dataset_from_text(texts=text_path, lower_case=args.lower_case)
+        logging.info("Loaded the text dataset into memory")
+
+        # tokenize text data into sub-words
+        chunk_paths, chunk_lens = __tokenize_text(
+            text_dataset,
+            tokenizer=tokenizer,
+            tokenized_cachedir=tokenized_cachedir,
+            chunk_size=args.chunk_size,
+            write_buffer=args.chunk_write_buffer,
+        )
+        logging.info(f"Tokenized dataset into sub-words and serialized cache at {tokenized_cachedir}")
+
+        # free up memory
+        del text_dataset
+
+    # Write tarred dataset
+    __write_tarred_tokenized_text_dataset(
+        data_root, num_shards=args.num_shards, chunk_paths=chunk_paths, chunk_lens=chunk_lens
+    )
+
+    logging.info('Done preparing tokenized dataset!')
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/create_tarred_transformer_lm_dataset.py
+++ b/scripts/create_tarred_transformer_lm_dataset.py
@@ -178,11 +178,11 @@ def __tokenize_text(data, tokenizer, tokenized_cachedir, chunk_size=8192, write_
 
 
 def __create_chunk(data_root, chunk_path, shard_id, compute_metrics=False):
-    """Creates a tarball containing the audio files from `entries`.
+    """Creates a tarball containing the tokenized text chunks.
        """
     tar = tarfile.open(os.path.join(data_root, f'text_{shard_id}.tar'), mode='a')
 
-    # We squash the filename since we do not preserve directory structure of audio files in the tarball.
+    # We squash the filename since we do not preserve directory structure of tokenized text in the tarball.
     base, ext = os.path.splitext(chunk_path)
     base = base.replace(os.pathsep, '_')
     # Need the following replacement as long as WebDataset splits on first period
@@ -236,16 +236,16 @@ def main():
     if args.log:
         logging.basicConfig(level=logging.INFO)
 
-    if os.path.exists(data_root):
+    tokenized_cachedir = os.path.join(data_root, '_tokenized_dataset_cachedir')
+
+    if os.path.exists(tokenized_cachedir):
         logging.warning(
-            f'Data root {data_root} already potentially contains files. In such a case,'
-            f'please be aware that the tarfiles will be **appended** instead of overridden!'
+            f'Tokenized cache directory {tokenized_cachedir} already potentially contains files.'
+            f'In such a case, please be aware that the tarfiles will be **appended** instead of overridden!'
         )
 
     if not os.path.exists(data_root):
         os.makedirs(data_root)
-
-    tokenized_cachedir = os.path.join(data_root, '_tokenized_dataset_cachedir')
 
     chunk_paths = None
     chunk_lens = None

--- a/scripts/create_tarred_transformer_lm_dataset.py
+++ b/scripts/create_tarred_transformer_lm_dataset.py
@@ -165,9 +165,9 @@ def __tokenize_text(data, tokenizer, tokenized_cachedir, chunk_size=8192, write_
 
                     global_chunk_idx += 1
 
-                logging.info(f"Wrote a buffer size of {chunk_idx} chunks to file...")
+                logging.info(f"Wrote a total of {global_chunk_idx} chunks to file...")
 
-                # reset caches
+                # reset buffers
                 data_cache.clear()
                 del data_cache
 

--- a/scripts/create_tarred_transformer_lm_dataset.py
+++ b/scripts/create_tarred_transformer_lm_dataset.py
@@ -127,9 +127,6 @@ def __tokenize_str(texts, tokenizer):
 def __tokenize_text(
     text_paths, tokenizer, tokenized_cachedir, lower_case: bool = False, chunk_size=8192, write_buffer: int = -1
 ):
-    # dataset_len = len(data)
-    #
-
     if write_buffer < 1:
         write_buffer = max(os.cpu_count() - write_buffer, 1)
 
@@ -148,7 +145,6 @@ def __tokenize_text(
     chunk_idx = 0
 
     text_generator = iter(__build_dataset_from_text(text_paths, lower_case=lower_case, chunk_size=chunk_size))
-    idx = 0
     global_num_lines = 0
     last_batch = False
 

--- a/scripts/create_tarred_transformer_lm_dataset.py
+++ b/scripts/create_tarred_transformer_lm_dataset.py
@@ -29,14 +29,14 @@ python create_tarred_tokenized_text_lm_dataset.py \
 
 
 import argparse
+import glob
 import json
-import tarfile
 import logging
 import os
-import numpy as np
-import joblib
-import glob
+import tarfile
 
+import joblib
+import numpy as np
 from tqdm import tqdm
 
 from nemo.collections.nlp.modules.common.tokenizer_utils import get_tokenizer

--- a/scripts/create_tarred_transformer_lm_dataset.py
+++ b/scripts/create_tarred_transformer_lm_dataset.py
@@ -16,10 +16,10 @@
 Execution :
 
 python create_tarred_tokenized_text_lm_dataset.py \
-    --data_root="/media/smajumdar/data/Datasets/Librispeech_LM/tokenized_dataset/" \
-    --text_path="/media/smajumdar/data/Datasets/Librispeech_LM/librispeech-lm-norm.txt" \
+    --text_path=<comma seperated text filepaths> \
+    --data_root=<path to output directory> \
     --tokenizer_name="bert-base-cased" \
-    --tokenizer_vocab_file="/home/smajumdar/PycharmProjects/nemo-eval/nemo_eval/librispeech/manifests/full/LibriSpeechTokenizer/librispeech_tokenizer_wpe_v1024/vocab.txt" \
+    --tokenizer_vocab_file=<path to vocab file for tokenizer> \
     --num_shards=64 \
     --chunk_size=8192 \
     --chunk_write_buffer=512 \
@@ -36,7 +36,6 @@ import os
 import numpy as np
 import joblib
 import glob
-from pathlib import Path
 
 from tqdm import tqdm
 
@@ -56,7 +55,7 @@ parser.add_argument(
     help='Number of chunks of `chunk_size` to buffer for parallel tokenization and serial write to disk',
 )
 parser.add_argument('--lower_case', action='store_true', help='Whether to lower case the corpus')
-parser.add_argument('--log', action='store_true')
+parser.add_argument('--log', action='store_true', help='Whether to print logs to terminal')
 
 # Tokenizer arguments
 parser.add_argument('--tokenizer_name', required=False, default=None, type=str, help='Tokenizer name for resolution')
@@ -127,7 +126,7 @@ def __tokenize_text(data, tokenizer, tokenized_cachedir, chunk_size=8192, write_
     if write_buffer < 1:
         write_buffer = max(os.cpu_count() - write_buffer, 1)
 
-    logging.info(f"Using chunk write buffer of size {write_buffer}")
+    logging.info(f"Using write chunk buffer of size {write_buffer}")
 
     if not os.path.exists(tokenized_cachedir):
         os.makedirs(tokenized_cachedir)


### PR DESCRIPTION
# Changelog
- Adds tarred dataset support for transformer based Language models
- Pre-tokenizes and chunks the dataset for more efficient external dataset handling
- Adds utility script to construct a tarred tokenized LM dataset
- Adds `cache_ids` flag support for transformer based language models