### PR TITLE
Add character coverage to SPE for ASR/NLP custom tokenizers

### DIFF
--- a/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
+++ b/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
@@ -188,6 +188,7 @@ def create_spt_model(
     do_lower_case: bool,
     tokenizer_type: str = 'unigram',
     output_dir: Optional[str] = None,
+    character_coverage: float = 1.0,
 ):
     """
     Creates sentence piece tokenizer model from data file.
@@ -196,6 +197,8 @@ def create_spt_model(
         vocab_size: vocabulary size
         sample_size: maximum size of sentences the trainer loads
         do_lower_case: if text should be lower cased before tokenizer model is created
+        character_coverage: float value between 0 and 1 (as a percentage). For languages with a vast charset,
+            can be < 1.0, but for all other languages, it should be set as 1.0
         output_dir: folder to save created tokenizer model. If not specified will store model at data_file/../spt folder
     """
 
@@ -216,6 +219,7 @@ def create_spt_model(
         f"--vocab_size={vocab_size} "
         f"--shuffle_input_sentence=true --hard_vocab_limit=false "
         f"--model_type={tokenizer_type} "
+        f"--character_coverage={character_coverage} "
         f"--bos_id=-1 --eos_id=-1"
     )
     if do_lower_case:

--- a/scripts/process_asr_text_tokenizer.py
+++ b/scripts/process_asr_text_tokenizer.py
@@ -57,7 +57,7 @@ parser.add_argument(
     type=float,
     default=1.0,
     help="Character coverage percentage for SentencePiece tokenization. For languages "
-         "with large vocabulary, should be close to 0.9995, otherwise kept as 1.0",
+    "with large vocabulary, should be close to 0.9995, otherwise kept as 1.0",
 )
 parser.add_argument('--no_lower_case', dest='lower_case', action='store_false')
 parser.add_argument("--log", action='store_true')

--- a/scripts/process_asr_text_tokenizer.py
+++ b/scripts/process_asr_text_tokenizer.py
@@ -52,6 +52,13 @@ parser.add_argument(
     help='Type of the SentencePiece model. Can be `bpe`, `unigram`, `char` or `word`.'
     'Used only if --tokenizer == `spe`',
 )
+parser.add_argument(
+    '--spe_character_coverage',
+    type=float,
+    default=1.0,
+    help="Character coverage percentage for SentencePiece tokenization. For languages "
+         "with large vocabulary, should be close to 0.9995, otherwise kept as 1.0",
+)
 parser.add_argument('--no_lower_case', dest='lower_case', action='store_false')
 parser.add_argument("--log", action='store_true')
 parser.set_defaults(log=False, lower_case=True)
@@ -96,7 +103,13 @@ def __build_document_from_manifests(
 
 
 def __process_data(
-    text_path: str, dst_folder: str, vocab_size: int, tokenizer_type: str, spe_type: str, lower_case: bool
+    text_path: str,
+    dst_folder: str,
+    vocab_size: int,
+    tokenizer_type: str,
+    spe_type: str,
+    spe_character_coverage: float,
+    lower_case: bool,
 ):
     """
     Converts flac to wav and build manifests's json
@@ -106,16 +119,18 @@ def __process_data(
         vocab_size: vocabular size used in encoding the text
         tokenizer_type: type of tokenization to perform - wpe or spe
         spe_type: type of tokenization model used for spe.
+        spe_character_coverage: float value between 0 and 1 (as a percentage). For languages with a vast charset,
+            can be < 1.0, but for all other languages, it should be set as 1.0
         lower_case: whether to tokenize with lower case character set only (for english)
 
     Returns:
     """
-    tokenizer_dir = os.path.join(dst_folder, 'tokenizer_{}_v{}').format(tokenizer_type, vocab_size)
-
-    if not os.path.exists(tokenizer_dir):
-        os.makedirs(tokenizer_dir)
-
     if tokenizer_type == 'spe':
+        tokenizer_dir = os.path.join(dst_folder, 'tokenizer_{}_{}_v{}').format(tokenizer_type, spe_type, vocab_size)
+
+        if not os.path.exists(tokenizer_dir):
+            os.makedirs(tokenizer_dir)
+
         if os.path.exists(os.path.join(tokenizer_dir, 'tokenizer.model')):
             logging.warning("Model file already exists, overriding old model file !")
             os.remove(os.path.join(tokenizer_dir, 'tokenizer.model'))
@@ -127,9 +142,15 @@ def __process_data(
             do_lower_case=lower_case,
             output_dir=tokenizer_dir,
             tokenizer_type=spe_type,
+            character_coverage=spe_character_coverage,
         )
 
     else:
+        tokenizer_dir = os.path.join(dst_folder, 'tokenizer_{}_v{}').format(tokenizer_type, vocab_size)
+
+        if not os.path.exists(tokenizer_dir):
+            os.makedirs(tokenizer_dir)
+
         tokenizer = tokenizers.BertWordPieceTokenizer(lowercase=lower_case)
 
         tokenizer.train(text_path, vocab_size=vocab_size)
@@ -145,6 +166,7 @@ def main():
     vocab_size = args.vocab_size
     tokenizer = args.tokenizer
     spe_type = args.spe_type
+    spe_character_coverage = args.spe_character_coverage
     lower_case = args.lower_case
 
     if not os.path.exists(data_root):
@@ -158,7 +180,13 @@ def main():
     else:
         text_corpus_path = data_file
     tokenizer_path = __process_data(
-        text_corpus_path, data_root, vocab_size, tokenizer, spe_type, lower_case=lower_case
+        text_corpus_path,
+        data_root,
+        vocab_size,
+        tokenizer,
+        spe_type,
+        lower_case=lower_case,
+        spe_character_coverage=spe_character_coverage,
     )
 
     print("Serialized tokenizer at location :", tokenizer_path)


### PR DESCRIPTION
# Bugfix
- Enables sentencepiece tokenizers to capture the entire vocabulary for small vocab languages like English with cases.

Signed-off-by: smajumdar <titu1994@gmail.com>