### PR TITLE
Fix quantization dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,13 @@ WORKDIR /tmp/nemo
 COPY requirements .
 RUN for f in $(ls requirements/*.txt); do pip install --disable-pip-version-check --no-cache-dir -r $f; done
 
+# install quantization support
+RUN git clone https://github.com/NVIDIA/TensorRT.git && \
+    cd TensorRT/tools/pytorch-quantization && \
+    python setup.py install && \
+    cd - && \
+    rm -rf TensorRT
+
 # build CTC beam search decoder
 COPY scripts/install_ctc_decoders.sh .
 RUN ./install_ctc_decoders.sh

--- a/examples/asr/speech_to_text_calibrate.py
+++ b/examples/asr/speech_to_text_calibrate.py
@@ -19,21 +19,20 @@ Script for calibrating a pretrained ASR model for quantization
 from argparse import ArgumentParser
 
 import torch
-from pytorch_quantization import nn as quant_nn
-from pytorch_quantization import quant_modules
-from pytorch_quantization.tensor_quant import QuantDescriptor
 
 from nemo.collections.asr.models import EncDecCTCModel
 from nemo.utils import logging
 
 try:
     from pytorch_quantization import calib
+    from pytorch_quantization import nn as quant_nn
+    from pytorch_quantization import quant_modules
+    from pytorch_quantization.tensor_quant import QuantDescriptor
 except ImportError:
     raise ImportError(
         "pytorch-quantization is not installed. Install from "
         "https://github.com/NVIDIA/TensorRT/tree/master/tools/pytorch-quantization."
     )
-
 
 try:
     from torch.cuda.amp import autocast

--- a/examples/asr/speech_to_text_calibrate.py
+++ b/examples/asr/speech_to_text_calibrate.py
@@ -19,13 +19,21 @@ Script for calibrating a pretrained ASR model for quantization
 from argparse import ArgumentParser
 
 import torch
-from pytorch_quantization import calib
 from pytorch_quantization import nn as quant_nn
 from pytorch_quantization import quant_modules
 from pytorch_quantization.tensor_quant import QuantDescriptor
 
 from nemo.collections.asr.models import EncDecCTCModel
 from nemo.utils import logging
+
+try:
+    from pytorch_quantization import calib
+except ImportError:
+    raise ImportError(
+        "pytorch-quantization is not installed. Install from "
+        "https://github.com/NVIDIA/TensorRT/tree/master/tools/pytorch-quantization."
+    )
+
 
 try:
     from torch.cuda.amp import autocast

--- a/examples/asr/speech_to_text_quant_infer.py
+++ b/examples/asr/speech_to_text_quant_infer.py
@@ -21,7 +21,6 @@ from argparse import ArgumentParser
 from pprint import pprint
 
 import torch
-from pytorch_quantization import quant_modules
 
 from nemo.collections.asr.metrics.wer import WER, word_error_rate
 from nemo.collections.asr.models import EncDecCTCModel
@@ -29,6 +28,7 @@ from nemo.utils import logging
 
 try:
     from pytorch_quantization import nn as quant_nn
+    from pytorch_quantization import quant_modules
 except ImportError:
     raise ImportError(
         "pytorch-quantization is not installed. Install from "

--- a/examples/asr/speech_to_text_quant_infer.py
+++ b/examples/asr/speech_to_text_quant_infer.py
@@ -21,12 +21,20 @@ from argparse import ArgumentParser
 from pprint import pprint
 
 import torch
-from pytorch_quantization import nn as quant_nn
 from pytorch_quantization import quant_modules
 
 from nemo.collections.asr.metrics.wer import WER, word_error_rate
 from nemo.collections.asr.models import EncDecCTCModel
 from nemo.utils import logging
+
+try:
+    from pytorch_quantization import nn as quant_nn
+except ImportError:
+    raise ImportError(
+        "pytorch-quantization is not installed. Install from "
+        "https://github.com/NVIDIA/TensorRT/tree/master/tools/pytorch-quantization."
+    )
+
 
 try:
     from torch.cuda.amp import autocast

--- a/requirements/requirements_quantization.txt
+++ b/requirements/requirements_quantization.txt
@@ -1,2 +1,0 @@
---extra-index-url https://pypi.ngc.nvidia.com
-pytorch-quantization


### PR DESCRIPTION
There is only one python version of prebuild wheel of TensorRT's pytorch-quantization on nvidia pyindex, which causes install with all other version of python to fail with a confusion error message.

Removed requirement_quantization.txt. Instead, install from source in Dockerfile. 

Also added error message if running quantization scripts without pytorch-quantization.

@okuchaiev 