### PR TITLE
Preserve absolute path of model restore file

### DIFF
--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -476,7 +476,7 @@ class ModelPT(LightningModule, Model):
             raise FileNotFoundError(f"Can't find {restore_path}")
 
         global _MODEL_RESTORE_PATH
-        _MODEL_RESTORE_PATH = os.path.abspath(restore_path)
+        _MODEL_RESTORE_PATH = os.path.abspath(os.path.expanduser(restore_path))
 
         if _EFF_PRESENT_:
             # Try to load the EFF archive.

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -476,7 +476,7 @@ class ModelPT(LightningModule, Model):
             raise FileNotFoundError(f"Can't find {restore_path}")
 
         global _MODEL_RESTORE_PATH
-        _MODEL_RESTORE_PATH = restore_path
+        _MODEL_RESTORE_PATH = os.path.abspath(restore_path)
 
         if _EFF_PRESENT_:
             # Try to load the EFF archive.


### PR DESCRIPTION
# Changelog
- Preserve absolute path of provided path in order to correctly check whether its a tarfile - when cwd() is inside of another tarfile.

Signed-off-by: smajumdar <titu1994@gmail.com>