### PR TITLE
fixed bug where exp_manager would pass a .nemo file to PTL trainer

### DIFF
--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -290,7 +290,6 @@ def check_resume(
     checkpoint_dir = Path(Path(log_dir) / "checkpoints")
     checkpoint = None
     end_checkpoints = list(checkpoint_dir.glob("*end.ckpt"))
-    end_checkpoints.extend(list(checkpoint_dir.glob("*.nemo")))
     last_checkpoints = list(checkpoint_dir.glob("*last.ckpt"))
     if not checkpoint_dir.exists():
         if resume_ignore_no_checkpoint:


### PR DESCRIPTION
The following line was passing a `.nemo` file as an argument for PTL Trainer's `resume_from_checkpoint` option.
This would lead to PTL trying to unpickle a tar file and raise an exception.