### PR TITLE
Freeze modules during transcribe to prevent graph accumulation during transcribe loop

### DIFF
--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -162,6 +162,9 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel):
             self.preprocessor.featurizer.pad_to = 0
             # Switch model to evaluation mode
             self.eval()
+            # Freeze the encoder and decoder modules
+            self.encoder.freeze()
+            self.decoder.freeze()
             logging_level = logging.get_verbosity()
             logging.set_verbosity(logging.WARNING)
             # Work in tmp directory - will store manifest file there
@@ -194,6 +197,9 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel):
             self.train(mode=mode)
             self.preprocessor.featurizer.dither = dither_value
             self.preprocessor.featurizer.pad_to = pad_to_value
+            if mode is True:
+                self.encoder.unfreeze()
+                self.decoder.unfreeze()
             logging.set_verbosity(logging_level)
         return hypotheses
 

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -163,6 +163,10 @@ class EncDecRNNTModel(ASRModel):
         try:
             # Switch model to evaluation mode
             self.eval()
+            # Freeze the encoder and decoder modules
+            self.encoder.freeze()
+            self.decoder.freeze()
+            self.joint.freeze()
             logging_level = logging.get_verbosity()
             logging.set_verbosity(logging.WARNING)
             # Work in tmp directory - will store manifest file there
@@ -188,6 +192,10 @@ class EncDecRNNTModel(ASRModel):
             # set mode back to its original value
             self.train(mode=mode)
             logging.set_verbosity(logging_level)
+            if mode is True:
+                self.encoder.unfreeze()
+                self.decoder.unfreeze()
+                self.joint.unfreeze()
         return hypotheses
 
     def change_vocabulary(self, new_vocabulary: List[str], decoding_cfg: Optional[DictConfig] = None):


### PR DESCRIPTION
# Changelog
- Freeze internal modules when transcribing data so as to prevent graph from accumulating data during loop

Signed-off-by: smajumdar <titu1994@gmail.com>