### PR TITLE
Patch SPE support for ASR

### DIFF
--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -67,7 +67,7 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
 
         # Set the new vocabulary
         with open_dict(cfg):
-            cfg.decoder.vocabulary = ListConfig(list(vocabulary.values()))
+            cfg.decoder.vocabulary = ListConfig(list(vocabulary.keys()))
 
         # Override number of classes if placeholder provided
         num_classes = cfg.decoder["num_classes"]

--- a/nemo/collections/asr/parts/mixins.py
+++ b/nemo/collections/asr/parts/mixins.py
@@ -70,11 +70,11 @@ class ASRBPEMixin(ABC):
             vocab_path = self.register_artifact('tokenizer.vocab_path', vocab_path)
             self.vocab_path = vocab_path
 
-            vocabulary = {0: '<unk>'}
+            vocabulary = {'<unk>': 0}
             with open(vocab_path) as f:
                 for i, piece in enumerate(f):
                     piece = piece.replace('\n', '')
-                    vocabulary[i + 1] = piece
+                    vocabulary[piece] = i + 1
 
             # wrapper method to get vocabulary conveniently
             def get_vocab():


### PR DESCRIPTION
# Changelog
- Create SPE vocabulary as a key=subword to value=id mapping to be consistent with WPE
- Use keys() as the actual vocabulary to inject into the decoder

Signed-off-by: smajumdar <titu1994@gmail.com>