### PR TITLE
Enable `default` pytorch initialization mode for ConvASREncoder/ConvASRDecoder modules

### DIFF
--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from collections import OrderedDict
+from typing import Optional
 
 import torch
 import torch.nn as nn
@@ -108,14 +109,14 @@ class ConvASREncoder(NeuralModule, Exportable):
     def __init__(
         self,
         jasper,
-        activation,
-        feat_in,
-        normalization_mode="batch",
-        residual_mode="add",
-        norm_groups=-1,
-        conv_mask=True,
-        frame_splicing=1,
-        init_mode='xavier_uniform',
+        activation: str,
+        feat_in: int,
+        normalization_mode: str = "batch",
+        residual_mode: str = "add",
+        norm_groups: int = -1,
+        conv_mask: bool = True,
+        frame_splicing: int = 1,
+        init_mode: Optional[str] = 'xavier_uniform',
     ):
         super().__init__()
         if isinstance(jasper, ListConfig):
@@ -288,7 +289,14 @@ class ConvASRDecoderClassification(NeuralModule, Exportable):
     def output_types(self):
         return OrderedDict({"logits": NeuralType(('B', 'D'), LogitsType())})
 
-    def __init__(self, feat_in, num_classes, init_mode="xavier_uniform", return_logits=True, pooling_type='avg'):
+    def __init__(
+        self,
+        feat_in: int,
+        num_classes: int,
+        init_mode: Optional[str] = "xavier_uniform",
+        return_logits: bool = True,
+        pooling_type='avg',
+    ):
         super().__init__()
 
         self._feat_in = feat_in

--- a/nemo/collections/asr/parts/jasper.py
+++ b/nemo/collections/asr/parts/jasper.py
@@ -24,20 +24,21 @@ from nemo.collections.asr.parts.activations import Swish
 jasper_activations = {"hardtanh": nn.Hardtanh, "relu": nn.ReLU, "selu": nn.SELU, "swish": Swish}
 
 
-def init_weights(m, mode='xavier_uniform'):
+def init_weights(m, mode: Optional[str] = 'xavier_uniform'):
     if isinstance(m, MaskedConv1d):
         init_weights(m.conv, mode)
     if isinstance(m, (nn.Conv1d, nn.Linear)):
-        if mode == 'xavier_uniform':
-            nn.init.xavier_uniform_(m.weight, gain=1.0)
-        elif mode == 'xavier_normal':
-            nn.init.xavier_normal_(m.weight, gain=1.0)
-        elif mode == 'kaiming_uniform':
-            nn.init.kaiming_uniform_(m.weight, nonlinearity="relu")
-        elif mode == 'kaiming_normal':
-            nn.init.kaiming_normal_(m.weight, nonlinearity="relu")
-        else:
-            raise ValueError("Unknown Initialization mode: {0}".format(mode))
+        if mode is not None:
+            if mode == 'xavier_uniform':
+                nn.init.xavier_uniform_(m.weight, gain=1.0)
+            elif mode == 'xavier_normal':
+                nn.init.xavier_normal_(m.weight, gain=1.0)
+            elif mode == 'kaiming_uniform':
+                nn.init.kaiming_uniform_(m.weight, nonlinearity="relu")
+            elif mode == 'kaiming_normal':
+                nn.init.kaiming_normal_(m.weight, nonlinearity="relu")
+            else:
+                raise ValueError("Unknown Initialization mode: {0}".format(mode))
     elif isinstance(m, nn.BatchNorm1d):
         if m.track_running_stats:
             m.running_mean.zero_()


### PR DESCRIPTION
# Changelog
- Adds `init_mode=None` option which will preserve the default pytorch initialization for the `ConvASREncoder` and `ConvASRDecoder` modules

Signed-off-by: smajumdar <titu1994@gmail.com>