### PR TITLE
Add sentencepiece as dependency explicitly

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,3 +10,4 @@ scikit-learn
 omegaconf>=2.0.2
 hydra-core>=1.0.3
 transformers>=3.1.0,<4.0.0
+sentencepiece<1.0.0


### PR DESCRIPTION
# Changelog
- Huggingface tokenizers 4.0+ drops the explicit dependency on sentencepiece
- Therefore add it as a dependency explicitly 

Signed-off-by: smajumdar <titu1994@gmail.com>