### PR TITLE
Make onnx-graphsurgery an optional deferred import

### DIFF
--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -478,7 +478,7 @@ class EncDecClassificationModel(ASRModel, Exportable):
         output_example=None,
         verbose=False,
         export_params=True,
-        do_constant_folding=True,
+        do_constant_folding: Optional[bool] = None,
         keep_initializers_as_inputs=False,
         onnx_opset_version: int = 12,
         try_script: bool = False,

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -489,7 +489,7 @@ class EncDecCTCModel(ASRModel, Exportable):
         output_example=None,
         verbose=False,
         export_params=True,
-        do_constant_folding=True,
+        do_constant_folding: Optional[bool] = None,
         keep_initializers_as_inputs=False,
         onnx_opset_version: int = 12,
         try_script: bool = False,

--- a/nemo/collections/asr/models/label_models.py
+++ b/nemo/collections/asr/models/label_models.py
@@ -319,7 +319,7 @@ class EncDecSpeakerLabelModel(ModelPT, Exportable):
         output_example=None,
         verbose=False,
         export_params=True,
-        do_constant_folding=True,
+        do_constant_folding: Optional[bool] = None,
         keep_initializers_as_inputs=False,
         onnx_opset_version: int = 12,
         try_script: bool = False,

--- a/nemo/collections/nlp/models/intent_slot_classification/intent_slot_classification_model.py
+++ b/nemo/collections/nlp/models/intent_slot_classification/intent_slot_classification_model.py
@@ -491,7 +491,7 @@ class IntentSlotClassificationModel(NLPModel, Exportable):
         output_example=None,
         verbose=False,
         export_params=True,
-        do_constant_folding=True,
+        do_constant_folding: Optional[bool] = None,
         keep_initializers_as_inputs=False,
         onnx_opset_version: int = 12,
         try_script: bool = False,

--- a/nemo/collections/nlp/models/question_answering/qa_model.py
+++ b/nemo/collections/nlp/models/question_answering/qa_model.py
@@ -362,7 +362,7 @@ class QAModel(NLPModel, Exportable):
         output_example=None,
         verbose=False,
         export_params=True,
-        do_constant_folding=True,
+        do_constant_folding: Optional[bool] = None,
         keep_initializers_as_inputs=False,
         onnx_opset_version: int = 12,
         try_script: bool = False,

--- a/nemo/collections/nlp/models/text_classification/text_classification_model.py
+++ b/nemo/collections/nlp/models/text_classification/text_classification_model.py
@@ -331,7 +331,7 @@ class TextClassificationModel(NLPModel, Exportable):
         output_example=None,
         verbose=False,
         export_params=True,
-        do_constant_folding=True,
+        do_constant_folding: Optional[bool] = None,
         keep_initializers_as_inputs=False,
         onnx_opset_version: int = 12,
         try_script: bool = False,

--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
@@ -476,7 +476,7 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
         output_example=None,
         verbose=False,
         export_params=True,
-        do_constant_folding=True,
+        do_constant_folding: Optional[bool] = None,
         keep_initializers_as_inputs=False,
         onnx_opset_version: int = 12,
         try_script: bool = False,

--- a/nemo/collections/nlp/models/token_classification/token_classification_model.py
+++ b/nemo/collections/nlp/models/token_classification/token_classification_model.py
@@ -530,7 +530,7 @@ class TokenClassificationModel(NLPModel, Exportable):
         output_example=None,
         verbose=False,
         export_params=True,
-        do_constant_folding=True,
+        do_constant_folding: Optional[bool] = None,
         keep_initializers_as_inputs=False,
         onnx_opset_version: int = 12,
         try_script: bool = False,

--- a/nemo/core/classes/exportable.py
+++ b/nemo/core/classes/exportable.py
@@ -18,12 +18,19 @@ from enum import Enum
 from typing import Dict
 
 import onnx
-import onnx_graphsurgeon as gs
 import torch
 
 from nemo.core.classes import typecheck
 from nemo.core.neural_types import AxisKind, NeuralType
 from nemo.utils.export_utils import replace_for_export
+
+try:
+    import onnx_graphsurgeon as gs
+
+    ONNX_GRAPHSURGEON_AVAILABLE = True
+
+except (ImportError, ModuleNotFoundError):
+    ONNX_GRAPHSURGEON_AVAILABLE = False
 
 __all__ = ['ExportFormat', 'Exportable']
 
@@ -161,6 +168,14 @@ class Exportable(ABC):
                     onnx.checker.check_model(onnx_model, full_check=True)
 
                     if do_constant_folding:
+                        if not ONNX_GRAPHSURGEON_AVAILABLE:
+                            raise ImportError(
+                                "`onnx-graphsurgeon` could not be imported."
+                                "Please follow the instructions available at :"
+                                "https://github.com/NVIDIA/TensorRT/tree/master/tools/onnx-graphsurgeon"
+                                "to install it prior to attemtping export with constant folding."
+                            )
+
                         # This pass is to remove/recast certain constants that are generated as 'double'
                         # Those constants break ONNX -> TRT conversion (TRT does not support 'double' as of 7.2)
                         # Can probably be removed once TRT has automatic downcast for double ( NVBUG #3221866).

--- a/nemo/core/classes/exportable.py
+++ b/nemo/core/classes/exportable.py
@@ -69,7 +69,7 @@ class Exportable(ABC):
         output_example=None,
         verbose=False,
         export_params=True,
-        do_constant_folding=True,
+        do_constant_folding=False,
         keep_initializers_as_inputs=False,
         onnx_opset_version: int = 12,
         try_script: bool = False,

--- a/nemo/core/classes/exportable.py
+++ b/nemo/core/classes/exportable.py
@@ -80,7 +80,7 @@ class Exportable(ABC):
     ):
         if do_constant_folding is None:
             # If None, perform constant folding iff available, otherwise skip
-            logging.debug(f"Constant folding available = {ONNX_GRAPHSURGEON_AVAILABLE}")
+            logging.info(f"Constant folding available = {ONNX_GRAPHSURGEON_AVAILABLE}")
             do_constant_folding = ONNX_GRAPHSURGEON_AVAILABLE
 
         try:

--- a/nemo/core/classes/exportable.py
+++ b/nemo/core/classes/exportable.py
@@ -15,7 +15,7 @@ import os
 from abc import ABC
 from collections import defaultdict
 from enum import Enum
-from typing import Dict
+from typing import Dict, Optional
 
 import onnx
 import torch
@@ -23,6 +23,7 @@ import torch
 from nemo.core.classes import typecheck
 from nemo.core.neural_types import AxisKind, NeuralType
 from nemo.utils.export_utils import replace_for_export
+from nemo.utils import logging
 
 try:
     import onnx_graphsurgeon as gs
@@ -69,7 +70,7 @@ class Exportable(ABC):
         output_example=None,
         verbose=False,
         export_params=True,
-        do_constant_folding=False,
+        do_constant_folding: Optional[bool] = None,
         keep_initializers_as_inputs=False,
         onnx_opset_version: int = 12,
         try_script: bool = False,
@@ -77,6 +78,11 @@ class Exportable(ABC):
         check_trace: bool = True,
         use_dynamic_axes: bool = True,
     ):
+        if do_constant_folding is None:
+            # If None, perform constant folding iff available, otherwise skip
+            logging.debug(f"Constant folding available = {ONNX_GRAPHSURGEON_AVAILABLE}")
+            do_constant_folding = ONNX_GRAPHSURGEON_AVAILABLE
+
         try:
             # Disable typechecks
             typecheck.set_typecheck_enabled(enabled=False)

--- a/nemo/core/classes/exportable.py
+++ b/nemo/core/classes/exportable.py
@@ -22,8 +22,8 @@ import torch
 
 from nemo.core.classes import typecheck
 from nemo.core.neural_types import AxisKind, NeuralType
-from nemo.utils.export_utils import replace_for_export
 from nemo.utils import logging
+from nemo.utils.export_utils import replace_for_export
 
 try:
     import onnx_graphsurgeon as gs

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,5 +12,3 @@ hydra-core>=1.0.4
 transformers>=4.0.1
 sentencepiece<1.0.0
 webdataset
-nvidia-pyindex>=1.0.6
-onnx-graphsurgeon>=0.2.7

--- a/setup.py
+++ b/setup.py
@@ -232,7 +232,7 @@ setuptools.setup(
     ],
     packages=setuptools.find_packages(),
     install_requires=install_requires,
-    setup_requires=['pytest-runner', 'nvidia-pyindex'],
+    setup_requires=['pytest-runner'],
     tests_require=tests_requirements,
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
# Changelog
- onnx-graphsurgery is not available on all platforms, and breaks pip install (currently tested on darwin and some versions of ubuntu).
- Make it an optional import that performs runtime check instead.