### PR TITLE
hotfix in ja preprocessing

### DIFF
--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -39,7 +39,7 @@ class MTEncDecModelConfig(EncDecNLPModelConfig):
     find_unused_parameters: Optional[bool] = True
     shared_tokenizer: Optional[bool] = True
     preproc_out_dir: Optional[str] = None
-    sentencepiece_model = None
+    sentencepiece_model: Optional[str] = None
 
 
 @dataclass


### PR DESCRIPTION
this is a hotfix on top of [PR 1781](https://github.com/NVIDIA/NeMo/pull/1781). the type of `sentencepiece_model` argument wasn't specified, leading to the inability to set it via config file.