### PR TITLE
fix for scripts for audio->manifest in SD/VAD

### DIFF
--- a/scripts/write_long_audio_manifest.py
+++ b/scripts/write_long_audio_manifest.py
@@ -64,9 +64,13 @@ def write_manifest(file, args_func):
 
         while left > 0:
             if left <= split_duration:
-                status = 'end'
-                write_duration = left + time_length
-                current_offset -= time_length
+                if status == 'single':
+                    write_duration = left
+                    current_offset = 0
+                else:
+                    status = 'end'
+                    write_duration = left + time_length
+                    current_offset -= time_length
                 offset_inc = left
                 left = 0
             else:


### PR DESCRIPTION
tiny fix write_long_audio_manifest.py 
Results are same actually, Just the previous code casue negative offsets in manifests which is not good.


Signed-off-by: fayejf <fayejf07@gmail.com>