### PR TITLE
Patch SPE tokenizer not being available in older ASR Checkpoints

### DIFF
--- a/nemo/collections/asr/parts/mixins.py
+++ b/nemo/collections/asr/parts/mixins.py
@@ -71,9 +71,13 @@ class ASRBPEMixin(ABC):
             vocab_path = self.register_artifact('tokenizer.vocab_path', vocab_path)
             self.vocab_path = vocab_path
 
-            spe_vocab_path = os.path.join(self.tokenizer_dir, 'tokenizer.vocab')
-            spe_vocab_path = self.register_artifact('spe_tokenizer.vocab', spe_vocab_path)
-            self.spe_vocab_path = spe_vocab_path
+            try:
+                spe_vocab_path = os.path.join(self.tokenizer_dir, 'tokenizer.vocab')
+                spe_vocab_path = self.register_artifact('spe_tokenizer.vocab', spe_vocab_path)
+                self.spe_vocab_path = spe_vocab_path
+            except FileNotFoundError:
+                # fallback case for older checkpoints that did not preserve the tokenizer.vocab
+                self.spe_vocab_path = None
 
             vocabulary = {'<unk>': 0}
             with open(vocab_path) as f:


### PR DESCRIPTION
# Bugfix
- Older checkpoints might not have the `tokenizer.vocab` file when using SentencePiece tokenizers. This will cause model restoration to fail.
- Wrap in a try catch that catches ModelPT raised FileNotFoundError for this particular case to enable backward compatibility

Signed-off-by: smajumdar <titu1994@gmail.com>