### PR TITLE
NMT fix for DDP training hanging

### DIFF
--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -265,7 +265,7 @@ class MTEncDecModel(EncDecNLPModel):
         Called at the end of validation to aggregate outputs.
         :param outputs: list of individual outputs of each validation step.
         """
-        self.log_dict(self.eval_epoch_end(outputs, 'val'))
+        self.log_dict(self.eval_epoch_end(outputs, 'val'), sync_dist=True)
 
     def test_epoch_end(self, outputs):
         return self.eval_epoch_end(outputs, 'test')


### PR DESCRIPTION
NMT DDP training is hanging after training for a few epochs. This hanging is likely due to validation metrics becoming out of sync. 

See the PTL discussion here: https://github.com/PyTorchLightning/pytorch-lightning/issues/5604

Was able to train for over 24 epochs with 4 GPUs without hanging.
