### PR TITLE
fix container version - no leading v

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ It has all requirements and NeMo 1.0.0b2 already installed.
 
     docker run --gpus all -it --rm -v <nemo_github_folder>:/NeMo --shm-size=8g \
     -p 8888:8888 -p 6006:6006 --ulimit memlock=-1 --ulimit \
-    stack=67108864 --device=/dev/snd nvcr.io/nvidia/nemo:v1.0.0b3
+    stack=67108864 --device=/dev/snd nvcr.io/nvidia/nemo:1.0.0b3
 
 
 If you chose to work with main branch, we recommend using NVIDIA's PyTorch container version 20.09-py3.


### PR DESCRIPTION
readme has wrong container, there is no leading v on the version for the container on NGC.  