### PR TITLE
[Bug] Ensure lr scheduler uses limit_train_batches when working out max steps

### DIFF
--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -628,6 +628,7 @@ class ModelPT(LightningModule, Model):
                 # Store information needed to calculate max_steps
                 optim_config['sched']['t_max_epochs'] = self._trainer.max_epochs
                 optim_config['sched']['t_accumulate_grad_batches'] = self._trainer.accumulate_grad_batches
+                optim_config['sched']['t_limit_train_batches'] = self._trainer.limit_train_batches
                 if self._trainer.distributed_backend is None:
                     optim_config['sched']['t_num_workers'] = self._trainer.num_gpus or 1
                 elif self._trainer.distributed_backend == "ddp_cpu":

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -638,8 +638,9 @@ def prepare_lr_scheduler(
     return schedule_dict
 
 
-def compute_max_steps(max_epochs, accumulate_grad_batches, limit_train_batches,
-                      num_workers, num_samples, batch_size, drop_last):
+def compute_max_steps(
+    max_epochs, accumulate_grad_batches, limit_train_batches, num_workers, num_samples, batch_size, drop_last
+):
     _round = math.floor if drop_last else math.ceil
 
     sampler_num_samples = math.ceil(num_samples / num_workers)

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -482,6 +482,7 @@ def prepare_lr_scheduler(
             scheduler_args.pop('name', None)
             scheduler_args.pop('t_max_epochs', None)
             scheduler_args.pop('t_accumulate_grad_batches', None)
+            scheduler_args.pop('t_limit_train_batches', None)
             scheduler_args.pop('t_num_workers', None)
             scheduler_args.pop('monitor', None)
             scheduler_args.pop('reduce_on_plateau', None)
@@ -577,6 +578,7 @@ def prepare_lr_scheduler(
         # Get iters_per_batch
         max_epochs = scheduler_config.get('t_max_epochs')
         accumulate_grad_batches = scheduler_config.get('t_accumulate_grad_batches')
+        limit_train_batches = scheduler_config.get('t_limit_train_batches')
         num_workers = scheduler_config.get('t_num_workers')
 
         # Compute effective num max_steps
@@ -585,7 +587,13 @@ def prepare_lr_scheduler(
         drop_last = train_dataloader.drop_last
 
         max_steps = compute_max_steps(
-            max_epochs, accumulate_grad_batches, num_workers, num_samples, batch_size, drop_last,
+            max_epochs=max_epochs,
+            accumulate_grad_batches=accumulate_grad_batches,
+            limit_train_batches=limit_train_batches,
+            num_workers=num_workers,
+            num_samples=num_samples,
+            batch_size=batch_size,
+            drop_last=drop_last,
         )
 
     else:
@@ -630,7 +638,8 @@ def prepare_lr_scheduler(
     return schedule_dict
 
 
-def compute_max_steps(max_epochs, accumulate_grad_batches, num_workers, num_samples, batch_size, drop_last):
+def compute_max_steps(max_epochs, accumulate_grad_batches, limit_train_batches,
+                      num_workers, num_samples, batch_size, drop_last):
     _round = math.floor if drop_last else math.ceil
 
     sampler_num_samples = math.ceil(num_samples / num_workers)
@@ -643,6 +652,12 @@ def compute_max_steps(max_epochs, accumulate_grad_batches, num_workers, num_samp
         # sampler_num_samples = math.ceil((num_samples - num_workers)/ num_workers)
 
     steps_per_epoch = _round(sampler_num_samples / batch_size)
+
+    if isinstance(limit_train_batches, int) or limit_train_batches == 0.0:
+        steps_per_epoch = min(steps_per_epoch, int(limit_train_batches))
+    elif steps_per_epoch != float('inf'):
+        # limit_train_batches is a percentage of batches per epoch
+        steps_per_epoch = int(steps_per_epoch * limit_train_batches)
 
     return math.ceil(steps_per_epoch / accumulate_grad_batches) * max_epochs
 

--- a/tests/core/test_optimizers_schedulers.py
+++ b/tests/core/test_optimizers_schedulers.py
@@ -749,7 +749,10 @@ class TestOptimizersSchedulers:
         for _ in range(5):
             drop_last = bool(random.randint(0, 1))
             accumulate_grad_batches = random.randint(1, 10)
-            limit_train_batches = random.randint(1, 10)
+
+            limit_train_batches_int = random.randint(1, 10)
+            limit_train_batches_float = random.uniform(0, 1)
+            limit_train_batches = random.choice([limit_train_batches_int, limit_train_batches_float])
             max_epochs = random.randint(4, 20)
             num_processes = random.randint(1, 5)
             dataset_len = random.randint(20, num_processes * 500)

--- a/tests/core/test_optimizers_schedulers.py
+++ b/tests/core/test_optimizers_schedulers.py
@@ -733,7 +733,7 @@ class TestOptimizersSchedulers:
         train(31, accumulate_grad_batches=1, limit_train_batches=1.0,
               num_processes=9, batch_size=60, dataset_len=1613, drop_last=True)
 
-        for _ in range(1):
+        for _ in range(5):
             drop_last = bool(random.randint(0, 1))
             accumulate_grad_batches = random.randint(1, 10)
             limit_train_batches = random.randint(1, 10)

--- a/tests/core/test_optimizers_schedulers.py
+++ b/tests/core/test_optimizers_schedulers.py
@@ -709,8 +709,9 @@ class TestOptimizersSchedulers:
     @pytest.mark.unit
     @pytest.mark.run_only_on('CPU')
     def test_max_step_computation(self, cleanup_local_folder):
-        def train(max_epochs, accumulate_grad_batches, limit_train_batches,
-                  num_processes, batch_size, dataset_len, drop_last):
+        def train(
+            max_epochs, accumulate_grad_batches, limit_train_batches, num_processes, batch_size, dataset_len, drop_last
+        ):
             trainer = pl.Trainer(
                 max_epochs=max_epochs,
                 accelerator="ddp_cpu",
@@ -722,16 +723,28 @@ class TestOptimizersSchedulers:
                 weights_summary=None,
             )
             max_steps = optim.lr_scheduler.compute_max_steps(
-                max_epochs, accumulate_grad_batches, limit_train_batches,
-                num_processes, dataset_len, batch_size, drop_last
+                max_epochs,
+                accumulate_grad_batches,
+                limit_train_batches,
+                num_processes,
+                dataset_len,
+                batch_size,
+                drop_last,
             )
             model = ExampleModel(batch_size, dataset_len, drop_last, max_steps)
             trainer.callbacks.append(Callback())
             trainer.fit(model)
 
         # This test will break once we and lightning upgrade to pytorch 1.7.0 due to a bug fix in pytorch 1.7.0
-        train(31, accumulate_grad_batches=1, limit_train_batches=1.0,
-              num_processes=9, batch_size=60, dataset_len=1613, drop_last=True)
+        train(
+            31,
+            accumulate_grad_batches=1,
+            limit_train_batches=1.0,
+            num_processes=9,
+            batch_size=60,
+            dataset_len=1613,
+            drop_last=True,
+        )
 
         for _ in range(5):
             drop_last = bool(random.randint(0, 1))
@@ -741,5 +754,12 @@ class TestOptimizersSchedulers:
             num_processes = random.randint(1, 5)
             dataset_len = random.randint(20, num_processes * 500)
             batch_size = random.randint(math.ceil(5.0 / num_processes), min(dataset_len // num_processes, 128))
-            train(max_epochs, accumulate_grad_batches, limit_train_batches,
-                  num_processes, batch_size, dataset_len, drop_last)
+            train(
+                max_epochs,
+                accumulate_grad_batches,
+                limit_train_batches,
+                num_processes,
+                batch_size,
+                dataset_len,
+                drop_last,
+            )

--- a/tests/core/test_optimizers_schedulers.py
+++ b/tests/core/test_optimizers_schedulers.py
@@ -709,31 +709,37 @@ class TestOptimizersSchedulers:
     @pytest.mark.unit
     @pytest.mark.run_only_on('CPU')
     def test_max_step_computation(self, cleanup_local_folder):
-        def train(max_epochs, accumulate_grad_batches, num_processes, batch_size, dataset_len, drop_last):
+        def train(max_epochs, accumulate_grad_batches, limit_train_batches,
+                  num_processes, batch_size, dataset_len, drop_last):
             trainer = pl.Trainer(
                 max_epochs=max_epochs,
                 accelerator="ddp_cpu",
                 num_processes=num_processes,
                 accumulate_grad_batches=accumulate_grad_batches,
+                limit_train_batches=limit_train_batches,
                 checkpoint_callback=False,
                 progress_bar_refresh_rate=0,
                 weights_summary=None,
             )
             max_steps = optim.lr_scheduler.compute_max_steps(
-                max_epochs, accumulate_grad_batches, num_processes, dataset_len, batch_size, drop_last
+                max_epochs, accumulate_grad_batches, limit_train_batches,
+                num_processes, dataset_len, batch_size, drop_last
             )
             model = ExampleModel(batch_size, dataset_len, drop_last, max_steps)
             trainer.callbacks.append(Callback())
             trainer.fit(model)
 
         # This test will break once we and lightning upgrade to pytorch 1.7.0 due to a bug fix in pytorch 1.7.0
-        train(31, accumulate_grad_batches=1, num_processes=9, batch_size=60, dataset_len=1613, drop_last=True)
+        train(31, accumulate_grad_batches=1, limit_train_batches=1.0,
+              num_processes=9, batch_size=60, dataset_len=1613, drop_last=True)
 
-        for _ in range(5):
+        for _ in range(1):
             drop_last = bool(random.randint(0, 1))
             accumulate_grad_batches = random.randint(1, 10)
+            limit_train_batches = random.randint(1, 10)
             max_epochs = random.randint(4, 20)
             num_processes = random.randint(1, 5)
             dataset_len = random.randint(20, num_processes * 500)
             batch_size = random.randint(math.ceil(5.0 / num_processes), min(dataset_len // num_processes, 128))
-            train(max_epochs, accumulate_grad_batches, num_processes, batch_size, dataset_len, drop_last)
+            train(max_epochs, accumulate_grad_batches, limit_train_batches,
+                  num_processes, batch_size, dataset_len, drop_last)


### PR DESCRIPTION
When `limit_train_batches` is different to the default, this is not included in the inferred calculation of max_steps. This leads to the incorrect schedule being used when `limit_train_batches` is used.

This PR adds `limit_train_batches` to the calculation to ensure the schedule is correct!