### PR TITLE
Clarify comments and neural types in Model Primer Notebook 

### DIFF
--- a/tutorials/01_NeMo_Models.ipynb
+++ b/tutorials/01_NeMo_Models.ipynb
@@ -580,7 +580,7 @@
       },
       "source": [
         "# Case 2 [ERROR CELL]\n",
-        "x2 = torch.randn(1, 5, 1)\n",
+        "x2 = torch.randn(1, 5, 1)  # Input = [B=1, T=5, C=1]\n",
         "print(\"x :\", x2)\n",
         "print(\"lstm(x) :\", lstm_module(x=x2)[0].shape)  # Let's take all timestep outputs of the LSTM"
       ],
@@ -598,9 +598,13 @@
         "\n",
         "What exactly is going on here? Well, inside our `LSTMModule` class, we declare the output types to be a single NeuralType - an `EncodedRepresentation` of shape [B, T, C].\n",
         "\n",
-        "But the output of an LSTM layer is a tuple of two state values - the hidden state `h` and the cell state `c`!\n",
+        "But the output of an LSTM layer is a tuple of \n",
+        "1) the encoded representation of shape [B, T, C]\n",
+        "2) another tuple containing two state values - the hidden state `h` and the cell state `c`, each of shape [num_layers * num_directions, B, C]!\n",
         "\n",
         "So the neural type system raises an error saying that the number of output arguments does not match what is expected.\n",
+        "\n",
+        "**NOTE**: The axis kind information of the two states will be represented by `D` to represent a general \"Dimension\" - since `num_layers` and `num_directions` are collapsed under a single axis. For NeMo, Axis types of `C` and `D` are equivalent and can be interchanged, so we will use `C` here to represent the hidden dimension of the LSTM and `D` to represent the merged axis `num_layers * num_direction`.\n",
         "\n",
         "Let's fix the above."
       ]
@@ -615,8 +619,8 @@
         "  @property\n",
         "  def output_types(self):\n",
         "    return {\n",
-        "        'h': NeuralType(axes=('B', 'T', 'C'), elements_type=EncodedRepresentation()),\n",
-        "        'c': NeuralType(axes=('B', 'T', 'C'), elements_type=EncodedRepresentation()),\n",
+        "        'y': NeuralType(axes=('B', 'T', 'C'), elements_type=EncodedRepresentation()),\n",
+        "        'h_c': NeuralType(axes=('D', 'B', 'C'), elements_type=EncodedRepresentation()),\n",
         "    }"
       ],
       "execution_count": null,
@@ -641,8 +645,11 @@
       "source": [
         "# Case 2\n",
         "x2 = torch.randn(1, 5, 1)\n",
+        "y2, (h, c) = lstm_module(x=x2)\n",
         "print(\"x :\", x2)\n",
-        "print(\"lstm(x) :\", lstm_module(x=x2)[0].shape)  # Let's take all timestep outputs of the LSTM `h` gate"
+        "print(\"lstm(x) :\", y2.shape)  # The output of the LSTM RNN\n",
+        "print(\"hidden state (h) :\", h.shape)  # The first hidden state of the LSTM RNN\n",
+        "print(\"hidden state (c) :\", c.shape)  # The second hidden state of the LSTM RNN"
       ],
       "execution_count": null,
       "outputs": []
@@ -1108,13 +1115,13 @@
         "\n",
         "As we discussed above, Neural Modules are generally higher-level components of the Model and can potentially be replaced by equivalent Neural Modules.\n",
         "\n",
-        "As we see above, the embedding modules, deep transformer network, and final decoder layer have all been combined inside the PyTorch Lightning implementation constructor.\n",
+        "As we see above, the embedding modules, deep transformer decoder network, and final decoder layer have all been combined inside the PyTorch Lightning implementation constructor.\n",
         "\n",
         "------\n",
         "\n",
-        "However, the decoder could have been an RNN instead of a simple Linear layer, or it could have been a 1D-CNN instead.\n",
+        "However, the final decoder module could have been an RNN instead of a simple Linear layer, or it could have been a 1D-CNN instead.\n",
         "\n",
-        "Likewise, the deep encoder could potentially have a different implementation of Self Attention modules.\n",
+        "Likewise, the deep transformer decoder could potentially have a different implementation of Self Attention modules.\n",
         "\n",
         "These changes cannot be easily implemented any more inside the above implementation. However, if we refactor these components into their respective NeuralModules, then we can easily replace them with equivalent modules we construct in the future!"
       ]
@@ -1178,7 +1185,21 @@
       "source": [
         "### Refactoring the Encoder\n",
         "\n",
-        "Next, let's refactor the Encoder - the multi layer Transformer Encoder"
+        "Next, let's refactor the GPT Encoder - which is implemented as a multi layer Transformer (Decoder) network.\n",
+        "\n",
+        "------\n",
+        "It can be noted that we refer to the GPT \"Encoder\" module - but it is constructed by using Transformer \"Decoder\" blocks.\n",
+        "\n",
+        "***When we discuss Neural Modules - we are discussing an abstract module with a certain input neural type and a certain output neural type.***\n",
+        "\n",
+        "For us, the GPT \"Encoder\" neural module will accept any  implementation, whose\n",
+        "\n",
+        "- input neural type is `NeuralType(('B', 'T', 'C'), EmbeddedTextType())`\n",
+        "\n",
+        "- output type is `NeuralType(('B', 'T', 'C'), EncodedRepresentation())`\n",
+        "\n",
+        "-----\n",
+        "One concrete implementation of such a GPT \"Encoder\" neural module is a Deep Transformer \"Decoder\" network."
       ]
     },
     {


### PR DESCRIPTION
# Changelog
- Address Neural Type comments from https://github.com/NVIDIA/NeMo/issues/1634 regarding LSTM
- Address clarification of "GPT Encoder neural module" vs "Transformer Decoder network" issue raised in https://github.com/NVIDIA/NeMo/issues/1638

Closes https://github.com/NVIDIA/NeMo/issues/1634 and https://github.com/NVIDIA/NeMo/issues/1638

Signed-off-by: smajumdar <titu1994@gmail.com>