### PR TITLE
Add tutorial entry for external language model

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -207,6 +207,9 @@ To run tutorials:
    * - ASR
      - Online Noise Augmentation
      - `Online noise augmentation <https://colab.research.google.com/github/NVIDIA/NeMo/blob/v1.0.0b2/tutorials/asr/05_Online_Noise_Augmentation.ipynb>`_
+   * - ASR
+     - Beam Search and External Language Model Rescoring
+     - `Beam search and external language model rescoring <https://colab.research.google.com/github/NVIDIA/NeMo/blob/v1.0.0b2/tutorials/asr/Offline_ASR.ipynb>`_
    * - NLP
      - Using Pretrained Language Models for Downstream Tasks
      - `Pretrained language models for downstream tasks <https://colab.research.google.com/github/NVIDIA/NeMo/blob/v1.0.0b2/tutorials/nlp/01_Pretrained_Language_Models_for_Downstream_Tasks.ipynb>`_


### PR DESCRIPTION
I asked this before I found the tutorial notebook: https://github.com/NVIDIA/NeMo/issues/1503

This question of how to add external language models is very common, so now that it is supported I think it would be worthwhile to add it to the chart of the main README - I'd guess you will all get fewer questions that way as well.

Figured I'd save others some time and go on and submit this small PR.