### PR TITLE
Add support for computing CTC / RNNT alignments

### DIFF
--- a/nemo/collections/asr/metrics/rnnt_wer.py
+++ b/nemo/collections/asr/metrics/rnnt_wer.py
@@ -95,7 +95,7 @@ class AbstractRNNTDecoding(ABC):
                 joint_model=joint,
                 blank_index=self.blank_id,
                 max_symbols_per_step=self.cfg.greedy.get('max_symbols', None),
-                preserve_logprobs=self.cfg.greedy.get('preserve_logprobs', False),
+                preserve_alignments=self.cfg.greedy.get('preserve_alignments', False),
             )
 
         elif self.cfg.strategy == 'greedy_batch':
@@ -104,7 +104,7 @@ class AbstractRNNTDecoding(ABC):
                 joint_model=joint,
                 blank_index=self.blank_id,
                 max_symbols_per_step=self.cfg.greedy.get('max_symbols', None),
-                preserve_logprobs=self.cfg.greedy.get('preserve_logprobs', False),
+                preserve_alignments=self.cfg.greedy.get('preserve_alignments', False),
             )
 
         elif self.cfg.strategy == 'beam':
@@ -116,7 +116,7 @@ class AbstractRNNTDecoding(ABC):
                 return_best_hypothesis=decoding_cfg.beam.get('return_best_hypothesis', True),
                 search_type='default',
                 score_norm=self.cfg.beam.get('score_norm', True),
-                preserve_logprobs=self.cfg.greedy.get('preserve_logprobs', False),
+                preserve_alignments=self.cfg.greedy.get('preserve_alignments', False),
             )
 
         elif self.cfg.strategy == 'tsd':
@@ -129,7 +129,7 @@ class AbstractRNNTDecoding(ABC):
                 search_type='tsd',
                 score_norm=self.cfg.beam.get('score_norm', True),
                 tsd_max_sym_exp_per_step=self.cfg.beam.get('tsd_max_sym_exp', 50),
-                preserve_logprobs=self.cfg.greedy.get('preserve_logprobs', False),
+                preserve_alignments=self.cfg.greedy.get('preserve_alignments', False),
             )
 
         elif self.cfg.strategy == 'alsd':
@@ -142,7 +142,7 @@ class AbstractRNNTDecoding(ABC):
                 search_type='alsd',
                 score_norm=self.cfg.beam.get('score_norm', True),
                 alsd_max_target_len=self.cfg.beam.get('alsd_max_target_len', 2),
-                preserve_logprobs=self.cfg.greedy.get('preserve_logprobs', False),
+                preserve_alignments=self.cfg.greedy.get('preserve_alignments', False),
             )
 
     def rnnt_decoder_predictions_tensor(

--- a/nemo/collections/asr/metrics/rnnt_wer.py
+++ b/nemo/collections/asr/metrics/rnnt_wer.py
@@ -116,6 +116,7 @@ class AbstractRNNTDecoding(ABC):
                 return_best_hypothesis=decoding_cfg.beam.get('return_best_hypothesis', True),
                 search_type='default',
                 score_norm=self.cfg.beam.get('score_norm', True),
+                preserve_logprobs=self.cfg.greedy.get('preserve_logprobs', False),
             )
 
         elif self.cfg.strategy == 'tsd':
@@ -128,6 +129,7 @@ class AbstractRNNTDecoding(ABC):
                 search_type='tsd',
                 score_norm=self.cfg.beam.get('score_norm', True),
                 tsd_max_sym_exp_per_step=self.cfg.beam.get('tsd_max_sym_exp', 50),
+                preserve_logprobs=self.cfg.greedy.get('preserve_logprobs', False),
             )
 
         elif self.cfg.strategy == 'alsd':
@@ -140,6 +142,7 @@ class AbstractRNNTDecoding(ABC):
                 search_type='alsd',
                 score_norm=self.cfg.beam.get('score_norm', True),
                 alsd_max_target_len=self.cfg.beam.get('alsd_max_target_len', 2),
+                preserve_logprobs=self.cfg.greedy.get('preserve_logprobs', False),
             )
 
     def rnnt_decoder_predictions_tensor(

--- a/nemo/collections/asr/metrics/rnnt_wer.py
+++ b/nemo/collections/asr/metrics/rnnt_wer.py
@@ -95,7 +95,7 @@ class AbstractRNNTDecoding(ABC):
                 joint_model=joint,
                 blank_index=self.blank_id,
                 max_symbols_per_step=self.cfg.greedy.get('max_symbols', None),
-                preserve_logprobs=self.cfg.greedy.get('preserve_logprobs', False)
+                preserve_logprobs=self.cfg.greedy.get('preserve_logprobs', False),
             )
 
         elif self.cfg.strategy == 'greedy_batch':
@@ -104,6 +104,7 @@ class AbstractRNNTDecoding(ABC):
                 joint_model=joint,
                 blank_index=self.blank_id,
                 max_symbols_per_step=self.cfg.greedy.get('max_symbols', None),
+                preserve_logprobs=self.cfg.greedy.get('preserve_logprobs', False),
             )
 
         elif self.cfg.strategy == 'beam':

--- a/nemo/collections/asr/metrics/rnnt_wer.py
+++ b/nemo/collections/asr/metrics/rnnt_wer.py
@@ -285,6 +285,17 @@ class RNNTDecoding(AbstractRNNTDecoding):
                 tokens as well as the decoded string. Default is False in order to avoid double decoding
                 unless required.
 
+            preserve_alignments: Bool flag which preserves the history of logprobs generated during
+                decoding (sample / batched). When set to true, the Hypothesis will contain
+                the non-null value for `logprobs` in it. Here, `logprobs` is a List of torch.Tensors.
+
+                In order to obtain this hypothesis, please utilize `rnnt_decoder_predictions_tensor` function
+                with the `return_hypotheses` flag set to True.
+
+                The length of the list corresponds to the Acoustic Length (T).
+                Each value in the list (Ti) is a torch.Tensor (U), representing 1 or more targets from a vocabulary.
+                U is the number of target tokens for the current timestep Ti.
+
             The config may further contain the following sub-dictionaries:
             "greedy":
                 max_symbols: int, describing the maximum number of target tokens to decode per
@@ -339,7 +350,7 @@ class RNNTDecoding(AbstractRNNTDecoding):
         Returns:
             A decoded string.
         """
-        hypothesis = ''.join([self.labels_map[c] for c in tokens if c != self.blank_id])
+        hypothesis = ''.join(self.decode_ids_to_tokens(tokens))
         return hypothesis
 
     def decode_ids_to_tokens(self, tokens: List[int]) -> List[str]:

--- a/nemo/collections/asr/metrics/rnnt_wer.py
+++ b/nemo/collections/asr/metrics/rnnt_wer.py
@@ -95,6 +95,7 @@ class AbstractRNNTDecoding(ABC):
                 joint_model=joint,
                 blank_index=self.blank_id,
                 max_symbols_per_step=self.cfg.greedy.get('max_symbols', None),
+                preserve_logprobs=self.cfg.greedy.get('preserve_logprobs', False)
             )
 
         elif self.cfg.strategy == 'greedy_batch':

--- a/nemo/collections/asr/metrics/rnnt_wer_bpe.py
+++ b/nemo/collections/asr/metrics/rnnt_wer_bpe.py
@@ -44,6 +44,17 @@ class RNNTBPEDecoding(AbstractRNNTDecoding):
                 tokens as well as the decoded string. Default is False in order to avoid double decoding
                 unless required.
 
+            preserve_alignments: Bool flag which preserves the history of logprobs generated during
+                decoding (sample / batched). When set to true, the Hypothesis will contain
+                the non-null value for `logprobs` in it. Here, `logprobs` is a List of torch.Tensors.
+
+                In order to obtain this hypothesis, please utilize `rnnt_decoder_predictions_tensor` function
+                with the `return_hypotheses` flag set to True.
+
+                The length of the list corresponds to the Acoustic Length (T).
+                Each value in the list (Ti) is a torch.Tensor (U), representing 1 or more targets from a vocabulary.
+                U is the number of target tokens for the current timestep Ti.
+
             The config may further contain the following sub-dictionaries:
             "greedy":
                 max_symbols: int, describing the maximum number of target tokens to decode per

--- a/nemo/collections/asr/metrics/wer.py
+++ b/nemo/collections/asr/metrics/wer.py
@@ -18,6 +18,7 @@ import editdistance
 import torch
 from pytorch_lightning.metrics import Metric
 
+from nemo.collections.asr.parts.rnnt_utils import Hypothesis
 from nemo.utils import logging
 
 __all__ = ['word_error_rate', 'WER']
@@ -115,10 +116,25 @@ class WER(Metric):
         self.add_state("words", default=torch.tensor(0), dist_reduce_fx='sum', persistent=False)
 
     def ctc_decoder_predictions_tensor(
-        self, predictions: torch.Tensor, predictions_len: torch.Tensor = None
+        self, predictions: torch.Tensor, predictions_len: torch.Tensor = None, return_hypotheses: bool = False,
     ) -> List[str]:
         """
         Decodes a sequence of labels to words
+
+        Args:
+            predictions: A torch.Tensor of shape [Batch, Time] of integer indices that correspond
+                to the index of some character in the label set.
+            predictions_len: Optional tensor of length `Batch` which contains the integer lengths
+                of the sequence in the padded `predictions` tensor.
+            return_hypotheses: Bool flag whether to return just the decoding predictions of the model
+                or a Hypothesis object that holds information such as the decoded `text`,
+                the `alignment` of emited by the CTC Model, and the `length` of the sequence (if available).
+                May also contain the log-probabilities of the decoder (if this method is called via
+                transcribe())
+
+        Returns:
+            Either a list of str which represent the CTC decoded strings per sample,
+            or a list of Hypothesis objects containing additional information.
         """
         hypotheses = []
         # Drop predictions to CPU
@@ -135,9 +151,49 @@ class WER(Metric):
                 if (p != previous or previous == self.blank_id) and p != self.blank_id:
                     decoded_prediction.append(p)
                 previous = p
-            hypothesis = ''.join([self.labels_map[c] for c in decoded_prediction])
+
+            text = self.decode_tokens_to_str(decoded_prediction)
+
+            if not return_hypotheses:
+                hypothesis = text
+            else:
+                hypothesis = Hypothesis(
+                    y_sequence=None,
+                    score=-1.0,
+                    text=text,
+                    alignments=prediction,
+                    length=predictions_len[ind] if predictions_len is not None else 0,
+                )
+
             hypotheses.append(hypothesis)
         return hypotheses
+
+    def decode_tokens_to_str(self, tokens: List[int]) -> str:
+        """
+        Implemented in order to decoder a token list into a string.
+
+        Args:
+            tokens: List of int representing the token ids.
+
+        Returns:
+            A decoded string.
+        """
+        hypothesis = ''.join(self.decode_ids_to_tokens(tokens))
+        return hypothesis
+
+    def decode_ids_to_tokens(self, tokens: List[int]) -> List[str]:
+        """
+        Implemented in order to decode a token id list into a token list.
+        A token list is the string representation of each token id.
+
+        Args:
+            tokens: List of int representing the token ids.
+
+        Returns:
+            A list of decoded tokens.
+        """
+        token_list = [self.labels_map[c] for c in tokens if c != self.blank_id]
+        return token_list
 
     def update(
         self,
@@ -158,7 +214,7 @@ class WER(Metric):
             for ind in range(targets_cpu_tensor.shape[self.batch_dim_index]):
                 tgt_len = tgt_lenths_cpu_tensor[ind].item()
                 target = targets_cpu_tensor[ind][:tgt_len].numpy().tolist()
-                reference = ''.join([self.labels_map[c] for c in target])
+                reference = self.decode_tokens_to_str(target)
                 references.append(reference)
             if self.ctc_decode:
                 hypotheses = self.ctc_decoder_predictions_tensor(predictions, predictions_lengths)

--- a/nemo/collections/asr/parts/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_beam_decoding.py
@@ -789,3 +789,4 @@ class BeamRNNTInferConfig:
     alsd_max_target_len: float = 1.0
     nsc_max_timesteps_expansion: int = 1
     nsc_prefix_alpha: int = 1
+    preserve_alignments: bool = False

--- a/nemo/collections/asr/parts/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_beam_decoding.py
@@ -442,7 +442,6 @@ class BeamRNNTInfer(Typing):
                     if self.preserve_alignments:
                         # convert Ti-th logits into a torch array
                         for kept_h in kept_most_prob:
-                            # kept_h.alignments[-1] = torch.tensor(kept_h.alignments[-1], dtype=torch.long)
                             kept_h.alignments.append([])  # blank buffer for next timestep
 
                     kept_hyps = kept_most_prob
@@ -466,6 +465,9 @@ class BeamRNNTInfer(Typing):
         Returns:
             nbest_hyps: N-best decoding results
         """
+        if self.preserve_alignments:
+            raise NotImplementedError("`preseve_alignments` is not implemented for Time-Synchronous Decoding.")
+
         # Precompute some constants for blank position
         ids = list(range(self.vocab_size + 1))
         ids.remove(self.blank)
@@ -576,6 +578,11 @@ class BeamRNNTInfer(Typing):
         Returns:
             nbest_hyps: N-best decoding results
         """
+        if self.preserve_alignments:
+            raise NotImplementedError(
+                "`preseve_alignments` is not implemented for Alignment-length Synchronous Decoding."
+            )
+
         # Precompute some constants for blank position
         ids = list(range(self.vocab_size + 1))
         ids.remove(self.blank)

--- a/nemo/collections/asr/parts/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_beam_decoding.py
@@ -329,7 +329,6 @@ class BeamRNNTInfer(Typing):
 
                     if self.preserve_alignments:
                         # convert Ti-th logits into a torch array
-                        alignments[-1] = torch.tensor(alignments[-1], dtype=torch.long)
                         alignments.append([])  # blank buffer for next timestep
                 else:
                     # Update state and current sequence

--- a/nemo/collections/asr/parts/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_beam_decoding.py
@@ -111,6 +111,17 @@ class BeamRNNTInfer(Typing):
         nsc_max_timesteps_expansion: Unused int.
 
         nsc_prefix_alpha: Unused int.
+
+        preserve_alignments: Bool flag which preserves the history of alignments generated during
+            beam decoding (sample). When set to true, the Hypothesis will contain
+            the non-null value for `alignments` in it. Here, `alignments` is a List of List of ints.
+
+            The length of the list corresponds to the Acoustic Length (T).
+            Each value in the list (Ti) is a torch.Tensor (U), representing 1 or more targets from a vocabulary.
+            U is the number of target tokens for the current timestep Ti.
+
+            NOTE: `preserve_alignments` is an invalid argument for any `search_type`
+            other than basic beam search.
     """
 
     @property

--- a/nemo/collections/asr/parts/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_beam_decoding.py
@@ -275,7 +275,7 @@ class BeamRNNTInfer(Typing):
             hyp: 1-best decoding results
         """
         if self.preserve_alignments:
-            # Logprobs is a 2-dimensional dangling list representing T x U
+            # Alignments is a 2-dimensional dangling list representing T x U
             alignments = [[]]
         else:
             alignments = None
@@ -331,12 +331,12 @@ class BeamRNNTInfer(Typing):
                     y, state, _ = self.decoder.score_hypothesis(hyp, cache)
                 symbols_added += 1
 
-        # Remove trailing empty list of logprobs
+        # Remove trailing empty list of alignments
         if self.preserve_alignments:
             if len(alignments[-1]) == 0:
                 del alignments[-1]
 
-        # attach logprobs to hypothesis
+        # attach alignments to hypothesis
         hyp.alignments = alignments
 
         return [hyp]
@@ -447,7 +447,7 @@ class BeamRNNTInfer(Typing):
                     kept_hyps = kept_most_prob
                     break
 
-        # Remove trailing empty list of logprobs
+        # Remove trailing empty list of alignments
         if self.preserve_alignments:
             for h in kept_hyps:
                 if len(h.alignments[-1]) == 0:

--- a/nemo/collections/asr/parts/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_greedy_decoding.py
@@ -42,7 +42,7 @@ def pack_hypotheses(
     hypotheses: List[List[int]],
     timesteps: List[List[int]],
     logitlen: torch.Tensor,
-    alignments: Optional[List[List[torch.Tensor]]] = None,
+    alignments: Optional[List[List[int]]] = None,
 ) -> List[rnnt_utils.Hypothesis]:
     logitlen_cpu = logitlen.to("cpu")
     return [
@@ -240,7 +240,7 @@ class GreedyRNNTInfer(_GreedyRNNTInfer):
 
             hypotheses = []
             timesteps = []
-            alignments = []
+            alignments = [] if self.preserve_alignments else None
             # Process each sequence independently
             with self.decoder.as_frozen(), self.joint.as_frozen():
                 for batch_idx in range(encoder_output.size(0)):
@@ -249,7 +249,9 @@ class GreedyRNNTInfer(_GreedyRNNTInfer):
                     sentence, timestep, alignment = self._greedy_decode(inseq, logitlen)
                     hypotheses.append(sentence)
                     timesteps.append(timestep)
-                    alignments.append(alignment)
+
+                    if self.preserve_alignments:
+                        alignments.append(alignment)
 
             # Pack results into Hypotheses
             packed_result = pack_hypotheses(hypotheses, timesteps, encoded_lengths, alignments=alignments)
@@ -317,7 +319,6 @@ class GreedyRNNTInfer(_GreedyRNNTInfer):
 
                     if self.preserve_alignments:
                         # convert Ti-th logits into a torch array
-                        alignments[-1] = torch.tensor(alignments[-1], dtype=torch.long)
                         alignments.append([])  # blank buffer for next timestep
                 else:
                     # Append token to label set, update RNN state.
@@ -407,10 +408,10 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
 
             with self.decoder.as_frozen(), self.joint.as_frozen():
                 inseq = encoder_output  # [B, T, D]
-                hypotheses, timesteps, logprobs = self._greedy_decode(inseq, logitlen, device=inseq.device)
+                hypotheses, timesteps, alignments = self._greedy_decode(inseq, logitlen, device=inseq.device)
 
             # Pack the hypotheses results
-            packed_result = pack_hypotheses(hypotheses, timesteps, logitlen, alignments=logprobs)
+            packed_result = pack_hypotheses(hypotheses, timesteps, logitlen, alignments=alignments)
 
             del hypotheses, timesteps
 
@@ -524,7 +525,6 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
                                 if len(alignments[batch_idx][-1]) > 0:
                                     # alignments[batch_idx][-1] = torch.stack(alignments[batch_idx][-1], dim=0)
                                     # alignments[batch_idx][-1] = alignments[batch_idx][-1].max(1)[1]
-                                    alignments[batch_idx][-1] = torch.tensor(alignments[batch_idx][-1], dtype=torch.long)
                                     alignments[batch_idx].append([])  # blank buffer for next timestep
                     else:
                         # Collect batch indices where blanks occurred now/past
@@ -676,7 +676,6 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
                             # If current timestep > sample-level AM length, no logprobs will be added
                             # Therefore the list of Uj logprobs is empty here.
                             if len(alignments[batch_idx][-1]) > 0:
-                                alignments[batch_idx][-1] = torch.tensor(alignments[batch_idx][-1], dtype=torch.long)
                                 alignments[batch_idx].append([])  # blank buffer for next timestep
                 else:
                     # Collect batch indices where blanks occurred now/past

--- a/nemo/collections/asr/parts/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_greedy_decoding.py
@@ -722,8 +722,10 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
 @dataclass
 class GreedyRNNTInferConfig:
     max_symbols_per_step: Optional[int] = None
+    preserve_alignments: bool = False
 
 
 @dataclass
 class GreedyBatchedRNNTInferConfig:
     max_symbols_per_step: Optional[int] = None
+    preserve_alignments: bool = False

--- a/nemo/collections/asr/parts/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_greedy_decoding.py
@@ -69,6 +69,18 @@ class _GreedyRNNTInfer(Typing):
         max_symbols_per_step: Optional int. The maximum number of symbols that can be added
             to a sequence in a single time step; if set to None then there is
             no limit.
+        preserve_logprobs: Bool flag which preserves the history of logprobs generated during
+            greedy decoding (sample / batched). When set to true, the Hypothesis will contain
+            the non-null value for `logprobs` in it. Here, `logprobs` is a List of torch.Tensors.
+
+            The length of the list corresponds to the Acoustic Length (T).
+            Each value in the list (Ti) is a torch.Tensor (U), representing 1 or more targets from a vocabulary.
+
+            U has a shape [U, V + 1], where U is the number of target tokens for the current timestep Ti.
+            Each target timestep Uj is a vector of length V + 1, where V is the vocabulary size of the
+            prediction network.
+
+            The blank token is indexed as the final value of this vector (i.e. index V, 0-based indexing rule).
     """
 
     @property
@@ -182,6 +194,18 @@ class GreedyRNNTInfer(_GreedyRNNTInfer):
         max_symbols_per_step: Optional int. The maximum number of symbols that can be added
             to a sequence in a single time step; if set to None then there is
             no limit.
+        preserve_logprobs: Bool flag which preserves the history of logprobs generated during
+            greedy decoding (sample / batched). When set to true, the Hypothesis will contain
+            the non-null value for `logprobs` in it. Here, `logprobs` is a List of torch.Tensors.
+
+            The length of the list corresponds to the Acoustic Length (T).
+            Each value in the list (Ti) is a torch.Tensor (U), representing 1 or more targets from a vocabulary.
+
+            U has a shape [U, V + 1], where U is the number of target tokens for the current timestep Ti.
+            Each target timestep Uj is a vector of length V + 1, where V is the vocabulary size of the
+            prediction network.
+
+            The blank token is indexed as the final value of this vector (i.e. index V, 0-based indexing rule).
     """
 
     def __init__(
@@ -334,6 +358,18 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
         max_symbols_per_step: Optional int. The maximum number of symbols that can be added
             to a sequence in a single time step; if set to None then there is
             no limit.
+        preserve_logprobs: Bool flag which preserves the history of logprobs generated during
+            greedy decoding (sample / batched). When set to true, the Hypothesis will contain
+            the non-null value for `logprobs` in it. Here, `logprobs` is a List of torch.Tensors.
+
+            The length of the list corresponds to the Acoustic Length (T).
+            Each value in the list (Ti) is a torch.Tensor (U), representing 1 or more targets from a vocabulary.
+
+            U has a shape [U, V + 1], where U is the number of target tokens for the current timestep Ti.
+            Each target timestep Uj is a vector of length V + 1, where V is the vocabulary size of the
+            prediction network.
+
+            The blank token is indexed as the final value of this vector (i.e. index V, 0-based indexing rule).
     """
 
     def __init__(

--- a/nemo/collections/asr/parts/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/rnnt_greedy_decoding.py
@@ -75,12 +75,7 @@ class _GreedyRNNTInfer(Typing):
 
             The length of the list corresponds to the Acoustic Length (T).
             Each value in the list (Ti) is a torch.Tensor (U), representing 1 or more targets from a vocabulary.
-
-            U has a shape [U, V + 1], where U is the number of target tokens for the current timestep Ti.
-            Each target timestep Uj is a vector of length V + 1, where V is the vocabulary size of the
-            prediction network.
-
-            The blank token is indexed as the final value of this vector (i.e. index V, 0-based indexing rule).
+            U is the number of target tokens for the current timestep Ti.
     """
 
     @property
@@ -200,12 +195,7 @@ class GreedyRNNTInfer(_GreedyRNNTInfer):
 
             The length of the list corresponds to the Acoustic Length (T).
             Each value in the list (Ti) is a torch.Tensor (U), representing 1 or more targets from a vocabulary.
-
-            U has a shape [U, V + 1], where U is the number of target tokens for the current timestep Ti.
-            Each target timestep Uj is a vector of length V + 1, where V is the vocabulary size of the
-            prediction network.
-
-            The blank token is indexed as the final value of this vector (i.e. index V, 0-based indexing rule).
+            U is the number of target tokens for the current timestep Ti.
     """
 
     def __init__(
@@ -364,12 +354,7 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
 
             The length of the list corresponds to the Acoustic Length (T).
             Each value in the list (Ti) is a torch.Tensor (U), representing 1 or more targets from a vocabulary.
-
-            U has a shape [U, V + 1], where U is the number of target tokens for the current timestep Ti.
-            Each target timestep Uj is a vector of length V + 1, where V is the vocabulary size of the
-            prediction network.
-
-            The blank token is indexed as the final value of this vector (i.e. index V, 0-based indexing rule).
+            U is the number of target tokens for the current timestep Ti.
     """
 
     def __init__(

--- a/nemo/collections/asr/parts/rnnt_utils.py
+++ b/nemo/collections/asr/parts/rnnt_utils.py
@@ -59,7 +59,7 @@ class Hypothesis:
     tokens: Optional[Union[List[int], torch.Tensor]] = None
     text: str = None
     timestep: Union[List[int], torch.Tensor] = field(default_factory=list)
-    logprobs: List[torch.Tensor] = None
+    alignments: List[torch.Tensor] = None
     length: int = 0
 
 

--- a/nemo/collections/asr/parts/rnnt_utils.py
+++ b/nemo/collections/asr/parts/rnnt_utils.py
@@ -43,24 +43,43 @@ class Hypothesis:
 
     dec_state: A list (or list of list) of LSTM-RNN decoder states. Can be None.
 
+    text: (Optional) A decoded string after processing via CTC / RNN-T decoding (removing the CTC/RNNT
+        `blank` tokens, and optionally merging word-pieces). Should be used as decoded string for
+        Word Error Rate calculation.
+
+    timestep: (Optional) A list of integer indices representing at which index in the decoding
+        process did the token appear. Should be of same length as the number of non-blank tokens.
+
+    alignments: (Optional) Represents the CTC / RNNT token alignments as integer tokens along an axis of
+        time T (for CTC) or Time x Target (TxU).
+        For CTC, represented as a single list of integer indices.
+        For RNNT, represented as a dangling list of list of integer indices.
+        Outer list represents Time dimension (T), inner list represents Target dimension (U).
+        The set of valid indices **includes** the CTC / RNNT blank token in order to represent alignments.
+
+    length: Represents the length of the sequence (the original length without padding), otherwise
+        defaults to 0.
+
     y: (Unused) A list of torch.Tensors representing the list of hypotheses.
 
     lm_state: (Unused) A dictionary state cache used by an external Language Model.
 
     lm_scores: (Unused) Score of the external Language Model.
+
+    tokens: (Optional) A list of decoded tokens (can be characters or word-pieces.
     """
 
     score: float
     y_sequence: Union[List[int], torch.Tensor]
     dec_state: Optional[Union[List[List[torch.Tensor]], List[torch.Tensor]]] = None
+    text: Optional[str] = None
+    timestep: Union[List[int], torch.Tensor] = field(default_factory=list)
+    alignments: Optional[Union[List[int], List[List[int]]]] = None
+    length: int = 0
     y: List[torch.tensor] = None
     lm_state: Union[Dict[str, Any], List[Any]] = None
     lm_scores: torch.Tensor = None
     tokens: Optional[Union[List[int], torch.Tensor]] = None
-    text: str = None
-    timestep: Union[List[int], torch.Tensor] = field(default_factory=list)
-    alignments: List[torch.Tensor] = None
-    length: int = 0
 
 
 @dataclass

--- a/nemo/collections/asr/parts/rnnt_utils.py
+++ b/nemo/collections/asr/parts/rnnt_utils.py
@@ -59,6 +59,7 @@ class Hypothesis:
     tokens: Optional[Union[List[int], torch.Tensor]] = None
     text: str = None
     timestep: Union[List[int], torch.Tensor] = field(default_factory=list)
+    logprobs: List[torch.Tensor] = None
     length: int = 0
 
 


### PR DESCRIPTION
# Changelog
- Adds support for CTC/RNNT models to compute alignments for their respective decoding schemes. Valid schemes listed below.
- Adds support for CTC models to return a `Hypothesis` object that contains additional information about the decoded / transcribed tensor.
- Adds test for hypothesis in CTC

## Valid alignment computations
- CTC
  - CTC + Char encoding
  - CTC + Subword encoding
- RNNT
  - RNNT with Greedy (sample) and Greedy (batched, both variants)
  - RNNT with Basic Beam (beam size >= 1)

## Invalid alignment computations
- RNNT
  - RNNT with TSD / ALSD

# Example (CTC / CTC-BPE)

```python
import torch
...

trainer = Trainer(...)
asr_model = EncDecCTCModel.from_pretrained(pretrained_name, map_location=torch.device('cpu'), strict=True)
asr_model.set_trainer(trainer)

device = torch.device('cuda:0') if torch.cuda.is_available() else torch.device('cpu')
asr_model = asr_model.to(device)

# Compute alignments
audio_paths = [...]  # path of audio files
hypotheses = asr_model.transcribe(audio_paths , batch_size=32, return_hypotheses=True)

SAMPLE_IDX = 0
h = hypotheses[SAMPLE_IDX]  # type: Hypothesis
alignments = h.alignments  # log probs of first sample

token_set = []
for p in alignments:
    tokens = asr_model._wer.decode_tokens_to_str([p])
    token_set.append(tokens)

print("Predicted text :", h.text)
print()
print("Alignments :")
for t, p in enumerate(token_set):
    print(f"t = {t:4d} : {p}")
```

# Example (RNNT / RNNT-BPE)

```python
import torch
from omegaconf import OmegaConf, open_dict
...

trainer = Trainer(...)
asr_model = EncDecRNNTBPEModel.restore_from(<path to RNNT model>, map_location=torch.device('cpu'), strict=True)
asr_model.set_trainer(trainer)

device = torch.device('cuda:0') if torch.cuda.is_available() else torch.device('cpu')
asr_model = asr_model.to(device)

# Change decoding strategy to preserve alignments
decoding_cfg = asr_model.cfg.decoding

# Add `preserve_alignments` flag to RNNT models.
with open_dict(decoding_cfg):
    decoding_cfg.preserve_alignments = True

asr_model.change_decoding_strategy(decoding_cfg)  # cfg.model.decoding is the `decoding` portion of an RNNT yaml config.

# Compute alignments
audio_paths = [...]  # path of audio files
hypotheses = asr_model.transcribe(audio_paths , batch_size=32, return_hypotheses=True)

# Above hypotheses is a list of 2 items
# [0] - best Hypothesis. This is always available, for both greedy and beam search
# [1] - NBestHypothesis (if beam search size > 1). None for greedy and beam search size of 1.

SAMPLE_IDX = 0
hypotheses = hypotheses[0]  # select best hypothesis
h = hypotheses[SAMPLE_IDX]  # type: Hypothesis
alignments = h.alignments  # log probs of first sample

token_set = []
for p in alignments:
    tokens = [asr_model.decoding.decode_tokens_to_str([p_i]) for p_i in p]
    token_set.append(tokens)

print("Predicted text :", h.text)
print()
print("Alignments  :")
for t, p in enumerate(token_set):
    print(f"t = {t:4d} : {p}")
```