### PR TITLE
Add timestep and length in Hypothesis

### DIFF
--- a/nemo/collections/asr/metrics/rnnt_wer.py
+++ b/nemo/collections/asr/metrics/rnnt_wer.py
@@ -180,16 +180,17 @@ class AbstractRNNTDecoding(ABC):
                 all_hypotheses.append(decoded_hyps)
             if return_hypotheses:
                 return hypotheses, all_hypotheses
-            return [h.text for h in hypotheses], [h.text for hh in all_hypotheses for h in hh]
+            best_hyp_text = [h.text for h in hypotheses]
+            all_hyp_text = [h.text for hh in all_hypotheses for h in hh]
+            return best_hyp_text, all_hyp_text
         else:
             hypotheses = self.decode_hypothesis(prediction_list)  # type: List[str]
             if return_hypotheses:
                 return hypotheses, None
-            return [h.text for h in hypotheses], None
+            best_hyp_text = [h.text for h in hypotheses]
+            return best_hyp_text, None
 
-    def decode_hypothesis(
-        self, hypotheses_list: List[Hypothesis]
-    ) -> List[Union[Hypothesis, NBestHypotheses]]:
+    def decode_hypothesis(self, hypotheses_list: List[Hypothesis]) -> List[Union[Hypothesis, NBestHypotheses]]:
         """
         Decode a list of hypotheses into a list of strings.
 

--- a/nemo/collections/asr/metrics/rnnt_wer.py
+++ b/nemo/collections/asr/metrics/rnnt_wer.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import List, Optional, Union
 
 import editdistance
 import torch
@@ -136,7 +136,7 @@ class AbstractRNNTDecoding(ABC):
 
     def rnnt_decoder_predictions_tensor(
         self, encoder_output: torch.Tensor, encoded_lengths: torch.Tensor, return_hypotheses: bool = False
-    ) -> (List[str], Optional[List[List[str]]], Optional[Union[rnnt_utils.Hypothesis, rnnt_utils.NBestHypotheses]]):
+    ) -> (List[str], Optional[List[List[str]]], Optional[Union[Hypothesis, NBestHypotheses]]):
         """
         Decode an encoder output by autoregressive decoding of the Decoder+Joint networks.
 
@@ -189,7 +189,7 @@ class AbstractRNNTDecoding(ABC):
 
     def decode_hypothesis(
         self, hypotheses_list: List[Hypothesis]
-    ) -> List[Union[rnnt_utils.Hypothesis, rnnt_utils.NBestHypotheses]]:
+    ) -> List[Union[Hypothesis, NBestHypotheses]]:
         """
         Decode a list of hypotheses into a list of strings.
 

--- a/nemo/collections/asr/metrics/rnnt_wer.py
+++ b/nemo/collections/asr/metrics/rnnt_wer.py
@@ -135,15 +135,15 @@ class AbstractRNNTDecoding(ABC):
             )
 
     def rnnt_decoder_predictions_tensor(
-        self, encoder_output: torch.Tensor, encoded_lengths: torch.Tensor,return_string:bool=True
-    ) -> (List[str], Optional[List[List[str]]]):
+        self, encoder_output: torch.Tensor, encoded_lengths: torch.Tensor, return_hypotheses: bool = False
+    ) -> (List[str], Optional[List[List[str]]], Optional[Union[rnnt_utils.Hypothesis, rnnt_utils.NBestHypotheses]]):
         """
         Decode an encoder output by autoregressive decoding of the Decoder+Joint networks.
 
         Args:
             encoder_output: torch.Tensor of shape [B, D, T].
             encoded_lengths: torch.Tensor containing lengths of the padded encoder outputs. Shape [B].
-            return_string: bool
+            return_hypotheses: bool. If set to True it will return list of Hypothesis or NBestHypotheses
 
         Returns:
             If `return_best_hypothesis` is set:
@@ -178,16 +178,18 @@ class AbstractRNNTDecoding(ABC):
                 decoded_hyps = self.decode_hypothesis(n_hyps)  # type: List[str]
                 hypotheses.append(decoded_hyps[0])  # best hypothesis
                 all_hypotheses.append(decoded_hyps)
-            if return_string:
-                return [h.text for h in hypotheses],[h.text for hh in all_hypotheses for h in hh]
-            return hypotheses, all_hypotheses
+            if return_hypotheses:
+                return hypotheses, all_hypotheses
+            return [h.text for h in hypotheses], [h.text for hh in all_hypotheses for h in hh]
         else:
             hypotheses = self.decode_hypothesis(prediction_list)  # type: List[str]
-            if return_string:
-                return [h.text for h in hypotheses], None
-            return hypotheses, None
+            if return_hypotheses:
+                return hypotheses, None
+            return [h.text for h in hypotheses], None
 
-    def decode_hypothesis(self, hypotheses_list: List[Hypothesis]) -> List[str]:
+    def decode_hypothesis(
+        self, hypotheses_list: List[Hypothesis]
+    ) -> List[Union[rnnt_utils.Hypothesis, rnnt_utils.NBestHypotheses]]:
         """
         Decode a list of hypotheses into a list of strings.
 

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -129,7 +129,7 @@ class EncDecRNNTModel(ASRModel):
             self._optim_variational_noise_start = 0
 
     @torch.no_grad()
-    def transcribe(self, paths2audio_files: List[str], batch_size: int = 4) -> List[str]:
+    def transcribe(self, paths2audio_files: List[str], batch_size: int = 4,return_string=True) -> List[str]:
         """
         Uses greedy decoding to transcribe audio files. Use this method for debugging and prototyping.
 
@@ -171,7 +171,7 @@ class EncDecRNNTModel(ASRModel):
                     encoded, encoded_len = self.forward(
                         input_signal=test_batch[0].to(device), input_signal_length=test_batch[1].to(device)
                     )
-                    hypotheses += self.decoding.rnnt_decoder_predictions_tensor(encoded, encoded_len)
+                    hypotheses += self.decoding.rnnt_decoder_predictions_tensor(encoded, encoded_len,return_string)
                     del test_batch
         finally:
             # set mode back to its original value

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -142,7 +142,8 @@ class EncDecRNNTModel(ASRModel):
         But it is possible to pass a few hours long file if enough GPU memory is available.
             batch_size: (int) batch size to use during inference. \
         Bigger will result in better throughput performance but would use more memory.
-
+            return_hypotheses: (bool) Either return hypotheses or text
+        With hypotheses can do some postprocessing like getting timestamp or rescoring
         Returns:
 
             A list of transcriptions in the same order as paths2audio_files

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -129,7 +129,9 @@ class EncDecRNNTModel(ASRModel):
             self._optim_variational_noise_start = 0
 
     @torch.no_grad()
-    def transcribe(self, paths2audio_files: List[str], batch_size: int = 4,return_string=True) -> List[str]:
+    def transcribe(
+        self, paths2audio_files: List[str], batch_size: int = 4, return_hypotheses: bool = False
+    ) -> List[str]:
         """
         Uses greedy decoding to transcribe audio files. Use this method for debugging and prototyping.
 
@@ -171,7 +173,9 @@ class EncDecRNNTModel(ASRModel):
                     encoded, encoded_len = self.forward(
                         input_signal=test_batch[0].to(device), input_signal_length=test_batch[1].to(device)
                     )
-                    hypotheses += self.decoding.rnnt_decoder_predictions_tensor(encoded, encoded_len,return_string)
+                    hypotheses += self.decoding.rnnt_decoder_predictions_tensor(
+                        encoded, encoded_len, return_hypotheses=return_hypotheses
+                    )
                     del test_batch
         finally:
             # set mode back to its original value

--- a/nemo/collections/asr/parts/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_beam_decoding.py
@@ -338,7 +338,7 @@ class BeamRNNTInfer(Typing):
         dec_state = self.decoder.initialize_state(h)
 
         # Initialize first hypothesis for the beam (blank)
-        kept_hyps = [Hypothesis(score=0.0, y_sequence=[self.blank], dec_state=dec_state,timestep=[-1],length=0)]
+        kept_hyps = [Hypothesis(score=0.0, y_sequence=[self.blank], dec_state=dec_state, timestep=[-1], length=0)]
         cache = {}
 
         for i in range(int(encoded_lengths)):
@@ -374,7 +374,8 @@ class BeamRNNTInfer(Typing):
                         y_sequence=max_hyp.y_sequence[:],
                         dec_state=max_hyp.dec_state,
                         lm_state=max_hyp.lm_state,
-                        timestep=max_hyp.timestep[:],length=encoded_lengths
+                        timestep=max_hyp.timestep[:],
+                        length=encoded_lengths,
                     )
 
                     # if current token is blank, dont update sequence, just store the current hypothesis
@@ -427,7 +428,15 @@ class BeamRNNTInfer(Typing):
         )  # [L, B, H], [L, B, H] (for LSTMs)
 
         # Initialize first hypothesis for the beam (blank)
-        B = [Hypothesis(y_sequence=[self.blank], score=0.0, dec_state=self.decoder.batch_select_state(beam_state, 0), timestep=[-1],length=0)]
+        B = [
+            Hypothesis(
+                y_sequence=[self.blank],
+                score=0.0,
+                dec_state=self.decoder.batch_select_state(beam_state, 0),
+                timestep=[-1],
+                length=0,
+            )
+        ]
         cache = {}
 
         for i in range(int(encoded_lengths)):
@@ -464,7 +473,8 @@ class BeamRNNTInfer(Typing):
                                 y_sequence=hyp.y_sequence[:],
                                 dec_state=hyp.dec_state,
                                 lm_state=hyp.lm_state,
-                                timestep=hyp.timestep[:],length=encoded_lengths
+                                timestep=hyp.timestep[:],
+                                length=encoded_lengths,
                             )
                         )
                     else:
@@ -487,7 +497,8 @@ class BeamRNNTInfer(Typing):
                                 y_sequence=(hyp.y_sequence + [int(k)]),
                                 dec_state=self.decoder.batch_select_state(beam_state, j),
                                 lm_state=hyp.lm_state,
-                                timestep=hyp.timestep[:]+[i],length=encoded_lengths
+                                timestep=hyp.timestep[:] + [i],
+                                length=encoded_lengths,
                             )
 
                             D.append(new_hyp)
@@ -537,7 +548,15 @@ class BeamRNNTInfer(Typing):
             u_max = int(self.alsd_max_target_length)
 
         # Initialize first hypothesis for the beam (blank)
-        B = [Hypothesis(y_sequence=[self.blank], score=0.0, dec_state=self.decoder.batch_select_state(beam_state, 0),timestep=[-1],length=0)]
+        B = [
+            Hypothesis(
+                y_sequence=[self.blank],
+                score=0.0,
+                dec_state=self.decoder.batch_select_state(beam_state, 0),
+                timestep=[-1],
+                length=0,
+            )
+        ]
 
         final = []
         cache = {}
@@ -614,7 +633,8 @@ class BeamRNNTInfer(Typing):
                         y_sequence=hyp.y_sequence[:],
                         dec_state=hyp.dec_state,
                         lm_state=hyp.lm_state,
-                        timestep=hyp.timestep[:],length=i
+                        timestep=hyp.timestep[:],
+                        length=i,
                     )
 
                     # Add blank prediction to A
@@ -642,7 +662,8 @@ class BeamRNNTInfer(Typing):
                             y_sequence=(hyp.y_sequence[:] + [int(k)]),
                             dec_state=self.decoder.batch_select_state(beam_state, h_states_idx),
                             lm_state=hyp.lm_state,
-                            timestep=hyp.timestep[:]+[i],length=i
+                            timestep=hyp.timestep[:] + [i],
+                            length=i,
                         )
 
                         A.append(new_hyp)

--- a/nemo/collections/asr/parts/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_beam_decoding.py
@@ -338,7 +338,7 @@ class BeamRNNTInfer(Typing):
         dec_state = self.decoder.initialize_state(h)
 
         # Initialize first hypothesis for the beam (blank)
-        kept_hyps = [Hypothesis(score=0.0, y_sequence=[self.blank], dec_state=dec_state)]
+        kept_hyps = [Hypothesis(score=0.0, y_sequence=[self.blank], dec_state=dec_state,timestep=[-1],length=0)]
         cache = {}
 
         for i in range(int(encoded_lengths)):
@@ -374,6 +374,7 @@ class BeamRNNTInfer(Typing):
                         y_sequence=max_hyp.y_sequence[:],
                         dec_state=max_hyp.dec_state,
                         lm_state=max_hyp.lm_state,
+                        timestep=max_hyp.timestep[:],length=encoded_lengths
                     )
 
                     # if current token is blank, dont update sequence, just store the current hypothesis
@@ -383,6 +384,7 @@ class BeamRNNTInfer(Typing):
                         # if non-blank token was predicted, update state and sequence and then search more hypothesis
                         new_hyp.dec_state = state
                         new_hyp.y_sequence.append(int(k))
+                        new_hyp.timestep.append(i)
 
                         hyps.append(new_hyp)
 
@@ -425,7 +427,7 @@ class BeamRNNTInfer(Typing):
         )  # [L, B, H], [L, B, H] (for LSTMs)
 
         # Initialize first hypothesis for the beam (blank)
-        B = [Hypothesis(y_sequence=[self.blank], score=0.0, dec_state=self.decoder.batch_select_state(beam_state, 0))]
+        B = [Hypothesis(y_sequence=[self.blank], score=0.0, dec_state=self.decoder.batch_select_state(beam_state, 0), timestep=[-1],length=0)]
         cache = {}
 
         for i in range(int(encoded_lengths)):
@@ -462,6 +464,7 @@ class BeamRNNTInfer(Typing):
                                 y_sequence=hyp.y_sequence[:],
                                 dec_state=hyp.dec_state,
                                 lm_state=hyp.lm_state,
+                                timestep=hyp.timestep[:],length=encoded_lengths
                             )
                         )
                     else:
@@ -484,6 +487,7 @@ class BeamRNNTInfer(Typing):
                                 y_sequence=(hyp.y_sequence + [int(k)]),
                                 dec_state=self.decoder.batch_select_state(beam_state, j),
                                 lm_state=hyp.lm_state,
+                                timestep=hyp.timestep[:]+[i],length=encoded_lengths
                             )
 
                             D.append(new_hyp)
@@ -533,7 +537,7 @@ class BeamRNNTInfer(Typing):
             u_max = int(self.alsd_max_target_length)
 
         # Initialize first hypothesis for the beam (blank)
-        B = [Hypothesis(y_sequence=[self.blank], score=0.0, dec_state=self.decoder.batch_select_state(beam_state, 0))]
+        B = [Hypothesis(y_sequence=[self.blank], score=0.0, dec_state=self.decoder.batch_select_state(beam_state, 0),timestep=[-1],length=0)]
 
         final = []
         cache = {}
@@ -610,6 +614,7 @@ class BeamRNNTInfer(Typing):
                         y_sequence=hyp.y_sequence[:],
                         dec_state=hyp.dec_state,
                         lm_state=hyp.lm_state,
+                        timestep=hyp.timestep[:],length=encoded_lengths
                     )
 
                     # Add blank prediction to A
@@ -637,6 +642,7 @@ class BeamRNNTInfer(Typing):
                             y_sequence=(hyp.y_sequence[:] + [int(k)]),
                             dec_state=self.decoder.batch_select_state(beam_state, h_states_idx),
                             lm_state=hyp.lm_state,
+                            timestep=hyp.timestep[:]+[i],length=encoded_lengths
                         )
 
                         A.append(new_hyp)

--- a/nemo/collections/asr/parts/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_beam_decoding.py
@@ -614,7 +614,7 @@ class BeamRNNTInfer(Typing):
                         y_sequence=hyp.y_sequence[:],
                         dec_state=hyp.dec_state,
                         lm_state=hyp.lm_state,
-                        timestep=hyp.timestep[:],length=encoded_lengths
+                        timestep=hyp.timestep[:],length=i
                     )
 
                     # Add blank prediction to A
@@ -642,7 +642,7 @@ class BeamRNNTInfer(Typing):
                             y_sequence=(hyp.y_sequence[:] + [int(k)]),
                             dec_state=self.decoder.batch_select_state(beam_state, h_states_idx),
                             lm_state=hyp.lm_state,
-                            timestep=hyp.timestep[:]+[i],length=encoded_lengths
+                            timestep=hyp.timestep[:]+[i],length=i
                         )
 
                         A.append(new_hyp)

--- a/nemo/collections/asr/parts/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_greedy_decoding.py
@@ -26,7 +26,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union, List
+from typing import List, Optional, Union
 
 import torch
 

--- a/nemo/collections/asr/parts/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_greedy_decoding.py
@@ -26,7 +26,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional, Union
+from typing import Optional, Union, List
 
 import torch
 

--- a/nemo/collections/asr/parts/rnnt_utils.py
+++ b/nemo/collections/asr/parts/rnnt_utils.py
@@ -52,6 +52,8 @@ class Hypothesis:
 
     score: float
     y_sequence: Union[List[int], torch.Tensor]
+    timestep: Union[List[int], torch.Tensor]
+    length:int
     dec_state: Optional[Union[List[List[torch.Tensor]], List[torch.Tensor]]] = None
     y: List[torch.tensor] = None
     lm_state: Union[Dict[str, Any], List[Any]] = None

--- a/nemo/collections/asr/parts/rnnt_utils.py
+++ b/nemo/collections/asr/parts/rnnt_utils.py
@@ -26,7 +26,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
 import torch
@@ -52,14 +52,14 @@ class Hypothesis:
 
     score: float
     y_sequence: Union[List[int], torch.Tensor]
-    timestep: Union[List[int], torch.Tensor]
-    length: int
     dec_state: Optional[Union[List[List[torch.Tensor]], List[torch.Tensor]]] = None
     y: List[torch.tensor] = None
     lm_state: Union[Dict[str, Any], List[Any]] = None
     lm_scores: torch.Tensor = None
     tokens: Union[List[int], torch.Tensor] = None
     text: str = None
+    timestep: Union[List[int], torch.Tensor] = field(default_factory=list)
+    length: int = 0
 
 
 @dataclass

--- a/nemo/collections/asr/parts/rnnt_utils.py
+++ b/nemo/collections/asr/parts/rnnt_utils.py
@@ -58,6 +58,8 @@ class Hypothesis:
     y: List[torch.tensor] = None
     lm_state: Union[Dict[str, Any], List[Any]] = None
     lm_scores: torch.Tensor = None
+    tokens: Union[List[int], torch.Tensor] = None
+    text: str = None
 
 
 @dataclass

--- a/nemo/collections/asr/parts/rnnt_utils.py
+++ b/nemo/collections/asr/parts/rnnt_utils.py
@@ -53,7 +53,7 @@ class Hypothesis:
     score: float
     y_sequence: Union[List[int], torch.Tensor]
     timestep: Union[List[int], torch.Tensor]
-    length:int
+    length: int
     dec_state: Optional[Union[List[List[torch.Tensor]], List[torch.Tensor]]] = None
     y: List[torch.tensor] = None
     lm_state: Union[Dict[str, Any], List[Any]] = None


### PR DESCRIPTION
Add timestep and length for calculating timestamp

Example code for calculating timestamp:
```
@torch.no_grad()
def predict(filename):
    if type(filename) != list:
        filename = [filename]
    res = {}
    hypotheses,_ = asr_model.transcribe([str(i) for i in filename],len(filename),return_string=False)
    timesteps = []
    print("start timesteps")
    for j,h in enumerate(hypotheses):
        tt = h.timestep
        align_list = []
        time = []
        for k,v in zip(tt,h.tokens):
            if "[" in v:
                pass
            elif "##" in v:
                align_list[-1] += v.replace("##","")
            else:
                align_list.append(v)
                time.append(int(k))
        duration = librosa.core.get_duration(filename=filename[j],sr=None)
        mult = duration/float(h.length)
        ttt = [{"time":round(t[1]*mult,2), "word":t[0]} for t in zip(align_list,time)]
        timesteps.append(ttt)
    return timesteps
predict("filename.wav")
 ```