### PR TITLE
Limit the maximum length of subwords generated from corpus

### DIFF
--- a/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
+++ b/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
@@ -204,7 +204,7 @@ def create_spt_model(
         output_dir: folder to save created tokenizer model. If not specified will store model at data_file/../spt folder
         train_extremely_large_corpus: If training on huge datasets, pass this flag to allow SentencePiece
             to build the tokenizer.
-        max_sentencepiece_length: Limits the maximum length of the subword that can be constructed.
+        max_sentencepiece_length: Limits the maximum length of the SentencePiece subword that can be constructed.
             By default, no limit is placed.
     """
 

--- a/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
+++ b/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
@@ -190,6 +190,7 @@ def create_spt_model(
     output_dir: Optional[str] = None,
     character_coverage: float = 1.0,
     train_extremely_large_corpus: bool = False,
+    max_sentencepiece_length: int = -1
 ):
     """
     Creates sentence piece tokenizer model from data file.
@@ -233,6 +234,9 @@ def create_spt_model(
 
     if train_extremely_large_corpus:
         cmd += " --train_extremely_large_corpus=true"
+
+    if max_sentencepiece_length >= 0:
+        cmd += f" --max_sentencepiece_length={max_sentencepiece_length}"
 
     sentencepiece.SentencePieceTrainer.Train(cmd)
 

--- a/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
+++ b/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
@@ -190,7 +190,7 @@ def create_spt_model(
     output_dir: Optional[str] = None,
     character_coverage: float = 1.0,
     train_extremely_large_corpus: bool = False,
-    max_sentencepiece_length: int = -1
+    max_sentencepiece_length: int = -1,
 ):
     """
     Creates sentence piece tokenizer model from data file.
@@ -204,6 +204,8 @@ def create_spt_model(
         output_dir: folder to save created tokenizer model. If not specified will store model at data_file/../spt folder
         train_extremely_large_corpus: If training on huge datasets, pass this flag to allow SentencePiece
             to build the tokenizer.
+        max_sentencepiece_length: Limits the maximum length of the subword that can be constructed.
+            By default, no limit is placed.
     """
 
     if not data_file or not os.path.exists(data_file):

--- a/scripts/process_asr_text_tokenizer.py
+++ b/scripts/process_asr_text_tokenizer.py
@@ -110,6 +110,9 @@ parser.add_argument(
     help="Samples the dataset by `sample_size` if positive integer, otherwise uses whole dataset",
 )
 parser.add_argument('--spe_train_extremely_large_corpus', action='store_true', help='')
+parser.add_argument(
+    '--spe_max_sentencepiece_length', type=int, default=-1, help='Limit the maximum number of tokens in each subword'
+)
 parser.add_argument('--no_lower_case', dest='lower_case', action='store_false')
 parser.add_argument("--log", action='store_true')
 parser.set_defaults(log=False, lower_case=True, spe_train_extremely_large_corpus=False)
@@ -162,6 +165,7 @@ def __process_data(
     spe_character_coverage: float,
     spe_train_extremely_large_corpus: bool,
     spe_sample_size: int,
+    spe_max_sentencepiece_length: int,
     lower_case: bool,
 ):
     """
@@ -201,6 +205,7 @@ def __process_data(
             tokenizer_type=spe_type,
             character_coverage=spe_character_coverage,
             train_extremely_large_corpus=spe_train_extremely_large_corpus,
+            max_sentencepiece_length=spe_max_sentencepiece_length
         )
 
     else:
@@ -227,6 +232,7 @@ def main():
     spe_character_coverage = args.spe_character_coverage
     spe_sample_size = args.spe_sample_size
     spe_train_extremely_large_corpus = args.spe_train_extremely_large_corpus
+    spe_max_sentencepiece_length = args.spe_max_sentencepiece_length
     lower_case = args.lower_case
 
     if not os.path.exists(data_root):
@@ -249,6 +255,7 @@ def main():
         spe_character_coverage=spe_character_coverage,
         spe_sample_size=spe_sample_size,
         spe_train_extremely_large_corpus=spe_train_extremely_large_corpus,
+        spe_max_sentencepiece_length=spe_max_sentencepiece_length,
     )
 
     print("Serialized tokenizer at location :", tokenizer_path)

--- a/scripts/process_asr_text_tokenizer.py
+++ b/scripts/process_asr_text_tokenizer.py
@@ -70,8 +70,8 @@
 #       train_extremely_large_corpus=true". If your machine has large amounts of RAM, it might still be possible
 #       to build the tokenizer using the above flag. Will silently fail if it runs out of RAM.
 #
-#   --spe_max_sentencepiece_length: Limits the maximum length that any any subword can be. Using this will change
-#       the subword tokens generated.
+#   --spe_max_sentencepiece_length: Limits the maximum length that any any SentencePiecesubword can be.
+#       Using this will change the subword tokens generated.
 #
 #   --log: Whether the script should display log messages
 
@@ -117,7 +117,7 @@ parser.add_argument(
     '--spe_max_sentencepiece_length',
     type=int,
     default=-1,
-    help='Limit the maximum number of tokens in each subword. '
+    help='Limit the maximum number of tokens in each SentencePiece subword. '
     'Must be a positive integer > 0. By default places no limit on subword length.',
 )
 parser.add_argument('--no_lower_case', dest='lower_case', action='store_false')
@@ -189,7 +189,7 @@ def __process_data(
             by given sample size.
         spe_train_extremely_large_corpus: bool. If dataset is too large, and user has sufficient RAM,
             this flag can be set to try to trained the tokenizer. Will silently fail if it runs out of RAM.
-        spe_max_sentencepiece_length: Limits the maximum length of the subword that can be constructed.
+        spe_max_sentencepiece_length: Limits the maximum length of the SentencePiece subword that can be constructed.
             By default, no limit is placed.
         lower_case: whether to tokenize with lower case character set only (for english)
 

--- a/scripts/process_asr_text_tokenizer.py
+++ b/scripts/process_asr_text_tokenizer.py
@@ -70,6 +70,9 @@
 #       train_extremely_large_corpus=true". If your machine has large amounts of RAM, it might still be possible
 #       to build the tokenizer using the above flag. Will silently fail if it runs out of RAM.
 #
+#   --spe_max_sentencepiece_length: Limits the maximum length that any any subword can be. Using this will change
+#       the subword tokens generated.
+#
 #   --log: Whether the script should display log messages
 
 
@@ -111,7 +114,11 @@ parser.add_argument(
 )
 parser.add_argument('--spe_train_extremely_large_corpus', action='store_true', help='')
 parser.add_argument(
-    '--spe_max_sentencepiece_length', type=int, default=-1, help='Limit the maximum number of tokens in each subword'
+    '--spe_max_sentencepiece_length',
+    type=int,
+    default=-1,
+    help='Limit the maximum number of tokens in each subword. '
+    'Must be a positive integer > 0. By default places no limit on subword length.',
 )
 parser.add_argument('--no_lower_case', dest='lower_case', action='store_false')
 parser.add_argument("--log", action='store_true')
@@ -182,6 +189,8 @@ def __process_data(
             by given sample size.
         spe_train_extremely_large_corpus: bool. If dataset is too large, and user has sufficient RAM,
             this flag can be set to try to trained the tokenizer. Will silently fail if it runs out of RAM.
+        spe_max_sentencepiece_length: Limits the maximum length of the subword that can be constructed.
+            By default, no limit is placed.
         lower_case: whether to tokenize with lower case character set only (for english)
 
     Returns:
@@ -205,7 +214,7 @@ def __process_data(
             tokenizer_type=spe_type,
             character_coverage=spe_character_coverage,
             train_extremely_large_corpus=spe_train_extremely_large_corpus,
-            max_sentencepiece_length=spe_max_sentencepiece_length
+            max_sentencepiece_length=spe_max_sentencepiece_length,
         )
 
     else:

--- a/scripts/process_asr_text_tokenizer.py
+++ b/scripts/process_asr_text_tokenizer.py
@@ -15,7 +15,7 @@
 # USAGE: python process_asr_text_tokenizer.py --manifest=<path to train manifest files, seperated by commas> \
 #         --data_root="<output directory>" \
 #         --vocab_size=<number of tokens in vocabulary> \
-#         --tokenizer=<"bpe" or "wpe"> \
+#         --tokenizer=<"spe" or "wpe"> \
 #         --log
 # where <manifest> can be: train_clean_100, train_clean_360, train_other_500
 # You can also put more than one data_set comma-separated:


### PR DESCRIPTION
# Changelog
- Add tokenizer generator flag to limit the maximum length of subwords generated