### PR TITLE
NMT export, _prepare_for_export refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:20.11-py3
+ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:21.02-py3
 
 
 # build an image that includes only the nemo dependencies, ensures that dependencies

--- a/examples/tts/tacotron2.py
+++ b/examples/tts/tacotron2.py
@@ -19,6 +19,7 @@ from nemo.collections.tts.models import Tacotron2Model
 from nemo.core.config import hydra_runner
 from nemo.utils.exp_manager import exp_manager
 
+
 # hydra_runner is a thin NeMo wrapper around Hydra
 # It looks for a config named tacotron2.yaml inside the conf folder
 # Hydra parses the yaml and returns it as a Omegaconf DictConfig

--- a/nemo/collections/asr/models/asr_model.py
+++ b/nemo/collections/asr/models/asr_model.py
@@ -82,6 +82,6 @@ class ExportableEncDecModel(Exportable):
     def forward_for_export(self, input):
         return self.output_module(self.input_module(input))
 
-    def _prepare_for_export(self):
-        self.input_module._prepare_for_export()
-        self.output_module._prepare_for_export()
+    def _prepare_for_export(self, **kwargs):
+        self.input_module._prepare_for_export(**kwargs)
+        self.output_module._prepare_for_export(**kwargs)

--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -72,9 +72,6 @@ class ConformerEncoder(NeuralModule, Exportable):
             Defaults to 0.0.
     """
 
-    def _prepare_for_export(self):
-        Exportable._prepare_for_export(self)
-
     def input_example(self):
         """
         Generates input examples for tracing etc.

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -52,12 +52,13 @@ class ConvASREncoder(NeuralModule, Exportable):
         https://arxiv.org/pdf/1910.10261.pdf
     """
 
-    def _prepare_for_export(self):
+    def _prepare_for_export(self, **kwargs):
         m_count = 0
         for m in self.modules():
             if isinstance(m, MaskedConv1d):
                 m.use_mask = False
                 m_count += 1
+        Exportable._prepare_for_export(self, **kwargs)
         logging.warning(f"Turned off {m_count} masked convolutions")
 
     def input_example(self):
@@ -250,7 +251,7 @@ class ConvASRDecoder(NeuralModule, Exportable):
         input_example = torch.randn(bs, self._feat_in, seq).to(next(self.parameters()).device)
         return tuple([input_example])
 
-    def _prepare_for_export(self):
+    def _prepare_for_export(self, **kwargs):
         m_count = 0
         for m in self.modules():
             if type(m).__name__ == "MaskedConv1d":
@@ -258,7 +259,7 @@ class ConvASRDecoder(NeuralModule, Exportable):
                 m_count += 1
         if m_count > 0:
             logging.warning(f"Turned off {m_count} masked convolutions")
-        Exportable._prepare_for_export(self)
+        Exportable._prepare_for_export(self, **kwargs)
 
     @property
     def vocabulary(self):

--- a/nemo/collections/asr/modules/lstm_decoder.py
+++ b/nemo/collections/asr/modules/lstm_decoder.py
@@ -86,9 +86,6 @@ class LSTMDecoder(NeuralModule, Exportable):
         input_example = torch.randn(bs, self._feat_in, seq).to(next(self.parameters()).device)
         return tuple([input_example])
 
-    def _prepare_for_export(self):
-        Exportable._prepare_for_export(self)
-
     @property
     def vocabulary(self):
         return self.__vocabulary

--- a/nemo/collections/common/parts/transformer_utils.py
+++ b/nemo/collections/common/parts/transformer_utils.py
@@ -41,7 +41,7 @@ def form_attention_mask(input_mask, diagonal=None):
         return None
     attn_shape = (1, input_mask.shape[1], input_mask.shape[1])
     attn_mask = input_mask.to(dtype=bool).unsqueeze(1)
-    if False:  # diagonal is not None:
+    if diagonal is not None:
         future_mask = torch.tril(torch.ones(attn_shape, dtype=torch.bool, device=input_mask.device), diagonal)
         attn_mask = attn_mask & future_mask
     attention_mask = (1 - attn_mask.to(torch.float)) * NEG_INF

--- a/nemo/collections/common/parts/transformer_utils.py
+++ b/nemo/collections/common/parts/transformer_utils.py
@@ -40,8 +40,8 @@ def form_attention_mask(input_mask, diagonal=None):
     if input_mask is None:
         return None
     attn_shape = (1, input_mask.shape[1], input_mask.shape[1])
-    attn_mask = input_mask.bool().unsqueeze(1)
-    if diagonal is not None:
+    attn_mask = input_mask.to(dtype=bool).unsqueeze(1)
+    if False:  # diagonal is not None:
         future_mask = torch.tril(torch.ones(attn_shape, dtype=torch.bool, device=input_mask.device), diagonal)
         attn_mask = attn_mask & future_mask
     attention_mask = (1 - attn_mask.to(torch.float)) * NEG_INF

--- a/nemo/collections/nlp/models/enc_dec_nlp_model.py
+++ b/nemo/collections/nlp/models/enc_dec_nlp_model.py
@@ -104,3 +104,11 @@ class EncDecNLPModel(NLPModel):
             tokenizer_model=self.register_artifact("cfg.decoder_tokenizer.tokenizer_model", decoder_tokenizer_model),
             bpe_dropout=decoder_bpe_dropout,
         )
+
+    @property
+    def input_module(self):
+        return self.encoder
+
+    @property
+    def output_module(self):
+        return self.decoder

--- a/nemo/collections/nlp/models/enc_dec_nlp_model.py
+++ b/nemo/collections/nlp/models/enc_dec_nlp_model.py
@@ -105,10 +105,5 @@ class EncDecNLPModel(NLPModel):
             bpe_dropout=decoder_bpe_dropout,
         )
 
-    @property
-    def input_module(self):
-        return self.encoder
-
-    @property
-    def output_module(self):
-        return self.decoder
+    def export(self, **kwargs):
+        raise NotImplementedError('For EncDecNLPModel, you must export encoder and decoder separately!')

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -168,7 +168,7 @@ class MTEncDecModel(EncDecNLPModel):
         tgt_hiddens = self.decoder(tgt, tgt_mask, src_hiddens, src_mask)
         log_probs = self.log_softmax(hidden_states=tgt_hiddens)
         return log_probs
-    
+
     def training_step(self, batch, batch_idx):
         """
         Lightning calls this inside the training loop with the data from the training dataloader
@@ -436,14 +436,19 @@ class MTEncDecModel(EncDecNLPModel):
     def list_available_models(cls) -> Optional[Dict[str, str]]:
         pass
 
-    def forward_for_export(self, src, encoder_input_mask):
-        encoder_hidden_states = self.encoder(src, encoder_input_mask)
-        tgt, batch_size, max_generation_length = self.beam_search._prepare_for_search(decoder_input_ids=None, encoder_hidden_states=encoder_hidden_states)
+    def forward_for_export(self, src: torch.Tensor, src_mask: torch.Tensor):
+        src_hiddens = self.encoder(input_ids=src, encoder_mask=src_mask)
+        beam_results = self.beam_search(encoder_hidden_states=src_hiddens, encoder_input_mask=src_mask)
+        beam_results = self.filter_predicted_ids(beam_results)
+        return beam_results
 
-        # generate initial buffer of beam_size prefixes-hypotheses
-        return self.beam_search._one_step_forward(tgt, encoder_hidden_states, encoder_input_mask, None, 0)
-
-#        ret = self.beam_search(encoder_hidden_states=src_hiddens, encoder_input_mask=src_mask)
-#        log_probs = self.log_softmax(hidden_states=tgt_hiddens)
-#        return ret
-
+    def input_example(self):
+        """
+        Generates input examples for tracing etc.
+        Returns:
+            A tuple of input examples.
+        """
+        sample = next(self.parameters())
+        input_ids = torch.randint(low=0, high=2048, size=(2, 16), device=sample.device)
+        encoder_mask = torch.randint(low=0, high=1, size=(2, 16), device=sample.device)
+        return tuple([input_ids, encoder_mask])

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -435,20 +435,3 @@ class MTEncDecModel(EncDecNLPModel):
     @classmethod
     def list_available_models(cls) -> Optional[Dict[str, str]]:
         pass
-
-    def forward_for_export(self, src: torch.Tensor, src_mask: torch.Tensor):
-        src_hiddens = self.encoder(input_ids=src, encoder_mask=src_mask)
-        beam_results = self.beam_search(encoder_hidden_states=src_hiddens, encoder_input_mask=src_mask)
-        beam_results = self.filter_predicted_ids(beam_results)
-        return beam_results
-
-    def input_example(self):
-        """
-        Generates input examples for tracing etc.
-        Returns:
-            A tuple of input examples.
-        """
-        sample = next(self.parameters())
-        input_ids = torch.randint(low=0, high=2048, size=(2, 16), device=sample.device)
-        encoder_mask = torch.randint(low=0, high=1, size=(2, 16), device=sample.device)
-        return tuple([input_ids, encoder_mask])

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -168,7 +168,7 @@ class MTEncDecModel(EncDecNLPModel):
         tgt_hiddens = self.decoder(tgt, tgt_mask, src_hiddens, src_mask)
         log_probs = self.log_softmax(hidden_states=tgt_hiddens)
         return log_probs
-
+    
     def training_step(self, batch, batch_idx):
         """
         Lightning calls this inside the training loop with the data from the training dataloader
@@ -435,3 +435,15 @@ class MTEncDecModel(EncDecNLPModel):
     @classmethod
     def list_available_models(cls) -> Optional[Dict[str, str]]:
         pass
+
+    def forward_for_export(self, src, encoder_input_mask):
+        encoder_hidden_states = self.encoder(src, encoder_input_mask)
+        tgt, batch_size, max_generation_length = self.beam_search._prepare_for_search(decoder_input_ids=None, encoder_hidden_states=encoder_hidden_states)
+
+        # generate initial buffer of beam_size prefixes-hypotheses
+        return self.beam_search._one_step_forward(tgt, encoder_hidden_states, encoder_input_mask, None, 0)
+
+#        ret = self.beam_search(encoder_hidden_states=src_hiddens, encoder_input_mask=src_mask)
+#        log_probs = self.log_softmax(hidden_states=tgt_hiddens)
+#        return ret
+

--- a/nemo/collections/nlp/models/neural_machine_translation/neural_machine_translation_model.py
+++ b/nemo/collections/nlp/models/neural_machine_translation/neural_machine_translation_model.py
@@ -134,7 +134,7 @@ class NeuralMachineTranslationModel(ModelPT):
         return outputs
 
     @typecheck.disable_checks()
-    def generate(self, input_ids: Union[torch.Tensor, torch.LongTensor]) -> torch.Tensor:
+    def generate(self, input_ids: torch.Tensor) -> torch.Tensor:
         """Wraps huggingface EncoderDecoder.generate()."""
         outputs = self.model.generate(
             input_ids=input_ids,

--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
@@ -489,8 +489,3 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
     @property
     def output_module(self):
         return self
-
-    def _prepare_for_export(self):
-        self.bert_model._prepare_for_export()
-        self.punct_classifier._prepare_for_export()
-        self.capit_classifier._prepare_for_export()

--- a/nemo/collections/nlp/models/token_classification/token_classification_model.py
+++ b/nemo/collections/nlp/models/token_classification/token_classification_model.py
@@ -518,6 +518,3 @@ class TokenClassificationModel(NLPModel):
         )
         result.append(model)
         return result
-
-    def _prepare_for_export(self):
-        return self.bert_model._prepare_for_export()

--- a/nemo/collections/nlp/modules/common/transformer/transformer.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer.py
@@ -22,7 +22,8 @@ from nemo.collections.nlp.modules.common.transformer.transformer_decoders import
 from nemo.collections.nlp.modules.common.transformer.transformer_encoders import TransformerEncoder
 from nemo.collections.nlp.modules.common.transformer.transformer_modules import TransformerEmbedding
 from nemo.core.classes.common import typecheck
-
+from nemo.core.classes.exportable import Exportable
+import torch
 
 @dataclass
 class TransformerConfig:
@@ -51,7 +52,7 @@ class TransformerEncoderConfig(TransformerConfig):
     mask_future: bool = False
 
 
-class TransformerEncoderNM(EncoderModule):
+class TransformerEncoderNM(EncoderModule, Exportable):
     def __init__(
         self,
         vocab_size: int,
@@ -107,8 +108,18 @@ class TransformerEncoderNM(EncoderModule):
     def hidden_size(self):
         return self._hidden_size
 
+    def input_example(self):
+        """
+        Generates input examples for tracing etc.
+        Returns:
+            A tuple of input examples.
+        """
+        sample = next(self.parameters())
+        input_ids = torch.randint(low=0, high=2048, size=(2, 16), device=sample.device)
+        encoder_mask = torch.randint(low=0, high=1, size=(2, 16), device=sample.device)
+        return tuple([input_ids, encoder_mask])
 
-class TransformerDecoderNM(DecoderModule):
+class TransformerDecoderNM(DecoderModule, Exportable):
     def __init__(
         self,
         vocab_size: int,
@@ -178,3 +189,4 @@ class TransformerDecoderNM(DecoderModule):
     @property
     def decoder(self):
         return self._decoder
+

--- a/nemo/collections/nlp/modules/common/transformer/transformer.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer.py
@@ -14,6 +14,7 @@
 
 from dataclasses import dataclass
 
+import torch
 from omegaconf.omegaconf import MISSING
 
 from nemo.collections.nlp.modules.common.decoder_module import DecoderModule
@@ -23,7 +24,7 @@ from nemo.collections.nlp.modules.common.transformer.transformer_encoders import
 from nemo.collections.nlp.modules.common.transformer.transformer_modules import TransformerEmbedding
 from nemo.core.classes.common import typecheck
 from nemo.core.classes.exportable import Exportable
-import torch
+
 
 @dataclass
 class TransformerConfig:
@@ -119,6 +120,7 @@ class TransformerEncoderNM(EncoderModule, Exportable):
         encoder_mask = torch.randint(low=0, high=1, size=(2, 16), device=sample.device)
         return tuple([input_ids, encoder_mask])
 
+
 class TransformerDecoderNM(DecoderModule, Exportable):
     def __init__(
         self,
@@ -190,3 +192,13 @@ class TransformerDecoderNM(DecoderModule, Exportable):
     def decoder(self):
         return self._decoder
 
+    def input_example(self):
+        """
+        Generates input examples for tracing etc.
+        Returns:
+            A tuple of input examples.
+        """
+        sample = next(self.parameters())
+        input_ids = torch.randint(low=0, high=2048, size=(2, 16), device=sample.device)
+        encoder_mask = torch.randint(low=0, high=1, size=(2, 16), device=sample.device)
+        return tuple([input_ids, encoder_mask, self._embedding(input_ids), encoder_mask])

--- a/nemo/collections/nlp/modules/common/transformer/transformer_decoders.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_decoders.py
@@ -159,3 +159,14 @@ class TransformerDecoder(nn.Module):
             return cached_mems_list
         else:
             return cached_mems_list[-1]
+
+    def input_example(self):
+        """
+        Generates input examples for tracing etc.
+        Returns:
+            A tuple of input examples.
+        """
+        sample = next(self.parameters())
+        input_ids = torch.randint(low=0, high=2048, size=(2, 16, 1024), device=sample.device)
+        encoder_mask = torch.randint(low=0, high=1, size=(2, 16), device=sample.device)
+        return tuple([input_ids, encoder_mask, input_ids, encoder_mask])

--- a/nemo/collections/nlp/modules/common/transformer/transformer_decoders.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_decoders.py
@@ -122,6 +122,7 @@ class TransformerDecoder(nn.Module):
             pre_ln,
         )
         self.layers = nn.ModuleList([copy.deepcopy(layer) for _ in range(num_layers)])
+        self.diagonal = 0
 
     def _get_memory_states(self, decoder_states, decoder_mems_list=None, i=0):
         if decoder_mems_list is not None:
@@ -145,7 +146,7 @@ class TransformerDecoder(nn.Module):
             return_mems: bool, whether to return outputs of all decoder layers
                 or the last layer only
         """
-        decoder_attn_mask = form_attention_mask(decoder_mask, diagonal=0)
+        decoder_attn_mask = form_attention_mask(decoder_mask, diagonal=self.diagonal)
         encoder_attn_mask = form_attention_mask(encoder_mask)
         memory_states = self._get_memory_states(decoder_states, decoder_mems_list, 0)
         cached_mems_list = [memory_states]
@@ -159,6 +160,17 @@ class TransformerDecoder(nn.Module):
             return cached_mems_list
         else:
             return cached_mems_list[-1]
+
+    def eval(self):
+        self.diagonal = None
+        super().eval()
+
+    def train(self, mode=True):
+        if mode is True:
+            self.diagonal = 0
+        else:
+            self.diagonal = None
+        super().train(mode)
 
     def input_example(self):
         """

--- a/nemo/collections/nlp/modules/common/transformer/transformer_modules.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_modules.py
@@ -20,7 +20,9 @@ from dataclasses import dataclass
 import torch
 from omegaconf.omegaconf import MISSING
 from torch import nn
+from torch import Tensor
 from torch.nn.functional import gelu
+from typing import Dict, Optional
 
 __all__ = ["TransformerEmbedding"]
 
@@ -88,7 +90,7 @@ class TransformerEmbedding(nn.Module):
         self.layer_norm = nn.LayerNorm(hidden_size, eps=1e-5)
         self.dropout = nn.Dropout(embedding_dropout)
 
-    def forward(self, input_ids, token_type_ids=None, start_pos=0):
+    def forward(self, input_ids: Tensor, token_type_ids: Optional[Tensor]=None, start_pos: int=0):
         seq_length = input_ids.size(1)
         if seq_length > self.max_sequence_length:
             raise ValueError(

--- a/nemo/collections/nlp/modules/common/transformer/transformer_modules.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_modules.py
@@ -20,9 +20,7 @@ from dataclasses import dataclass
 import torch
 from omegaconf.omegaconf import MISSING
 from torch import nn
-from torch import Tensor
 from torch.nn.functional import gelu
-from typing import Dict, Optional
 
 __all__ = ["TransformerEmbedding"]
 
@@ -90,7 +88,7 @@ class TransformerEmbedding(nn.Module):
         self.layer_norm = nn.LayerNorm(hidden_size, eps=1e-5)
         self.dropout = nn.Dropout(embedding_dropout)
 
-    def forward(self, input_ids: Tensor, token_type_ids: Optional[Tensor]=None, start_pos: int=0):
+    def forward(self, input_ids, token_type_ids=None, start_pos=0):
         seq_length = input_ids.size(1)
         if seq_length > self.max_sequence_length:
             raise ValueError(

--- a/nemo/collections/tts/models/waveglow.py
+++ b/nemo/collections/tts/models/waveglow.py
@@ -236,9 +236,9 @@ class WaveGlowModel(GlowVocoder, Exportable):
     def output_module(self):
         return self.waveglow
 
-    def _prepare_for_export(self):
+    def _prepare_for_export(self, **kwargs):
         self.update_bias_spect()
-        self.waveglow._prepare_for_export()
+        self.waveglow._prepare_for_export(**kwargs)
 
     def forward_for_export(self, spec, z=None):
         return self.waveglow(spec, z)

--- a/nemo/collections/tts/modules/waveglow.py
+++ b/nemo/collections/tts/modules/waveglow.py
@@ -99,14 +99,14 @@ class WaveGlowModule(NeuralModule, Exportable):
         self.removed_weightnorm = False
         self.converted_to_2D = False
 
-    def _prepare_for_export(self):
+    def _prepare_for_export(self, **kwargs):
         """
         Override this method to prepare module for export. This is in-place operation.
         Base version does common necessary module replacements (Apex etc)
         """
         self.remove_weightnorm()
         if not self.converted_to_2D:
-            super()._prepare_for_export(replace_1D_2D=True)
+            super()._prepare_for_export(replace_1D_2D=True, **kwargs)
             self.converted_to_2D = True
 
     @typecheck()

--- a/nemo/core/classes/exportable.py
+++ b/nemo/core/classes/exportable.py
@@ -19,7 +19,6 @@ from typing import Dict
 
 import onnx
 import torch
-import trtorch
 
 from nemo.core.classes import typecheck
 from nemo.core.neural_types import AxisKind, NeuralType
@@ -203,12 +202,6 @@ class Exportable(ABC):
                 if format == ExportFormat.TORCHSCRIPT:
                     jitted_model.save(output)
                     assert os.path.exists(output)
-                    # Compile module with TRTorch
-                    shapes = [i.shape for i in input_example]
-                    compiled_trt_model = trtorch.compile(
-                        jitted_model, {"input_shapes": shapes, "op_precision": torch.half,}  # Run in FP16
-                    )
-                    results = compiled_trt_model(data.half())
 
                 elif format == ExportFormat.ONNX:
                     if jitted_model is None:

--- a/nemo/core/classes/exportable.py
+++ b/nemo/core/classes/exportable.py
@@ -186,20 +186,19 @@ class Exportable(ABC):
                     except Exception as e:
                         print("jit.script() failed!", e)
 
-            if jitted_model is None:
-                jitted_model = torch.jit.trace(
-                    self,
-                    input_example,
-                    strict=False,
-                    optimize=True,
-                    check_trace=check_trace,
-                    check_tolerance=check_tolerance,
-                )
-                if verbose:
-                    print(jitted_model.code)
-
             with torch.jit.optimized_execution(True), torch.no_grad():
                 if format == ExportFormat.TORCHSCRIPT:
+                    if jitted_model is None:
+                        jitted_model = torch.jit.trace(
+                            self,
+                            input_example,
+                            strict=False,
+                            optimize=True,
+                            check_trace=check_trace,
+                            check_tolerance=check_tolerance,
+                        )
+                    if verbose:
+                        print(jitted_model.code)
                     jitted_model.save(output)
                     assert os.path.exists(output)
 

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -1170,7 +1170,11 @@ class ModelPT(LightningModule, Model):
         """
         Utility property that returns the total number of parameters of the Model.
         """
-        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+        num: int = 0
+        for p in self.parameters():
+            if p.requires_grad:
+                num += p.numel()
+        return num
 
     @property
     def cfg(self):

--- a/nemo/core/classes/module.py
+++ b/nemo/core/classes/module.py
@@ -28,7 +28,14 @@ class NeuralModule(Module, Typing, Serialization, FileIO):
 
     @property
     def num_weights(self):
-        return sum(p.numel() for p in self.parameters() if p.requires_grad)
+        """
+        Utility property that returns the total number of parameters of NeuralModule.
+        """
+        num: int = 0
+        for p in self.parameters():
+            if p.requires_grad:
+                num += p.numel()
+        return num
 
     def input_example(self):
         """

--- a/tests/collections/asr/test_asr_exportables.py
+++ b/tests/collections/asr/test_asr_exportables.py
@@ -25,31 +25,6 @@ from nemo.collections.asr.modules import ConvASRDecoder, ConvASREncoder
 class TestExportable:
     @pytest.mark.run_only_on('GPU')
     @pytest.mark.unit
-    def test_ConvASREncoder_export_to_onnx(self):
-        with tempfile.TemporaryDirectory() as tmpdir:
-            encoder_instance = ConvASREncoder.from_config_dict(DictConfig(self.encoder_dict)).cuda()
-            assert isinstance(encoder_instance, ConvASREncoder)
-            filename = os.path.join(tmpdir, 'qn_encoder.onnx')
-            encoder_instance.export(output=filename)
-            onnx_model = onnx.load(filename)
-            onnx.checker.check_model(onnx_model, full_check=True)  # throws when failed
-            assert onnx_model.graph.input[0].name == 'audio_signal'
-            assert onnx_model.graph.output[0].name == 'outputs'
-
-    @pytest.mark.run_only_on('GPU')
-    @pytest.mark.unit
-    def test_ConvASRDecoder_export_to_onnx(self):
-        decoder = ConvASRDecoder.from_config_dict(config=DictConfig(self.decoder_dict)).cuda()
-        with tempfile.TemporaryDirectory() as tmpdir:
-            filename = os.path.join(tmpdir, 'qn_decoder.onnx')
-            decoder.export(output=filename)
-            onnx_model = onnx.load(filename)
-            onnx.checker.check_model(onnx_model, full_check=True)  # throws when failed
-            assert onnx_model.graph.input[0].name == 'encoder_output'
-            assert onnx_model.graph.output[0].name == 'logprobs'
-
-    @pytest.mark.run_only_on('GPU')
-    @pytest.mark.unit
     def test_EncDecCTCModel_export_to_onnx(self):
         model_config = DictConfig(
             {
@@ -87,6 +62,17 @@ class TestExportable:
             assert onnx_model.graph.input[0].name == 'audio_signal'
             assert onnx_model.graph.output[0].name == 'logits'
 
+    def test_EncDecCitrinetModel_export_to_onnx(self, citrinet_model):
+        model = citrinet_model.train()
+        with tempfile.TemporaryDirectory() as tmpdir:
+            filename = os.path.join(tmpdir, 'sl.onnx')
+            model.export(output=filename)
+            onnx_model = onnx.load(filename)
+            onnx.checker.check_model(onnx_model, full_check=True)  # throws when failed
+            assert onnx_model.graph.input[0].name == 'audio_signal'
+            assert onnx_model.graph.output[0].name == 'logprobs'
+
+            
     def setup_method(self):
         self.preprocessor = {
             'cls': 'nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor',
@@ -232,3 +218,113 @@ def speaker_label_model():
     )
     speaker_model = EncDecSpeakerLabelModel(cfg=modelConfig)
     return speaker_model
+
+
+@pytest.fixture()
+def citrinet_model():
+    preprocessor = {'cls': 'nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor', 'params': dict({})}
+    encoder = {
+        'cls': 'nemo.collections.asr.modules.ConvASREncoder',
+        'params': {
+            'feat_in': 80,
+            'activation': 'relu',
+            'conv_mask': True,
+            'jasper': [
+                {
+                    'filters': 512,
+                    'repeat': 1,
+                    'kernel': [5],
+                    'stride': [1],
+                    'dilation': [1],
+                    'dropout': 0.0,
+                    'residual': False,
+                    'separable': True,
+                    'se': True,
+                    'se_context_size': -1,
+                },
+                {
+                    'filters': 512,
+                    'repeat': 5,
+                    'kernel': [11],
+                    'stride': [2],
+                    'dilation': [1],
+                    'dropout': 0.1,
+                    'residual': True,
+                    'separable': True,
+                    'se': True,
+                    'se_context_size': -1,
+                    'stride_last': True,
+                    'residual_mode': 'stride_add',
+                },
+                {
+                    'filters': 512,
+                    'repeat': 5,
+                    'kernel': [13],
+                    'stride': [1],
+                    'dilation': [1],
+                    'dropout': 0.1,
+                    'residual': True,
+                    'separable': True,
+                    'se': True,
+                    'se_context_size': -1,
+                },
+                {
+                    'filters': 640,
+                    'repeat': 1,
+                    'kernel': [41],
+                    'stride': [1],
+                    'dilation': [1],
+                    'dropout': 0.0,
+                    'residual': True,
+                    'separable': True,
+                    'se': True,
+                    'se_context_size': -1,
+                }
+
+            ],
+        },
+    }
+    
+    decoder = {
+        'cls': 'nemo.collections.asr.modules.ConvASRDecoder',
+        'params': {
+            'feat_in': 640,
+            'num_classes': 28,
+            'vocabulary': [
+                ' ',
+                'a',
+                'b',
+                'c',
+                'd',
+                'e',
+                'f',
+                'g',
+                'h',
+                'i',
+                'j',
+                'k',
+                'l',
+                'm',
+                'n',
+                'o',
+                'p',
+                'q',
+                'r',
+                's',
+                't',
+                'u',
+                'v',
+                'w',
+                'x',
+                'y',
+                'z',
+                "'",
+            ],
+        },
+    }
+    
+    modelConfig = DictConfig(
+        {'preprocessor': DictConfig(preprocessor), 'encoder': DictConfig(encoder), 'decoder': DictConfig(decoder)}
+    )
+    citri_model = EncDecSpeakerLabelModel(cfg=modelConfig)
+    return citri_model

--- a/tests/collections/asr/test_asr_exportables.py
+++ b/tests/collections/asr/test_asr_exportables.py
@@ -65,7 +65,7 @@ class TestExportable:
     def test_EncDecCitrinetModel_export_to_onnx(self, citrinet_model):
         model = citrinet_model.train()
         with tempfile.TemporaryDirectory() as tmpdir:
-            filename = os.path.join(tmpdir, 'sl.onnx')
+            filename = os.path.join('.', 'citri.onnx')
             model.export(output=filename)
             onnx_model = onnx.load(filename)
             onnx.checker.check_model(onnx_model, full_check=True)  # throws when failed
@@ -287,37 +287,8 @@ def citrinet_model():
         'cls': 'nemo.collections.asr.modules.ConvASRDecoder',
         'params': {
             'feat_in': 640,
-            'num_classes': 28,
-            'vocabulary': [
-                ' ',
-                'a',
-                'b',
-                'c',
-                'd',
-                'e',
-                'f',
-                'g',
-                'h',
-                'i',
-                'j',
-                'k',
-                'l',
-                'm',
-                'n',
-                'o',
-                'p',
-                'q',
-                'r',
-                's',
-                't',
-                'u',
-                'v',
-                'w',
-                'x',
-                'y',
-                'z',
-                "'",
-            ],
+            'num_classes': 1024,
+            'vocabulary': list(chr(i%28) for i in range(0,1024))
         },
     }
 

--- a/tests/collections/asr/test_asr_exportables.py
+++ b/tests/collections/asr/test_asr_exportables.py
@@ -285,11 +285,7 @@ def citrinet_model():
 
     decoder = {
         'cls': 'nemo.collections.asr.modules.ConvASRDecoder',
-        'params': {
-            'feat_in': 640,
-            'num_classes': 1024,
-            'vocabulary': list(chr(i%28) for i in range(0,1024))
-        },
+        'params': {'feat_in': 640, 'num_classes': 1024, 'vocabulary': list(chr(i % 28) for i in range(0, 1024))},
     }
 
     modelConfig = DictConfig(

--- a/tests/collections/asr/test_asr_exportables.py
+++ b/tests/collections/asr/test_asr_exportables.py
@@ -72,7 +72,6 @@ class TestExportable:
             assert onnx_model.graph.input[0].name == 'audio_signal'
             assert onnx_model.graph.output[0].name == 'logprobs'
 
-            
     def setup_method(self):
         self.preprocessor = {
             'cls': 'nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor',
@@ -279,12 +278,11 @@ def citrinet_model():
                     'separable': True,
                     'se': True,
                     'se_context_size': -1,
-                }
-
+                },
             ],
         },
     }
-    
+
     decoder = {
         'cls': 'nemo.collections.asr.modules.ConvASRDecoder',
         'params': {
@@ -322,7 +320,7 @@ def citrinet_model():
             ],
         },
     }
-    
+
     modelConfig = DictConfig(
         {'preprocessor': DictConfig(preprocessor), 'encoder': DictConfig(encoder), 'decoder': DictConfig(decoder)}
     )

--- a/tests/collections/nlp/test_megatron.py
+++ b/tests/collections/nlp/test_megatron.py
@@ -30,6 +30,12 @@ import torch
 import nemo.collections.nlp as nemo_nlp
 from nemo.core.classes import typecheck
 
+def get_pretrained_bert_345m_uncased_model():
+    model_name = "megatron-bert-345m-uncased"
+    model = nemo_nlp.modules.get_lm_model(pretrained_model_name=model_name)
+    if torch.cuda.is_available():
+        model = model.cuda()
+    return model
 
 class TestMegatron(TestCase):
     @pytest.mark.run_only_on('GPU')
@@ -40,31 +46,27 @@ class TestMegatron(TestCase):
 
     @pytest.mark.run_only_on('GPU')
     @pytest.mark.unit
-    def test_get_pretrained_bert_345m_uncased_model(self):
-        model_name = "megatron-bert-345m-uncased"
-        model = nemo_nlp.modules.get_lm_model(pretrained_model_name=model_name)
-        if torch.cuda.is_available():
-            model = model.cuda()
-
+    @pytest.mark.skip("Only one Megatron model is allowed")
+    def test_get_model(self):
+        model = get_pretrained_bert_345m_uncased_model()
         assert isinstance(model, nemo_nlp.modules.MegatronBertEncoder)
 
         typecheck.set_typecheck_enabled(enabled=False)
         inp = model.input_example()
         out = model.forward(*inp)
         typecheck.set_typecheck_enabled(enabled=True)
-        self.model = model
 
     @pytest.mark.run_only_on('GPU')
     @pytest.mark.unit
-    @pytest.mark.skip('ONNX export is broken in PyTorch')
     def test_onnx_export(self):
-        assert self.model
+        model = get_pretrained_bert_345m_uncased_model()
+        assert model
         with tempfile.TemporaryDirectory() as tmpdir:
             # Generate filename in the temporary directory.
             # Test export.
-            self.model.export(os.path.join(tmpdir, "megatron.onnx"))
+            model.export(os.path.join(tmpdir, "megatron.onnx"))
 
 
 if __name__ == "__main__":
     t = TestMegatron()
-    t.test_get_pretrained_bert_345m_uncased_model()
+    t.test_onnx_export()

--- a/tests/collections/nlp/test_megatron.py
+++ b/tests/collections/nlp/test_megatron.py
@@ -30,12 +30,14 @@ import torch
 import nemo.collections.nlp as nemo_nlp
 from nemo.core.classes import typecheck
 
+
 def get_pretrained_bert_345m_uncased_model():
     model_name = "megatron-bert-345m-uncased"
     model = nemo_nlp.modules.get_lm_model(pretrained_model_name=model_name)
     if torch.cuda.is_available():
         model = model.cuda()
     return model
+
 
 class TestMegatron(TestCase):
     @pytest.mark.run_only_on('GPU')

--- a/tests/collections/nlp/test_nmt_model.py
+++ b/tests/collections/nlp/test_nmt_model.py
@@ -30,6 +30,7 @@ def export_test(model, suffix, try_script=False):
         assert os.path.exists(enc_filename)
         assert os.path.exists(dec_filename)
 
+
 def get_cfg():
     cfg = AAYNBaseConfig()
     cfg.encoder_tokenizer.tokenizer_name = 'yttm'
@@ -40,6 +41,7 @@ def get_cfg():
     cfg.validation_ds = None
     cfg.test_ds = None
     return cfg
+
 
 class TestMTEncDecModel:
     @pytest.mark.unit
@@ -78,7 +80,7 @@ class TestMTEncDecModel:
         assert isinstance(model, MTEncDecModel)
         export_test(model, ".onnx")
         export_test(model, ".ts")
-    
+
 
 if __name__ == "__main__":
     t = TestMTEncDecModel()

--- a/tests/collections/nlp/test_nmt_model.py
+++ b/tests/collections/nlp/test_nmt_model.py
@@ -67,21 +67,32 @@ class TestMTEncDecModel:
             assert model.num_weights == model_copy.num_weights
 
     @pytest.mark.unit
-    def test_cpu_export(self):
+    def test_cpu_export_onnx(self):
+        model = MTEncDecModel(cfg=get_cfg())
+        assert isinstance(model, MTEncDecModel)
+        export_test(model, ".ts")
+
+    @pytest.mark.unit
+    def test_cpu_export_ts(self):
         model = MTEncDecModel(cfg=get_cfg())
         assert isinstance(model, MTEncDecModel)
         export_test(model, ".onnx")
+
+    @pytest.mark.run_only_on('GPU')
+    @pytest.mark.unit
+    def test_gpu_export_ts(self):
+        model = MTEncDecModel(cfg=get_cfg()).cuda()
+        assert isinstance(model, MTEncDecModel)
         export_test(model, ".ts")
 
     @pytest.mark.run_only_on('GPU')
     @pytest.mark.unit
-    def test_gpu_export(self):
+    def test_gpu_export_onnx(self):
         model = MTEncDecModel(cfg=get_cfg()).cuda()
         assert isinstance(model, MTEncDecModel)
         export_test(model, ".onnx")
-        export_test(model, ".ts")
 
 
 if __name__ == "__main__":
     t = TestMTEncDecModel()
-    t.test_gpu_export()
+    t.test_gpu_export_ts()

--- a/tests/collections/nlp/test_nmt_model.py
+++ b/tests/collections/nlp/test_nmt_model.py
@@ -49,13 +49,15 @@ class TestMTEncDecModel:
             assert not os.path.exists(model_save_path)
             assert os.path.exists(model_restore_path)
             # attempt to restore
-            model_copy = model.__class__.restore_from(restore_path=model_restore_path)
+            model_copy = model.__class__.restore_from(restore_path=model_restore_path).cuda()
             assert model.num_weights == model_copy.num_weights
 
-            filename = os.path.join(restore_folder, 'nmt.onnx')
-            model.export(output=filename, try_script=True, verbose=True)
+            enc_filename = os.path.join(restore_folder, 'nmt_e.onnx')
+            dec_filename = os.path.join(restore_folder, 'nmt_d.onnx')
+            model_copy.encoder.export(output=enc_filename, try_script=True, verbose=True)
+            model_copy.decoder.export(output=dec_filename, try_script=True, verbose=True)
+
 
 if __name__ == "__main__":
     t = TestMTEncDecModel()
     t.test_creation_saving_restoring()
-

--- a/tests/collections/nlp/test_nmt_model.py
+++ b/tests/collections/nlp/test_nmt_model.py
@@ -51,3 +51,11 @@ class TestMTEncDecModel:
             # attempt to restore
             model_copy = model.__class__.restore_from(restore_path=model_restore_path)
             assert model.num_weights == model_copy.num_weights
+
+            filename = os.path.join(restore_folder, 'nmt.onnx')
+            model.export(output=filename, try_script=True, verbose=True)
+
+if __name__ == "__main__":
+    t = TestMTEncDecModel()
+    t.test_creation_saving_restoring()
+

--- a/tests/collections/nlp/test_nmt_model.py
+++ b/tests/collections/nlp/test_nmt_model.py
@@ -21,18 +21,30 @@ from nemo.collections.nlp.models import MTEncDecModel
 from nemo.collections.nlp.models.machine_translation.mt_enc_dec_config import AAYNBaseConfig
 
 
+def export_test(model, suffix, try_script=False):
+    with tempfile.TemporaryDirectory() as restore_folder:
+        enc_filename = os.path.join(restore_folder, 'nmt_e' + suffix)
+        dec_filename = os.path.join(restore_folder, 'nmt_d' + suffix)
+        model.encoder.export(output=enc_filename, try_script=try_script)
+        model.decoder.export(output=dec_filename, try_script=try_script)
+        assert os.path.exists(enc_filename)
+        assert os.path.exists(dec_filename)
+
+def get_cfg():
+    cfg = AAYNBaseConfig()
+    cfg.encoder_tokenizer.tokenizer_name = 'yttm'
+    cfg.encoder_tokenizer.tokenizer_model = 'tests/.data/yttm.4096.en-de.model'
+    cfg.decoder_tokenizer.tokenizer_name = 'yttm'
+    cfg.decoder_tokenizer.tokenizer_model = 'tests/.data/yttm.4096.en-de.model'
+    cfg.train_ds = None
+    cfg.validation_ds = None
+    cfg.test_ds = None
+    return cfg
+
 class TestMTEncDecModel:
     @pytest.mark.unit
     def test_creation_saving_restoring(self):
-        cfg = AAYNBaseConfig()
-        cfg.encoder_tokenizer.tokenizer_name = 'yttm'
-        cfg.encoder_tokenizer.tokenizer_model = 'tests/.data/yttm.4096.en-de.model'
-        cfg.decoder_tokenizer.tokenizer_name = 'yttm'
-        cfg.decoder_tokenizer.tokenizer_model = 'tests/.data/yttm.4096.en-de.model'
-        cfg.train_ds = None
-        cfg.validation_ds = None
-        cfg.test_ds = None
-        model = MTEncDecModel(cfg=cfg)
+        model = MTEncDecModel(cfg=get_cfg())
         assert isinstance(model, MTEncDecModel)
         # Create a new temporary directory
         with tempfile.TemporaryDirectory() as restore_folder:
@@ -49,15 +61,25 @@ class TestMTEncDecModel:
             assert not os.path.exists(model_save_path)
             assert os.path.exists(model_restore_path)
             # attempt to restore
-            model_copy = model.__class__.restore_from(restore_path=model_restore_path).cuda()
+            model_copy = model.__class__.restore_from(restore_path=model_restore_path)
             assert model.num_weights == model_copy.num_weights
 
-            enc_filename = os.path.join(restore_folder, 'nmt_e.onnx')
-            dec_filename = os.path.join(restore_folder, 'nmt_d.onnx')
-            model_copy.encoder.export(output=enc_filename, try_script=True, verbose=True)
-            model_copy.decoder.export(output=dec_filename, try_script=True, verbose=True)
+    @pytest.mark.unit
+    def test_cpu_export(self):
+        model = MTEncDecModel(cfg=get_cfg())
+        assert isinstance(model, MTEncDecModel)
+        export_test(model, ".onnx")
+        export_test(model, ".ts")
 
+    @pytest.mark.run_only_on('GPU')
+    @pytest.mark.unit
+    def test_gpu_export(self):
+        model = MTEncDecModel(cfg=get_cfg()).cuda()
+        assert isinstance(model, MTEncDecModel)
+        export_test(model, ".onnx")
+        export_test(model, ".ts")
+    
 
 if __name__ == "__main__":
     t = TestMTEncDecModel()
-    t.test_creation_saving_restoring()
+    t.test_gpu_export()


### PR DESCRIPTION
Here, added export tp NMT's encoder and decoder. 
The design decision is is to have those 2 parts explicitly exportable, instead of having whole model's export() produce 2 files. 
Test added. 