### PR TITLE
added deps on new versions of packages

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -12,3 +12,5 @@ hydra-core>=1.0.4
 transformers>=4.0.1
 sentencepiece<1.0.0
 webdataset
+nvidia-eff>=0.2.5
+onnx-graphsurgeon>=0.2.7


### PR DESCRIPTION
Dependencies on new NVDIA PyPI packages.

Note: This will work "outside" once the new wheels will be distributed.