### PR TITLE
Adding the feature of variational noise to the RNNT-based models

### DIFF
--- a/examples/asr/experimental/conformer/conformer_linear_decoder_bpe.yaml
+++ b/examples/asr/experimental/conformer/conformer_linear_decoder_bpe.yaml
@@ -121,6 +121,10 @@ model:
       min_lr: 1e-6
       last_epoch: -1
 
+    var_noise:
+      std: 0.0 # variance of the Gaussian noise, recommended: 0.075
+      start_step: 0
+
 trainer:
   gpus: 0 # number of gpus
   num_nodes: 1

--- a/examples/asr/experimental/conformer/conformer_linear_decoder_bpe.yaml
+++ b/examples/asr/experimental/conformer/conformer_linear_decoder_bpe.yaml
@@ -121,10 +121,6 @@ model:
       min_lr: 1e-6
       last_epoch: -1
 
-    var_noise:
-      std: 0.0 # variance of the Gaussian noise, recommended: 0.075
-      start_step: 0
-
 trainer:
   gpus: 0 # number of gpus
   num_nodes: 1

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -121,9 +121,9 @@ class EncDecRNNTModel(ASRModel):
             self.joint.set_wer(self.wer)
 
         # setting up the variational noise for the decoder
-        if hasattr(self.cfg, 'var_noise'):
-            self._optim_variational_noise_std = self.cfg['var_noise'].get('std', None)
-            self._optim_variational_noise_start = self.cfg['var_noise'].get('start_step', 0)
+        if hasattr(self.cfg, 'variational_noise'):
+            self._optim_variational_noise_std = self.cfg['variational_noise'].get('std', None)
+            self._optim_variational_noise_start = self.cfg['variational_noise'].get('start_step', 0)
         else:
             self._optim_variational_noise_std = 0
             self._optim_variational_noise_start = 0

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -120,12 +120,13 @@ class EncDecRNNTModel(ASRModel):
             self.joint.set_loss(self.loss)
             self.joint.set_wer(self.wer)
 
+        # setting up the variational noise for the decoder
         if hasattr(self.cfg, 'var_noise'):
-            self._var_noise_std = self.cfg['var_noise'].get('std', None)
-            self._var_noise_start = self.cfg['var_noise'].get('start_step', 0)
+            self._optim_variational_noise_std = self.cfg['var_noise'].get('std', None)
+            self._optim_variational_noise_start = self.cfg['var_noise'].get('start_step', 0)
         else:
-            self._var_noise_std = 0
-            self._var_noise_start = 0
+            self._optim_variational_noise_std = 0
+            self._optim_variational_noise_start = 0
 
     @torch.no_grad()
     def transcribe(self, paths2audio_files: List[str], batch_size: int = 4) -> List[str]:
@@ -578,12 +579,10 @@ class EncDecRNNTModel(ASRModel):
 
     def on_after_backward(self):
         super().on_after_backward()
-        if self._var_noise_std > 0 and self.global_step >= self._var_noise_start:
+        if self._optim_variational_noise_std > 0 and self.global_step >= self._optim_variational_noise_start:
             for param_name, param in self.decoder.named_parameters():
                 if param.grad is not None:
-                    print(param_name)
                     noise = torch.normal(
-                        mean=0.0, std=self._var_noise_std, size=param.size(), device=param.device, dtype=param.dtype
+                        mean=0.0, std=self._optim_variational_noise_std, size=param.size(), device=param.device, dtype=param.dtype
                     )
                     param.grad.data.add_(noise)
-

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -127,45 +127,6 @@ class EncDecRNNTModel(ASRModel):
             self._var_noise_std = 0
             self._var_noise_start = 0
 
-        # if self._var_noise_std > 0:
-        #     self.decoder.register_backward_hook(functools.partial(EncDecRNNTModel.apply_var_noise, self))
-
-    # def apply_var_noise(model, module, grad_input, grad_output):
-    #     from time import time
-    #     start = time()
-    #     grad_output_new = []
-    #     if module._var_noise_std > 0 and model.global_step >= module._var_noise_start:
-    #         print(module)
-    #         for grad in grad_input:
-    #             print(grad.size())
-    #             print(grad)
-    #
-    #             noise = torch.normal(
-    #                 mean=0.0, std=module._var_noise_std, size=grad.size(), device=grad.device, dtype=grad.dtype
-    #             )
-    #             grad_output_new.append(grad + noise)
-    #
-    #     # for param_name, param in module.named_parameters():
-    #         #     print(param_name)
-    #         #     noise = torch.normal(
-    #         #         mean=0.0, std=module._var_noise_std, size=param.size(), device=param.device, dtype=param.dtype
-    #         #     )
-    #         #     param.grad.data.add_(noise)
-    #
-    #         # print(grad_input[0].size())
-    #         # print(grad_output[0].size())
-    #         # for param_name, param in module.named_parameters():
-    #         #     if param.grad is not None and param_name.startswith('decoder.'):
-    #         #         print(param_name)
-    #         #         noise = torch.normal(
-    #         #             mean=0.0, std=module._var_noise_std, size=param.size(), device=param.device, dtype=param.dtype
-    #         #         )
-    #         #         param.grad.data.add_(noise)
-    #
-    #     print(time()-start)
-    #     return tuple(grad_output_new)
-
-
     @torch.no_grad()
     def transcribe(self, paths2audio_files: List[str], batch_size: int = 4) -> List[str]:
         """
@@ -617,15 +578,12 @@ class EncDecRNNTModel(ASRModel):
 
     def on_after_backward(self):
         super().on_after_backward()
-        from time import time
-        start = time()
         if self._var_noise_std > 0 and self.global_step >= self._var_noise_start:
             for param_name, param in self.decoder.named_parameters():
-                if param.grad is not None: # and param_name.startswith('decoder.'):
+                if param.grad is not None:
                     print(param_name)
                     noise = torch.normal(
                         mean=0.0, std=self._var_noise_std, size=param.size(), device=param.device, dtype=param.dtype
                     )
                     param.grad.data.add_(noise)
 
-        print(time()-start)

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -583,6 +583,10 @@ class EncDecRNNTModel(ASRModel):
             for param_name, param in self.decoder.named_parameters():
                 if param.grad is not None:
                     noise = torch.normal(
-                        mean=0.0, std=self._optim_variational_noise_std, size=param.size(), device=param.device, dtype=param.dtype
+                        mean=0.0,
+                        std=self._optim_variational_noise_std,
+                        size=param.size(),
+                        device=param.device,
+                        dtype=param.dtype,
                     )
                     param.grad.data.add_(noise)

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -165,7 +165,7 @@ class ModelPT(LightningModule, Model):
         # ModelPT wrappers over subclass implementations
         self.training_step = model_utils.wrap_training_step(self.training_step)
 
-        self._var_noise_std = None
+        self._var_noise_std = 0
         self._var_noise_start = 0
 
     def register_artifact(self, config_path: str, src: str):
@@ -798,7 +798,7 @@ class ModelPT(LightningModule, Model):
             self._var_noise_start = optimizer_args['var_noise'].get('start_step', 0)
             optimizer_args.pop('var_noise')
         else:
-            self._var_noise_std = None
+            self._var_noise_std = 0
             self._var_noise_start = 0
 
         # Actually instantiate the optimizer

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -165,9 +165,6 @@ class ModelPT(LightningModule, Model):
         # ModelPT wrappers over subclass implementations
         self.training_step = model_utils.wrap_training_step(self.training_step)
 
-        self._var_noise_std = 0
-        self._var_noise_start = 0
-
     def register_artifact(self, config_path: str, src: str):
         """
         Register model artifacts with this function. These artifacts (files) will be included inside .nemo file


### PR DESCRIPTION
It is going to add Gaussian noise to the decoder's weights of rnnt models after each step to avoid overfitting.
This section need to be added to the model section of the config:

```
model:
    var_noise:
      std: 0.075
      start_step: 2000
```
