### PR TITLE
Add OS flag for tokenizer parallelism for ASR BPE

### DIFF
--- a/nemo/collections/asr/parts/mixins.py
+++ b/nemo/collections/asr/parts/mixins.py
@@ -38,6 +38,10 @@ class ASRBPEMixin(ABC):
     """
 
     def _setup_tokenizer(self, tokenizer_cfg: DictConfig):
+        # Prevent tokenizer parallelism (unless user has explicitly set it)
+        if 'TOKENIZERS_PARALLELISM' not in os.environ:
+            os.environ['TOKENIZERS_PARALLELISM'] = 'false'
+
         self.tokenizer_cfg = OmegaConf.to_container(tokenizer_cfg, resolve=True)  # type: dict
         self.tokenizer_dir = self.tokenizer_cfg.pop('dir')  # Remove tokenizer directory
         self.tokenizer_type = self.tokenizer_cfg.pop('type').lower()  # Remove tokenizer_type


### PR DESCRIPTION
# Changelog
- ASR BPE now will explicitly set Hugging Face flag `TOKENIZERS_PARALLELISM` if not provided by user

Signed-off-by: smajumdar <titu1994@gmail.com>