### PR TITLE
EnJa tokenize output format fix

### DIFF
--- a/nemo/collections/common/tokenizers/chinese_tokenizers.py
+++ b/nemo/collections/common/tokenizers/chinese_tokenizers.py
@@ -58,6 +58,5 @@ class ChineseProcessor:
         detokenize = lambda s: spacing(RE_WS_IN_FW.sub(r'\1', s)).strip()
         return detokenize(' '.join(text))
 
-    def tokenize(self, text: str):
-        text = jieba.cut(text)
-        return ' '.join(text)
+    def tokenize(self, text: str) -> List[str]:
+        return jieba.cut(text)

--- a/nemo/collections/common/tokenizers/chinese_tokenizers.py
+++ b/nemo/collections/common/tokenizers/chinese_tokenizers.py
@@ -59,4 +59,5 @@ class ChineseProcessor:
         return detokenize(' '.join(text))
 
     def tokenize(self, text: str) -> str:
-        return ' '.join(jieba.cut(text))
+        text = jieba.cut(text)
+        return ' '.join(text)

--- a/nemo/collections/common/tokenizers/chinese_tokenizers.py
+++ b/nemo/collections/common/tokenizers/chinese_tokenizers.py
@@ -58,5 +58,5 @@ class ChineseProcessor:
         detokenize = lambda s: spacing(RE_WS_IN_FW.sub(r'\1', s)).strip()
         return detokenize(' '.join(text))
 
-    def tokenize(self, text: str) -> List[str]:
-        return jieba.cut(text)
+    def tokenize(self, text: str) -> str:
+        return ' '.join(jieba.cut(text))

--- a/nemo/collections/common/tokenizers/en_ja_tokenizers.py
+++ b/nemo/collections/common/tokenizers/en_ja_tokenizers.py
@@ -45,7 +45,8 @@ class EnJaProcessor:
         """
         Tokenizes text using Moses. Returns a string of tokens.
         """
-        return ' '.join(self.moses_tokenizer.tokenize(text))
+        tokens = self.moses_tokenizer.tokenize(text)
+        return ' '.join(tokens)
 
     def normalize(self, text) -> str:
         # Normalization doesn't handle Japanese periods correctly;

--- a/nemo/collections/common/tokenizers/en_ja_tokenizers.py
+++ b/nemo/collections/common/tokenizers/en_ja_tokenizers.py
@@ -41,13 +41,13 @@ class EnJaProcessor:
         """
         return self.moses_detokenizer.detokenize(tokens)
 
-    def tokenize(self, text):
+    def tokenize(self, text) -> List[str]:
         """
         Tokenizes text using Moses.
         """
         return self.moses_tokenizer.tokenize(text)
 
-    def normalize(self, text):
+    def normalize(self, text) -> str:
         # Normalization doesn't handle Japanese periods correctly;
         # '。'becomes '.'.
         if self.lang_id == 'en':

--- a/nemo/collections/common/tokenizers/en_ja_tokenizers.py
+++ b/nemo/collections/common/tokenizers/en_ja_tokenizers.py
@@ -41,11 +41,11 @@ class EnJaProcessor:
         """
         return self.moses_detokenizer.detokenize(tokens)
 
-    def tokenize(self, text) -> List[str]:
+    def tokenize(self, text) -> str:
         """
-        Tokenizes text using Moses.
+        Tokenizes text using Moses. Returns a string of tokens.
         """
-        return self.moses_tokenizer.tokenize(text)
+        return ' '.join(self.moses_tokenizer.tokenize(text))
 
     def normalize(self, text) -> str:
         # Normalization doesn't handle Japanese periods correctly;

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -416,10 +416,8 @@ class MTEncDecModel(EncDecNLPModel):
             for txt in text:
                 if self.source_processor is not None:
                     txt = self.source_processor.normalize(txt)
-                    tokens = self.source_processor.tokenize(txt)
-                    ids = self.encoder_tokenizer.tokens_to_ids(tokens)
-                else:
-                    ids = self.encoder_tokenizer.text_to_ids(txt)
+                    txt = self.source_processor.tokenize(txt)
+                ids = self.encoder_tokenizer.text_to_ids(txt)
                 ids = [self.encoder_tokenizer.bos_id] + ids + [self.encoder_tokenizer.eos_id]
                 inputs.append(ids)
             max_len = max(len(txt) for txt in inputs)

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -416,8 +416,8 @@ class MTEncDecModel(EncDecNLPModel):
             for txt in text:
                 if self.source_processor is not None:
                     txt = self.source_processor.normalize(txt)
-                    txt = self.source_processor.tokenize(txt)
-                    ids = self.encoder_tokenizer.tokens_to_ids(txt)
+                    tokens = self.source_processor.tokenize(txt)
+                    ids = self.encoder_tokenizer.tokens_to_ids(tokens)
                 else:
                     ids = self.encoder_tokenizer.text_to_ids(txt)
                 ids = [self.encoder_tokenizer.bos_id] + ids + [self.encoder_tokenizer.eos_id]

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -417,7 +417,9 @@ class MTEncDecModel(EncDecNLPModel):
                 if self.source_processor is not None:
                     txt = self.source_processor.normalize(txt)
                     txt = self.source_processor.tokenize(txt)
-                ids = self.encoder_tokenizer.text_to_ids(txt)
+                    ids = self.encoder_tokenizer.tokens_to_ids(txt)
+                else:
+                    ids = self.encoder_tokenizer.text_to_ids(txt)
                 ids = [self.encoder_tokenizer.bos_id] + ids + [self.encoder_tokenizer.eos_id]
                 inputs.append(ids)
             max_len = max(len(txt) for txt in inputs)


### PR DESCRIPTION
~preprocessor `tokenize(txt)` methods should probably return a list of tokens, not a string. these can then be converted into ids without the intermediate steps of producing a string and then immediately splitting it for the tokens again, as was being done in `translate`~

it turns out that `text_to_ids(txt)` acts differently than `tokens_to_ids(txt.split(' '))`, so i am changing the output of the `processsor.tokenize` to be `str` again.