### PR TITLE
Switch ruamel.yaml to ruamel_yaml in notebook for compatibility with …

### DIFF
--- a/tutorials/asr/01_ASR_with_NeMo.ipynb
+++ b/tutorials/asr/01_ASR_with_NeMo.ipynb
@@ -553,7 +553,7 @@
    "outputs": [],
    "source": [
     "# --- Config Information ---#\n",
-    "from ruamel.yaml import YAML\n",
+    "from ruamel_yaml import YAML\n",
     "config_path = './configs/config.yaml'\n",
     "\n",
     "yaml = YAML(typ='safe')\n",


### PR DESCRIPTION
…nvcr.io/nvidia/pytorch:20.09-py3 container

Signed-off-by: Jocelyn Huang <jocelynh@nvidia.com>