### PR TITLE
Correct onesided for PT < 1.7 compatibility

### DIFF
--- a/nemo/collections/common/parts/patch_utils.py
+++ b/nemo/collections/common/parts/patch_utils.py
@@ -61,7 +61,7 @@ def stft_patch(
             center=center,
             pad_mode=pad_mode,
             normalized=normalized,
-            onesided=onesided,
+            onesided=True,
         )
     else:
         return torch.stft(


### PR DESCRIPTION
# Bugfix
- PT 1.6 expects explicit bool type for `onesided` (defaults to true)

Signed-off-by: smajumdar <titu1994@gmail.com>