### PR TITLE
Add preliminary support for ASR Model dataclasses

### DIFF
--- a/examples/asr/experimental/structured/speech_to_text_structured_v2.py
+++ b/examples/asr/experimental/structured/speech_to_text_structured_v2.py
@@ -1,0 +1,87 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import asdict
+
+import pytorch_lightning as pl
+
+from nemo.collections.asr.models import EncDecCTCModel, configs
+from nemo.core.config import optimizers, schedulers
+from nemo.utils.exp_manager import exp_manager
+
+"""
+python speech_to_text_structured_v2.py
+"""
+
+# fmt: off
+LABELS = [
+    " ", "a", "b", "c", "d", "e",
+    "f", "g", "h", "i", "j", "k",
+    "l", "m", "n", "o", "p", "q",
+    "r", "s", "t", "u", "v", "w",
+    "x", "y", "z", "'",
+]
+
+optim_cfg = optimizers.NovogradParams(
+    lr=0.01,
+    betas=(0.8, 0.5),
+    weight_decay=0.001
+)
+
+sched_cfg = schedulers.CosineAnnealingParams(
+    warmup_steps=None,
+    warmup_ratio=None,
+    min_lr=0.0,
+)
+# fmt: on
+
+
+def main():
+    # Generate default asr model config
+    builder = configs.QuartzNetConfigBuilder(name='quartznet_15x5')
+
+    # set global values
+    builder.set_repeat(5)
+    builder.set_labels(LABELS)
+    builder.set_optim(cfg=optim_cfg, sched_cfg=sched_cfg)
+
+    cfg = builder.build()
+
+    # Update values
+    # MODEL UPDATES
+    cfg.name = "Custom QuartzNet15x5"
+
+    # train ds
+    cfg.model.train_ds.manifest_filepath = "<path to train dataset>"
+
+    # validation ds
+    cfg.model.validation_ds.manifest_filepath = "<path to test dataset>"
+
+    # Trainer config
+    cfg.trainer.gpus = 1
+    cfg.trainer.max_epochs = 5
+
+    # Exp Manager config
+    cfg.exp_manager.name = cfg.name
+
+    # Note usage of asdict
+    trainer = pl.Trainer(**asdict(cfg.trainer))
+    exp_manager(trainer, asdict(cfg.exp_manager))
+    asr_model = EncDecCTCModel(cfg=cfg.model, trainer=trainer)
+
+    trainer.fit(asr_model)
+
+
+if __name__ == '__main__':
+    main()  # noqa pylint: disable=no-value-for-parameter

--- a/examples/asr/experimental/structured/speech_to_text_structured_v2.py
+++ b/examples/asr/experimental/structured/speech_to_text_structured_v2.py
@@ -17,7 +17,7 @@ from dataclasses import asdict
 import pytorch_lightning as pl
 
 from nemo.collections.asr.models import EncDecCTCModel, configs
-from nemo.core.config import optimizers, schedulers, modelPT
+from nemo.core.config import modelPT, optimizers, schedulers
 from nemo.utils.exp_manager import exp_manager
 
 """

--- a/examples/asr/experimental/structured/speech_to_text_structured_v2.py
+++ b/examples/asr/experimental/structured/speech_to_text_structured_v2.py
@@ -63,10 +63,10 @@ def main():
     cfg.name = "Custom QuartzNet15x5"
 
     # train ds
-    cfg.model.train_ds.manifest_filepath = "<path to train dataset>"
+    cfg.model.train_ds.manifest_filepath = "/home/smajumdar/PycharmProjects/NeMo-som/examples/asr/an4/train_manifest.json"
 
     # validation ds
-    cfg.model.validation_ds.manifest_filepath = "<path to test dataset>"
+    cfg.model.validation_ds.manifest_filepath = "/home/smajumdar/PycharmProjects/NeMo-som/examples/asr/an4/test_manifest.json"
 
     # Trainer config
     cfg.trainer.gpus = 1

--- a/examples/asr/experimental/structured/speech_to_text_structured_v2.py
+++ b/examples/asr/experimental/structured/speech_to_text_structured_v2.py
@@ -67,10 +67,10 @@ def main():
     # Update values
     # MODEL UPDATES
     # train ds
-    model_cfg.train_ds.manifest_filepath = "/home/smajumdar/PycharmProjects/NeMo-som/examples/asr/an4/train_manifest.json"
+    model_cfg.train_ds.manifest_filepath = ""
 
     # validation ds
-    model_cfg.validation_ds.manifest_filepath = "/home/smajumdar/PycharmProjects/NeMo-som/examples/asr/an4/test_manifest.json"
+    model_cfg.validation_ds.manifest_filepath = ""
 
     # Trainer config
     cfg.trainer.gpus = 1

--- a/examples/asr/experimental/structured/speech_to_text_structured_v2.py
+++ b/examples/asr/experimental/structured/speech_to_text_structured_v2.py
@@ -55,7 +55,6 @@ def main():
     builder = configs.EncDecCTCModelConfigBuilder(name='quartznet_15x5')
 
     # set model global values
-    builder.set_repeat(5)
     builder.set_labels(LABELS)
     builder.set_optim(cfg=optim_cfg, sched_cfg=sched_cfg)
 

--- a/examples/asr/experimental/structured/speech_to_text_structured_v2.py
+++ b/examples/asr/experimental/structured/speech_to_text_structured_v2.py
@@ -17,7 +17,7 @@ from dataclasses import asdict
 import pytorch_lightning as pl
 
 from nemo.collections.asr.models import EncDecCTCModel, configs
-from nemo.core.config import optimizers, schedulers
+from nemo.core.config import optimizers, schedulers, modelPT
 from nemo.utils.exp_manager import exp_manager
 
 """
@@ -48,25 +48,29 @@ sched_cfg = schedulers.CosineAnnealingParams(
 
 
 def main():
-    # Generate default asr model config
-    builder = configs.QuartzNetConfigBuilder(name='quartznet_15x5')
+    # NeMo Model config
+    cfg = modelPT.ModelPTConfig(name='Custom QuartzNet')
 
-    # set global values
+    # Generate default asr model config
+    builder = configs.EncDecCTCModelConfigBuilder(name='quartznet_15x5')
+
+    # set model global values
     builder.set_repeat(5)
     builder.set_labels(LABELS)
     builder.set_optim(cfg=optim_cfg, sched_cfg=sched_cfg)
 
-    cfg = builder.build()
+    model_cfg = builder.build()
+
+    # set the model config to the NeMo Model
+    cfg.model = model_cfg
 
     # Update values
     # MODEL UPDATES
-    cfg.name = "Custom QuartzNet15x5"
-
     # train ds
-    cfg.model.train_ds.manifest_filepath = "/home/smajumdar/PycharmProjects/NeMo-som/examples/asr/an4/train_manifest.json"
+    model_cfg.train_ds.manifest_filepath = "/home/smajumdar/PycharmProjects/NeMo-som/examples/asr/an4/train_manifest.json"
 
     # validation ds
-    cfg.model.validation_ds.manifest_filepath = "/home/smajumdar/PycharmProjects/NeMo-som/examples/asr/an4/test_manifest.json"
+    model_cfg.validation_ds.manifest_filepath = "/home/smajumdar/PycharmProjects/NeMo-som/examples/asr/an4/test_manifest.json"
 
     # Trainer config
     cfg.trainer.gpus = 1

--- a/examples/asr/experimental/structured/speech_to_text_structured_v2.py
+++ b/examples/asr/experimental/structured/speech_to_text_structured_v2.py
@@ -49,7 +49,7 @@ sched_cfg = schedulers.CosineAnnealingParams(
 
 def main():
     # NeMo Model config
-    cfg = modelPT.ModelPTConfig(name='Custom QuartzNet')
+    cfg = modelPT.NemoConfig(name='Custom QuartzNet')
 
     # Generate default asr model config
     builder = configs.EncDecCTCModelConfigBuilder(name='quartznet_15x5')

--- a/nemo/collections/asr/models/configs/__init__.py
+++ b/nemo/collections/asr/models/configs/__init__.py
@@ -12,30 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo.collections.asr.models.configs.ctc_models_config import (
-    EncDecCTCConfig,
-    EncDecCTCDatasetConfig,
-    EncDecCTCModelConfig,
-)
 from nemo.collections.asr.models.configs.classification_models_config import (
     EncDecClassificationConfig,
     EncDecClassificationDatasetConfig,
     EncDecClassificationModelConfig,
 )
+from nemo.collections.asr.models.configs.ctc_models_config import (
+    EncDecCTCConfig,
+    EncDecCTCDatasetConfig,
+    EncDecCTCModelConfig,
+)
+from nemo.collections.asr.models.configs.quartznet_config import (
+    EncDecCTCModelConfigBuilder,
+    JasperModelConfig,
+    QuartzNetModelConfig,
+)
 from nemo.collections.asr.modules.audio_preprocessing import (
     AudioToMelSpectrogramPreprocessorConfig,
     AudioToMFCCPreprocessorConfig,
-    SpectrogramAugmentationConfig,
     CropOrPadSpectrogramAugmentationConfig,
+    SpectrogramAugmentationConfig,
 )
 from nemo.collections.asr.modules.conv_asr import (
+    ConvASRDecoderClassificationConfig,
     ConvASRDecoderConfig,
     ConvASREncoderConfig,
-    ConvASRDecoderClassificationConfig,
     JasperEncoderConfig,
-)
-from nemo.collections.asr.models.configs.quartznet_config import (
-    QuartzNetModelConfig,
-    JasperModelConfig,
-    EncDecCTCModelConfigBuilder,
 )

--- a/nemo/collections/asr/models/configs/__init__.py
+++ b/nemo/collections/asr/models/configs/__init__.py
@@ -17,11 +17,23 @@ from nemo.collections.asr.models.configs.ctc_models_config import (
     EncDecCTCDatasetConfig,
     EncDecCTCModelConfig,
 )
+from nemo.collections.asr.models.configs.classification_models_config import (
+    EncDecClassificationConfig,
+    EncDecClassificationDatasetConfig,
+    EncDecClassificationModelConfig,
+)
 from nemo.collections.asr.modules.audio_preprocessing import (
     AudioToMelSpectrogramPreprocessorConfig,
+    AudioToMFCCPreprocessorConfig,
     SpectrogramAugmentationConfig,
+    CropOrPadSpectrogramAugmentationConfig,
 )
-from nemo.collections.asr.modules.conv_asr import ConvASRDecoderConfig, ConvASREncoderConfig, JasperEncoderConfig
+from nemo.collections.asr.modules.conv_asr import (
+    ConvASRDecoderConfig,
+    ConvASREncoderConfig,
+    ConvASRDecoderClassificationConfig,
+    JasperEncoderConfig,
+)
 from nemo.collections.asr.models.configs.quartznet_config import (
     QuartzNetModelConfig,
     JasperModelConfig,

--- a/nemo/collections/asr/models/configs/__init__.py
+++ b/nemo/collections/asr/models/configs/__init__.py
@@ -22,6 +22,11 @@ from nemo.collections.asr.models.configs.ctc_models_config import (
     EncDecCTCDatasetConfig,
     EncDecCTCModelConfig,
 )
+from nemo.collections.asr.models.configs.matchboxnet_config import (
+    EncDecClassificationModelConfigBuilder,
+    MatchboxNetModelConfig,
+    MatchboxNetVADModelConfig,
+)
 from nemo.collections.asr.models.configs.quartznet_config import (
     EncDecCTCModelConfigBuilder,
     JasperModelConfig,

--- a/nemo/collections/asr/models/configs/__init__.py
+++ b/nemo/collections/asr/models/configs/__init__.py
@@ -22,3 +22,9 @@ from nemo.collections.asr.modules.audio_preprocessing import (
     SpectrogramAugmentationConfig,
 )
 from nemo.collections.asr.modules.conv_asr import ConvASRDecoderConfig, ConvASREncoderConfig, JasperEncoderConfig
+from nemo.collections.asr.models.configs.quartznet_config import (
+    QuartzNetConfig,
+    QuartzNetModelConfig,
+    QuartzNet15x5,
+    QuartzNetConfigBuilder,
+)

--- a/nemo/collections/asr/models/configs/__init__.py
+++ b/nemo/collections/asr/models/configs/__init__.py
@@ -23,8 +23,7 @@ from nemo.collections.asr.modules.audio_preprocessing import (
 )
 from nemo.collections.asr.modules.conv_asr import ConvASRDecoderConfig, ConvASREncoderConfig, JasperEncoderConfig
 from nemo.collections.asr.models.configs.quartznet_config import (
-    QuartzNetConfig,
     QuartzNetModelConfig,
-    QuartzNet15x5,
-    QuartzNetConfigBuilder,
+    JasperModelConfig,
+    EncDecCTCModelConfigBuilder,
 )

--- a/nemo/collections/asr/models/configs/classification_models_config.py
+++ b/nemo/collections/asr/models/configs/classification_models_config.py
@@ -19,15 +19,16 @@ from omegaconf import MISSING
 
 import nemo.core.classes.dataset
 from nemo.collections.asr.modules.audio_preprocessing import (
-    AudioToMelSpectrogramPreprocessorConfig,
+    AudioToMFCCPreprocessorConfig,
     SpectrogramAugmentationConfig,
+    CropOrPadSpectrogramAugmentationConfig,
 )
-from nemo.collections.asr.modules.conv_asr import ConvASRDecoderConfig, ConvASREncoderConfig
+from nemo.collections.asr.modules.conv_asr import ConvASRDecoderClassificationConfig, ConvASREncoderConfig
 from nemo.core.config import modelPT as model_cfg
 
 
 @dataclass
-class EncDecCTCDatasetConfig(nemo.core.classes.dataset.DatasetConfig):
+class EncDecClassificationDatasetConfig(nemo.core.classes.dataset.DatasetConfig):
     manifest_filepath: Optional[str] = None
     sample_rate: int = MISSING
     labels: List[str] = MISSING
@@ -44,40 +45,51 @@ class EncDecCTCDatasetConfig(nemo.core.classes.dataset.DatasetConfig):
     augmentor: Optional[Dict[str, Any]] = None
     max_duration: Optional[float] = None
     min_duration: Optional[float] = None
-    max_utts: int = 0
-    blank_index: int = -1
-    unk_index: int = -1
-    normalize: bool = False
-    trim: bool = True
     load_audio: bool = True
-    parser: Optional[str] = 'en'
-    add_misc: bool = False
+
+    # VAD Optional
+    vad_stream: Optional[bool] = None
+    time_length: float = 0.31
+    shift_length: float = 0.01
+    normalize_audio: bool = False
 
 
 @dataclass
-class EncDecCTCConfig(model_cfg.ModelConfig):
+class EncDecClassificationConfig(model_cfg.ModelConfig):
     # Model global arguments
     sample_rate: int = 16000
     repeat: int = 1
     dropout: float = 0.0
-    separable: bool = False
+    separable: bool = True
+    kernel_size_factor: float = 1.0
     labels: List[str] = MISSING
+    timesteps: int = MISSING
 
     # Dataset configs
-    train_ds: EncDecCTCDatasetConfig = EncDecCTCDatasetConfig(manifest_filepath=None, shuffle=True, trim_silence=True)
-    validation_ds: EncDecCTCDatasetConfig = EncDecCTCDatasetConfig(manifest_filepath=None, shuffle=False)
-    test_ds: EncDecCTCDatasetConfig = EncDecCTCDatasetConfig(manifest_filepath=None, shuffle=False)
+    train_ds: EncDecClassificationDatasetConfig = EncDecClassificationDatasetConfig(
+        manifest_filepath=None, shuffle=True, trim_silence=False
+    )
+    validation_ds: EncDecClassificationDatasetConfig = EncDecClassificationDatasetConfig(
+        manifest_filepath=None, shuffle=False
+    )
+    test_ds: EncDecClassificationDatasetConfig = EncDecClassificationDatasetConfig(
+        manifest_filepath=None, shuffle=False
+    )
 
     # Optimizer / Scheduler config
     optim: Optional[model_cfg.OptimConfig] = model_cfg.OptimConfig(sched=model_cfg.SchedConfig())
 
     # Model component configs
-    preprocessor: AudioToMelSpectrogramPreprocessorConfig = AudioToMelSpectrogramPreprocessorConfig()
+    preprocessor: AudioToMFCCPreprocessorConfig = AudioToMFCCPreprocessorConfig()
     spec_augment: Optional[SpectrogramAugmentationConfig] = SpectrogramAugmentationConfig()
+    crop_or_pad_augment: Optional[CropOrPadSpectrogramAugmentationConfig] = CropOrPadSpectrogramAugmentationConfig(
+        audio_length=timesteps
+    )
+
     encoder: ConvASREncoderConfig = ConvASREncoderConfig()
-    decoder: ConvASRDecoderConfig = ConvASRDecoderConfig()
+    decoder: ConvASRDecoderClassificationConfig = ConvASRDecoderClassificationConfig()
 
 
 @dataclass
-class EncDecCTCModelConfig(model_cfg.NemoConfig):
-    model: EncDecCTCConfig = EncDecCTCConfig()
+class EncDecClassificationModelConfig(model_cfg.NemoConfig):
+    model: EncDecClassificationConfig = EncDecClassificationConfig()

--- a/nemo/collections/asr/models/configs/classification_models_config.py
+++ b/nemo/collections/asr/models/configs/classification_models_config.py
@@ -20,8 +20,8 @@ from omegaconf import MISSING
 import nemo.core.classes.dataset
 from nemo.collections.asr.modules.audio_preprocessing import (
     AudioToMFCCPreprocessorConfig,
-    SpectrogramAugmentationConfig,
     CropOrPadSpectrogramAugmentationConfig,
+    SpectrogramAugmentationConfig,
 )
 from nemo.collections.asr.modules.conv_asr import ConvASRDecoderClassificationConfig, ConvASREncoderConfig
 from nemo.core.config import modelPT as model_cfg

--- a/nemo/collections/asr/models/configs/ctc_models_config.py
+++ b/nemo/collections/asr/models/configs/ctc_models_config.py
@@ -73,8 +73,8 @@ class EncDecCTCConfig(model_cfg.ModelConfig):
     # Model component configs
     preprocessor: AudioToMelSpectrogramPreprocessorConfig = AudioToMelSpectrogramPreprocessorConfig()
     spec_augment: Optional[SpectrogramAugmentationConfig] = SpectrogramAugmentationConfig()
-    encoder: Any = ConvASREncoderConfig()
-    decoder: Any = ConvASRDecoderConfig()
+    encoder: ConvASREncoderConfig = ConvASREncoderConfig()
+    decoder: ConvASRDecoderConfig = ConvASRDecoderConfig()
 
 
 @dataclass

--- a/nemo/collections/asr/models/configs/ctc_models_config.py
+++ b/nemo/collections/asr/models/configs/ctc_models_config.py
@@ -52,6 +52,10 @@ class EncDecCTCDatasetConfig(nemo.core.classes.dataset.DatasetConfig):
     load_audio: bool = True
     parser: Optional[str] = 'en'
     add_misc: bool = False
+    eos_id: Optional[int] = None
+    bos_id: Optional[int] = None
+    pad_id: int = 0
+    use_start_end_token: bool = False
 
 
 @dataclass

--- a/nemo/collections/asr/models/configs/matchboxnet_config.py
+++ b/nemo/collections/asr/models/configs/matchboxnet_config.py
@@ -13,23 +13,23 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
-from typing import Any, List, Optional, Callable
+from typing import Any, Callable, List, Optional
 
 from omegaconf import MISSING
 
+from nemo.collections.asr.models.configs import classification_models_config as clf_cfg
 from nemo.collections.asr.modules.audio_preprocessing import (
     AudioToMFCCPreprocessorConfig,
-    SpectrogramAugmentationConfig,
     CropOrPadSpectrogramAugmentationConfig,
+    SpectrogramAugmentationConfig,
 )
 from nemo.collections.asr.modules.conv_asr import (
-    ConvASREncoderConfig,
-    ConvASRDecoderConfig,
     ConvASRDecoderClassificationConfig,
+    ConvASRDecoderConfig,
+    ConvASREncoderConfig,
     JasperEncoderConfig,
 )
 from nemo.core.config import modelPT as model_cfg
-from nemo.collections.asr.models.configs import classification_models_config as clf_cfg
 
 
 # fmt: off

--- a/nemo/collections/asr/models/configs/matchboxnet_config.py
+++ b/nemo/collections/asr/models/configs/matchboxnet_config.py
@@ -25,7 +25,6 @@ from nemo.collections.asr.modules.audio_preprocessing import (
 )
 from nemo.collections.asr.modules.conv_asr import (
     ConvASRDecoderClassificationConfig,
-    ConvASRDecoderConfig,
     ConvASREncoderConfig,
     JasperEncoderConfig,
 )

--- a/nemo/collections/asr/models/configs/matchboxnet_config.py
+++ b/nemo/collections/asr/models/configs/matchboxnet_config.py
@@ -134,7 +134,7 @@ class MatchboxNetModelConfig(clf_cfg.EncDecClassificationConfig):
 @dataclass
 class MatchboxNetVADModelConfig(MatchboxNetModelConfig):
     timesteps: int = 64
-    labels: List[str] = field(default=['background', 'speech'])
+    labels: List[str] = field(default_factory=lambda: ['background', 'speech'])
 
     crop_or_pad_augment: Optional[CropOrPadSpectrogramAugmentationConfig] = None
 

--- a/nemo/collections/asr/models/configs/matchboxnet_config.py
+++ b/nemo/collections/asr/models/configs/matchboxnet_config.py
@@ -1,0 +1,249 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Callable
+
+from omegaconf import MISSING
+
+from nemo.collections.asr.modules.audio_preprocessing import (
+    AudioToMFCCPreprocessorConfig,
+    SpectrogramAugmentationConfig,
+    CropOrPadSpectrogramAugmentationConfig,
+)
+from nemo.collections.asr.modules.conv_asr import (
+    ConvASREncoderConfig,
+    ConvASRDecoderConfig,
+    ConvASRDecoderClassificationConfig,
+    JasperEncoderConfig,
+)
+from nemo.core.config import modelPT as model_cfg
+from nemo.collections.asr.models.configs import classification_models_config as clf_cfg
+
+
+# fmt: off
+def matchboxnet_3x1x64():
+    config = [
+        JasperEncoderConfig(filters=128, repeat=1, kernel=[11], stride=[1], dilation=[1], dropout=0.0,
+                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=64, repeat=1, kernel=[13], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=64, repeat=1, kernel=[15], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=64, repeat=1, kernel=[17], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=128, repeat=1, kernel=[29], stride=[1], dilation=[2], dropout=0.0,
+                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=128, repeat=1, kernel=[1], stride=[1], dilation=[1], dropout=0.0,
+                            residual=False, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False)
+    ]
+    return config
+
+
+def matchboxnet_3x1x64_vad():
+    config = [
+        JasperEncoderConfig(filters=128, repeat=1, kernel=[11], stride=[1], dilation=[1], dropout=0.0,
+                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=64, repeat=1, kernel=[13], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=64, repeat=1, kernel=[15], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=64, repeat=1, kernel=[17], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=128, repeat=1, kernel=[29], stride=[1], dilation=[2], dropout=0.0,
+                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=128, repeat=1, kernel=[1], stride=[1], dilation=[1], dropout=0.0,
+                            residual=False, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False)
+    ]
+    return config
+# fmt: on
+
+
+@dataclass
+class MatchboxNetModelConfig(clf_cfg.EncDecClassificationConfig):
+    # Model global arguments
+    sample_rate: int = 16000
+    repeat: int = 1
+    dropout: float = 0.0
+    separable: bool = True
+    kernel_size_factor: float = 1.0
+    timesteps: int = 128
+    labels: List[str] = MISSING
+
+    # Dataset configs
+    train_ds: clf_cfg.EncDecClassificationDatasetConfig = clf_cfg.EncDecClassificationDatasetConfig(
+        manifest_filepath=None, shuffle=True, trim_silence=False
+    )
+    validation_ds: clf_cfg.EncDecClassificationDatasetConfig = clf_cfg.EncDecClassificationDatasetConfig(
+        manifest_filepath=None, shuffle=False
+    )
+    test_ds: clf_cfg.EncDecClassificationDatasetConfig = clf_cfg.EncDecClassificationDatasetConfig(
+        manifest_filepath=None, shuffle=False
+    )
+
+    # Optimizer / Scheduler config
+    optim: Optional[model_cfg.OptimConfig] = model_cfg.OptimConfig(sched=model_cfg.SchedConfig())
+
+    # Model general component configs
+    preprocessor: AudioToMFCCPreprocessorConfig = AudioToMFCCPreprocessorConfig(window_size=0.025)
+    spec_augment: Optional[SpectrogramAugmentationConfig] = SpectrogramAugmentationConfig(
+        freq_masks=2, time_masks=2, freq_width=15, time_width=25, rect_masks=5, rect_time=25, rect_freq=15
+    )
+    crop_or_pad_augment: Optional[CropOrPadSpectrogramAugmentationConfig] = CropOrPadSpectrogramAugmentationConfig(
+        audio_length=128
+    )
+
+    encoder: ConvASREncoderConfig = ConvASREncoderConfig(activation="relu")
+    decoder: ConvASRDecoderClassificationConfig = ConvASRDecoderClassificationConfig()
+
+
+@dataclass
+class MatchboxNetVADModelConfig(MatchboxNetModelConfig):
+    timesteps: int = 64
+    labels: List[str] = field(default=['background', 'speech'])
+
+    crop_or_pad_augment: Optional[CropOrPadSpectrogramAugmentationConfig] = None
+
+
+class EncDecClassificationModelConfigBuilder(model_cfg.ModelConfigBuilder):
+    VALID_CONFIGS = ['matchboxnet_3x1x64', 'matchboxnet_3x1x64_vad']
+
+    def __init__(self, name: str = 'matchboxnet_3x1x64', encoder_cfg_func: Optional[Callable[[], List[Any]]] = None):
+        if name not in EncDecClassificationModelConfigBuilder.VALID_CONFIGS:
+            raise ValueError("`name` must be one of : \n" f"{EncDecClassificationModelConfigBuilder.VALID_CONFIGS}")
+
+        self.name = name
+
+        if 'matchboxnet_3x1x64_vad' in name:
+            if encoder_cfg_func is None:
+                encoder_cfg_func = matchboxnet_3x1x64_vad
+
+            model_cfg = MatchboxNetVADModelConfig(
+                repeat=1,
+                separable=True,
+                encoder=ConvASREncoderConfig(jasper=encoder_cfg_func(), activation="relu"),
+                decoder=ConvASRDecoderClassificationConfig(),
+            )
+
+        elif 'matchboxnet_3x1x64' in name:
+            if encoder_cfg_func is None:
+                encoder_cfg_func = matchboxnet_3x1x64
+
+            model_cfg = MatchboxNetModelConfig(
+                repeat=1,
+                separable=False,
+                spec_augment=SpectrogramAugmentationConfig(rect_masks=5, rect_freq=50, rect_time=120),
+                encoder=ConvASREncoderConfig(jasper=encoder_cfg_func(), activation="relu"),
+                decoder=ConvASRDecoderClassificationConfig(),
+            )
+
+        else:
+            raise ValueError(f"Invalid config name submitted to {self.__class__.__name__}")
+
+        super(EncDecClassificationModelConfigBuilder, self).__init__(model_cfg)
+        self.model_cfg: clf_cfg.EncDecClassificationConfig = model_cfg  # enable type hinting
+
+    def set_labels(self, labels: List[str]):
+        self.model_cfg.labels = labels
+
+    def set_separable(self, separable: bool):
+        self.model_cfg.separable = separable
+
+    def set_repeat(self, repeat: int):
+        self.model_cfg.repeat = repeat
+
+    def set_sample_rate(self, sample_rate: int):
+        self.model_cfg.sample_rate = sample_rate
+
+    def set_dropout(self, dropout: float = 0.0):
+        self.model_cfg.dropout = dropout
+
+    def set_timesteps(self, timesteps: int):
+        self.model_cfg.timesteps = timesteps
+
+    # Note: Autocomplete for users wont work without these overrides
+    # But practically it is not needed since python will infer at runtime
+
+    # def set_train_ds(self, cfg: Optional[clf_cfg.EncDecClassificationDatasetConfig] = None):
+    #     super().set_train_ds(cfg)
+    #
+    # def set_validation_ds(self, cfg: Optional[clf_cfg.EncDecClassificationDatasetConfig] = None):
+    #     super().set_validation_ds(cfg)
+    #
+    # def set_test_ds(self, cfg: Optional[clf_cfg.EncDecClassificationDatasetConfig] = None):
+    #     super().set_test_ds(cfg)
+
+    def _finalize_cfg(self):
+        # propagate labels
+        self.model_cfg.train_ds.labels = self.model_cfg.labels
+        self.model_cfg.validation_ds.labels = self.model_cfg.labels
+        self.model_cfg.test_ds.labels = self.model_cfg.labels
+        self.model_cfg.decoder.vocabulary = self.model_cfg.labels
+
+        # propagate num classes
+        self.model_cfg.decoder.num_classes = len(self.model_cfg.labels)
+
+        # propagate sample rate
+        self.model_cfg.sample_rate = self.model_cfg.sample_rate
+        self.model_cfg.preprocessor.sample_rate = self.model_cfg.sample_rate
+        self.model_cfg.train_ds.sample_rate = self.model_cfg.sample_rate
+        self.model_cfg.validation_ds.sample_rate = self.model_cfg.sample_rate
+        self.model_cfg.test_ds.sample_rate = self.model_cfg.sample_rate
+
+        # propagate filters
+        self.model_cfg.encoder.feat_in = self.model_cfg.preprocessor.features
+        self.model_cfg.decoder.feat_in = self.model_cfg.encoder.jasper[-1].filters
+
+        # propagate timeteps
+        if self.model_cfg.crop_or_pad_augment is not None:
+            self.model_cfg.crop_or_pad_augment.audio_length = self.model_cfg.timesteps
+
+        # propagate separable
+        for layer in self.model_cfg.encoder.jasper[:-1]:  # type: JasperEncoderConfig
+            layer.separable = self.model_cfg.separable
+
+        # propagate repeat
+        for layer in self.model_cfg.encoder.jasper[1:-2]:  # type: JasperEncoderConfig
+            layer.repeat = self.model_cfg.repeat
+
+        # propagate dropout
+        for layer in self.model_cfg.encoder.jasper:  # type: JasperEncoderConfig
+            layer.dropout = self.model_cfg.dropout
+
+    def build(self) -> clf_cfg.EncDecClassificationConfig:
+        return super().build()

--- a/nemo/collections/asr/models/configs/quartznet_config.py
+++ b/nemo/collections/asr/models/configs/quartznet_config.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Callable
 
 from omegaconf import MISSING
 
@@ -26,7 +26,7 @@ from nemo.core.config import modelPT as model_cfg
 from nemo.collections.asr.models.configs import ctc_models_config as ctc_cfg
 
 
-# fmt: on
+# fmt: off
 def qn_15x5():
     config = [
         JasperEncoderConfig(filters=256, repeat=1, kernel=[33], stride=[2], dilation=[1], dropout=0.0,
@@ -103,11 +103,69 @@ def qn_15x5():
                             se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False)
     ]
     return config
+
+
+def jasper_10x5_dr():
+    config = [
+        JasperEncoderConfig(filters=256, repeat=1, kernel=[11], stride=[2], dilation=[1], dropout=0.2,
+                            residual=False, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=256, repeat=5, kernel=[11], stride=[1], dilation=[1], dropout=0.2,
+                            residual=True, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=True, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=256, repeat=5, kernel=[11], stride=[1], dilation=[1], dropout=0.2,
+                            residual=True, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=True, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=384, repeat=5, kernel=[13], stride=[1], dilation=[1], dropout=0.2,
+                            residual=True, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=True, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=384, repeat=5, kernel=[13], stride=[1], dilation=[1], dropout=0.2,
+                            residual=True, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=True, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=512, repeat=5, kernel=[17], stride=[1], dilation=[1], dropout=0.2,
+                            residual=True, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=True, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=512, repeat=5, kernel=[17], stride=[1], dilation=[1], dropout=0.2,
+                            residual=True, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=True, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=640, repeat=5, kernel=[21], stride=[1], dilation=[1], dropout=0.3,
+                            residual=True, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=True, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=640, repeat=5, kernel=[21], stride=[1], dilation=[1], dropout=0.3,
+                            residual=True, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=True, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=768, repeat=5, kernel=[25], stride=[1], dilation=[1], dropout=0.3,
+                            residual=True, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=True, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=768, repeat=5, kernel=[25], stride=[1], dilation=[1], dropout=0.3,
+                            residual=True, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=True, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=896, repeat=1, kernel=[29], stride=[1], dilation=[2], dropout=0.4,
+                            residual=False, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=1024, repeat=1, kernel=[1], stride=[1], dilation=[1], dropout=0.4,
+                            residual=False, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False)
+    ]
+    return config
 # fmt: on
 
 
 @dataclass
-class QuartzNetModelConfig(model_cfg.ModelConfig):
+class QuartzNetModelConfig(ctc_cfg.EncDecCTCConfig):
     # Model global arguments
     sample_rate: int = 16000
     repeat: int = 1
@@ -134,106 +192,109 @@ class QuartzNetModelConfig(model_cfg.ModelConfig):
     decoder: ConvASRDecoderConfig = ConvASRDecoderConfig()
 
 
-# Base QuartzNet class
 @dataclass
-class QuartzNetConfig(model_cfg.ModelPTConfig):
-    model: QuartzNetModelConfig = MISSING
+class JasperModelConfig(QuartzNetModelConfig):
+    separable: bool = False
 
 
-@dataclass
-class QuartzNet15x5(QuartzNetConfig):
-    # Model global arguments
-    name: str = 'Quartznet15x5'
-    model: QuartzNetModelConfig = QuartzNetModelConfig(
-        spec_augment=SpectrogramAugmentationConfig(rect_masks=5, rect_freq=50, rect_time=120),
-        encoder=ConvASREncoderConfig(jasper=qn_15x5(), activation="relu"),
-        decoder=ConvASRDecoderConfig()
-    )
+class EncDecCTCModelConfigBuilder(model_cfg.ModelConfigBuilder):
+    VALID_CONFIGS = ['quartznet_15x5', 'quartznet_15x5_zh', 'jasper_10x5dr']
 
-
-class QuartzNetConfigBuilder(model_cfg.ModelPTConfigBuilder):
-    VALID_CONFIGS = ['quartznet_15x5', 'quartznet_15x5_zh']
-
-    def __init__(self, name: str = 'quartznet_15x5'):
-        if name not in QuartzNetConfigBuilder.VALID_CONFIGS:
-            raise ValueError("`name` must be one of : \n"
-                             f"{QuartzNetConfigBuilder.VALID_CONFIGS}")
+    def __init__(self, name: str = 'quartznet_15x5', encoder_cfg_func: Optional[Callable[[], List[Any]]] = None):
+        if name not in EncDecCTCModelConfigBuilder.VALID_CONFIGS:
+            raise ValueError("`name` must be one of : \n" f"{EncDecCTCModelConfigBuilder.VALID_CONFIGS}")
 
         self.name = name
 
-        if '15x5' in name:
-            model_cfg = QuartzNet15x5()
-        else:
-            raise ValueError("Invalid config name")
+        if 'quartznet_15x5' in name:
+            if encoder_cfg_func is None:
+                encoder_cfg_func = qn_15x5
 
-        super(QuartzNetConfigBuilder, self).__init__(model_cfg)
-        self.model_cfg: QuartzNetConfig = model_cfg  # enable type hinting
+            model_cfg = QuartzNetModelConfig(
+                repeat=5,
+                separable=True,
+                spec_augment=SpectrogramAugmentationConfig(rect_masks=5, rect_freq=50, rect_time=120),
+                encoder=ConvASREncoderConfig(jasper=encoder_cfg_func(), activation="relu"),
+                decoder=ConvASRDecoderConfig(),
+            )
+
+        elif 'jasper_10x5' in name:
+            if encoder_cfg_func is None:
+                encoder_cfg_func = jasper_10x5_dr
+
+            model_cfg = JasperModelConfig(
+                repeat=5,
+                separable=False,
+                spec_augment=SpectrogramAugmentationConfig(rect_masks=5, rect_freq=50, rect_time=120),
+                encoder=ConvASREncoderConfig(jasper=encoder_cfg_func(), activation="relu"),
+                decoder=ConvASRDecoderConfig(),
+            )
+
+        else:
+            raise ValueError(f"Invalid config name submitted to {self.__class__.__name__}")
+
+        super(EncDecCTCModelConfigBuilder, self).__init__(model_cfg)
+        self.model_cfg: ctc_cfg.EncDecCTCConfig = model_cfg  # enable type hinting
 
     def set_labels(self, labels: List[str]):
-        self.model_cfg.model.labels = labels
+        self.model_cfg.labels = labels
 
     def set_separable(self, separable: bool):
-        self.model_cfg.model.separable = separable
+        self.model_cfg.separable = separable
 
     def set_repeat(self, repeat: int):
-        self.model_cfg.model.repeat = repeat
+        self.model_cfg.repeat = repeat
 
     def set_sample_rate(self, sample_rate: int):
-        self.model_cfg.model.sample_rate = sample_rate
+        self.model_cfg.sample_rate = sample_rate
 
     def set_dropout(self, dropout: float = 0.0):
-        self.model_cfg.model.dropout = dropout
+        self.model_cfg.dropout = dropout
 
     # Note: Autocomplete for users wont work without these overrides
     # But practically it is not needed since python will infer at runtime
 
     # def set_train_ds(self, cfg: Optional[ctc_cfg.EncDecCTCDatasetConfig] = None):
-    #     super(QuartzNetConfigBuilder, self).set_train_ds(cfg)
+    #     super().set_train_ds(cfg)
     #
     # def set_validation_ds(self, cfg: Optional[ctc_cfg.EncDecCTCDatasetConfig] = None):
-    #     super(QuartzNetConfigBuilder, self).set_validation_ds(cfg)
+    #     super().set_validation_ds(cfg)
     #
     # def set_test_ds(self, cfg: Optional[ctc_cfg.EncDecCTCDatasetConfig] = None):
-    #     super(QuartzNetConfigBuilder, self).set_test_ds(cfg)
+    #     super().set_test_ds(cfg)
 
     def _finalize_cfg(self):
-        # propagate labels 
-        self.model_cfg.model.train_ds.labels = self.model_cfg.model.labels
-        self.model_cfg.model.validation_ds.labels = self.model_cfg.model.labels
-        self.model_cfg.model.test_ds.labels = self.model_cfg.model.labels
-        self.model_cfg.model.decoder.vocabulary = self.model_cfg.model.labels
+        # propagate labels
+        self.model_cfg.train_ds.labels = self.model_cfg.labels
+        self.model_cfg.validation_ds.labels = self.model_cfg.labels
+        self.model_cfg.test_ds.labels = self.model_cfg.labels
+        self.model_cfg.decoder.vocabulary = self.model_cfg.labels
 
         # propagate num classes
-        self.model_cfg.model.decoder.num_classes = len(self.model_cfg.model.labels)
+        self.model_cfg.decoder.num_classes = len(self.model_cfg.labels)
 
         # propagate sample rate
-        self.model_cfg.model.sample_rate = self.model_cfg.model.sample_rate
-        self.model_cfg.model.preprocessor.sample_rate = self.model_cfg.model.sample_rate
-        self.model_cfg.model.train_ds.sample_rate = self.model_cfg.model.sample_rate
-        self.model_cfg.model.validation_ds.sample_rate = self.model_cfg.model.sample_rate
-        self.model_cfg.model.test_ds.sample_rate = self.model_cfg.model.sample_rate
+        self.model_cfg.sample_rate = self.model_cfg.sample_rate
+        self.model_cfg.preprocessor.sample_rate = self.model_cfg.sample_rate
+        self.model_cfg.train_ds.sample_rate = self.model_cfg.sample_rate
+        self.model_cfg.validation_ds.sample_rate = self.model_cfg.sample_rate
+        self.model_cfg.test_ds.sample_rate = self.model_cfg.sample_rate
 
         # propagate filters
-        self.model_cfg.model.encoder.feat_in = self.model_cfg.model.preprocessor.features
-        self.model_cfg.model.decoder.feat_in = self.model_cfg.model.encoder.jasper[-1].filters
+        self.model_cfg.encoder.feat_in = self.model_cfg.preprocessor.features
+        self.model_cfg.decoder.feat_in = self.model_cfg.encoder.jasper[-1].filters
 
         # propagate separable
-        for layer in self.model_cfg.model.encoder.jasper[:-1]:  # type: JasperEncoderConfig
-            layer.separable = self.model_cfg.model.separable
+        for layer in self.model_cfg.encoder.jasper[:-1]:  # type: JasperEncoderConfig
+            layer.separable = self.model_cfg.separable
 
         # propagate repeat
-        for layer in self.model_cfg.model.encoder.jasper[1:-2]:  # type: JasperEncoderConfig
-            layer.repeat = self.model_cfg.model.repeat
+        for layer in self.model_cfg.encoder.jasper[1:-2]:  # type: JasperEncoderConfig
+            layer.repeat = self.model_cfg.repeat
 
         # propagate dropout
-        for layer in self.model_cfg.model.encoder.jasper:  # type: JasperEncoderConfig
-            layer.dropout = self.model_cfg.model.dropout
+        for layer in self.model_cfg.encoder.jasper:  # type: JasperEncoderConfig
+            layer.dropout = self.model_cfg.dropout
 
-    def build(self) -> QuartzNetConfig:
-        return super(QuartzNetConfigBuilder, self).build()
-
-
-if __name__ == '__main__':
-
-    cfg = QuartzNet15x5()
-    print(cfg)
+    def build(self) -> ctc_cfg.EncDecCTCConfig:
+        return super().build()

--- a/nemo/collections/asr/models/configs/quartznet_config.py
+++ b/nemo/collections/asr/models/configs/quartznet_config.py
@@ -26,38 +26,88 @@ from nemo.core.config import modelPT as model_cfg
 from nemo.collections.asr.models.configs import ctc_models_config as ctc_cfg
 
 
-def qn_15x5(separable, dropout):
+# fmt: on
+def qn_15x5():
     config = [
-        JasperEncoderConfig(
-            filters=256,
-            repeat=1,
-            kernel=[33],
-            stride=[2],
-            separable=separable,
-            dilation=[1],
-            dropout=dropout,
-            residual=False,
-        ),
-        JasperEncoderConfig(
-            filters=256,
-            repeat=1,
-            kernel=[33],
-            stride=[1],
-            separable=separable,
-            dilation=[1],
-            dropout=dropout,
-            residual=True,
-        ),
-        # ... repeat 14 more times
-        JasperEncoderConfig(
-            filters=1024, repeat=1, kernel=[1], stride=[1], dilation=[1], dropout=dropout, residual=False,
-        ),
+        JasperEncoderConfig(filters=256, repeat=1, kernel=[33], stride=[2], dilation=[1], dropout=0.0,
+                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=256, repeat=5, kernel=[33], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=256, repeat=5, kernel=[33], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=256, repeat=5, kernel=[33], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=256, repeat=5, kernel=[39], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=256, repeat=5, kernel=[39], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=256, repeat=5, kernel=[39], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=512, repeat=5, kernel=[51], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=512, repeat=5, kernel=[51], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=512, repeat=5, kernel=[51], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=512, repeat=5, kernel=[63], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=512, repeat=5, kernel=[63], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=512, repeat=5, kernel=[63], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=512, repeat=5, kernel=[75], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=512, repeat=5, kernel=[75], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=512, repeat=5, kernel=[75], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=512, repeat=1, kernel=[87], stride=[1], dilation=[2], dropout=0.0,
+                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=1024, repeat=1, kernel=[1], stride=[1], dilation=[1], dropout=0.0,
+                            residual=False, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False)
     ]
     return config
+# fmt: on
 
 
 @dataclass
-class QuartzNetConfig(model_cfg.ModelConfig):
+class QuartzNetModelConfig(model_cfg.ModelConfig):
     # Model global arguments
     sample_rate: int = 16000
     repeat: int = 1
@@ -77,29 +127,110 @@ class QuartzNetConfig(model_cfg.ModelConfig):
     # Optimizer / Scheduler config
     optim: Optional[model_cfg.OptimConfig] = model_cfg.OptimConfig(sched=model_cfg.SchedConfig())
 
-    # Model component configs
+    # Model general component configs
     preprocessor: AudioToMelSpectrogramPreprocessorConfig = AudioToMelSpectrogramPreprocessorConfig()
     spec_augment: Optional[SpectrogramAugmentationConfig] = SpectrogramAugmentationConfig()
-    encoder: Any = ConvASREncoderConfig(activation="relu")
-    decoder: Any = ConvASRDecoderConfig()
+    encoder: ConvASREncoderConfig = ConvASREncoderConfig(activation="relu")
+    decoder: ConvASRDecoderConfig = ConvASRDecoderConfig()
+
+
+# Base QuartzNet class
+@dataclass
+class QuartzNetConfig(model_cfg.ModelPTConfig):
+    model: QuartzNetModelConfig = MISSING
 
 
 @dataclass
 class QuartzNet15x5(QuartzNetConfig):
     # Model global arguments
-    labels: List[str] = MISSING
-
-    # Model component configs
-    preprocessor: AudioToMelSpectrogramPreprocessorConfig = AudioToMelSpectrogramPreprocessorConfig()
-    spec_augment: Optional[SpectrogramAugmentationConfig] = SpectrogramAugmentationConfig(
-        rect_masks=5, rect_freq=50, rect_time=120
+    name = 'Quartznet15x5'
+    model = QuartzNetModelConfig(
+        spec_augment=SpectrogramAugmentationConfig(rect_masks=5, rect_freq=50, rect_time=120),
+        encoder=ConvASREncoderConfig(jasper=qn_15x5(), activation="relu"),
+        decoder=ConvASRDecoderConfig()
     )
-    encoder: Any = ConvASREncoderConfig(activation="relu")
-    decoder: Any = ConvASRDecoderConfig()
 
 
-def get_qn_15x5_config(labels=MISSING, ):
-    pass
+class QuartzNetConfigBuilder(model_cfg.ModelPTConfigBuilder):
+    VALID_CONFIGS = ['quartznet_15x5', 'quartznet_15x5_zh']
+
+    def __init__(self, name: str = 'quartznet_15x5'):
+        if name not in QuartzNetConfigBuilder.VALID_CONFIGS:
+            raise ValueError("`name` must be one of : \n"
+                             f"{QuartzNetConfigBuilder.VALID_CONFIGS}")
+
+        self.name = name
+
+        if '15x5' in name:
+            model_cfg = QuartzNet15x5()
+        else:
+            raise ValueError("Invalid config name")
+
+        super(QuartzNetConfigBuilder, self).__init__(model_cfg)
+        self.model_cfg: QuartzNetConfig = model_cfg  # enable type hinting
+
+    def set_labels(self, labels: List[str]):
+        self.model_cfg.model.labels = labels
+
+    def set_separable(self, separable: bool):
+        self.model_cfg.model.separable = separable
+
+    def set_repeat(self, repeat: int):
+        self.model_cfg.model.repeat = repeat
+
+    def set_sample_rate(self, sample_rate: int):
+        self.model_cfg.model.sample_rate = sample_rate
+
+    def set_dropout(self, dropout: float = 0.0):
+        self.model_cfg.model.dropout = dropout
+
+    # Note: Autocomplete for users wont work without these overrides
+    # But practically it is not needed since python will infer at runtime
+
+    # def set_train_ds(self, cfg: Optional[ctc_cfg.EncDecCTCDatasetConfig] = None):
+    #     super(QuartzNetConfigBuilder, self).set_train_ds(cfg)
+    #
+    # def set_validation_ds(self, cfg: Optional[ctc_cfg.EncDecCTCDatasetConfig] = None):
+    #     super(QuartzNetConfigBuilder, self).set_validation_ds(cfg)
+    #
+    # def set_test_ds(self, cfg: Optional[ctc_cfg.EncDecCTCDatasetConfig] = None):
+    #     super(QuartzNetConfigBuilder, self).set_test_ds(cfg)
+
+    def _finalize_cfg(self):
+        # propagate labels 
+        self.model_cfg.model.train_ds.labels = self.model_cfg.model.labels
+        self.model_cfg.model.validation_ds.labels = self.model_cfg.model.labels
+        self.model_cfg.model.test_ds.labels = self.model_cfg.model.labels
+        self.model_cfg.model.decoder.vocabulary = self.model_cfg.model.labels
+
+        # propagate num classes
+        self.model_cfg.model.decoder.num_classes = len(self.model_cfg.model.labels)
+
+        # propagate sample rate
+        self.model_cfg.model.sample_rate = self.model_cfg.model.sample_rate
+        self.model_cfg.model.preprocessor.sample_rate = self.model_cfg.model.sample_rate
+        self.model_cfg.model.train_ds.sample_rate = self.model_cfg.model.sample_rate
+        self.model_cfg.model.validation_ds.sample_rate = self.model_cfg.model.sample_rate
+        self.model_cfg.model.test_ds.sample_rate = self.model_cfg.model.sample_rate
+
+        # propagate filters
+        self.model_cfg.model.encoder.feat_in = self.model_cfg.model.preprocessor.features
+        self.model_cfg.model.decoder.feat_in = self.model_cfg.model.encoder.jasper[-1].filters
+
+        # propagate separable
+        for layer in self.model_cfg.model.encoder.jasper[:-1]:  # type: JasperEncoderConfig
+            layer.separable = self.model_cfg.model.separable
+
+        # propagate repeat
+        for layer in self.model_cfg.model.encoder.jasper[1:-2]:  # type: JasperEncoderConfig
+            layer.repeat = self.model_cfg.model.repeat
+
+        # propagate dropout
+        for layer in self.model_cfg.model.encoder.jasper:  # type: JasperEncoderConfig
+            layer.dropout = self.model_cfg.model.dropout
+
+    def build(self) -> QuartzNetConfig:
+        return super(QuartzNetConfigBuilder, self).build()
 
 
 if __name__ == '__main__':

--- a/nemo/collections/asr/models/configs/quartznet_config.py
+++ b/nemo/collections/asr/models/configs/quartznet_config.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Callable
+from typing import Any, List, Optional, Callable
 
 from omegaconf import MISSING
 
@@ -161,6 +161,66 @@ def jasper_10x5_dr():
                             se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False)
     ]
     return config
+
+
+def matchboxnet_3x1x64():
+    config = [
+        JasperEncoderConfig(filters=128, repeat=1, kernel=[11], stride=[1], dilation=[1], dropout=0.0,
+                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=64, repeat=1, kernel=[13], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=64, repeat=1, kernel=[15], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=64, repeat=1, kernel=[17], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=128, repeat=1, kernel=[29], stride=[1], dilation=[2], dropout=0.0,
+                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=128, repeat=1, kernel=[1], stride=[1], dilation=[1], dropout=0.0,
+                            residual=False, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False)
+    ]
+    return config
+
+
+def matchboxnet_3x1x64_vad():
+    config = [
+        JasperEncoderConfig(filters=128, repeat=1, kernel=[11], stride=[1], dilation=[1], dropout=0.0,
+                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=64, repeat=1, kernel=[13], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=64, repeat=1, kernel=[15], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=64, repeat=1, kernel=[17], stride=[1], dilation=[1], dropout=0.0,
+                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=128, repeat=1, kernel=[29], stride=[1], dilation=[2], dropout=0.0,
+                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
+        JasperEncoderConfig(filters=128, repeat=1, kernel=[1], stride=[1], dilation=[1], dropout=0.0,
+                            residual=False, groups=1, separable=False, heads=-1, residual_mode='add',
+                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
+                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False)
+    ]
+    return config
 # fmt: on
 
 
@@ -236,6 +296,9 @@ class EncDecCTCModelConfigBuilder(model_cfg.ModelConfigBuilder):
         super(EncDecCTCModelConfigBuilder, self).__init__(model_cfg)
         self.model_cfg: ctc_cfg.EncDecCTCConfig = model_cfg  # enable type hinting
 
+        if 'zh' in name:
+            self.set_dataset_normalize(normalize=False)
+
     def set_labels(self, labels: List[str]):
         self.model_cfg.labels = labels
 
@@ -250,6 +313,11 @@ class EncDecCTCModelConfigBuilder(model_cfg.ModelConfigBuilder):
 
     def set_dropout(self, dropout: float = 0.0):
         self.model_cfg.dropout = dropout
+
+    def set_dataset_normalize(self, normalize: bool):
+        self.model_cfg.train_ds.normalize = normalize
+        self.model_cfg.validation_ds.normalize = normalize
+        self.model_cfg.test_ds.normalize = normalize
 
     # Note: Autocomplete for users wont work without these overrides
     # But practically it is not needed since python will infer at runtime

--- a/nemo/collections/asr/models/configs/quartznet_config.py
+++ b/nemo/collections/asr/models/configs/quartznet_config.py
@@ -13,17 +13,17 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from typing import Any, List, Optional, Callable
+from typing import Any, Callable, List, Optional
 
 from omegaconf import MISSING
 
+from nemo.collections.asr.models.configs import ctc_models_config as ctc_cfg
 from nemo.collections.asr.modules.audio_preprocessing import (
     AudioToMelSpectrogramPreprocessorConfig,
     SpectrogramAugmentationConfig,
 )
 from nemo.collections.asr.modules.conv_asr import ConvASRDecoderConfig, ConvASREncoderConfig, JasperEncoderConfig
 from nemo.core.config import modelPT as model_cfg
-from nemo.collections.asr.models.configs import ctc_models_config as ctc_cfg
 
 
 # fmt: off
@@ -156,66 +156,6 @@ def jasper_10x5_dr():
                             residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
                             se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
         JasperEncoderConfig(filters=1024, repeat=1, kernel=[1], stride=[1], dilation=[1], dropout=0.4,
-                            residual=False, groups=1, separable=False, heads=-1, residual_mode='add',
-                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
-                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False)
-    ]
-    return config
-
-
-def matchboxnet_3x1x64():
-    config = [
-        JasperEncoderConfig(filters=128, repeat=1, kernel=[11], stride=[1], dilation=[1], dropout=0.0,
-                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
-                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
-                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
-        JasperEncoderConfig(filters=64, repeat=1, kernel=[13], stride=[1], dilation=[1], dropout=0.0,
-                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
-                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
-                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
-        JasperEncoderConfig(filters=64, repeat=1, kernel=[15], stride=[1], dilation=[1], dropout=0.0,
-                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
-                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
-                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
-        JasperEncoderConfig(filters=64, repeat=1, kernel=[17], stride=[1], dilation=[1], dropout=0.0,
-                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
-                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
-                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
-        JasperEncoderConfig(filters=128, repeat=1, kernel=[29], stride=[1], dilation=[2], dropout=0.0,
-                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
-                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
-                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
-        JasperEncoderConfig(filters=128, repeat=1, kernel=[1], stride=[1], dilation=[1], dropout=0.0,
-                            residual=False, groups=1, separable=False, heads=-1, residual_mode='add',
-                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
-                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False)
-    ]
-    return config
-
-
-def matchboxnet_3x1x64_vad():
-    config = [
-        JasperEncoderConfig(filters=128, repeat=1, kernel=[11], stride=[1], dilation=[1], dropout=0.0,
-                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
-                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
-                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
-        JasperEncoderConfig(filters=64, repeat=1, kernel=[13], stride=[1], dilation=[1], dropout=0.0,
-                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
-                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
-                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
-        JasperEncoderConfig(filters=64, repeat=1, kernel=[15], stride=[1], dilation=[1], dropout=0.0,
-                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
-                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
-                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
-        JasperEncoderConfig(filters=64, repeat=1, kernel=[17], stride=[1], dilation=[1], dropout=0.0,
-                            residual=True, groups=1, separable=True, heads=-1, residual_mode='add',
-                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
-                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
-        JasperEncoderConfig(filters=128, repeat=1, kernel=[29], stride=[1], dilation=[2], dropout=0.0,
-                            residual=False, groups=1, separable=True, heads=-1, residual_mode='add',
-                            residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
-                            se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False),
-        JasperEncoderConfig(filters=128, repeat=1, kernel=[1], stride=[1], dilation=[1], dropout=0.0,
                             residual=False, groups=1, separable=False, heads=-1, residual_mode='add',
                             residual_dense=False, se=False, se_reduction_ratio=8, se_context_size=-1,
                             se_interpolation_mode='nearest', kernel_size_factor=1.0, stride_last=False)

--- a/nemo/collections/asr/models/configs/quartznet_config.py
+++ b/nemo/collections/asr/models/configs/quartznet_config.py
@@ -1,0 +1,108 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+from omegaconf import MISSING
+
+from nemo.collections.asr.modules.audio_preprocessing import (
+    AudioToMelSpectrogramPreprocessorConfig,
+    SpectrogramAugmentationConfig,
+)
+from nemo.collections.asr.modules.conv_asr import ConvASRDecoderConfig, ConvASREncoderConfig, JasperEncoderConfig
+from nemo.core.config import modelPT as model_cfg
+from nemo.collections.asr.models.configs import ctc_models_config as ctc_cfg
+
+
+def qn_15x5(separable, dropout):
+    config = [
+        JasperEncoderConfig(
+            filters=256,
+            repeat=1,
+            kernel=[33],
+            stride=[2],
+            separable=separable,
+            dilation=[1],
+            dropout=dropout,
+            residual=False,
+        ),
+        JasperEncoderConfig(
+            filters=256,
+            repeat=1,
+            kernel=[33],
+            stride=[1],
+            separable=separable,
+            dilation=[1],
+            dropout=dropout,
+            residual=True,
+        ),
+        # ... repeat 14 more times
+        JasperEncoderConfig(
+            filters=1024, repeat=1, kernel=[1], stride=[1], dilation=[1], dropout=dropout, residual=False,
+        ),
+    ]
+    return config
+
+
+@dataclass
+class QuartzNetConfig(model_cfg.ModelConfig):
+    # Model global arguments
+    sample_rate: int = 16000
+    repeat: int = 1
+    dropout: float = 0.0
+    separable: bool = True
+    labels: List[str] = MISSING
+
+    # Dataset configs
+    train_ds: ctc_cfg.EncDecCTCDatasetConfig = ctc_cfg.EncDecCTCDatasetConfig(
+        manifest_filepath=None, shuffle=True, trim_silence=True
+    )
+    validation_ds: ctc_cfg.EncDecCTCDatasetConfig = ctc_cfg.EncDecCTCDatasetConfig(
+        manifest_filepath=None, shuffle=False
+    )
+    test_ds: ctc_cfg.EncDecCTCDatasetConfig = ctc_cfg.EncDecCTCDatasetConfig(manifest_filepath=None, shuffle=False)
+
+    # Optimizer / Scheduler config
+    optim: Optional[model_cfg.OptimConfig] = model_cfg.OptimConfig(sched=model_cfg.SchedConfig())
+
+    # Model component configs
+    preprocessor: AudioToMelSpectrogramPreprocessorConfig = AudioToMelSpectrogramPreprocessorConfig()
+    spec_augment: Optional[SpectrogramAugmentationConfig] = SpectrogramAugmentationConfig()
+    encoder: Any = ConvASREncoderConfig(activation="relu")
+    decoder: Any = ConvASRDecoderConfig()
+
+
+@dataclass
+class QuartzNet15x5(QuartzNetConfig):
+    # Model global arguments
+    labels: List[str] = MISSING
+
+    # Model component configs
+    preprocessor: AudioToMelSpectrogramPreprocessorConfig = AudioToMelSpectrogramPreprocessorConfig()
+    spec_augment: Optional[SpectrogramAugmentationConfig] = SpectrogramAugmentationConfig(
+        rect_masks=5, rect_freq=50, rect_time=120
+    )
+    encoder: Any = ConvASREncoderConfig(activation="relu")
+    decoder: Any = ConvASRDecoderConfig()
+
+
+def get_qn_15x5_config(labels=MISSING, ):
+    pass
+
+
+if __name__ == '__main__':
+
+    cfg = QuartzNet15x5()
+    print(cfg)

--- a/nemo/collections/asr/models/configs/quartznet_config.py
+++ b/nemo/collections/asr/models/configs/quartznet_config.py
@@ -143,8 +143,8 @@ class QuartzNetConfig(model_cfg.ModelPTConfig):
 @dataclass
 class QuartzNet15x5(QuartzNetConfig):
     # Model global arguments
-    name = 'Quartznet15x5'
-    model = QuartzNetModelConfig(
+    name: str = 'Quartznet15x5'
+    model: QuartzNetModelConfig = QuartzNetModelConfig(
         spec_augment=SpectrogramAugmentationConfig(rect_masks=5, rect_freq=50, rect_time=120),
         encoder=ConvASREncoderConfig(jasper=qn_15x5(), activation="relu"),
         decoder=ConvASRDecoderConfig()

--- a/nemo/collections/asr/models/configs/quartznet_config.py
+++ b/nemo/collections/asr/models/configs/quartznet_config.py
@@ -165,12 +165,12 @@ def jasper_10x5_dr():
 
 
 @dataclass
-class QuartzNetModelConfig(ctc_cfg.EncDecCTCConfig):
+class JasperModelConfig(ctc_cfg.EncDecCTCConfig):
     # Model global arguments
     sample_rate: int = 16000
     repeat: int = 1
     dropout: float = 0.0
-    separable: bool = True
+    separable: bool = False
     labels: List[str] = MISSING
 
     # Dataset configs
@@ -193,8 +193,8 @@ class QuartzNetModelConfig(ctc_cfg.EncDecCTCConfig):
 
 
 @dataclass
-class JasperModelConfig(QuartzNetModelConfig):
-    separable: bool = False
+class QuartzNetModelConfig(JasperModelConfig):
+    separable: bool = True
 
 
 class EncDecCTCModelConfigBuilder(model_cfg.ModelConfigBuilder):

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -602,6 +602,7 @@ class SpectrogramAugmentationConfig:
     rect_masks: int = 0
     rect_time: int = 0
     rect_freq: int = 0
+    rng: Optional[Any] = None  # random.Random() type
 
 
 @dataclass

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -574,6 +574,25 @@ class AudioToMelSpectrogramPreprocessorConfig:
 
 
 @dataclass
+class AudioToMFCCPreprocessorConfig:
+    _target_: str = 'nemo.collections.asr.modules.AudioToMFCCPreprocessor'
+    sample_rate: int = 16000
+    window_size: float = 0.02
+    window_stride: float = 0.01
+    n_window_size: Optional[int] = None
+    n_window_stride: Optional[int] = None
+    window: str = 'hann'
+    n_fft: Optional[int] = None
+    lowfreq: Optional[float] = 0.0
+    highfreq: Optional[float] = None
+    n_mels: int = 64
+    n_mfcc: int = 64
+    dct_type: int = 2
+    norm: str = 'ortho'
+    log: bool = True
+
+
+@dataclass
 class SpectrogramAugmentationConfig:
     _target_: str = "nemo.collections.asr.modules.SpectrogramAugmentation"
     freq_masks: int = 0
@@ -583,3 +602,9 @@ class SpectrogramAugmentationConfig:
     rect_masks: int = 0
     rect_time: int = 0
     rect_freq: int = 0
+
+
+@dataclass
+class CropOrPadSpectrogramAugmentationConfig:
+    audio_length: int
+    _target_: str = "nemo.collections.asr.modules.CropOrPadSpectrogramAugmentation"

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -481,3 +481,13 @@ class ConvASRDecoderConfig:
     num_classes: int = MISSING
     init_mode: Optional[str] = "xavier_uniform"
     vocabulary: Optional[List[str]] = field(default_factory=list)
+
+
+@dataclass
+class ConvASRDecoderClassificationConfig:
+    _target_: str = 'nemo.collections.asr.modules.ConvASRDecoderClassification'
+    feat_in: int = MISSING
+    num_classes: int = MISSING
+    init_mode: Optional[str] = "xavier_uniform",
+    return_logits: bool = True
+    pooling_type: str = 'avg'

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -488,6 +488,6 @@ class ConvASRDecoderClassificationConfig:
     _target_: str = 'nemo.collections.asr.modules.ConvASRDecoderClassification'
     feat_in: int = MISSING
     num_classes: int = MISSING
-    init_mode: Optional[str] = "xavier_uniform",
+    init_mode: Optional[str] = "xavier_uniform"
     return_logits: bool = True
     pooling_type: str = 'avg'

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -471,7 +471,7 @@ class ConvASREncoderConfig:
     norm_groups: int = -1
     conv_mask: bool = True
     frame_splicing: int = 1
-    init_mode: str = "xavier_uniform"
+    init_mode: Optional[str] = "xavier_uniform"
 
 
 @dataclass
@@ -479,5 +479,5 @@ class ConvASRDecoderConfig:
     _target_: str = 'nemo.collections.asr.modules.ConvASRDecoder'
     feat_in: int = MISSING
     num_classes: int = MISSING
-    init_mode: str = "xavier_uniform"
+    init_mode: Optional[str] = "xavier_uniform"
     vocabulary: Optional[List[str]] = field(default_factory=list)

--- a/nemo/core/config/modelPT.py
+++ b/nemo/core/config/modelPT.py
@@ -66,7 +66,6 @@ class NemoConfig:
 
 
 class ModelConfigBuilder:
-
     def __init__(self, model_cfg: ModelConfig):
         self.model_cfg = model_cfg
         self.train_ds_cfg = None
@@ -93,6 +92,7 @@ class ModelConfigBuilder:
         wrapped_cfg = WrappedOptimConfig(name=optim_name, sched=None, **vars(cfg))
 
         if sched_cfg is not None:
+
             @dataclass
             class WrappedSchedConfig(SchedConfig, sched_cfg.__class__):
                 pass
@@ -113,5 +113,3 @@ class ModelConfigBuilder:
         self._finalize_cfg()
 
         return self.model_cfg
-
-

--- a/nemo/core/config/modelPT.py
+++ b/nemo/core/config/modelPT.py
@@ -32,7 +32,7 @@ class SchedConfig:
 @dataclass
 class OptimConfig:
     name: str = MISSING
-    lr: float = MISSING
+    lr: Optional[float] = MISSING
     sched: Optional[SchedConfig] = None
 
 
@@ -64,3 +64,39 @@ class NemoConfig:
     )
     exp_manager: Optional[Any] = exp_manager.ExpManagerConfig()
     hydra: HydraConfig = HydraConfig()
+
+
+class ModelPTConfigBuilder:
+
+    def __init__(self, model_cfg: ModelPTConfig):
+        self.model_cfg = model_cfg
+        self.train_ds_cfg = None
+        self.validation_ds_cfg = None
+        self.test_ds_cfg = None
+        self.optim_cfg = None
+
+    def set_train_ds(self, cfg: Optional[DatasetConfig] = None):
+        self.model_cfg.model.train_ds = cfg
+
+    def set_validation_ds(self, cfg: Optional[DatasetConfig] = None):
+        self.model_cfg.model.validation_ds = cfg
+
+    def set_test_ds(self, cfg: Optional[DatasetConfig] = None):
+        self.model_cfg.model.test_ds = cfg
+
+    def set_optim(self, cfg: OptimConfig, sched_cfg: Optional[SchedConfig] = None):
+        if sched_cfg is not None:
+            cfg.sched = sched_cfg
+
+        self.model_cfg.model.optim = cfg
+
+    def _finalize_cfg(self):
+        raise NotImplementedError()
+
+    def build(self) -> ModelPTConfig:
+        # validate config
+        self._finalize_cfg()
+
+        return self.model_cfg
+
+

--- a/nemo/core/config/modelPT.py
+++ b/nemo/core/config/modelPT.py
@@ -65,9 +65,9 @@ class NemoConfig:
     hydra: HydraConfig = HydraConfig()
 
 
-class ModelPTConfigBuilder:
+class ModelConfigBuilder:
 
-    def __init__(self, model_cfg: ModelPTConfig):
+    def __init__(self, model_cfg: ModelConfig):
         self.model_cfg = model_cfg
         self.train_ds_cfg = None
         self.validation_ds_cfg = None
@@ -75,13 +75,13 @@ class ModelPTConfigBuilder:
         self.optim_cfg = None
 
     def set_train_ds(self, cfg: Optional[DatasetConfig] = None):
-        self.model_cfg.model.train_ds = cfg
+        self.model_cfg.train_ds = cfg
 
     def set_validation_ds(self, cfg: Optional[DatasetConfig] = None):
-        self.model_cfg.model.validation_ds = cfg
+        self.model_cfg.validation_ds = cfg
 
     def set_test_ds(self, cfg: Optional[DatasetConfig] = None):
-        self.model_cfg.model.test_ds = cfg
+        self.model_cfg.test_ds = cfg
 
     def set_optim(self, cfg: OptimConfig, sched_cfg: Optional[SchedConfig] = None):
         @dataclass
@@ -103,12 +103,12 @@ class ModelPTConfigBuilder:
 
             wrapped_cfg.sched = wrapped_sched_cfg
 
-        self.model_cfg.model.optim = wrapped_cfg
+        self.model_cfg.optim = wrapped_cfg
 
     def _finalize_cfg(self):
         raise NotImplementedError()
 
-    def build(self) -> ModelPTConfig:
+    def build(self) -> ModelConfig:
         # validate config
         self._finalize_cfg()
 

--- a/nemo/core/config/modelPT.py
+++ b/nemo/core/config/modelPT.py
@@ -67,6 +67,63 @@ class NemoConfig:
 
 class ModelConfigBuilder:
     def __init__(self, model_cfg: ModelConfig):
+        """
+        Base class for any Model Config Builder.
+
+        A Model Config Builder is a utility class that accepts a ModelConfig dataclass,
+        and via a set of utility methods (that are implemented by the subclassed ModelConfigBuilder),
+        builds a finalized ModelConfig that can be supplied to a NemoModel dataclass as
+        the `model` component.
+
+        Subclasses *must* implement the private method `_finalize_cfg`.
+            Inside this method, they must update `self.model_cfg` with all interdependent config
+            options that need to be set (either updated by user explicitly or with their default value).
+
+            The updated model config must then be preserved in `self.model_cfg`.
+
+        Example:
+            # Create the config builder
+            config_builder = <subclass>ModelConfigBuilder()
+
+            # Update the components of the config that are modifiable
+            config_builder.set_X(X)
+            config_builder.set_Y(Y)
+
+            # Create a "finalized" config dataclass that will contain all the updates
+            # that were specified by the builder
+            model_config = config_builder.build()
+
+            # Use model config as is (or further update values), then create a new Model
+            model = nemo.<domain>.models.<ModelName>Model(cfg=model_config, trainer=Trainer())
+
+        Supported build methods:
+        -   set_train_ds: All model configs can accept a subclass of `DatasetConfig` as their
+                training config. Subclasses can override this method to enable auto-complete
+                by replacing `Optional[DatasetConfif]` with `Optional[<subclass of DatasetConfig>]`.
+
+        -   set_validation_ds: All model configs can accept a subclass of `DatasetConfig` as their
+                validation config. Subclasses can override this method to enable auto-complete
+                by replacing `Optional[DatasetConfif]` with `Optional[<subclass of DatasetConfig>]`.
+
+        -   set_test_ds: All model configs can accept a subclass of `DatasetConfig` as their
+                test config. Subclasses can override this method to enable auto-complete
+                by replacing `Optional[DatasetConfif]` with `Optional[<subclass of DatasetConfig>]`.
+
+        -   set_optim: A build method that supports changes to the Optimizer (and optionally,
+                the Scheduler) used for training the model. The function accepts two inputs -
+
+                `cfg`: A subclass of `OptimizerParams` - any OptimizerParams subclass can be used,
+                    in order to select an appropriate Optimizer. Examples: AdamParams.
+
+                `sched_cfg`: A subclass of `SchedulerParams` - any SchedulerParams subclass can be used,
+                    in order to select an appropriate Scheduler. Examples: CosineAnnealingParams.
+                    Note that this argument is optional.
+
+        Any additional build methods must be added by subclasses of ModelConfigBuilder.
+
+        Args:
+            model_cfg:
+        """
         self.model_cfg = model_cfg
         self.train_ds_cfg = None
         self.validation_ds_cfg = None
@@ -82,7 +139,7 @@ class ModelConfigBuilder:
     def set_test_ds(self, cfg: Optional[DatasetConfig] = None):
         self.model_cfg.test_ds = cfg
 
-    def set_optim(self, cfg: OptimConfig, sched_cfg: Optional[SchedConfig] = None):
+    def set_optim(self, cfg: config.OptimizerParams, sched_cfg: Optional[config.SchedulerParams] = None):
         @dataclass
         class WrappedOptimConfig(OptimConfig, cfg.__class__):
             pass

--- a/nemo/core/config/modelPT.py
+++ b/nemo/core/config/modelPT.py
@@ -99,15 +99,15 @@ class ModelConfigBuilder:
         Supported build methods:
         -   set_train_ds: All model configs can accept a subclass of `DatasetConfig` as their
                 training config. Subclasses can override this method to enable auto-complete
-                by replacing `Optional[DatasetConfif]` with `Optional[<subclass of DatasetConfig>]`.
+                by replacing `Optional[DatasetConfig]` with `Optional[<subclass of DatasetConfig>]`.
 
         -   set_validation_ds: All model configs can accept a subclass of `DatasetConfig` as their
                 validation config. Subclasses can override this method to enable auto-complete
-                by replacing `Optional[DatasetConfif]` with `Optional[<subclass of DatasetConfig>]`.
+                by replacing `Optional[DatasetConfig]` with `Optional[<subclass of DatasetConfig>]`.
 
         -   set_test_ds: All model configs can accept a subclass of `DatasetConfig` as their
                 test config. Subclasses can override this method to enable auto-complete
-                by replacing `Optional[DatasetConfif]` with `Optional[<subclass of DatasetConfig>]`.
+                by replacing `Optional[DatasetConfig]` with `Optional[<subclass of DatasetConfig>]`.
 
         -   set_optim: A build method that supports changes to the Optimizer (and optionally,
                 the Scheduler) used for training the model. The function accepts two inputs -
@@ -118,6 +118,15 @@ class ModelConfigBuilder:
                 `sched_cfg`: A subclass of `SchedulerParams` - any SchedulerParams subclass can be used,
                     in order to select an appropriate Scheduler. Examples: CosineAnnealingParams.
                     Note that this argument is optional.
+
+        -   build(): The method which should return a "finalized" ModelConfig dataclass.
+                Subclasses *should* always override this method, and update the signature
+                of this method with the return type of the Dataclass, so that it enables
+                autocomplete for the user.
+
+                Example:
+                    def build(self) -> EncDecCTCConfig:
+                        return super().build()
 
         Any additional build methods must be added by subclasses of ModelConfigBuilder.
 

--- a/nemo/core/config/optimizers.py
+++ b/nemo/core/config/optimizers.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any, Dict, Optional, Tuple
 
-from omegaconf import OmegaConf, MISSING
+from omegaconf import MISSING, OmegaConf
 
 __all__ = [
     'OptimizerParams',
@@ -38,6 +38,7 @@ class OptimizerParams:
     Base Optimizer params with no values. User can chose it to explicitly override via
     command line arguments
     """
+
     lr: Optional[float] = MISSING
 
 

--- a/nemo/core/config/optimizers.py
+++ b/nemo/core/config/optimizers.py
@@ -38,6 +38,7 @@ class OptimizerParams:
     Base Optimizer params with no values. User can chose it to explicitly override via
     command line arguments
     """
+    lr: Optional[float] = None
 
 
 @dataclass

--- a/nemo/core/config/optimizers.py
+++ b/nemo/core/config/optimizers.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any, Dict, Optional, Tuple
 
-from omegaconf import OmegaConf
+from omegaconf import OmegaConf, MISSING
 
 __all__ = [
     'OptimizerParams',
@@ -38,7 +38,7 @@ class OptimizerParams:
     Base Optimizer params with no values. User can chose it to explicitly override via
     command line arguments
     """
-    lr: Optional[float] = None
+    lr: Optional[float] = MISSING
 
 
 @dataclass

--- a/nemo/core/config/pytorch_lightning.py
+++ b/nemo/core/config/pytorch_lightning.py
@@ -83,6 +83,8 @@ class TrainerConfig:
     amp_backend: str = 'native'
     amp_level: str = 'O2'  # backward compatible, todo: remove in v1.0.0
     enable_pl_optimizer: Optional[bool] = None
+    plugins: Optional[Any] = None  # Optional[Union[str, list]]
+    move_metrics_to_cpu: bool = False
 
 
 # Register the trainer config.

--- a/nemo/utils/config_utils.py
+++ b/nemo/utils/config_utils.py
@@ -237,7 +237,7 @@ def assert_dataclass_signature_match(
 
         class_params = class_params - ignore_args
         dataclass_params = dataclass_params - ignore_args
-        logging.info(f"Removing deprecated arguments - {ignore_args}")
+        logging.info(f"Removing ignored arguments - {ignore_args}")
 
     if len(class_params) != len(dataclass_params):
         logging.error(f"Class {cls.__name__} arguments do not match " f"Dataclass {datacls.__name__}!")

--- a/nemo/utils/config_utils.py
+++ b/nemo/utils/config_utils.py
@@ -36,13 +36,13 @@ def update_model_config(model_cls: NemoConfig, update_cfg: DictConfig, drop_miss
         -   `optim` + nested `sched`.
 
     Args:
-        model_cls: A subclass of ModelPTConfig, that details in entirety all of the parameters that constitute
+        model_cls: A subclass of NemoConfig, that details in entirety all of the parameters that constitute
             the NeMo Model.
 
-        update_cfg: A DictConfig that mirrors the structure of the ModelPTConfig data class. Used to update the
+        update_cfg: A DictConfig that mirrors the structure of the NemoConfig data class. Used to update the
             default values of the config class.
 
-        drop_missing_subconfigs: Bool which determins whether to drop certain sub-configs from the ModelPTConfig
+        drop_missing_subconfigs: Bool which determins whether to drop certain sub-configs from the NemoConfig
             class, if the corresponding sub-config is missing from `update_cfg`.
 
     Returns:
@@ -92,7 +92,7 @@ def _update_subconfig(
     model_cfg: DictConfig, update_cfg: DictConfig, subconfig_key: str, drop_missing_subconfigs: bool
 ):
     """
-    Updates the ModelPTConfig DictConfig such that:
+    Updates the NemoConfig DictConfig such that:
     1)  If the sub-config key exists in the `update_cfg`, but does not exist in ModelPT config:
         - Add the sub-config from update_cfg to ModelPT config
 
@@ -100,14 +100,14 @@ def _update_subconfig(
         - Remove the sub-config from the ModelPT config; iff the `drop_missing_subconfigs` flag is set.
 
     Args:
-        model_cfg: A DictConfig instantiated from the ModelPTConfig subclass.
+        model_cfg: A DictConfig instantiated from the NemoConfig subclass.
         update_cfg: A DictConfig that mirrors the structure of `model_cfg`, used to update its default values.
         subconfig_key: A str key used to check and update the sub-config.
-        drop_missing_subconfigs: A bool flag, whether to allow deletion of the ModelPTConfig sub-config,
+        drop_missing_subconfigs: A bool flag, whether to allow deletion of the NemoConfig sub-config,
             if its mirror sub-config does not exist in the `update_cfg`.
 
     Returns:
-        The updated DictConfig for the ModelPTConfig
+        The updated DictConfig for the NemoConfig
     """
     with open_dict(model_cfg.model):
         # If update config has the key, but model cfg doesnt have the key
@@ -126,7 +126,7 @@ def _update_subconfig(
 
 def _add_subconfig_keys(model_cfg: DictConfig, update_cfg: DictConfig, subconfig_key: str):
     """
-    For certain sub-configs, the default values specified by the ModelPTConfig class is insufficient.
+    For certain sub-configs, the default values specified by the NemoConfig class is insufficient.
     In order to support every potential value in the merge between the `update_cfg`, it would require
     explicit definition of all possible cases.
 
@@ -139,13 +139,13 @@ def _add_subconfig_keys(model_cfg: DictConfig, update_cfg: DictConfig, subconfig
 
     In order to enable the merge, we first need to update the update sub-config to incorporate the keys,
     with dummy temporary values (merge update config with model config). This is done on a copy of the
-    update sub-config, as the actual override values might be overriden by the ModelPTConfig defaults.
+    update sub-config, as the actual override values might be overriden by the NemoConfig defaults.
 
     Then we perform a merge of this temporary sub-config with the actual override config in a later step
     (merge model_cfg with original update_cfg, done outside this function).
 
     Args:
-        model_cfg: A DictConfig instantiated from the ModelPTConfig subclass.
+        model_cfg: A DictConfig instantiated from the NemoConfig subclass.
         update_cfg: A DictConfig that mirrors the structure of `model_cfg`, used to update its default values.
         subconfig_key: A str key used to check and update the sub-config.
 

--- a/nemo/utils/config_utils.py
+++ b/nemo/utils/config_utils.py
@@ -13,11 +13,14 @@
 # limitations under the License.
 
 import copy
+import inspect
 from dataclasses import is_dataclass
+from typing import Dict, List, Optional
 
 from omegaconf import DictConfig, OmegaConf, open_dict
 
 from nemo.core.config.modelPT import NemoConfig
+from nemo.utils import logging
 
 
 def update_model_config(model_cls: NemoConfig, update_cfg: DictConfig, drop_missing_subconfigs: bool = True):
@@ -168,3 +171,88 @@ def _add_subconfig_keys(model_cfg: DictConfig, update_cfg: DictConfig, subconfig
             model_cfg.model[subconfig_key] = subconfig
 
     return model_cfg
+
+
+def assert_dataclass_signature_match(
+    cls: 'class_type',
+    datacls: 'dataclass',
+    ignore_args: Optional[List[str]] = None,
+    remap_args: Optional[Dict[str, str]] = None,
+):
+    """
+    Analyses the signature of a provided class and its respective data class,
+    asserting that the dataclass signature matches the class __init__ signature.
+
+    Note:
+        This is not a value based check. This function only checks if all argument
+        names exist on both class and dataclass and logs mismatches.
+
+    Args:
+        cls: Any class type - but not an instance of a class. Pass type(x) where x is an instance
+            if class type is not easily available.
+        datacls: A corresponding dataclass for the above class.
+        ignore_args: (Optional) A list of string argument names which are forcibly ignored,
+            even if mismatched in the signature. Useful when a dataclass is a superset of the
+            arguments of a class.
+        remap_args: (Optional) A dictionary, mapping an argument name that exists (in either the
+            class or its dataclass), to another name. Useful when argument names are mismatched between
+            a class and its dataclass due to indirect instantiation via a helper method.
+
+    Returns:
+        A tuple containing information about the analysis:
+        1) A bool value which is True if the signatures matched exactly / after ignoring values.
+            False otherwise.
+        2) A set of arguments names that exist in the class, but *do not* exist in the dataclass.
+            If exact signature match occurs, this will be None instead.
+        3) A set of argument names that exist in the data class, but *do not* exist in the class itself.
+            If exact signature match occurs, this will be None instead.
+    """
+    class_sig = inspect.signature(cls.__init__)
+
+    class_params = dict(**class_sig.parameters)
+    class_params.pop('self')
+
+    dataclass_sig = inspect.signature(datacls)
+
+    dataclass_params = dict(**dataclass_sig.parameters)
+    dataclass_params.pop("_target_", None)
+
+    class_params = set(class_params.keys())
+    dataclass_params = set(dataclass_params.keys())
+
+    if remap_args is not None:
+        for original_arg, new_arg in remap_args.items():
+            if original_arg in class_params:
+                class_params.remove(original_arg)
+                class_params.add(new_arg)
+                logging.info(f"Remapped {original_arg} -> {new_arg} in {cls.__name__}")
+
+            if original_arg in dataclass_params:
+                dataclass_params.remove(original_arg)
+                dataclass_params.add(new_arg)
+                logging.info(f"Remapped {original_arg} -> {new_arg} in {datacls.__name__}")
+
+    if ignore_args is not None:
+        ignore_args = set(ignore_args)
+
+        class_params = class_params - ignore_args
+        dataclass_params = dataclass_params - ignore_args
+        logging.info(f"Removing deprecated arguments - {ignore_args}")
+
+    if len(class_params) != len(dataclass_params):
+        logging.error(f"Class {cls.__name__} arguments do not match " f"Dataclass {datacls.__name__}!")
+
+        intersection = set.intersection(class_params, dataclass_params)
+        subset_cls = class_params - intersection
+        subset_datacls = dataclass_params - intersection
+
+        if len(subset_cls) > 0:
+            logging.error(f"Class {cls.__name__} has additional arguments :\n" f"{subset_cls}")
+
+        if len(subset_datacls):
+            logging.error(f"Dataclass {datacls.__name__} has additional arguments :\n{subset_datacls}")
+
+        return False, subset_cls, subset_datacls
+
+    else:
+        return True, None, None

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -343,12 +343,12 @@ def wrap_training_step(wrapped, instance: pl.LightningModule, args, kwargs):
     return output_dict
 
 
-def convert_model_config_to_dict_config(cfg: Union[DictConfig, 'ModelPTConfig']) -> DictConfig:
+def convert_model_config_to_dict_config(cfg: Union[DictConfig, 'NemoConfig']) -> DictConfig:
     """
     Converts its input into a standard DictConfig.
     Possible input values are:
     -   DictConfig
-    -   A dataclass which is a subclass of ModelPTConfig
+    -   A dataclass which is a subclass of NemoConfig
 
     Args:
         cfg: A dict-like object.

--- a/tests/collections/asr/test_asr_classification_model.py
+++ b/tests/collections/asr/test_asr_classification_model.py
@@ -19,7 +19,9 @@ import pytest
 import torch
 from omegaconf import DictConfig, ListConfig
 
-from nemo.collections.asr.models import EncDecClassificationModel
+from nemo.collections.asr.data import audio_to_label
+from nemo.collections.asr.models import EncDecClassificationModel, configs
+from nemo.utils.config_utils import assert_dataclass_signature_match
 
 
 @pytest.fixture()
@@ -167,3 +169,40 @@ class TestEncDecClassificationModel:
         results = model.transcribe(audio_paths, batch_size=2, logprobs=True)
         assert len(results) == 2
         assert results[0].shape == torch.Size([len(model.cfg.labels)])
+
+    @pytest.mark.unit
+    def test_EncDecClassificationDatasetConfig_for_AudioToSpeechLabelDataSet(self):
+        # ignore some additional arguments as dataclass is generic
+        IGNORE_ARGS = [
+            'is_tarred',
+            'num_workers',
+            'batch_size',
+            'tarred_audio_filepaths',
+            'shuffle',
+            'pin_memory',
+            'drop_last',
+            'tarred_shard_strategy',
+            'shuffle_n',
+            # `featurizer` is supplied at runtime
+            'featurizer',
+            # additional ignored arguments
+            'vad_stream',
+            'int_values',
+            'sample_rate',
+            'normalize_audio',
+            'augmentor',
+        ]
+
+        REMAP_ARGS = {'trim_silence': 'trim'}
+
+        result = assert_dataclass_signature_match(
+            audio_to_label.AudioToSpeechLabelDataSet,
+            configs.EncDecClassificationDatasetConfig,
+            ignore_args=IGNORE_ARGS,
+            remap_args=REMAP_ARGS,
+        )
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None

--- a/tests/collections/asr/test_asr_ctc_encoder_model_bpe.py
+++ b/tests/collections/asr/test_asr_ctc_encoder_model_bpe.py
@@ -21,7 +21,10 @@ import pytest
 import torch
 from omegaconf import DictConfig
 
+from nemo.collections.asr.data import audio_to_text
+from nemo.collections.asr.models import configs
 from nemo.collections.asr.models.ctc_bpe_models import EncDecCTCModelBPE
+from nemo.utils.config_utils import assert_dataclass_signature_match
 
 
 @pytest.fixture()
@@ -211,3 +214,81 @@ class TestEncDecCTCModel:
 
             finally:
                 os.rename(old_tokenizer_dir + '.bkp', old_tokenizer_dir)
+
+    @pytest.mark.unit
+    def test_EncDecCTCDatasetConfig_for_AudioToBPEDataset(self):
+        # ignore some additional arguments as dataclass is generic
+        IGNORE_ARGS = [
+            'is_tarred',
+            'num_workers',
+            'batch_size',
+            'tarred_audio_filepaths',
+            'shuffle',
+            'pin_memory',
+            'drop_last',
+            'tarred_shard_strategy',
+            'shuffle_n',
+            'parser',
+            'normalize',
+            'unk_index',
+            'pad_id',
+            'bos_id',
+            'eos_id',
+            'blank_index',
+        ]
+
+        REMAP_ARGS = {'trim_silence': 'trim', 'labels': 'tokenizer'}
+
+        result = assert_dataclass_signature_match(
+            audio_to_text.AudioToBPEDataset,
+            configs.EncDecCTCDatasetConfig,
+            ignore_args=IGNORE_ARGS,
+            remap_args=REMAP_ARGS,
+        )
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None
+
+    @pytest.mark.unit
+    def test_EncDecCTCDatasetConfig_for_TarredAudioToBPEDataset(self):
+        # ignore some additional arguments as dataclass is generic
+        IGNORE_ARGS = [
+            'is_tarred',
+            'num_workers',
+            'batch_size',
+            'shuffle',
+            'pin_memory',
+            'drop_last',
+            'parser',
+            'normalize',
+            'unk_index',
+            'pad_id',
+            'bos_id',
+            'eos_id',
+            'blank_index',
+            'global_rank',
+            'world_size',
+            'load_audio',
+        ]
+
+        REMAP_ARGS = {
+            'trim_silence': 'trim',
+            'tarred_audio_filepaths': 'audio_tar_filepaths',
+            'tarred_shard_strategy': 'shard_strategy',
+            'shuffle_n': 'shuffle',
+            'labels': 'tokenizer',
+        }
+
+        result = assert_dataclass_signature_match(
+            audio_to_text.TarredAudioToBPEDataset,
+            configs.EncDecCTCDatasetConfig,
+            ignore_args=IGNORE_ARGS,
+            remap_args=REMAP_ARGS,
+        )
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None

--- a/tests/collections/asr/test_asr_ctcencdec_model.py
+++ b/tests/collections/asr/test_asr_ctcencdec_model.py
@@ -18,8 +18,9 @@ import torch
 from omegaconf import DictConfig, OmegaConf, open_dict
 
 import nemo.collections.asr as nemo_asr
+from nemo.collections.asr.data import audio_to_text
 from nemo.collections.asr.models import EncDecCTCModel, configs
-from nemo.utils.config_utils import update_model_config
+from nemo.utils.config_utils import assert_dataclass_signature_match, update_model_config
 
 
 @pytest.fixture()
@@ -211,3 +212,68 @@ class TestEncDecCTCModel:
 
         assert new_model.num_weights == asr_model.num_weights
         # trainer and exp manager should be there
+
+    @pytest.mark.unit
+    def test_EncDecCTCDatasetConfig_for_AudioToCharDataset(self):
+        # ignore some additional arguments as dataclass is generic
+        IGNORE_ARGS = [
+            'is_tarred',
+            'num_workers',
+            'batch_size',
+            'tarred_audio_filepaths',
+            'shuffle',
+            'pin_memory',
+            'drop_last',
+            'tarred_shard_strategy',
+            'shuffle_n',
+            'use_start_end_token',
+            'load_audio',
+            'use_start_end_token',
+        ]
+
+        REMAP_ARGS = {'trim_silence': 'trim'}
+
+        result = assert_dataclass_signature_match(
+            audio_to_text.AudioToCharDataset,
+            configs.EncDecCTCDatasetConfig,
+            ignore_args=IGNORE_ARGS,
+            remap_args=REMAP_ARGS,
+        )
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None
+
+    @pytest.mark.unit
+    def test_EncDecCTCDatasetConfig_for_TarredAudioToCharDataset(self):
+        # ignore some additional arguments as dataclass is generic
+        IGNORE_ARGS = [
+            'is_tarred',
+            'num_workers',
+            'batch_size',
+            'shuffle',
+            'pin_memory',
+            'drop_last',
+            'global_rank',
+            'world_size',
+        ]
+
+        REMAP_ARGS = {
+            'trim_silence': 'trim',
+            'tarred_audio_filepaths': 'audio_tar_filepaths',
+            'tarred_shard_strategy': 'shard_strategy',
+            'shuffle_n': 'shuffle',
+        }
+
+        result = assert_dataclass_signature_match(
+            audio_to_text.TarredAudioToCharDataset,
+            configs.EncDecCTCDatasetConfig,
+            ignore_args=IGNORE_ARGS,
+            remap_args=REMAP_ARGS,
+        )
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None

--- a/tests/collections/asr/test_asr_ctcencdec_model.py
+++ b/tests/collections/asr/test_asr_ctcencdec_model.py
@@ -257,6 +257,8 @@ class TestEncDecCTCModel:
             'drop_last',
             'global_rank',
             'world_size',
+            'use_start_end_token',
+            'load_audio'
         ]
 
         REMAP_ARGS = {

--- a/tests/collections/asr/test_asr_ctcencdec_model.py
+++ b/tests/collections/asr/test_asr_ctcencdec_model.py
@@ -258,7 +258,7 @@ class TestEncDecCTCModel:
             'global_rank',
             'world_size',
             'use_start_end_token',
-            'load_audio'
+            'load_audio',
         ]
 
         REMAP_ARGS = {

--- a/tests/collections/asr/test_asr_modules.py
+++ b/tests/collections/asr/test_asr_modules.py
@@ -18,6 +18,7 @@ from omegaconf import OmegaConf
 
 from nemo.collections.asr import modules
 from nemo.collections.asr.parts.rnnt_utils import Hypothesis
+from nemo.utils import config_utils
 
 
 class TestASRModulesBasicTests:
@@ -44,6 +45,19 @@ class TestASRModulesBasicTests:
             assert diff <= 1e-3
             diff = torch.max(torch.abs(res1 - res2))
             assert diff <= 1e-2
+
+    @pytest.mark.unit
+    def test_AudioToMelSpectrogramPreprocessor_config(self):
+        # Test that dataclass matches signature of module
+        result = config_utils.assert_dataclass_signature_match(
+            modules.AudioToMelSpectrogramPreprocessor,
+            modules.audio_preprocessing.AudioToMelSpectrogramPreprocessorConfig,
+        )
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None
 
     @pytest.mark.unit
     def test_AudioToMelSpectrogramPreprocessor_batch(self):
@@ -112,6 +126,18 @@ class TestASRModulesBasicTests:
         assert res.shape == res0[0].shape
 
     @pytest.mark.unit
+    def test_SpectrogramAugmentationr_config(self):
+        # Test that dataclass matches signature of module
+        result = config_utils.assert_dataclass_signature_match(
+            modules.SpectrogramAugmentation, modules.audio_preprocessing.SpectrogramAugmentationConfig,
+        )
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None
+
+    @pytest.mark.unit
     def test_CropOrPadSpectrogramAugmentation(self):
         # Make sure constructor works
         audio_length = 128
@@ -127,6 +153,19 @@ class TestASRModulesBasicTests:
 
         assert res.shape == torch.Size([4, 64, audio_length])
         assert all(new_length == torch.tensor([128] * 4))
+
+    @pytest.mark.unit
+    def test_CropOrPadSpectrogramAugmentation_config(self):
+        # Test that dataclass matches signature of module
+        result = config_utils.assert_dataclass_signature_match(
+            modules.CropOrPadSpectrogramAugmentation,
+            modules.audio_preprocessing.CropOrPadSpectrogramAugmentationConfig,
+        )
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None
 
     @pytest.mark.unit
     def test_RNNTDecoder(self):

--- a/tests/core/test_config_utils.py
+++ b/tests/core/test_config_utils.py
@@ -81,16 +81,32 @@ class TestConfigUtils:
         assert len(dataclass_subset) > 0
 
     @pytest.mark.unit
-    def test_extra_args_exist_but_is_deprecated(self, cls):
+    def test_extra_args_exist_but_is_ignored(self, cls):
         @dataclass
         class DummyDataClass:
             a: int = -1
             b: int = 5
             c: int = 0
             d: Any = None
-            e: float = 0.0  # Assume deprecated
+            e: float = 0.0  # Assume ignored
 
         result = config_utils.assert_dataclass_signature_match(cls, DummyDataClass, ignore_args=['e'])
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None
+
+    @pytest.mark.unit
+    def test_args_exist_but_is_remapped(self, cls):
+        @dataclass
+        class DummyDataClass:
+            a: int = -1
+            b: int = 5
+            c: int = 0
+            e: Any = None  # Assume remapped
+
+        result = config_utils.assert_dataclass_signature_match(cls, DummyDataClass, remap_args={'e': 'd'})
         signatures_match, cls_subset, dataclass_subset = result
 
         assert signatures_match

--- a/tests/core/test_config_utils.py
+++ b/tests/core/test_config_utils.py
@@ -1,0 +1,109 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+import pytorch_lightning as ptl
+
+from nemo.core.config.pytorch_lightning import TrainerConfig
+from nemo.utils import config_utils
+
+
+@pytest.fixture()
+def cls():
+    class DummyClass:
+        def __init__(self, a, b=5, c: int = 0, d: 'ABC' = None):
+            pass
+
+    return DummyClass
+
+
+class TestConfigUtils:
+    @pytest.mark.unit
+    def test_all_args_exist(self, cls):
+        @dataclass
+        class DummyDataClass:
+            a: int = -1
+            b: int = 5
+            c: int = 0
+            d: Any = None
+
+        result = config_utils.assert_dataclass_signature_match(cls, DummyDataClass)
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None
+
+    @pytest.mark.unit
+    def test_all_args_dont_exist(self, cls):
+        @dataclass
+        class DummyDataClass:
+            a: int = -1
+            b: int = 5
+            c: int = 0
+
+        result = config_utils.assert_dataclass_signature_match(cls, DummyDataClass)
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert not signatures_match
+        assert len(cls_subset) > 0
+        assert len(dataclass_subset) == 0
+
+    @pytest.mark.unit
+    def test_extra_args_exist(self, cls):
+        @dataclass
+        class DummyDataClass:
+            a: int = -1
+            b: int = 5
+            c: int = 0
+            d: Any = None
+            e: float = 0.0
+
+        result = config_utils.assert_dataclass_signature_match(cls, DummyDataClass)
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert not signatures_match
+        assert len(cls_subset) == 0
+        assert len(dataclass_subset) > 0
+
+    @pytest.mark.unit
+    def test_extra_args_exist_but_is_deprecated(self, cls):
+        @dataclass
+        class DummyDataClass:
+            a: int = -1
+            b: int = 5
+            c: int = 0
+            d: Any = None
+            e: float = 0.0  # Assume deprecated
+
+        result = config_utils.assert_dataclass_signature_match(cls, DummyDataClass, ignore_args=['e'])
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None
+
+    @pytest.mark.unit
+    def test_ptl_config(self):
+        PTL_DEPRECATED = ['distributed_backend', 'automatic_optimization']
+
+        result = config_utils.assert_dataclass_signature_match(ptl.Trainer, TrainerConfig, ignore_args=PTL_DEPRECATED)
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None


### PR DESCRIPTION
# Changelog
- Adds nearly concrete implementations of dataclasses for QuartzNet 15x5, Jasper 10x5-DR and MatchboxNet-3x1x64 and VAD modes.
- Adds *ConfigBuilder class supporting the construction of arbitrarily complex interdependencies between sub-configs
- Adds various dataclasses for ASR datasets + ASR Classification datasets
- Adds core support for class-dataclass testing