### PR TITLE
support other audio format

### DIFF
--- a/nemo/collections/asr/parts/segment.py
+++ b/nemo/collections/asr/parts/segment.py
@@ -123,8 +123,9 @@ class AudioSegment(object):
         :param duration: duration in seconds when loading audio
         :return: numpy array of samples
         """
-        ext = Path(audio_file).suffix
-        if ext == ".wav":
+        if isinstance(audio_file, (str, Path)):
+            ext = Path(audio_file).suffix
+        if not isinstance(audio_file, (str, Path)) or ext == ".wav":
             with sf.SoundFile(audio_file, 'r') as f:
                 dtype = 'int32' if int_values else 'float32'
                 sample_rate = f.samplerate

--- a/nemo/collections/asr/parts/segment.py
+++ b/nemo/collections/asr/parts/segment.py
@@ -34,10 +34,12 @@
 # This file contains code artifacts adapted from https://github.com/ryanleary/patter
 
 import random
+from pathlib import Path
 
 import librosa
 import numpy as np
 import soundfile as sf
+from pydub import AudioSegment as Audio
 
 
 class AudioSegment(object):
@@ -121,17 +123,30 @@ class AudioSegment(object):
         :param duration: duration in seconds when loading audio
         :return: numpy array of samples
         """
-        with sf.SoundFile(audio_file, 'r') as f:
-            dtype = 'int32' if int_values else 'float32'
-            sample_rate = f.samplerate
-            if offset > 0:
-                f.seek(int(offset * sample_rate))
-            if duration > 0:
-                samples = f.read(int(duration * sample_rate), dtype=dtype)
-            else:
-                samples = f.read(dtype=dtype)
+        ext = Path(audio_file).suffix
+        if ext == ".wav":
+            with sf.SoundFile(audio_file, 'r') as f:
+                dtype = 'int32' if int_values else 'float32'
+                sample_rate = f.samplerate
+                if offset > 0:
+                    f.seek(int(offset * sample_rate))
+                if duration > 0:
+                    samples = f.read(int(duration * sample_rate), dtype=dtype)
+                else:
+                    samples = f.read(dtype=dtype)
 
-        samples = samples.transpose()
+            samples = samples.transpose()
+        else:
+            samples = Audio.from_file(audio_file)
+            sample_rate = samples.frame_rate
+            samples = np.array(samples.get_array_of_samples())
+            if offset > 0:
+                # pydub does things in milliseconds
+                seconds = offset * 1000
+                samples = samples[int(seconds * sample_rate) :]
+            if duration > 0:
+                samples = samples[int(duration) :]
+
         return cls(samples, sample_rate, target_sr=target_sr, trim=trim, orig_sr=orig_sr)
 
     @classmethod

--- a/nemo/collections/asr/parts/segment.py
+++ b/nemo/collections/asr/parts/segment.py
@@ -144,7 +144,8 @@ class AudioSegment(object):
                 seconds = offset * 1000
                 samples = samples[int(seconds * sample_rate) :]
             if duration > 0:
-                samples = samples[: int(duration)]
+                seconds = duration * 1000
+                samples = samples[: int(seconds)]
             samples = np.array(samples.get_array_of_samples())
 
         return cls(samples, sample_rate, target_sr=target_sr, trim=trim, orig_sr=orig_sr)

--- a/nemo/collections/asr/parts/segment.py
+++ b/nemo/collections/asr/parts/segment.py
@@ -139,13 +139,13 @@ class AudioSegment(object):
         else:
             samples = Audio.from_file(audio_file)
             sample_rate = samples.frame_rate
-            samples = np.array(samples.get_array_of_samples())
             if offset > 0:
                 # pydub does things in milliseconds
                 seconds = offset * 1000
                 samples = samples[int(seconds * sample_rate) :]
             if duration > 0:
                 samples = samples[int(duration) :]
+            samples = np.array(samples.get_array_of_samples())
 
         return cls(samples, sample_rate, target_sr=target_sr, trim=trim, orig_sr=orig_sr)
 

--- a/nemo/collections/asr/parts/segment.py
+++ b/nemo/collections/asr/parts/segment.py
@@ -144,7 +144,7 @@ class AudioSegment(object):
                 seconds = offset * 1000
                 samples = samples[int(seconds * sample_rate) :]
             if duration > 0:
-                samples = samples[int(duration) :]
+                samples = samples[: int(duration)]
             samples = np.array(samples.get_array_of_samples())
 
         return cls(samples, sample_rate, target_sr=target_sr, trim=trim, orig_sr=orig_sr)

--- a/requirements/requirements_asr.txt
+++ b/requirements/requirements_asr.txt
@@ -15,3 +15,4 @@ kaldi-python-io
 scipy
 pandas
 g2p_en
+pydub


### PR DESCRIPTION
Might solve #1549 

Currently I let pydub handle file that is not .wav format because there is something I'm not understand with current implementation.
1. "samples.transpose()" before init with cls
2. User also need to install [ffmpeg](https://github.com/jiaaro/pydub#getting-ffmpeg-set-up) to be able to load non wav file format, I don't know where to put the warning or write a script when user pip install
3. I'm not sure if NeMo dataloader will cache the loaded samples because it might convert using ffmpeg everytime it try to load non wav file.

So far I only tested inference with mp3 audio from Common Voice with model trained on wav file format, there is no problem with the prediction result.