### PR TITLE
fix eval_model in IntentSlot tutorial

### DIFF
--- a/tutorials/nlp/Joint_Intent_and_Slot_Classification.ipynb
+++ b/tutorials/nlp/Joint_Intent_and_Slot_Classification.ipynb
@@ -505,7 +505,7 @@
     "eval_model.setup_test_data(test_data_config=config.model.test_ds)\n",
     "\n",
     "# run the evaluation on the test dataset\n",
-    "trainer.test(model=model, ckpt_path=None, verbose=False)"
+    "trainer.test(model=eval_model, ckpt_path=None, verbose=False)"
    ]
   },
   {


### PR DESCRIPTION
Ensures the reloaded (best) model is used for evaluation as intended.