### PR TITLE
Add entire dataset caching via a preproc script, bpe dropout and deto…

### DIFF
--- a/examples/nlp/machine_translation/nmt_transformer_infer.py
+++ b/examples/nlp/machine_translation/nmt_transformer_infer.py
@@ -29,6 +29,7 @@ import torch
 import nemo.collections.nlp as nemo_nlp
 from nemo.utils import logging
 
+
 def main():
     parser = ArgumentParser()
     parser.add_argument("--model", type=str, required=True, help="")

--- a/examples/nlp/machine_translation/nmt_transformer_infer.py
+++ b/examples/nlp/machine_translation/nmt_transformer_infer.py
@@ -29,13 +29,15 @@ import torch
 import nemo.collections.nlp as nemo_nlp
 from nemo.utils import logging
 
-
 def main():
     parser = ArgumentParser()
     parser.add_argument("--model", type=str, required=True, help="")
     parser.add_argument("--srctext", type=str, required=True, help="")
     parser.add_argument("--tgtout", type=str, required=True, help="")
     parser.add_argument("--batch_size", type=int, default=256, help="")
+    parser.add_argument("--beam_size", type=int, default=4, help="")
+    parser.add_argument("--len_pen", type=float, default=0.6, help="")
+    parser.add_argument("--target_lang", type=str, default="en", help="")
 
     args = parser.parse_args()
     torch.set_grad_enabled(False)
@@ -69,7 +71,7 @@ def main():
             # if count % 300 == 0:
             #    print(f"Translated {count} sentences")
         if len(src_text) > 0:
-            tgt_text += model.translate(text=src_text)
+            tgt_text += model.translate(text=src_text, target_lang=args.target_lang)
 
     with open(args.tgtout, 'w') as tgt_f:
         for line in tgt_text:

--- a/examples/nlp/machine_translation/preprocess_dataset.py
+++ b/examples/nlp/machine_translation/preprocess_dataset.py
@@ -44,8 +44,6 @@ if __name__ == '__main__':
                 help='Max Sequence Length')
     parser.add_argument('--min_seq_length', type=int, default=1,
                 help='Min Sequence Length')
-    parser.add_argument('--num_workers', type=int, default=8,
-                help='Number of workers')
     parser.add_argument('--tokens_in_batch', type=str, default="8000,12000,16000,40000",
                 help='# Tokens per batch per GPU')
 
@@ -108,20 +106,6 @@ if __name__ == '__main__':
             dataset,
             open(os.path.join(args.out_dir, 'batches.tokens.%d.pkl' % (num_tokens)), 'wb')
         )
-        '''
-        pickle.dump({
-            'batches': dataset.batches,
-            'batch_indices': dataset.batch_indices,
-            'src_fname': args.src_fname,
-            'tgt_fname': args.tgt_fname,
-            'tokens_in_batch': num_tokens,
-            'max_seq_length': args.max_seq_length,
-            'min_seq_length': args.min_seq_length,
-            'max_seq_length_diff': args.max_seq_length,
-            'max_seq_length_ratio': args.max_seq_length,
-            'clean': args.clean,
-        }, open(os.path.join(args.out_dir, 'batches.%d.pkl' % (num_tokens)), 'wb'))
-        '''
         end = time.time()
         print('Took %f time to pickle' % (end - start))
         start = time.time()

--- a/examples/nlp/machine_translation/preprocess_dataset.py
+++ b/examples/nlp/machine_translation/preprocess_dataset.py
@@ -13,37 +13,30 @@
 # limitations under the License.
 
 import argparse
-import youtokentome as yttm
 import os
-from pathlib import Path
 import pickle
 import time
+from pathlib import Path
+
+import youtokentome as yttm
 
 from nemo.collections.nlp.data import TranslationDataset
 from nemo.collections.nlp.modules.common.tokenizer_utils import get_tokenizer
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='NMT dataset pre-processing')
-    parser.add_argument('--shared_tokenizer', action="store_true",
-                help='Whether to share encoder/decoder tokenizers')
-    parser.add_argument('--clean', action="store_true",
-                help='Whether to clean dataset based on length diff')
-    parser.add_argument('--bpe_dropout', type=float, default=0.1,
-                help='Whether to share encoder/decoder tokenizers')
-    parser.add_argument('--src_fname', type=str, required=True,
-                help='Path to the source file')
-    parser.add_argument('--tgt_fname', type=str, required=True,
-                help='Path to the target file')
-    parser.add_argument('--out_dir', type=str, required=True,
-                help='Path to store dataloader and tokenizer models')
-    parser.add_argument('--vocab_size', type=int, default=32000,
-                help='Vocab size after BPE')
-    parser.add_argument('--max_seq_length', type=int, default=512,
-                help='Max Sequence Length')
-    parser.add_argument('--min_seq_length', type=int, default=1,
-                help='Min Sequence Length')
-    parser.add_argument('--tokens_in_batch', type=str, default="8000,12000,16000,40000",
-                help='# Tokens per batch per GPU')
+    parser.add_argument('--shared_tokenizer', action="store_true", help='Whether to share encoder/decoder tokenizers')
+    parser.add_argument('--clean', action="store_true", help='Whether to clean dataset based on length diff')
+    parser.add_argument('--bpe_dropout', type=float, default=0.1, help='Whether to share encoder/decoder tokenizers')
+    parser.add_argument('--src_fname', type=str, required=True, help='Path to the source file')
+    parser.add_argument('--tgt_fname', type=str, required=True, help='Path to the target file')
+    parser.add_argument('--out_dir', type=str, required=True, help='Path to store dataloader and tokenizer models')
+    parser.add_argument('--vocab_size', type=int, default=32000, help='Vocab size after BPE')
+    parser.add_argument('--max_seq_length', type=int, default=512, help='Max Sequence Length')
+    parser.add_argument('--min_seq_length', type=int, default=1, help='Min Sequence Length')
+    parser.add_argument(
+        '--tokens_in_batch', type=str, default="8000,12000,16000,40000", help='# Tokens per batch per GPU'
+    )
 
     args = parser.parse_args()
     if args.shared_tokenizer:
@@ -51,7 +44,7 @@ if __name__ == '__main__':
         yttm.BPE.train(
             data='/tmp/concat_dataset.txt',
             vocab_size=args.vocab_size,
-            model=os.path.join(args.out_dir, 'tokenizer.%d.BPE.model' % (args.vocab_size))
+            model=os.path.join(args.out_dir, 'tokenizer.%d.BPE.model' % (args.vocab_size)),
         )
         encoder_tokenizer_model = os.path.join(args.out_dir, 'tokenizer.%d.BPE.model' % (args.vocab_size))
         decoder_tokenizer_model = os.path.join(args.out_dir, 'tokenizer.%d.BPE.model' % (args.vocab_size))
@@ -59,27 +52,23 @@ if __name__ == '__main__':
         yttm.BPE.train(
             data=args.src_fname,
             vocab_size=args.vocab_size,
-            model=os.path.join(args.out_dir, 'tokenizer.encoder.%d.BPE.model' % (args.vocab_size))
+            model=os.path.join(args.out_dir, 'tokenizer.encoder.%d.BPE.model' % (args.vocab_size)),
         )
 
         yttm.BPE.train(
             data=args.tgt_fname,
             vocab_size=args.vocab_size,
-            model=os.path.join(args.out_dir, 'tokenizer.decoder.%d.BPE.model' % (args.vocab_size))
+            model=os.path.join(args.out_dir, 'tokenizer.decoder.%d.BPE.model' % (args.vocab_size)),
         )
         encoder_tokenizer_model = os.path.join(args.out_dir, 'tokenizer.encoder.%d.BPE.model' % (args.vocab_size))
         decoder_tokenizer_model = os.path.join(args.out_dir, 'tokenizer.decoder.%d.BPE.model' % (args.vocab_size))
 
     encoder_tokenizer = get_tokenizer(
-        tokenizer_name='yttm',
-        tokenizer_model=encoder_tokenizer_model,
-        bpe_dropout=args.bpe_dropout
+        tokenizer_name='yttm', tokenizer_model=encoder_tokenizer_model, bpe_dropout=args.bpe_dropout
     )
 
     decoder_tokenizer = get_tokenizer(
-        tokenizer_name='yttm',
-        tokenizer_model=decoder_tokenizer_model,
-        bpe_dropout=args.bpe_dropout
+        tokenizer_name='yttm', tokenizer_model=decoder_tokenizer_model, bpe_dropout=args.bpe_dropout
     )
 
     tokens_in_batch = [int(item) for item in args.tokens_in_batch.split(',')]
@@ -100,15 +89,10 @@ if __name__ == '__main__':
         print('Batchifying ...')
         dataset.batchify(encoder_tokenizer, decoder_tokenizer)
         start = time.time()
-        pickle.dump(
-            dataset,
-            open(os.path.join(args.out_dir, 'batches.tokens.%d.pkl' % (num_tokens)), 'wb')
-        )
+        pickle.dump(dataset, open(os.path.join(args.out_dir, 'batches.tokens.%d.pkl' % (num_tokens)), 'wb'))
         end = time.time()
         print('Took %f time to pickle' % (end - start))
         start = time.time()
-        dataset = pickle.load(
-            open(os.path.join(args.out_dir, 'batches.tokens.%d.pkl' % (num_tokens)), 'rb')
-        )
+        dataset = pickle.load(open(os.path.join(args.out_dir, 'batches.tokens.%d.pkl' % (num_tokens)), 'rb'))
         end = time.time()
         print('Took %f time to unpickle' % (end - start))

--- a/examples/nlp/machine_translation/preprocess_dataset.py
+++ b/examples/nlp/machine_translation/preprocess_dataset.py
@@ -16,8 +16,6 @@ import argparse
 import youtokentome as yttm
 import os
 from pathlib import Path
-import torch.utils.data as pt_data
-import torch
 import pickle
 import time
 

--- a/examples/nlp/machine_translation/preprocess_dataset.py
+++ b/examples/nlp/machine_translation/preprocess_dataset.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import youtokentome as yttm
+import os
+from pathlib import Path
+import torch.utils.data as pt_data
+import torch
+import pickle
+import time
+
+from nemo.collections.nlp.data import TranslationDataset
+from nemo.collections.nlp.modules.common.tokenizer_utils import get_tokenizer
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='NMT dataset pre-processing')
+    parser.add_argument('--shared_tokenizer', action="store_true",
+                help='Whether to share encoder/decoder tokenizers')
+    parser.add_argument('--clean', action="store_true",
+                help='Whether to clean dataset based on length diff')
+    parser.add_argument('--bpe_dropout', type=float, default=0.1,
+                help='Whether to share encoder/decoder tokenizers')
+    parser.add_argument('--src_fname', type=str, required=True,
+                help='Path to the source file')
+    parser.add_argument('--tgt_fname', type=str, required=True,
+                help='Path to the target file')
+    parser.add_argument('--out_dir', type=str, required=True,
+                help='Path to store dataloader and tokenizer models')
+    parser.add_argument('--vocab_size', type=int, default=32000,
+                help='Vocab size after BPE')
+    parser.add_argument('--max_seq_length', type=int, default=512,
+                help='Max Sequence Length')
+    parser.add_argument('--min_seq_length', type=int, default=1,
+                help='Min Sequence Length')
+    parser.add_argument('--num_workers', type=int, default=8,
+                help='Number of workers')
+    parser.add_argument('--tokens_in_batch', type=str, default="8000,12000,16000,40000",
+                help='# Tokens per batch per GPU')
+
+    args = parser.parse_args()
+    if args.shared_tokenizer:
+        os.system('cat %s %s > %s' % (args.src_fname, args.tgt_fname, '/tmp/concat_dataset.txt'))
+        yttm.BPE.train(
+            data='/tmp/concat_dataset.txt',
+            vocab_size=args.vocab_size,
+            model=os.path.join(args.out_dir, 'tokenizer.%d.BPE.model' % (args.vocab_size))
+        )
+        encoder_tokenizer_model = os.path.join(args.out_dir, 'tokenizer.%d.BPE.model' % (args.vocab_size))
+        decoder_tokenizer_model = os.path.join(args.out_dir, 'tokenizer.%d.BPE.model' % (args.vocab_size))
+    else:
+        yttm.BPE.train(
+            data=args.src_fname,
+            vocab_size=args.vocab_size,
+            model=os.path.join(args.out_dir, 'tokenizer.encoder.%d.BPE.model' % (args.vocab_size))
+        )
+
+        yttm.BPE.train(
+            data=args.tgt_fname,
+            vocab_size=args.vocab_size,
+            model=os.path.join(args.out_dir, 'tokenizer.decoder.%d.BPE.model' % (args.vocab_size))
+        )
+        encoder_tokenizer_model = os.path.join(args.out_dir, 'tokenizer.encoder.%d.BPE.model' % (args.vocab_size))
+        decoder_tokenizer_model = os.path.join(args.out_dir, 'tokenizer.decoder.%d.BPE.model' % (args.vocab_size))
+
+    encoder_tokenizer = get_tokenizer(
+        tokenizer_name='yttm',
+        tokenizer_model=encoder_tokenizer_model,
+        bpe_dropout=args.bpe_dropout
+    )
+
+    decoder_tokenizer = get_tokenizer(
+        tokenizer_name='yttm',
+        tokenizer_model=decoder_tokenizer_model,
+        bpe_dropout=args.bpe_dropout
+    )
+
+    tokens_in_batch = [int(item) for item in args.tokens_in_batch.split(',')]
+    for num_tokens in tokens_in_batch:
+        dataset = TranslationDataset(
+            dataset_src=str(Path(args.src_fname).expanduser()),
+            dataset_tgt=str(Path(args.tgt_fname).expanduser()),
+            tokens_in_batch=num_tokens,
+            clean=args.clean,
+            max_seq_length=args.max_seq_length,
+            min_seq_length=args.min_seq_length,
+            max_seq_length_diff=args.max_seq_length,
+            max_seq_length_ratio=args.max_seq_length,
+            cache_ids=False,
+            cache_data_per_node=False,
+            use_cache=False,
+        )
+        print('Batchifying ...')
+        dataset.batchify(encoder_tokenizer, decoder_tokenizer)
+        start = time.time()
+        pickle.dump(
+            dataset,
+            open(os.path.join(args.out_dir, 'batches.tokens.%d.pkl' % (num_tokens)), 'wb')
+        )
+        '''
+        pickle.dump({
+            'batches': dataset.batches,
+            'batch_indices': dataset.batch_indices,
+            'src_fname': args.src_fname,
+            'tgt_fname': args.tgt_fname,
+            'tokens_in_batch': num_tokens,
+            'max_seq_length': args.max_seq_length,
+            'min_seq_length': args.min_seq_length,
+            'max_seq_length_diff': args.max_seq_length,
+            'max_seq_length_ratio': args.max_seq_length,
+            'clean': args.clean,
+        }, open(os.path.join(args.out_dir, 'batches.%d.pkl' % (num_tokens)), 'wb'))
+        '''
+        end = time.time()
+        print('Took %f time to pickle' % (end - start))
+        start = time.time()
+        dataset = pickle.load(
+            open(os.path.join(args.out_dir, 'batches.tokens.%d.pkl' % (num_tokens)), 'rb')
+        )
+        end = time.time()
+        print('Took %f time to unpickle' % (end - start))

--- a/nemo/collections/common/tokenizers/youtokentome_tokenizer.py
+++ b/nemo/collections/common/tokenizers/youtokentome_tokenizer.py
@@ -22,20 +22,21 @@ __all__ = ['YouTokenToMeTokenizer']
 
 
 class YouTokenToMeTokenizer(TokenizerSpec):
-    def __init__(self, model_path):
+    def __init__(self, model_path, bpe_dropout=0.0):
         model_path = Path(model_path).expanduser()
         self.tokenizer = yttm.BPE(model=str(model_path))
         self.vocab_size = len(self.tokenizer.vocab())
         self.special_tokens = self.tokens_to_ids(["<PAD>", "<UNK>", "<BOS>", "<EOS>"])
+        self.bpe_dropout = bpe_dropout
 
     def text_to_tokens(self, text):
-        return self.tokenizer.encode(text, output_type=yttm.OutputType.SUBWORD)
+        return self.tokenizer.encode(text, output_type=yttm.OutputType.SUBWORD, dropout_prob=self.bpe_dropout)
 
     def tokens_to_text(self, tokens):
         return self.ids_to_text(self.tokens_to_ids(tokens))
 
     def text_to_ids(self, text):
-        return self.tokenizer.encode(text, output_type=yttm.OutputType.ID)
+        return self.tokenizer.encode(text, output_type=yttm.OutputType.ID, dropout_prob=self.bpe_dropout)
 
     def ids_to_text(self, ids):
         ids_ = [id_ for id_ in ids if id_ not in self.special_tokens]

--- a/nemo/collections/nlp/data/machine_translation/machine_translation_dataset.py
+++ b/nemo/collections/nlp/data/machine_translation/machine_translation_dataset.py
@@ -57,7 +57,7 @@ class TranslationDataset(Dataset):
         cache_ids=False,
         cache_data_per_node=False,
         use_cache=False,
-        reverse_lang_direction=False
+        reverse_lang_direction=False,
     ):
         self.dataset_src = dataset_src
         self.dataset_tgt = dataset_tgt

--- a/nemo/collections/nlp/data/machine_translation/machine_translation_dataset.py
+++ b/nemo/collections/nlp/data/machine_translation/machine_translation_dataset.py
@@ -57,6 +57,7 @@ class TranslationDataset(Dataset):
         cache_ids=False,
         cache_data_per_node=False,
         use_cache=False,
+        reverse_lang_direction=False
     ):
         self.dataset_src = dataset_src
         self.dataset_tgt = dataset_tgt
@@ -69,6 +70,7 @@ class TranslationDataset(Dataset):
         self.min_seq_length = min_seq_length
         self.max_seq_length_diff = max_seq_length_diff
         self.max_seq_length_ratio = max_seq_length_ratio
+        self.reverse_lang_direction = reverse_lang_direction
 
     def batchify(self, tokenizer_src, tokenizer_tgt):
         src_ids = dataset_to_ids(
@@ -106,6 +108,8 @@ class TranslationDataset(Dataset):
     def __getitem__(self, idx):
         src_ids = self.batches[idx]["src"]
         tgt = self.batches[idx]["tgt"]
+        if self.reverse_lang_direction:
+            src_ids, tgt = tgt, src_ids
         labels = tgt[:, 1:]
         tgt_ids = tgt[:, :-1]
         src_mask = (src_ids != self.src_pad_id).astype(np.int32)

--- a/nemo/collections/nlp/models/enc_dec_nlp_model.py
+++ b/nemo/collections/nlp/models/enc_dec_nlp_model.py
@@ -96,7 +96,7 @@ class EncDecNLPModel(NLPModel):
             tokenizer_model=self.register_artifact(
                 "cfg.encoder_tokenizer.tokenizer_model", cfg.encoder_tokenizer.tokenizer_model
             ),
-            bpe_dropout=cfg.encoder_tokenizer.get("bpe_dropout", 0.0)
+            bpe_dropout=cfg.encoder_tokenizer.get("bpe_dropout", 0.0),
         )
 
         self.decoder_tokenizer = get_tokenizer(
@@ -104,5 +104,5 @@ class EncDecNLPModel(NLPModel):
             tokenizer_model=self.register_artifact(
                 "cfg.decoder_tokenizer.tokenizer_model", cfg.decoder_tokenizer.tokenizer_model
             ),
-            bpe_dropout=cfg.decoder_tokenizer.get("bpe_dropout", 0.0)
+            bpe_dropout=cfg.decoder_tokenizer.get("bpe_dropout", 0.0),
         )

--- a/nemo/collections/nlp/models/enc_dec_nlp_model.py
+++ b/nemo/collections/nlp/models/enc_dec_nlp_model.py
@@ -96,7 +96,7 @@ class EncDecNLPModel(NLPModel):
             tokenizer_model=self.register_artifact(
                 "cfg.encoder_tokenizer.tokenizer_model", cfg.encoder_tokenizer.tokenizer_model
             ),
-            bpe_dropout=cfg.encoder_tokenizer.get("bpe_dropout", 0.0),
+            bpe_dropout=cfg.encoder_tokenizer.bpe_dropout,
         )
 
         self.decoder_tokenizer = get_tokenizer(
@@ -104,5 +104,5 @@ class EncDecNLPModel(NLPModel):
             tokenizer_model=self.register_artifact(
                 "cfg.decoder_tokenizer.tokenizer_model", cfg.decoder_tokenizer.tokenizer_model
             ),
-            bpe_dropout=cfg.decoder_tokenizer.get("bpe_dropout", 0.0),
+            bpe_dropout=cfg.decoder_tokenizer.bpe_dropout,
         )

--- a/nemo/collections/nlp/models/enc_dec_nlp_model.py
+++ b/nemo/collections/nlp/models/enc_dec_nlp_model.py
@@ -96,6 +96,7 @@ class EncDecNLPModel(NLPModel):
             tokenizer_model=self.register_artifact(
                 "cfg.encoder_tokenizer.tokenizer_model", cfg.encoder_tokenizer.tokenizer_model
             ),
+            bpe_dropout=cfg.encoder_tokenizer.get("bpe_dropout", 0.0)
         )
 
         self.decoder_tokenizer = get_tokenizer(
@@ -103,4 +104,5 @@ class EncDecNLPModel(NLPModel):
             tokenizer_model=self.register_artifact(
                 "cfg.decoder_tokenizer.tokenizer_model", cfg.decoder_tokenizer.tokenizer_model
             ),
+            bpe_dropout=cfg.decoder_tokenizer.get("bpe_dropout", 0.0)
         )

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -259,6 +259,7 @@ class MTEncDecModel(EncDecNLPModel):
             if cfg.src_file_name != cfg.tgt_file_name:
                 raise ValueError("src must be equal to target for cached dataset")
             dataset = pickle.load(open(cfg.src_file_name, 'rb'))
+            dataset.reverse_lang_direction = cfg.get("reverse_lang_direction", False)
         else:
             dataset = TranslationDataset(
                 dataset_src=str(Path(cfg.src_file_name).expanduser()),
@@ -272,6 +273,7 @@ class MTEncDecModel(EncDecNLPModel):
                 cache_ids=cfg.get("cache_ids", False),
                 cache_data_per_node=cfg.get("cache_data_per_node", False),
                 use_cache=cfg.get("use_cache", False),
+                reverse_lang_direction=cfg.get("reverse_lang_direction", False)
             )
             dataset.batchify(self.encoder_tokenizer, self.decoder_tokenizer)
         if cfg.shuffle:

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -14,12 +14,12 @@
 
 import itertools
 import math
-import random
 import pickle
+import random
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional
-from sacremoses import MosesDetokenizer
+
 import numpy as np
 import torch
 import torch.utils.data as pt_data
@@ -28,6 +28,7 @@ from omegaconf import DictConfig
 from pytorch_lightning import Trainer
 from pytorch_lightning.utilities import rank_zero_only
 from sacrebleu import corpus_bleu
+from sacremoses import MosesDetokenizer
 
 from nemo.collections.common.losses import SmoothedCrossEntropyLoss
 from nemo.collections.common.parts import transformer_weights_init
@@ -273,7 +274,7 @@ class MTEncDecModel(EncDecNLPModel):
                 cache_ids=cfg.get("cache_ids", False),
                 cache_data_per_node=cfg.get("cache_data_per_node", False),
                 use_cache=cfg.get("use_cache", False),
-                reverse_lang_direction=cfg.get("reverse_lang_direction", False)
+                reverse_lang_direction=cfg.get("reverse_lang_direction", False),
             )
             dataset.batchify(self.encoder_tokenizer, self.decoder_tokenizer)
         if cfg.shuffle:
@@ -290,7 +291,7 @@ class MTEncDecModel(EncDecNLPModel):
         )
 
     @torch.no_grad()
-    def translate(self, text: List[str], target_lang: str='en') -> List[str]:
+    def translate(self, text: List[str], target_lang: str = 'en') -> List[str]:
         """
         Translates list of sentences from source language to target language.
         Should be regular text, this method performs its own tokenization/de-tokenization

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -52,6 +52,7 @@ def get_tokenizer(
     vocab_file: Optional[str] = None,
     special_tokens: Optional[Dict[str, str]] = None,
     use_fast: Optional[bool] = False,
+    bpe_dropout: Optional[float] = 0.0
 ):
     """
     Args:
@@ -80,7 +81,7 @@ def get_tokenizer(
             model_path=tokenizer_model, special_tokens=special_tokens
         )
     elif tokenizer_name == 'yttm':
-        return YouTokenToMeTokenizer(model_path=tokenizer_model)
+        return YouTokenToMeTokenizer(model_path=tokenizer_model, bpe_dropout=bpe_dropout)
     elif tokenizer_name == 'word':
         return WordTokenizer(vocab_file=vocab_file, **special_tokens_dict)
     elif tokenizer_name == 'char':

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -44,6 +44,7 @@ class TokenizerConfig:
     tokenizer_model: Optional[str] = None
     vocab_file: Optional[str] = None
     special_tokens: Optional[Dict[str, str]] = None
+    bpe_dropout: Optional[float] = 0.0
 
 
 def get_tokenizer(

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -52,7 +52,7 @@ def get_tokenizer(
     vocab_file: Optional[str] = None,
     special_tokens: Optional[Dict[str, str]] = None,
     use_fast: Optional[bool] = False,
-    bpe_dropout: Optional[float] = 0.0
+    bpe_dropout: Optional[float] = 0.0,
 ):
     """
     Args:


### PR DESCRIPTION
Adding the following:

1. A way to cache the entire translation dataset object rather than just the IDs, to avoid recomputing the bucketing and padding steps. 
2. BPE dropout to YTTM.
3. Sacremoses for detokenization.