### PR TITLE
Add test stage to setup to finish megatron init

### DIFF
--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -305,3 +305,8 @@ class NLPModel(ModelPT):
                 if isinstance(self.bert_model, MegatronBertEncoder):
                     # finish megatron-lm initialization
                     self.bert_model._lazy_init_fn()
+        else:
+            # testing stage
+            if isinstance(self.bert_model, MegatronBertEncoder):
+                # finish megatron-lm initialization
+                self.bert_model._lazy_init_fn()


### PR DESCRIPTION
If only trainer.test was being called then megatron was not finishing it's init.

This should fix this issue: https://github.com/NVIDIA/NeMo/issues/1700

