### PR TITLE
Megatron-lm checkpoints need to have version set.

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
@@ -15,10 +15,10 @@
 # limitations under the License.
 
 import os
-from megatron.checkpointing import set_checkpoint_version
 
 import torch
 from megatron import get_args, initialize_megatron
+from megatron.checkpointing import set_checkpoint_version
 from megatron.model import get_language_model
 from megatron.model.bert_model import bert_attention_mask_func, bert_extended_attention_mask, bert_position_ids
 from megatron.mpu import get_model_parallel_group, model_parallel_is_initialized

--- a/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
@@ -143,6 +143,7 @@ class MegatronBertEncoder(BertModule):
                 if state_dict['checkpoint_version'] is not None:
                     set_checkpoint_version(state_dict['checkpoint_version'])
             else:
+                logging.warning('Megatron-lm checkpoint version not found. Setting checkpoint_version to 0.')
                 set_checkpoint_version(0)
             # to load from Megatron pretrained checkpoint
             if 'model' in state_dict:
@@ -151,6 +152,8 @@ class MegatronBertEncoder(BertModule):
                 self.load_state_dict(state_dict)
             logging.info(f"weights restored from {restore_path}")
         elif os.path.isdir(restore_path):
+            # TODO: need to refactor this so we're not repeating code
+
             # need model parallel groups to restore model parallel checkpoints
             if model_parallel_is_initialized():
                 model_parallel_rank = torch.distributed.get_rank(group=get_model_parallel_group())
@@ -161,6 +164,7 @@ class MegatronBertEncoder(BertModule):
                     if state_dict['checkpoint_version'] is not None:
                         set_checkpoint_version(state_dict['checkpoint_version'])
                 else:
+                    logging.warning('Megatron-lm checkpoint version not found. Setting checkpoint_version to 0.')
                     set_checkpoint_version(0)
                 # to load from Megatron pretrained checkpoint
                 if 'model' in state_dict:

--- a/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_bert.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import os
+from megatron.checkpointing import set_checkpoint_version
 
 import torch
 from megatron import get_args, initialize_megatron
@@ -52,6 +53,10 @@ class MegatronBertEncoder(BertModule):
         self._restore_path = None
         self._app_state = None
         self._model_name = model_name
+
+        # megatron-lm checkpoints on NGC are version 0
+        # we'll need a way to set this correctly moving forward
+        set_checkpoint_version(0)
 
         if not os.path.exists(vocab_file):
             raise ValueError(f'Vocab file not found at {vocab_file}')


### PR DESCRIPTION
Checking for version in restore and then setting it. 

Need to save checkpoint version when saving NeMo Megatron-lm models.