### PR TITLE
Waveglow ONNX->TRT conversion, TRT working now

### DIFF
--- a/examples/tts/test_tts_infer.py
+++ b/examples/tts/test_tts_infer.py
@@ -21,6 +21,7 @@ from math import ceil
 from pathlib import Path
 
 import librosa
+import soundfile
 import torch
 
 from nemo.collections.asr.metrics.wer import word_error_rate
@@ -133,7 +134,7 @@ def main():
         aud = aud.cpu().numpy()
         if args.trim:
             aud = librosa.effects.trim(aud, top_db=40)[0]
-        librosa.output.write_wav(f"{i}.wav", aud, sr=22050)
+        soundfile.write(f"{i}.wav", aud, samplerate=22050)
         audio_file_paths.append(str(Path(f"{i}.wav")))
 
     # Do ASR

--- a/nemo/collections/tts/modules/submodules.py
+++ b/nemo/collections/tts/modules/submodules.py
@@ -187,7 +187,7 @@ class Invertible1x1Conv(torch.nn.Module):
 
     def __init__(self, c):
         super().__init__()
-        self.conv = torch.nn.Conv1d(c, c, kernel_size=1)
+        self.conv = torch.nn.Conv1d(c, c, kernel_size=1, bias=False)
 
         # Sample a random orthonormal matrix to initialize weights
         W = torch.qr(torch.FloatTensor(c, c).normal_())[0]
@@ -207,7 +207,9 @@ class Invertible1x1Conv(torch.nn.Module):
                 # Inverse convolution - initialized here only for backwards
                 # compatibility with weights from existing checkpoints.
                 # Should be moved to init() with next incompatible change.
-                self.inv_conv = torch.nn.Conv1d(self.conv.in_channels, self.conv.out_channels, kernel_size=1)
+                self.inv_conv = torch.nn.Conv1d(
+                    self.conv.in_channels, self.conv.out_channels, kernel_size=1, bias=False
+                )
                 self.inv_conv.weight.data = self.W_inverse
                 self.inv_conv.to(device=self.conv.weight.device, dtype=self.conv.weight.dtype)
             return self.inv_conv(z)

--- a/nemo/collections/tts/modules/waveglow.py
+++ b/nemo/collections/tts/modules/waveglow.py
@@ -84,7 +84,7 @@ class WaveGlowModule(NeuralModule, Exportable):
                 )
             )
         self.n_remaining_channels = n_remaining_channels
-        self.removed_weightnorm = False
+        self.time_cutoff = self.upsample.kernel_size[0] - self.upsample.stride[0]
 
         # Pre-calculating the sizes of noise to use so it's not dynamic
         n_halves = []
@@ -96,12 +96,16 @@ class WaveGlowModule(NeuralModule, Exportable):
         n_halves.reverse()
         self.n_halves = n_halves
 
+        self.removed_weightnorm = False
+        self.converted_to_2D = False
+
     def _prepare_for_export(self):
         """
         Override this method to prepare module for export. This is in-place operation.
         Base version does common necessary module replacements (Apex etc)
         """
-        super()._prepare_for_export(replace_1D_2D=False)
+        super()._prepare_for_export(replace_1D_2D=True)
+        self.converted_to_2D = True
         self.remove_weightnorm()
 
     @typecheck()
@@ -204,39 +208,50 @@ class WaveGlowModule(NeuralModule, Exportable):
         return torch.cat(output_audio, 1), log_s_list, log_det_W_list
 
     def norm_dist_to_audio(self, *, spec, z=None, sigma: float = 1.0):
+        if self.converted_to_2D:
+            spec = torch.unsqueeze(spec, 3)
         spec = self.upsample(spec)
+        spec = spec.contiguous().view(spec.size(0), spec.size(1), -1)
         # trim conv artifacts. maybe pad spec to kernel multiple
-        time_cutoff = self.upsample.kernel_size[0] - self.upsample.stride[0]
-        spec = spec[:, :, :-time_cutoff]
+        if self.time_cutoff > 0:
+            spec = spec[:, :, : -self.time_cutoff]
 
         spec = spec.unfold(2, self.n_group, self.n_group).permute(0, 2, 1, 3)
         spec = spec.contiguous().view(spec.size(0), spec.size(1), -1)
         spec = spec.permute(0, 2, 1)
 
-        z_size = torch.Size([spec.size(0), spec.size(1) // self.n_group, spec.size(2)])
+        spec_size = spec.size()
+        z_size = torch.Size([spec.size(0), self.n_group, spec.size(2)])
         if z is None:
             z = sigma * torch.randn(z_size, device=spec.device).to(spec.dtype)
         else:
             assert z.size() == z_size, f"Size of z ({z.size()}) != expected ({z_size})"
 
-        audio = z[:, : self.n_remaining_channels, :]
-        z = z[:, self.n_remaining_channels :, :]
+        if self.converted_to_2D:
+            z = torch.unsqueeze(z, 3)
+            spec = torch.unsqueeze(spec, 3)
+
+        audio, z = torch.split(z, [self.n_remaining_channels, self.n_group - self.n_remaining_channels], 1)
 
         for k in reversed(range(self.n_flows)):
             n_half = self.n_halves[k]
-            audio_0 = audio[:, :n_half, :]
-            audio_1 = audio[:, n_half:, :]
+            audio_0, audio_1 = torch.split(audio, [n_half, audio.size(1) - n_half], 1)
 
             output = self.wavenet[k]((audio_0, spec))
-            s = output[:, n_half:, :]
-            b = output[:, :n_half, :]
-            audio_1 = (audio_1 - b) / torch.exp(s)
+
+            b, s = torch.split(output, [n_half, output.size(1) - n_half], 1)
+
+            audio_1 = audio_1 - b
+            audio_1 = audio_1 / torch.exp(s)
             audio = torch.cat((audio_0, audio_1), 1)
 
             audio = self.convinv[k](audio, reverse=True)
             if k % self.n_early_every == 0 and k > 0:
-                audio = torch.cat((z[:, : self.n_early_size, :], audio), 1)
-                z = z[:, self.n_early_size :, :]
+                z1, z = torch.split(z, [self.n_early_size, z.size(1) - self.n_early_size], 1)
+                audio = torch.cat((z1, audio), 1)
+
+        if self.converted_to_2D:
+            audio = audio.view(audio.size(0), audio.size(1), -1)
         return audio.permute(0, 2, 1).contiguous().view(audio.size(0), -1)
 
     def remove_weightnorm(self):

--- a/nemo/core/classes/exportable.py
+++ b/nemo/core/classes/exportable.py
@@ -139,7 +139,7 @@ class Exportable(ABC):
                 if isinstance(_in_example, Dict):
                     _in_example = tuple(_in_example.values())
 
-                if format == ExportFormat.TORCHSCRIPT or try_script:
+                if format == ExportFormat.TORCHSCRIPT:
                     if jitted_model is None:
                         jitted_model = torch.jit.trace(
                             self,
@@ -154,7 +154,7 @@ class Exportable(ABC):
                         jitted_model.save(output)
                         assert os.path.exists(output)
 
-                if format == ExportFormat.ONNX:
+                elif format == ExportFormat.ONNX:
                     if jitted_model is None:
                         jitted_model = self
                     if _out_example is None:

--- a/tests/collections/tts/test_waveglow.py
+++ b/tests/collections/tts/test_waveglow.py
@@ -94,7 +94,7 @@ class TestWaveGlow:
                 try_script=False,
                 check_trace=False,
                 do_constant_folding=True,
-                use_dynamic_axes=True,
+                use_dynamic_axes=False,
             )
 
             try:

--- a/tests/collections/tts/test_waveglow.py
+++ b/tests/collections/tts/test_waveglow.py
@@ -24,6 +24,15 @@ from omegaconf import DictConfig
 from nemo.collections.tts.models import WaveGlowModel
 from nemo.collections.tts.modules import WaveGlowModule
 
+try:
+    import tensorrt as trt
+
+    print("TRT is available!\n")
+    trt_available = True
+except Exception as e:
+    print("TRT is not available!\n")
+    trt_available = False
+
 mcfg = DictConfig(
     {
         "_target_": "nemo.collections.tts.modules.waveglow.WaveGlowModule",
@@ -50,16 +59,24 @@ pcfg = DictConfig(
 wcfg = DictConfig({"waveglow": mcfg, "sigma": 1.0, "preprocessor": pcfg,})
 
 
+def input_example(sz):
+    mel = torch.randn(1, 80, sz).cuda()  # .half()
+    z = torch.randn(1, 80, sz * 256 // 8).cuda()  # .half()
+    return {"spec": mel, "z": z}
+
+
 class TestWaveGlow:
     @pytest.mark.run_only_on('GPU')
     @pytest.mark.unit
     def test_export_to_onnx(self):
-        model = WaveGlowModel(wcfg).cuda().half()
+        model = WaveGlowModel(wcfg).cuda()  # .half()
         with tempfile.TemporaryDirectory() as tmpdir, model.nemo_infer():
             # Generate filename in the temporary directory.
             tmp_file_name = os.path.join("waveglow.onnx")
+
             # Test export.
-            inp = model.waveglow.input_example()
+            inp = input_example(32)
+
             inp2 = inp
             inp3 = inp2
             res1 = model.waveglow(**inp)
@@ -72,6 +89,8 @@ class TestWaveGlow:
                 output_example=res1,
                 try_script=False,
                 check_trace=False,
+                do_constant_folding=False,
+                use_dynamic_axes=False,
             )
 
             try:
@@ -85,3 +104,56 @@ class TestWaveGlow:
                 sess = onnxruntime.InferenceSession(omodel.SerializeToString())
                 output = sess.run(None, {"spec": inp["spec"].cpu().numpy(), "z": inp["z"].cpu().numpy()})[0]
                 assert torch.allclose(torch.from_numpy(output), res2.cpu(), rtol=0.01, atol=0.1)
+
+            if trt_available:
+                opt_profiles = [
+                    [
+                        {"input": "spec", "min": (1, 80, 32), "opt": (1, 80, 32), "max": (1, 80, 32)},
+                        {
+                            "input": "z",
+                            "min": (1, 80, 32 * 256 // 8),
+                            "opt": (1, 80, 32 * 256 // 8),
+                            "max": (1, 80, 32 * 256 // 8),
+                        },
+                    ]
+                ]
+
+                engine = build_trt_engine_from_onnx(tmp_file_name, opt_profiles)
+                assert engine is not None
+                engine.serialize(tmp_file_name + ".trt")
+
+
+def build_trt_engine_from_onnx(onnx_path, opt_profiles, verbose=False):
+    """Builds TRT engine from an ONNX file
+		"""
+    TRT_LOGGER = trt.Logger(trt.Logger.VERBOSE) if verbose else trt.Logger(trt.Logger.WARNING)
+    builder = trt.Builder(TRT_LOGGER)
+    builder.max_batch_size = 128
+
+    with open(onnx_path, 'rb') as model_fh:
+        model = model_fh.read()
+        model_onnx = onnx.load_model_from_string(model)
+
+    if True:  # self.model.args.fp16:
+        builder.fp16_mode = True
+        config_flags = 1 << int(trt.BuilderFlag.FP16)  # | 1 << int(trt.BuilderFlag.STRICT_TYPES)
+    else:
+        config_flags = 0
+    builder.max_workspace_size = 8 * 1024 * 1024 * 1024
+
+    config = builder.create_builder_config()
+    config.flags = config_flags
+
+    for x in opt_profiles:
+        profile = builder.create_optimization_profile()
+        for p in x:
+            profile.set_shape(**p)
+        config.add_optimization_profile(profile)
+
+    explicit_batch = 1 << (int)(trt.NetworkDefinitionCreationFlag.EXPLICIT_BATCH)
+    network = builder.create_network(explicit_batch)
+
+    with trt.OnnxParser(network, TRT_LOGGER) as parser:
+        parsed = parser.parse(model)
+        print(f"Parsing returned {parsed}, building TRT engine ...")
+        return builder.build_engine(network, config=config)


### PR DESCRIPTION
 I can build TRT from ONNX now after 1D->2D conversion. Please pull from the last branch.
To get the real ONNX built, run test_waveglow.py (without pytest), after uncommenting this line:

model = WaveGlowModel.restore_from(“../WaveGlow-22050Hz-268M.nemo”) 
(place .nemo accordingly).  
There is also sample TRT build routine there - but whatever you used before should work as well.
This PR does contain a number of cleanups, plumbing and fixes.