### PR TITLE
Update NeMo core for melgan

### DIFF
--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -104,11 +104,16 @@ class Typing(ABC):
                     NeuralTypeComparisonResult.SAME,
                     NeuralTypeComparisonResult.GREATER,
                 ):
-                    raise TypeError(
-                        f"{input_types[key].compare(value.neural_type)} : \n"
-                        f"Input type expected = {input_types[key]} | \n"
-                        f"Input type found : {value.neural_type}"
-                    )
+                    error_msg = [
+                        f"{input_types[key].compare(value.neural_type)} :",
+                        f"Input type expected : {input_types[key]}",
+                        f"Input type found : {value.neural_type}",
+                    ]
+                    for i, dict_tuple in enumerate(input_types[key].elements_type.type_parameters.items()):
+                        error_msg.insert(i + 2, f'  input param_{i} : {dict_tuple[0]}: {dict_tuple[1]}')
+                    for i, dict_tuple in enumerate(value.neural_type.elements_type.type_parameters.items()):
+                        error_msg.append(f'  input param_{i} : {dict_tuple[0]}: {dict_tuple[1]}')
+                    raise TypeError("\n".join(error_msg))
 
                 # Perform input ndim check
                 if hasattr(value, 'shape'):

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -505,7 +505,7 @@ class ModelPT(LightningModule, Model):
     @abstractmethod
     def setup_validation_data(self, val_data_config: Union[DictConfig, Dict]):
         """
-        (Optionally) Setups data loader to be used in validation
+        Setups data loader to be used in validation
         Args:
 
             val_data_layer_config: validation data layer parameters.

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -176,7 +176,7 @@ class ModelPT(LightningModule, Model):
 
     def _default_save_to(self, save_path: str):
         """
-        Saves model instance (weights and configuration) into .nemo file. 
+        Saves model instance (weights and configuration) into .nemo file.
         You can use "restore_from" method to fully restore instance from .nemo file.
 
         .nemo file is an archive (tar.gz) with the following:
@@ -210,7 +210,7 @@ class ModelPT(LightningModule, Model):
 
         Method creates an EFF-based file that is an archive (tar.gz) with the following:
             manifest.yaml - yaml file describing the content of the archive.
-            model_config.yaml - model configuration in .yaml format. 
+            model_config.yaml - model configuration in .yaml format.
                 You can deserialize this into cfg argument for model's constructor
             model_wights.chpt - model checkpoint
 
@@ -739,22 +739,13 @@ class ModelPT(LightningModule, Model):
         if self._train_dl is not None:
             return self._train_dl
 
-    def training_step(self, batch, batch_ix):
-        pass
-
     def val_dataloader(self):
         if self._validation_dl is not None:
             return self._validation_dl
 
-    def validation_step(self, batch, batch_ix):
-        return {}
-
     def test_dataloader(self):
         if self._test_dl is not None:
             return self._test_dl
-
-    def test_step(self, batch, batch_ix):
-        return {}
 
     def validation_epoch_end(
         self, outputs: Union[List[Dict[str, torch.Tensor]], List[List[Dict[str, torch.Tensor]]]]

--- a/nemo/core/neural_types/axes.py
+++ b/nemo/core/neural_types/axes.py
@@ -43,6 +43,7 @@ class AxisKind(AxisKindAbstract):
     Any = 5
     Sequence = 6
     FlowGroup = 7
+    Singleton = 8  # Used to represent a axis that has size 1
 
     def __repr__(self):
         return self.__str__()
@@ -64,6 +65,8 @@ class AxisKind(AxisKindAbstract):
             return AxisKind.Width
         elif _label == "h" or _label == "height":
             return AxisKind.Height
+        elif _label == "s" or _label == "singleton":
+            return AxisKind.Singleton
         elif _label == "flowgroup":
             return AxisKind.FlowGroup
         elif _label == "any":

--- a/nemo/core/neural_types/elements.py
+++ b/nemo/core/neural_types/elements.py
@@ -108,6 +108,9 @@ class ElementType(ABC):
                 return NeuralTypeComparisonResult.SAME_TYPE_INCOMPATIBLE_PARAMS
             else:
                 for k1, v1 in self.type_parameters.items():
+                    if v1 is None or second.type_parameters[k1] is None:
+                        # Treat None as Void
+                        continue
                     if v1 != second.type_parameters[k1]:
                         return NeuralTypeComparisonResult.SAME_TYPE_INCOMPATIBLE_PARAMS
             # check that all fields match
@@ -179,7 +182,7 @@ class AudioSignal(ElementType):
         freq is the same.
     """
 
-    def __init__(self, freq: int = 16000):
+    def __init__(self, freq: int = None):
         self._params = {}
         self._params['freq'] = freq
 

--- a/nemo/core/neural_types/neural_type.py
+++ b/nemo/core/neural_types/neural_type.py
@@ -50,8 +50,8 @@ class NeuralType(object):
     def __init__(self, axes: Optional[Tuple] = None, elements_type: ElementType = VoidType(), optional=False):
         if not isinstance(elements_type, ElementType):
             raise ValueError(
-                f"elements_type of NeuralType must be an instance of a class derived from ElementType."
-                f"Did you pass a class instead?"
+                "elements_type of NeuralType must be an instance of a class derived from ElementType. "
+                "Did you pass a class instead?"
             )
         self.elements_type = elements_type
         if axes is not None:
@@ -63,7 +63,7 @@ class NeuralType(object):
                 elif isinstance(axis, AxisType):
                     axes_list.append(axis)
                 else:
-                    raise ValueError(f"axis type must be either str or AxisType instance")
+                    raise ValueError("axis type must be either str or AxisType instance")
             self.axes = tuple(axes_list)
         else:
             self.axes = None
@@ -202,14 +202,13 @@ class NeuralType(object):
 class NeuralTypeError(Exception):
     """Base class for neural type related exceptions."""
 
-    pass
-
 
 class NeuralPortNameMismatchError(NeuralTypeError):
     """Exception raised when neural module is called with incorrect port
     names."""
 
     def __init__(self, input_port_name):
+        super().__init__()
         self.message = "Wrong input port name: {0}".format(input_port_name)
 
 
@@ -218,6 +217,7 @@ class NeuralPortNmTensorMismatchError(NeuralTypeError):
     type."""
 
     def __init__(self, class_name, port_name, first_type, second_type, type_comatibility):
+        super().__init__()
         self.message = "\nIn {}. \nPort: {} and a NmTensor it was fed are \n".format(class_name, port_name)
         self.message += "of incompatible neural types:\n\n{} \n\n and \n\n{}".format(first_type, second_type)
         self.message += "\n\nType comparison result: {}".format(type_comatibility)

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -315,7 +315,7 @@ def resolve_test_dataloaders(model: 'ModelPT'):
 def wrap_training_step(wrapped, instance: pl.LightningModule, args, kwargs):
     output_dict = wrapped(*args, **kwargs)
 
-    if 'log' in output_dict:
+    if isinstance(output_dict, dict) and output_dict is not None and 'log' in output_dict:
         log_dict = output_dict.pop('log')
         instance.log_dict(log_dict, on_step=True)
 


### PR DESCRIPTION
Split off updates to nemo core that are required for #1418 

Changes:
- Remove empty *_step() methods from ModelPT
- Treat None inside of ElementType's parameters as a Void that matches anything
  - Use case being removing the default 16kHz sample_rate from AudioSignal and replacing it with None. This allows a module with type AudioSignal() to match ANY AudioSignal regardless of sample_rate

Minor Changes:
- Add Singleton NeuralType
- Update wrap_training_step such it is doesn't require a dictionary to be passed
- Other cosmetic changes