### PR TITLE
NMT adding pretrained HF encoders

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -948,7 +948,7 @@ pipeline {
               model.shared_tokenizer=False \
               model.encoder_tokenizer.library=huggingface \
               model.encoder.library=huggingface \
-              model.encoder.model_name=bert-base-uncased \
+              model.encoder.model_name=bert-base-cased \
               model.encoder.pretrained=true \
               model.train_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
               model.train_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.ref \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -930,6 +930,70 @@ pipeline {
       }
     }
 
+    stage('L2: NMT with HuggingFace') {
+      when {
+        anyOf{
+          branch 'main'
+          changeRequest target: 'main'
+        }
+      }
+      failFast true
+      parallel {
+        stage('L2: NMT Pretrained HF Encoder') {
+            steps {
+              sh 'cd examples/nlp/machine_translation && \
+              python enc_dec_nmt.py \
+              --config-path=conf \
+              --config-name=huggingface \
+              model.shared_tokenizer=False \
+              model.encoder_tokenizer.library=huggingface \
+              model.encoder.library=huggingface \
+              model.encoder.model_name=bert-base-uncased \
+              model.encoder.pretrained=true \
+              model.train_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
+              model.train_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.ref \
+              model.validation_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
+              model.validation_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
+              model.test_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
+              model.test_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
+              model.decoder_tokenizer.tokenizer_model=/home/TestData/nlp/nmt/toy_data/tt_tokenizer.BPE.4096.model \
+              trainer.gpus=[0] \
+              +trainer.fast_dev_run=true \
+              exp_manager=null \
+              '
+            }
+        }
+
+        stage('L2: NMT Custom HF Encoder') {
+            steps {
+              sh 'cd examples/nlp/machine_translation && \
+              python enc_dec_nmt.py \
+              --config-path=conf \
+              --config-name=huggingface \
+              model.shared_tokenizer=False \
+              model.encoder_tokenizer.library=huggingface \
+              model.encoder.library=huggingface \
+              model.encoder.model_name=null \
+              model.encoder.pretrained=false \
+              +model.encoder._target_=transformers.BertConfig \
+              +model.encoder.hidden_size=1536 \
+              model.train_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
+              model.train_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.ref \
+              model.validation_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
+              model.validation_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
+              model.test_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
+              model.test_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
+              model.decoder_tokenizer.tokenizer_model=/home/TestData/nlp/nmt/toy_data/tt_tokenizer.BPE.4096.model \
+              trainer.gpus=[1] \
+              +trainer.fast_dev_run=true \
+              exp_manager=null \
+              '
+            }
+        }
+
+        }
+      }
+
     stage('L2: TTS Fast dev runs 1') {
       when {
         anyOf{

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -970,8 +970,9 @@ pipeline {
               python enc_dec_nmt.py \
               --config-path=conf \
               --config-name=huggingface \
-              model.shared_tokenizer=False \
-              model.encoder_tokenizer.library=huggingface \
+              model.shared_tokenizer=True \
+              model.encoder_tokenizer.library=yttm \
+              model.encoder_tokenizer.tokenizer_model=/home/TestData/nlp/nmt/toy_data/tt_tokenizer.BPE.4096.model \
               model.encoder.library=huggingface \
               model.encoder.model_name=null \
               model.encoder.pretrained=false \
@@ -990,9 +991,8 @@ pipeline {
               '
             }
         }
-
-        }
       }
+    }
 
     stage('L2: TTS Fast dev runs 1') {
       when {

--- a/examples/nlp/machine_translation/conf/aayn_base.yaml
+++ b/examples/nlp/machine_translation/conf/aayn_base.yaml
@@ -86,20 +86,24 @@ model:
     special_tokens: null
 
   encoder:
-    max_sequence_length: 512
-    num_token_types: 2
-    embedding_dropout: 0.1
-    learn_positional_encodings: false
-    hidden_size: 512
-    num_layers: 6
-    inner_size: 2048
-    num_attention_heads: 8
-    ffn_dropout: 0.1
-    attn_score_dropout: 0.1
-    attn_layer_dropout: 0.1
-    hidden_act: relu
-    mask_future: false
-    pre_ln: false
+    library: nemo
+    model_name: null
+    pretrained: false
+    transformer_config:
+      max_sequence_length: 512
+      num_token_types: 2
+      embedding_dropout: 0.1
+      learn_positional_encodings: false
+      hidden_size: 512
+      num_layers: 6
+      inner_size: 2048
+      num_attention_heads: 8
+      ffn_dropout: 0.1
+      attn_score_dropout: 0.1
+      attn_layer_dropout: 0.1
+      hidden_act: relu
+      mask_future: false
+      pre_ln: false
 
   decoder:
     max_sequence_length: 512

--- a/examples/nlp/machine_translation/conf/aayn_base.yaml
+++ b/examples/nlp/machine_translation/conf/aayn_base.yaml
@@ -89,40 +89,38 @@ model:
     library: nemo
     model_name: null
     pretrained: false
-    transformer:
-      max_sequence_length: 512
-      num_token_types: 2
-      embedding_dropout: 0.1
-      learn_positional_encodings: false
-      hidden_size: 512
-      num_layers: 6
-      inner_size: 2048
-      num_attention_heads: 8
-      ffn_dropout: 0.1
-      attn_score_dropout: 0.1
-      attn_layer_dropout: 0.1
-      hidden_act: relu
-      mask_future: false
-      pre_ln: false
+    max_sequence_length: 512
+    num_token_types: 2
+    embedding_dropout: 0.1
+    learn_positional_encodings: false
+    hidden_size: 512
+    num_layers: 6
+    inner_size: 2048
+    num_attention_heads: 8
+    ffn_dropout: 0.1
+    attn_score_dropout: 0.1
+    attn_layer_dropout: 0.1
+    hidden_act: relu
+    mask_future: false
+    pre_ln: false
 
   decoder:
     library: nemo
     model_name: null
     pretrained: false
-    transformer:
-      max_sequence_length: 512
-      num_token_types: 2
-      embedding_dropout: 0.1
-      learn_positional_encodings: false
-      hidden_size: 512
-      inner_size: 2048
-      num_layers: 6
-      num_attention_heads: 8
-      ffn_dropout: 0.1
-      attn_score_dropout: 0.1
-      attn_layer_dropout: 0.1
-      hidden_act: relu
-      pre_ln: false
+    max_sequence_length: 512
+    num_token_types: 2
+    embedding_dropout: 0.1
+    learn_positional_encodings: false
+    hidden_size: 512
+    inner_size: 2048
+    num_layers: 6
+    num_attention_heads: 8
+    ffn_dropout: 0.1
+    attn_score_dropout: 0.1
+    attn_layer_dropout: 0.1
+    hidden_act: relu
+    pre_ln: false
 
   head:
     num_layers: 1

--- a/examples/nlp/machine_translation/conf/aayn_base.yaml
+++ b/examples/nlp/machine_translation/conf/aayn_base.yaml
@@ -70,7 +70,7 @@ model:
       warmup_ratio: 0.1
 
   encoder_tokenizer:
-    tokenizer_name: yttm
+    library: yttm
     tokenizer_model: null
     vocab_size: null # vocab size for training bpe
     bpe_dropout: null
@@ -78,7 +78,7 @@ model:
     special_tokens: null
 
   decoder_tokenizer:
-    tokenizer_name: yttm
+    library: yttm
     tokenizer_model: null
     vocab_size: null # vocab size for training bpe
     bpe_dropout: null

--- a/examples/nlp/machine_translation/conf/aayn_base.yaml
+++ b/examples/nlp/machine_translation/conf/aayn_base.yaml
@@ -89,7 +89,7 @@ model:
     library: nemo
     model_name: null
     pretrained: false
-    transformer_config:
+    transformer:
       max_sequence_length: 512
       num_token_types: 2
       embedding_dropout: 0.1
@@ -106,19 +106,23 @@ model:
       pre_ln: false
 
   decoder:
-    max_sequence_length: 512
-    num_token_types: 2
-    embedding_dropout: 0.1
-    learn_positional_encodings: false
-    hidden_size: 512
-    inner_size: 2048
-    num_layers: 6
-    num_attention_heads: 8
-    ffn_dropout: 0.1
-    attn_score_dropout: 0.1
-    attn_layer_dropout: 0.1
-    hidden_act: relu
-    pre_ln: false
+    library: nemo
+    model_name: null
+    pretrained: false
+    transformer:
+      max_sequence_length: 512
+      num_token_types: 2
+      embedding_dropout: 0.1
+      learn_positional_encodings: false
+      hidden_size: 512
+      inner_size: 2048
+      num_layers: 6
+      num_attention_heads: 8
+      ffn_dropout: 0.1
+      attn_score_dropout: 0.1
+      attn_layer_dropout: 0.1
+      hidden_act: relu
+      pre_ln: false
 
   head:
     num_layers: 1

--- a/examples/nlp/machine_translation/conf/aayn_base.yaml
+++ b/examples/nlp/machine_translation/conf/aayn_base.yaml
@@ -8,6 +8,8 @@ model:
   label_smoothing: 0.1
   shared_tokenizer: True # train tokenizer model across src and tgt train data
   preproc_out_dir: null # path to store data preprocessing outputs
+  src_language: 'en'
+  tgt_language: 'de'
 
   train_ds:
     src_file_name: null

--- a/examples/nlp/machine_translation/conf/huggingface.yaml
+++ b/examples/nlp/machine_translation/conf/huggingface.yaml
@@ -1,0 +1,120 @@
+name: HuggingFaceEncoder
+do_training: true
+
+model:
+  beam_size: 4
+  len_pen: 0.6
+  max_generation_delta: 5
+  label_smoothing: 0.1
+  preproc_out_dir: null
+  shared_tokenizer: false
+
+  train_ds:
+    src_file_name: null
+    tgt_file_name: null
+    use_tarred_dataset: null
+    tokens_in_batch: 512
+    clean: true
+    max_seq_length: 512
+    shuffle: true
+    num_samples: -1
+    drop_last: false
+    pin_memory: false
+    num_workers: 8
+
+  validation_ds:
+    src_file_name: null
+    tgt_file_name: null
+    tokens_in_batch: 512
+    clean: false
+    max_seq_length: 512
+    shuffle: false
+    num_samples: -1
+    drop_last: false
+    pin_memory: false
+    num_workers: 8
+
+  test_ds:
+    src_file_name: null
+    tgt_file_name: null
+    tokens_in_batch: 512
+    clean: false
+    max_seq_length: 512
+    shuffle: false
+    num_samples: -1
+    drop_last: false
+    pin_memory: false
+    num_workers: 8
+
+  optim:
+    name: adam
+    lr: 0.001
+    betas:
+      - 0.9
+      - 0.98
+    weight_decay: 0.0
+    sched:
+      name: InverseSquareRootAnnealing
+      min_lr: 0.0
+      last_epoch: -1
+      warmup_ratio: 0.1
+
+  encoder_tokenizer:
+    library: huggingface
+    tokenizer_model: null
+    vocab_file: null
+    special_tokens: null
+    vocab_size: null
+
+  decoder_tokenizer:
+    library: yttm
+    tokenizer_model: null
+    vocab_file: null
+    special_tokens: null
+    vocab_size: 8192
+
+  encoder:
+    library: huggingface
+    model_name: bert-base-uncased
+    pretrained: true
+
+  decoder:
+    library: nemo
+    model_name: null
+    pretrained: false
+    max_sequence_length: 512
+    num_token_types: 2
+    embedding_dropout: 0.1
+    learn_positional_encodings: false
+    hidden_size: 512
+    inner_size: 2048
+    num_layers: 6
+    num_attention_heads: 8
+    ffn_dropout: 0.1
+    attn_score_dropout: 0.1
+    attn_layer_dropout: 0.1
+    hidden_act: relu
+    pre_ln: false
+
+  head:
+    num_layers: 1
+    activation: relu
+    log_softmax: true
+    dropout: 0.0
+    use_transformer_init: true
+
+trainer:
+  gpus: 4
+  num_nodes: 1
+  max_epochs: 200
+  amp_level: O2 # O1/O2 for mixed precision
+  precision: 16 # Should be set to 16 for O1 and O2, default is 16 as PT ignores it when am_level is O0
+  accelerator: ddp
+  checkpoint_callback: False
+  logger: False
+  log_every_n_steps: 50  # Interval of logging.
+  check_val_every_n_epoch: 1
+
+exp_manager:
+  name: HuggingFaceEncoder
+  files_to_copy: []

--- a/examples/nlp/machine_translation/conf/huggingface.yaml
+++ b/examples/nlp/machine_translation/conf/huggingface.yaml
@@ -71,7 +71,7 @@ model:
     tokenizer_model: null
     vocab_file: null
     special_tokens: null
-    vocab_size: 8192
+    vocab_size: null
 
   encoder:
     library: huggingface

--- a/examples/nlp/machine_translation/conf/huggingface.yaml
+++ b/examples/nlp/machine_translation/conf/huggingface.yaml
@@ -6,16 +6,28 @@ model:
   len_pen: 0.6
   max_generation_delta: 5
   label_smoothing: 0.1
-  preproc_out_dir: null
   shared_tokenizer: false
+  preproc_out_dir: null
+  src_language: 'en'
+  tgt_language: 'de'
 
   train_ds:
     src_file_name: null
     tgt_file_name: null
-    use_tarred_dataset: null
+    use_tarred_dataset: False # if true tar_file_name and meta_file_name will be used (or created automatically) 
+    # config for preprocessing training data and creating a tarred datset automatically
+    tar_files: null # if data has already been preprocessed (rest of config ignored)
+    metadata_file: null # metadata for tarred dataset
+    lines_per_dataset_fragment: 1000000 # Number of lines to consider for bucketing and padding
+    num_batches_per_tarfile: 100 # Number of batches (pickle files) within each tarfile
+    tar_shuffle_n: 100 # How many samples to look ahead and load to be shuffled
+    shard_strategy: scatter # tarred dataset shard distribution strategy
     tokens_in_batch: 512
     clean: true
     max_seq_length: 512
+    cache_ids: true
+    cache_data_per_node: false
+    use_cache: true
     shuffle: true
     num_samples: -1
     drop_last: false

--- a/examples/nlp/machine_translation/conf/huggingface.yaml
+++ b/examples/nlp/machine_translation/conf/huggingface.yaml
@@ -88,7 +88,7 @@ model:
   encoder:
     library: huggingface
     model_name: bert-base-uncased
-    pretrained: true
+    pretrained: false
 
   decoder:
     library: nemo

--- a/examples/nlp/machine_translation/create_tarred_parallel_dataset.py
+++ b/examples/nlp/machine_translation/create_tarred_parallel_dataset.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
             raise ValueError('Both encoder and decoder pre-trained tokenizer models must be specified')
 
     if args.encoder_tokenizer_model == 'None' and args.decoder_tokenizer_model == 'None':
-        encoder_tokenizer_model, decoder_tokenizer_model = MTDataPreproc.train_tokenizers(
+        encoder_tokenizer_model, decoder_tokenizer_model = MTDataPreproc.train_yttm_tokenizers(
             out_dir=args.out_dir,
             src_fname=args.src_fname,
             tgt_fname=args.tgt_fname,

--- a/examples/nlp/machine_translation/enc_dec_nmt.py
+++ b/examples/nlp/machine_translation/enc_dec_nmt.py
@@ -98,8 +98,7 @@ class MTEncDecConfig(NemoConfig):
 
 
 @hydra_runner(config_path="conf", config_name="aayn_base")
-# def main(cfg: MTEncDecConfig) -> None:
-def main(cfg) -> None:
+def main(cfg: MTEncDecConfig) -> None:
     # merge default config with user specified config
     # default_cfg = MTEncDecConfig()
     # cfg = update_model_config(default_cfg, cfg)

--- a/examples/nlp/machine_translation/enc_dec_nmt.py
+++ b/examples/nlp/machine_translation/enc_dec_nmt.py
@@ -100,8 +100,8 @@ class MTEncDecConfig(NemoConfig):
 @hydra_runner(config_path="conf", config_name="aayn_base")
 def main(cfg: MTEncDecConfig) -> None:
     # merge default config with user specified config
-    # default_cfg = MTEncDecConfig()
-    # cfg = update_model_config(default_cfg, cfg)
+    default_cfg = MTEncDecConfig()
+    cfg = update_model_config(default_cfg, cfg)
     logging.info("\n\n************** Experiment configuration ***********")
     logging.info(f'Config: {cfg.pretty()}')
 

--- a/examples/nlp/machine_translation/enc_dec_nmt.py
+++ b/examples/nlp/machine_translation/enc_dec_nmt.py
@@ -98,10 +98,11 @@ class MTEncDecConfig(NemoConfig):
 
 
 @hydra_runner(config_path="conf", config_name="aayn_base")
-def main(cfg: MTEncDecConfig) -> None:
+# def main(cfg: MTEncDecConfig) -> None:
+def main(cfg) -> None:
     # merge default config with user specified config
-    default_cfg = MTEncDecConfig()
-    cfg = update_model_config(default_cfg, cfg)
+    # default_cfg = MTEncDecConfig()
+    # cfg = update_model_config(default_cfg, cfg)
     logging.info("\n\n************** Experiment configuration ***********")
     logging.info(f'Config: {cfg.pretty()}')
 

--- a/examples/nlp/machine_translation/enc_dec_nmt.py
+++ b/examples/nlp/machine_translation/enc_dec_nmt.py
@@ -18,7 +18,7 @@ from typing import Optional
 from pytorch_lightning import Trainer
 
 from nemo.collections.nlp.data.machine_translation.preproc_mt_data import MTDataPreproc
-from nemo.collections.nlp.models.machine_translation.mt_enc_dec_config import AAYNBaseConfig
+from nemo.collections.nlp.models.machine_translation.mt_enc_dec_config import AAYNBaseConfig, MTEncDecModelConfig
 from nemo.collections.nlp.models.machine_translation.mt_enc_dec_model import MTEncDecModel
 from nemo.core.config import hydra_runner
 from nemo.core.config.modelPT import NemoConfig
@@ -92,7 +92,7 @@ Usage:
 class MTEncDecConfig(NemoConfig):
     name: Optional[str] = 'MTEncDec'
     do_training: bool = True
-    model: AAYNBaseConfig = AAYNBaseConfig()
+    model: MTEncDecModelConfig = MTEncDecModelConfig()
     trainer: Optional[TrainerConfig] = TrainerConfig()
     exp_manager: Optional[ExpManagerConfig] = ExpManagerConfig(name='MTEncDec', files_to_copy=[])
 

--- a/examples/nlp/machine_translation/enc_dec_nmt.py
+++ b/examples/nlp/machine_translation/enc_dec_nmt.py
@@ -18,7 +18,7 @@ from typing import Optional
 from pytorch_lightning import Trainer
 
 from nemo.collections.nlp.data.machine_translation.preproc_mt_data import MTDataPreproc
-from nemo.collections.nlp.models.machine_translation.mt_enc_dec_config import AAYNBaseConfig, MTEncDecModelConfig
+from nemo.collections.nlp.models.machine_translation.mt_enc_dec_config import MTEncDecModelConfig
 from nemo.collections.nlp.models.machine_translation.mt_enc_dec_model import MTEncDecModel
 from nemo.core.config import hydra_runner
 from nemo.core.config.modelPT import NemoConfig

--- a/nemo/collections/nlp/data/machine_translation/preproc_mt_data.py
+++ b/nemo/collections/nlp/data/machine_translation/preproc_mt_data.py
@@ -15,6 +15,7 @@
 
 import glob
 import json
+from nemo.collections.common.tokenizers import huggingface
 import os
 import pickle
 import tarfile
@@ -61,11 +62,12 @@ class MTDataPreproc:
             self.world_size = trainer.num_nodes * trainer.num_gpus
 
         if hasattr(cfg, 'train_ds'):
+            supported_tokenizers = ['yttm', 'huggingface']
             if (
-                cfg.encoder_tokenizer.get('tokenizer_name') != 'yttm'
-                or cfg.decoder_tokenizer.get('tokenizer_name') != 'yttm'
+                not cfg.encoder_tokenizer.get('library') in supported_tokenizers
+                or not cfg.decoder_tokenizer.get('library') in supported_tokenizers
             ):
-                raise NotImplementedError(f"Currently we only support yttm tokenizer.")
+                raise NotImplementedError(f"Currently we only support {supported_tokenizers}.")
 
             # Train tokenizer models if they don't exist
             if (
@@ -86,8 +88,8 @@ class MTDataPreproc:
                     shared_tokenizer=cfg.get('shared_tokenizer'),
                     encoder_tokenizer_vocab_size=cfg.encoder_tokenizer.get('vocab_size'),
                     decoder_tokenizer_vocab_size=cfg.decoder_tokenizer.get('vocab_size'),
-                    encoder_tokenizer_name=cfg.encoder_tokenizer.get('tokenizer_name'),
-                    decoder_tokenizer_name=cfg.decoder_tokenizer.get('tokenizer_name'),
+                    encoder_tokenizer_name=cfg.encoder_tokenizer.get('library'),
+                    decoder_tokenizer_name=cfg.decoder_tokenizer.get('library'),
                     encoder_tokenizer_coverage=cfg.encoder_tokenizer.get('coverage', 0.999),
                     decoder_tokenizer_coverage=cfg.decoder_tokenizer.get('coverage', 0.999),
                     global_rank=self.global_rank,

--- a/nemo/collections/nlp/data/machine_translation/preproc_mt_data.py
+++ b/nemo/collections/nlp/data/machine_translation/preproc_mt_data.py
@@ -130,7 +130,7 @@ class MTDataPreproc:
                     # Preprocess data and cache for use during training
                     if self.global_rank == 0:
                         logging.info(
-                            f"Using tarred dataset for src {cfg.train_ds.get('src_file_name')} and tgt {cfg.train_ds.get('tgt_file_name')}"
+                            f"Using tarred dataset for src: {cfg.train_ds.get('src_file_name')} and tgt: {cfg.train_ds.get('tgt_file_name')}"
                         )
                     self.train_tar_files, self.train_metadata_file = MTDataPreproc.preprocess_parallel_dataset(
                         clean=cfg.train_ds.clean,

--- a/nemo/collections/nlp/data/machine_translation/preproc_mt_data.py
+++ b/nemo/collections/nlp/data/machine_translation/preproc_mt_data.py
@@ -15,7 +15,6 @@
 
 import glob
 import json
-from nemo.collections.common.tokenizers import huggingface
 import os
 import pickle
 import tarfile
@@ -24,6 +23,7 @@ import tempfile
 import youtokentome as yttm
 from pytorch_lightning import Trainer
 
+from nemo.collections.common.tokenizers import huggingface
 from nemo.collections.nlp.data.machine_translation.machine_translation_dataset import TranslationDataset
 from nemo.collections.nlp.data.machine_translation.one_side_dataset import TranslationOneSideDataset
 from nemo.collections.nlp.models.machine_translation.mt_enc_dec_config import MTEncDecModelConfig

--- a/nemo/collections/nlp/data/machine_translation/preproc_mt_data.py
+++ b/nemo/collections/nlp/data/machine_translation/preproc_mt_data.py
@@ -27,7 +27,7 @@ from pytorch_lightning import Trainer
 from nemo.collections.nlp.data.machine_translation.machine_translation_dataset import TranslationDataset
 from nemo.collections.nlp.data.machine_translation.one_side_dataset import TranslationOneSideDataset
 from nemo.collections.nlp.models.machine_translation.mt_enc_dec_config import MTEncDecModelConfig
-from nemo.collections.nlp.modules.common.tokenizer_utils import get_tokenizer
+from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenizer, get_tokenizer
 from nemo.utils import logging
 
 
@@ -69,43 +69,51 @@ class MTDataPreproc:
             ):
                 raise NotImplementedError(f"Currently we only support {supported_tokenizers}.")
 
-            # Train tokenizer models if they don't exist
-            if (
-                cfg.encoder_tokenizer.get('tokenizer_model') is None
-                or cfg.decoder_tokenizer.get('tokenizer_model') is None
-            ):
-                if cfg.get('preproc_out_dir') is None:
-                    raise ValueError('Tokenizer model training required but cfg.preproc_out_dir is None.')
-                if cfg.train_ds.get('src_file_name') is None or cfg.train_ds.get('tgt_file_name') is None:
-                    raise ValueError(
-                        'src_file_name and tgt_file_name needed to train tokenizers but could not be found.'
+            # Prepare tokenizers
+            if cfg.encoder_tokenizer.get('library') == 'yttm' or cfg.decoder_tokenizer.get('library') == 'yttm':
+
+                # Train tokenizer models if using yttm and they don't exist
+                if (
+                    cfg.encoder_tokenizer.get('library') == 'yttm'
+                    and cfg.encoder_tokenizer.get('tokenizer_model') is None
+                ) or (
+                    cfg.decoder_tokenizer.get('library') == 'yttm'
+                    and cfg.decoder_tokenizer.get('tokenizer_model') is None
+                ):
+                    if cfg.get('preproc_out_dir') is None:
+                        raise ValueError('Tokenizer model training required but cfg.preproc_out_dir is None.')
+                    if cfg.train_ds.get('src_file_name') is None or cfg.train_ds.get('tgt_file_name') is None:
+                        raise ValueError(
+                            'src_file_name and tgt_file_name needed to train tokenizers but could not be found.'
+                        )
+                    # train tokenizer model on training data
+                    self.encoder_tokenizer_model, self.decoder_tokenizer_model = MTDataPreproc.train_yttm_tokenizers(
+                        out_dir=cfg.get('preproc_out_dir'),
+                        src_fname=cfg.train_ds.get('src_file_name'),
+                        tgt_fname=cfg.train_ds.get('tgt_file_name'),
+                        shared_tokenizer=cfg.get('shared_tokenizer'),
+                        encoder_tokenizer_vocab_size=cfg.encoder_tokenizer.get('vocab_size'),
+                        decoder_tokenizer_vocab_size=cfg.decoder_tokenizer.get('vocab_size'),
+                        encoder_tokenizer_name=cfg.encoder_tokenizer.get('library'),
+                        decoder_tokenizer_name=cfg.decoder_tokenizer.get('library'),
+                        encoder_tokenizer_coverage=cfg.encoder_tokenizer.get('coverage', 0.999),
+                        decoder_tokenizer_coverage=cfg.decoder_tokenizer.get('coverage', 0.999),
+                        global_rank=self.global_rank,
                     )
-                # train tokenizer model on training data
-                self.encoder_tokenizer_model, self.decoder_tokenizer_model = MTDataPreproc.train_tokenizers(
-                    out_dir=cfg.get('preproc_out_dir'),
-                    src_fname=cfg.train_ds.get('src_file_name'),
-                    tgt_fname=cfg.train_ds.get('tgt_file_name'),
-                    shared_tokenizer=cfg.get('shared_tokenizer'),
-                    encoder_tokenizer_vocab_size=cfg.encoder_tokenizer.get('vocab_size'),
-                    decoder_tokenizer_vocab_size=cfg.decoder_tokenizer.get('vocab_size'),
-                    encoder_tokenizer_name=cfg.encoder_tokenizer.get('library'),
-                    decoder_tokenizer_name=cfg.decoder_tokenizer.get('library'),
-                    encoder_tokenizer_coverage=cfg.encoder_tokenizer.get('coverage', 0.999),
-                    decoder_tokenizer_coverage=cfg.decoder_tokenizer.get('coverage', 0.999),
-                    global_rank=self.global_rank,
-                )
-                # update config
-                self._cfg.encoder_tokenizer.tokenizer_model = self.encoder_tokenizer_model
-                self._cfg.decoder_tokenizer.tokenizer_model = self.decoder_tokenizer_model
-            else:
-                self.encoder_tokenizer_model = cfg.encoder_tokenizer.get('tokenizer_model')
-                self.decoder_tokenizer_model = cfg.decoder_tokenizer.get('tokenizer_model')
+                    # update config
+                    self._cfg.encoder_tokenizer.tokenizer_model = self.encoder_tokenizer_model
+                    self._cfg.decoder_tokenizer.tokenizer_model = self.decoder_tokenizer_model
+                else:
+                    self.encoder_tokenizer_model = cfg.encoder_tokenizer.get('tokenizer_model')
+                    self.decoder_tokenizer_model = cfg.decoder_tokenizer.get('tokenizer_model')
 
             self.encoder_tokenizer, self.decoder_tokenizer = self.get_enc_dec_tokenizers(
-                encoder_tokenizer_name=cfg.encoder_tokenizer.get('tokenizer_name'),
+                encoder_tokenizer_name=cfg.encoder_tokenizer.get('library'),
+                encoder_model_name=cfg.encoder.get('model_name'),
                 encoder_tokenizer_model=self.encoder_tokenizer_model,
                 encoder_bpe_dropout=cfg.encoder_tokenizer.get('bpe_dropout', 0.0),
-                decoder_tokenizer_name=cfg.decoder_tokenizer.get('tokenizer_name'),
+                decoder_tokenizer_name=cfg.decoder_tokenizer.get('library'),
+                decoder_model_name=cfg.decoder.get('model_name'),
                 decoder_tokenizer_model=self.decoder_tokenizer_model,
                 decoder_bpe_dropout=cfg.decoder_tokenizer.get('bpe_dropout', 0.0),
             )
@@ -173,21 +181,25 @@ class MTDataPreproc:
         encoder_tokenizer_name=None,
         encoder_tokenizer_model=None,
         encoder_bpe_dropout=0.0,
+        encoder_model_name=None,
         decoder_tokenizer_name=None,
         decoder_tokenizer_model=None,
         decoder_bpe_dropout=0.0,
+        decoder_model_name=None,
     ):
 
-        if encoder_tokenizer_name != 'yttm' or decoder_tokenizer_name != 'yttm':
-            raise NotImplementedError(f"Currently we only support yttm tokenizer.")
+        # if encoder_tokenizer_name != 'yttm' or decoder_tokenizer_name != 'yttm':
+        #     raise NotImplementedError(f"Currently we only support yttm tokenizer.")
 
-        encoder_tokenizer = get_tokenizer(
-            tokenizer_name=encoder_tokenizer_name,
+        encoder_tokenizer = get_nmt_tokenizer(
+            library=encoder_tokenizer_name,
+            model_name=encoder_model_name,
             tokenizer_model=encoder_tokenizer_model,
             bpe_dropout=encoder_bpe_dropout,
         )
-        decoder_tokenizer = get_tokenizer(
-            tokenizer_name=decoder_tokenizer_name,
+        decoder_tokenizer = get_nmt_tokenizer(
+            library=decoder_tokenizer_name,
+            model_name=decoder_model_name,
             tokenizer_model=decoder_tokenizer_model,
             bpe_dropout=decoder_bpe_dropout,
         )
@@ -480,7 +492,7 @@ class MTDataPreproc:
         return tar_file_paths, metadata_path
 
     @staticmethod
-    def train_tokenizers(
+    def train_yttm_tokenizers(
         out_dir,
         src_fname,
         tgt_fname,
@@ -493,12 +505,14 @@ class MTDataPreproc:
         decoder_tokenizer_coverage,
         global_rank,
     ):
+        encoder_tokenizer_model = None
+        decoder_tokenizer_model = None
         os.makedirs(out_dir, exist_ok=True)
 
-        if encoder_tokenizer_name != 'yttm' or decoder_tokenizer_name != 'yttm':
-            raise NotImplementedError(f"Currently we only support yttm tokenizer.")
-
         if shared_tokenizer:
+            if encoder_tokenizer_name != 'yttm' or decoder_tokenizer_name != 'yttm':
+                raise NotImplementedError(f"Currently we only support yttm for shared tokenizer.")
+
             encoder_tokenizer_model = os.path.join(
                 out_dir, 'shared_tokenizer.%d.BPE.model' % (encoder_tokenizer_vocab_size)
             )
@@ -523,45 +537,47 @@ class MTDataPreproc:
                             n_threads=-1,
                         )
         else:
-            encoder_tokenizer_model = os.path.join(
-                out_dir, 'tokenizer.encoder.%d.BPE.model' % (encoder_tokenizer_vocab_size)
-            )
-            if global_rank == 0:
-                if os.path.isfile(encoder_tokenizer_model):
-                    logging.info(
-                        f'Encoder tokenizer model {encoder_tokenizer_model} already exists. Remove file if training a new tokenizer model.'
-                    )
-                else:
-                    logging.info(
-                        f'Encoder tokenizer model {encoder_tokenizer_model} not found. Training tokenizer model.'
-                    )
-                    yttm.BPE.train(
-                        data=src_fname,
-                        vocab_size=encoder_tokenizer_vocab_size,
-                        model=encoder_tokenizer_model,
-                        coverage=encoder_tokenizer_coverage,
-                        n_threads=-1,
-                    )
+            if encoder_tokenizer_name == 'yttm':
+                encoder_tokenizer_model = os.path.join(
+                    out_dir, 'tokenizer.encoder.%d.BPE.model' % (encoder_tokenizer_vocab_size)
+                )
+                if global_rank == 0:
+                    if os.path.isfile(encoder_tokenizer_model):
+                        logging.info(
+                            f'Encoder tokenizer model {encoder_tokenizer_model} already exists. Remove file if training a new tokenizer model.'
+                        )
+                    else:
+                        logging.info(
+                            f'Encoder tokenizer model {encoder_tokenizer_model} not found. Training tokenizer model.'
+                        )
+                        yttm.BPE.train(
+                            data=src_fname,
+                            vocab_size=encoder_tokenizer_vocab_size,
+                            model=encoder_tokenizer_model,
+                            coverage=encoder_tokenizer_coverage,
+                            n_threads=-1,
+                        )
 
-            decoder_tokenizer_model = os.path.join(
-                out_dir, 'tokenizer.decoder.%d.BPE.model' % (decoder_tokenizer_vocab_size)
-            )
-            if global_rank == 0:
-                if os.path.isfile(decoder_tokenizer_model):
-                    logging.info(
-                        f'Decoder tokenizer model {decoder_tokenizer_model} already exists. Remove file if training a new tokenizer model.'
-                    )
-                else:
-                    logging.info(
-                        f'Decoder tokenizer model {decoder_tokenizer_model} not found. Training tokenizer model.'
-                    )
-                    yttm.BPE.train(
-                        data=tgt_fname,
-                        vocab_size=decoder_tokenizer_vocab_size,
-                        model=decoder_tokenizer_model,
-                        coverage=decoder_tokenizer_coverage,
-                        n_threads=-1,
-                    )
+            if decoder_tokenizer_name == 'yttm':
+                decoder_tokenizer_model = os.path.join(
+                    out_dir, 'tokenizer.decoder.%d.BPE.model' % (decoder_tokenizer_vocab_size)
+                )
+                if global_rank == 0:
+                    if os.path.isfile(decoder_tokenizer_model):
+                        logging.info(
+                            f'Decoder tokenizer model {decoder_tokenizer_model} already exists. Remove file if training a new tokenizer model.'
+                        )
+                    else:
+                        logging.info(
+                            f'Decoder tokenizer model {decoder_tokenizer_model} not found. Training tokenizer model.'
+                        )
+                        yttm.BPE.train(
+                            data=tgt_fname,
+                            vocab_size=decoder_tokenizer_vocab_size,
+                            model=decoder_tokenizer_model,
+                            coverage=decoder_tokenizer_coverage,
+                            n_threads=-1,
+                        )
 
         return encoder_tokenizer_model, decoder_tokenizer_model
 

--- a/nemo/collections/nlp/data/machine_translation/preproc_mt_data.py
+++ b/nemo/collections/nlp/data/machine_translation/preproc_mt_data.py
@@ -23,7 +23,6 @@ import tempfile
 import youtokentome as yttm
 from pytorch_lightning import Trainer
 
-from nemo.collections.common.tokenizers import huggingface
 from nemo.collections.nlp.data.machine_translation.machine_translation_dataset import TranslationDataset
 from nemo.collections.nlp.data.machine_translation.one_side_dataset import TranslationOneSideDataset
 from nemo.collections.nlp.models.machine_translation.mt_enc_dec_config import MTEncDecModelConfig

--- a/nemo/collections/nlp/models/enc_dec_nlp_model.py
+++ b/nemo/collections/nlp/models/enc_dec_nlp_model.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from nemo.collections.nlp.modules.common.lm_utils import TransformerConfig
 from typing import Any
 
 from omegaconf.omegaconf import MISSING
@@ -22,6 +21,7 @@ from pytorch_lightning.trainer.trainer import Trainer
 from nemo.collections.nlp.models.nlp_model import NLPModel
 from nemo.collections.nlp.modules.common.decoder_module import DecoderModule
 from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
+from nemo.collections.nlp.modules.common.lm_utils import TransformerConfig
 from nemo.collections.nlp.modules.common.tokenizer_utils import TokenizerConfig, get_tokenizer
 from nemo.core.config.modelPT import ModelConfig
 

--- a/nemo/collections/nlp/models/enc_dec_nlp_model.py
+++ b/nemo/collections/nlp/models/enc_dec_nlp_model.py
@@ -91,8 +91,9 @@ class EncDecNLPModel(NLPModel):
         decoder_bpe_dropout=0.0,
     ):
 
-        if encoder_tokenizer_name != 'yttm' or decoder_tokenizer_name != 'yttm':
-            raise NotImplementedError(f"Currently we only support yttm tokenizer.")
+        supported_tokenizers = ['yttm', 'huggingface']
+        if encoder_tokenizer_name not in supported_tokenizers or decoder_tokenizer_name not in supported_tokenizers:
+            raise NotImplementedError(f"Currently we only support tokenizers in {supported_tokenizers}.")
 
         self.encoder_tokenizer = get_tokenizer(
             tokenizer_name=encoder_tokenizer_name,

--- a/nemo/collections/nlp/models/enc_dec_nlp_model.py
+++ b/nemo/collections/nlp/models/enc_dec_nlp_model.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
+from nemo.collections.nlp.modules.common.lm_utils import TransformerConfig
 from typing import Any
 
 from omegaconf.omegaconf import MISSING
@@ -29,7 +30,7 @@ from nemo.core.config.modelPT import ModelConfig
 class EncDecNLPModelConfig(ModelConfig):
     encoder_tokenizer: TokenizerConfig = MISSING
     decoder_tokenizer: TokenizerConfig = MISSING
-    encoder: Any = MISSING
+    encoder: TransformerConfig = MISSING
     decoder: Any = MISSING
     head: Any = MISSING
 

--- a/nemo/collections/nlp/models/enc_dec_nlp_model.py
+++ b/nemo/collections/nlp/models/enc_dec_nlp_model.py
@@ -81,30 +81,5 @@ class EncDecNLPModel(NLPModel):
     def decoder(self, decoder):
         self._decoder = decoder
 
-    def setup_enc_dec_tokenizers(
-        self,
-        encoder_tokenizer_name=None,
-        encoder_tokenizer_model=None,
-        encoder_bpe_dropout=0.0,
-        decoder_tokenizer_name=None,
-        decoder_tokenizer_model=None,
-        decoder_bpe_dropout=0.0,
-    ):
-
-        supported_tokenizers = ['yttm', 'huggingface']
-        if encoder_tokenizer_name not in supported_tokenizers or decoder_tokenizer_name not in supported_tokenizers:
-            raise NotImplementedError(f"Currently we only support tokenizers in {supported_tokenizers}.")
-
-        self.encoder_tokenizer = get_tokenizer(
-            tokenizer_name=encoder_tokenizer_name,
-            tokenizer_model=self.register_artifact("cfg.encoder_tokenizer.tokenizer_model", encoder_tokenizer_model),
-            bpe_dropout=encoder_bpe_dropout,
-        )
-        self.decoder_tokenizer = get_tokenizer(
-            tokenizer_name=decoder_tokenizer_name,
-            tokenizer_model=self.register_artifact("cfg.decoder_tokenizer.tokenizer_model", decoder_tokenizer_model),
-            bpe_dropout=decoder_bpe_dropout,
-        )
-
     def export(self, **kwargs):
         raise NotImplementedError('For EncDecNLPModel, you must export encoder and decoder separately!')

--- a/nemo/collections/nlp/models/enc_dec_nlp_model.py
+++ b/nemo/collections/nlp/models/enc_dec_nlp_model.py
@@ -21,7 +21,7 @@ from pytorch_lightning.trainer.trainer import Trainer
 from nemo.collections.nlp.models.nlp_model import NLPModel
 from nemo.collections.nlp.modules.common.decoder_module import DecoderModule
 from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
-from nemo.collections.nlp.modules.common.tokenizer_utils import TokenizerConfig, get_tokenizer
+from nemo.collections.nlp.modules.common.tokenizer_utils import TokenizerConfig
 from nemo.core.config.modelPT import ModelConfig
 
 

--- a/nemo/collections/nlp/models/enc_dec_nlp_model.py
+++ b/nemo/collections/nlp/models/enc_dec_nlp_model.py
@@ -21,7 +21,6 @@ from pytorch_lightning.trainer.trainer import Trainer
 from nemo.collections.nlp.models.nlp_model import NLPModel
 from nemo.collections.nlp.modules.common.decoder_module import DecoderModule
 from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
-from nemo.collections.nlp.modules.common.lm_utils import TransformerConfig
 from nemo.collections.nlp.modules.common.tokenizer_utils import TokenizerConfig, get_tokenizer
 from nemo.core.config.modelPT import ModelConfig
 
@@ -30,7 +29,7 @@ from nemo.core.config.modelPT import ModelConfig
 class EncDecNLPModelConfig(ModelConfig):
     encoder_tokenizer: TokenizerConfig = MISSING
     decoder_tokenizer: TokenizerConfig = MISSING
-    encoder: TransformerConfig = MISSING
+    encoder: Any = MISSING
     decoder: Any = MISSING
     head: Any = MISSING
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -80,7 +80,7 @@ class AAYNBaseConfig(MTEncDecModelConfig):
         library='nemo',
         model_name=None,
         pretrained=False,
-        transformer=NeMoTransformerEncoderConfig(
+        config_dict=NeMoTransformerEncoderConfig(
             vocab_size=MISSING,
             hidden_size=512,
             inner_size=2048,
@@ -97,7 +97,7 @@ class AAYNBaseConfig(MTEncDecModelConfig):
         library='nemo',
         model_name=None,
         pretrained=False,
-        transformer=NeMoTransformerConfig(
+        config_dict=NeMoTransformerConfig(
             vocab_size=MISSING,
             hidden_size=512,
             inner_size=2048,

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -80,7 +80,7 @@ class AAYNBaseConfig(MTEncDecModelConfig):
         library='nemo',
         model_name=None,
         pretrained=False,
-        config_dict=NeMoTransformerEncoderConfig(
+        transformer_args=NeMoTransformerEncoderConfig(
             vocab_size=MISSING,
             hidden_size=512,
             inner_size=2048,

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -72,25 +72,25 @@ class AAYNBaseConfig(MTEncDecModelConfig):
     encoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
     decoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
 
-    encoder: TransformerEncoderConfig = TransformerEncoderConfig(
-        hidden_size=512,
-        inner_size=2048,
-        num_layers=6,
-        num_attention_heads=8,
-        ffn_dropout=0.1,
-        attn_score_dropout=0.1,
-        attn_layer_dropout=0.1,
-    )
+    # encoder: TransformerEncoderConfig = TransformerEncoderConfig(
+    #     hidden_size=512,
+    #     inner_size=2048,
+    #     num_layers=6,
+    #     num_attention_heads=8,
+    #     ffn_dropout=0.1,
+    #     attn_score_dropout=0.1,
+    #     attn_layer_dropout=0.1,
+    # )
 
-    decoder: TransformerConfig = TransformerConfig(
-        hidden_size=512,
-        inner_size=2048,
-        num_layers=6,
-        num_attention_heads=8,
-        ffn_dropout=0.1,
-        attn_score_dropout=0.1,
-        attn_layer_dropout=0.1,
-    )
+    # decoder: TransformerConfig = TransformerConfig(
+    #     hidden_size=512,
+    #     inner_size=2048,
+    #     num_layers=6,
+    #     num_attention_heads=8,
+    #     ffn_dropout=0.1,
+    #     attn_score_dropout=0.1,
+    #     attn_layer_dropout=0.1,
+    # )
 
     head: TokenClassifierConfig = TokenClassifierConfig(log_softmax=True)
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -80,7 +80,7 @@ class AAYNBaseConfig(MTEncDecModelConfig):
         library='nemo',
         model_name=None,
         pretrained=False,
-        transformer_args=NeMoTransformerEncoderConfig(
+        transformer_config=NeMoTransformerEncoderConfig(
             vocab_size=MISSING,
             hidden_size=512,
             inner_size=2048,

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 from dataclasses import dataclass
-from nemo.collections.nlp.modules.common.lm_utils import TransformerConfig
 from typing import Optional, Tuple
 
 from omegaconf.omegaconf import MISSING
 
 from nemo.collections.nlp.data.machine_translation.machine_translation_dataset import TranslationDataConfig
 from nemo.collections.nlp.models.enc_dec_nlp_model import EncDecNLPModelConfig
+from nemo.collections.nlp.modules.common.lm_utils import TransformerConfig
 from nemo.collections.nlp.modules.common.token_classifier import TokenClassifierConfig
 from nemo.collections.nlp.modules.common.tokenizer_utils import TokenizerConfig
 from nemo.collections.nlp.modules.common.transformer.transformer import (

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -130,4 +130,3 @@ class AAYNBaseConfig(MTEncDecModelConfig):
         attn_score_dropout=0.1,
         attn_layer_dropout=0.1,
     )
-

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -76,37 +76,33 @@ class AAYNBaseConfig(MTEncDecModelConfig):
     encoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
     decoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
 
-    encoder: TransformerConfig = TransformerConfig(
+    encoder: NeMoTransformerEncoderConfig = NeMoTransformerEncoderConfig(
+        vocab_size=MISSING,
         library='nemo',
         model_name=None,
         pretrained=False,
-        config_dict=NeMoTransformerEncoderConfig(
-            vocab_size=MISSING,
-            hidden_size=512,
-            inner_size=2048,
-            num_layers=6,
-            num_attention_heads=8,
-            ffn_dropout=0.1,
-            attn_score_dropout=0.1,
-            attn_layer_dropout=0.1,
-        ),
+        hidden_size=512,
+        inner_size=2048,
+        num_layers=6,
+        num_attention_heads=8,
+        ffn_dropout=0.1,
+        attn_score_dropout=0.1,
+        attn_layer_dropout=0.1,
         encoder=True,
     )
 
-    decoder: TransformerConfig = TransformerConfig(
+    decoder: NeMoTransformerConfig = NeMoTransformerConfig(
+        vocab_size=MISSING,
         library='nemo',
         model_name=None,
         pretrained=False,
-        config_dict=NeMoTransformerConfig(
-            vocab_size=MISSING,
-            hidden_size=512,
-            inner_size=2048,
-            num_layers=6,
-            num_attention_heads=8,
-            ffn_dropout=0.1,
-            attn_score_dropout=0.1,
-            attn_layer_dropout=0.1,
-        ),
+        hidden_size=512,
+        inner_size=2048,
+        num_layers=6,
+        num_attention_heads=8,
+        ffn_dropout=0.1,
+        attn_score_dropout=0.1,
+        attn_layer_dropout=0.1,
         encoder=False,
     )
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -80,7 +80,7 @@ class AAYNBaseConfig(MTEncDecModelConfig):
         library='nemo',
         model_name=None,
         pretrained=False,
-        transformer_config=NeMoTransformerEncoderConfig(
+        transformer=NeMoTransformerEncoderConfig(
             vocab_size=MISSING,
             hidden_size=512,
             inner_size=2048,
@@ -93,14 +93,21 @@ class AAYNBaseConfig(MTEncDecModelConfig):
         encoder=True,
     )
 
-    decoder: NeMoTransformerConfig = NeMoTransformerConfig(
-        hidden_size=512,
-        inner_size=2048,
-        num_layers=6,
-        num_attention_heads=8,
-        ffn_dropout=0.1,
-        attn_score_dropout=0.1,
-        attn_layer_dropout=0.1,
+    decoder: TransformerConfig = TransformerConfig(
+        library='nemo',
+        model_name=None,
+        pretrained=False,
+        transformer=NeMoTransformerConfig(
+            vocab_size=MISSING,
+            hidden_size=512,
+            inner_size=2048,
+            num_layers=6,
+            num_attention_heads=8,
+            ffn_dropout=0.1,
+            attn_score_dropout=0.1,
+            attn_layer_dropout=0.1,
+        ),
+        encoder=False,
     )
 
     head: TokenClassifierConfig = TokenClassifierConfig(log_softmax=True)

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
+from nemo.collections.nlp.modules.common.lm_utils import TransformerConfig
 from typing import Optional, Tuple
 
 from omegaconf.omegaconf import MISSING
@@ -21,7 +22,10 @@ from nemo.collections.nlp.data.machine_translation.machine_translation_dataset i
 from nemo.collections.nlp.models.enc_dec_nlp_model import EncDecNLPModelConfig
 from nemo.collections.nlp.modules.common.token_classifier import TokenClassifierConfig
 from nemo.collections.nlp.modules.common.tokenizer_utils import TokenizerConfig
-from nemo.collections.nlp.modules.common.transformer.transformer import TransformerConfig, TransformerEncoderConfig
+from nemo.collections.nlp.modules.common.transformer.transformer import (
+    NeMoTransformerConfig,
+    NeMoTransformerEncoderConfig,
+)
 from nemo.core.config.modelPT import ModelConfig, OptimConfig, SchedConfig
 
 
@@ -72,17 +76,24 @@ class AAYNBaseConfig(MTEncDecModelConfig):
     encoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
     decoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
 
-    encoder: TransformerEncoderConfig = TransformerEncoderConfig(
-        hidden_size=512,
-        inner_size=2048,
-        num_layers=6,
-        num_attention_heads=8,
-        ffn_dropout=0.1,
-        attn_score_dropout=0.1,
-        attn_layer_dropout=0.1,
+    encoder: TransformerConfig = TransformerConfig(
+        library='nemo',
+        model_name=None,
+        pretrained=False,
+        config_dict=NeMoTransformerEncoderConfig(
+            vocab_size=MISSING,
+            hidden_size=512,
+            inner_size=2048,
+            num_layers=6,
+            num_attention_heads=8,
+            ffn_dropout=0.1,
+            attn_score_dropout=0.1,
+            attn_layer_dropout=0.1,
+        ),
+        encoder=True,
     )
 
-    decoder: TransformerConfig = TransformerConfig(
+    decoder: NeMoTransformerConfig = NeMoTransformerConfig(
         hidden_size=512,
         inner_size=2048,
         num_layers=6,

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -69,8 +69,8 @@ class AAYNBaseConfig(MTEncDecModelConfig):
     label_smoothing: Optional[float] = 0.0
 
     # Attention is All You Need Base Configuration
-    encoder_tokenizer: TokenizerConfig = TokenizerConfig(tokenizer_name='yttm')
-    decoder_tokenizer: TokenizerConfig = TokenizerConfig(tokenizer_name='yttm')
+    encoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
+    decoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
 
     encoder: TransformerEncoderConfig = TransformerEncoderConfig(
         hidden_size=512,

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -72,25 +72,25 @@ class AAYNBaseConfig(MTEncDecModelConfig):
     encoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
     decoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
 
-    # encoder: TransformerEncoderConfig = TransformerEncoderConfig(
-    #     hidden_size=512,
-    #     inner_size=2048,
-    #     num_layers=6,
-    #     num_attention_heads=8,
-    #     ffn_dropout=0.1,
-    #     attn_score_dropout=0.1,
-    #     attn_layer_dropout=0.1,
-    # )
+    encoder: TransformerEncoderConfig = TransformerEncoderConfig(
+        hidden_size=512,
+        inner_size=2048,
+        num_layers=6,
+        num_attention_heads=8,
+        ffn_dropout=0.1,
+        attn_score_dropout=0.1,
+        attn_layer_dropout=0.1,
+    )
 
-    # decoder: TransformerConfig = TransformerConfig(
-    #     hidden_size=512,
-    #     inner_size=2048,
-    #     num_layers=6,
-    #     num_attention_heads=8,
-    #     ffn_dropout=0.1,
-    #     attn_score_dropout=0.1,
-    #     attn_layer_dropout=0.1,
-    # )
+    decoder: TransformerConfig = TransformerConfig(
+        hidden_size=512,
+        inner_size=2048,
+        num_layers=6,
+        num_attention_heads=8,
+        ffn_dropout=0.1,
+        attn_score_dropout=0.1,
+        attn_layer_dropout=0.1,
+    )
 
     head: TokenClassifierConfig = TokenClassifierConfig(log_softmax=True)
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -48,17 +48,20 @@ class MTOptimConfig(OptimConfig):
 
 @dataclass
 class MTEncDecModelConfig(EncDecNLPModelConfig):
+    # machine translation configurations
+    num_val_examples: int = 3
+    num_test_examples: int = 3
+    max_generation_delta: int = 10
+    label_smoothing: Optional[float] = 0.0
     beam_size: int = 4
     len_pen: float = 0.0
-    max_generation_delta: int = 3
-    label_smoothing: Optional[float] = 0.0
     src_language: str = 'en'
     tgt_language: str = 'en'
     find_unused_parameters: Optional[bool] = True
     shared_tokenizer: Optional[bool] = True
     preproc_out_dir: Optional[str] = None
 
-    # neural network architectures
+    # network architecture configuration
     encoder: Any = MISSING
 
     decoder: Any = MISSING
@@ -98,13 +101,6 @@ class MTEncDecModelConfig(EncDecNLPModelConfig):
 
 @dataclass
 class AAYNBaseConfig(MTEncDecModelConfig):
-    # machine translation configurations
-    num_val_examples: int = 3
-    num_test_examples: int = 3
-    beam_size: int = 1
-    len_pen: float = 0.0
-    max_generation_delta: int = 10
-    label_smoothing: Optional[float] = 0.0
 
     # Attention is All You Need Base Configuration
     encoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -77,7 +77,6 @@ class AAYNBaseConfig(MTEncDecModelConfig):
     decoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
 
     encoder: NeMoTransformerEncoderConfig = NeMoTransformerEncoderConfig(
-        vocab_size=MISSING,
         library='nemo',
         model_name=None,
         pretrained=False,
@@ -88,11 +87,9 @@ class AAYNBaseConfig(MTEncDecModelConfig):
         ffn_dropout=0.1,
         attn_score_dropout=0.1,
         attn_layer_dropout=0.1,
-        encoder=True,
     )
 
     decoder: NeMoTransformerConfig = NeMoTransformerConfig(
-        vocab_size=MISSING,
         library='nemo',
         model_name=None,
         pretrained=False,
@@ -103,7 +100,6 @@ class AAYNBaseConfig(MTEncDecModelConfig):
         ffn_dropout=0.1,
         attn_score_dropout=0.1,
         attn_layer_dropout=0.1,
-        encoder=False,
     )
 
     head: TokenClassifierConfig = TokenClassifierConfig(log_softmax=True)

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -19,7 +19,6 @@ from omegaconf.omegaconf import MISSING
 
 from nemo.collections.nlp.data.machine_translation.machine_translation_dataset import TranslationDataConfig
 from nemo.collections.nlp.models.enc_dec_nlp_model import EncDecNLPModelConfig
-from nemo.collections.nlp.modules.common.lm_utils import TransformerConfig
 from nemo.collections.nlp.modules.common.token_classifier import TokenClassifierConfig
 from nemo.collections.nlp.modules.common.tokenizer_utils import TokenizerConfig
 from nemo.collections.nlp.modules.common.transformer.transformer import (

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -61,8 +61,10 @@ class MTEncDecModelConfig(EncDecNLPModelConfig):
     preproc_out_dir: Optional[str] = None
 
     # network architecture configuration
+    encoder_tokenizer: Any = MISSING
     encoder: Any = MISSING
 
+    decoder_tokenizer: Any = MISSING
     decoder: Any = MISSING
 
     head: TokenClassifierConfig = TokenClassifierConfig(log_softmax=True)

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -133,8 +133,15 @@ class MTEncDecModel(EncDecNLPModel):
 
         # TODO: encoder and decoder with different hidden size?
         std_init_range = 1 / self.encoder.hidden_size ** 0.5
-        # TODO: if using pretrained encoder/decoder we don't need to init weights
-        self.apply(lambda module: transformer_weights_init(module, std_init_range))
+
+        # initialize weights if not using pretrained encoder/decoder
+        if not self._cfg.encoder.get('pretrained', False):
+            self.encoder.apply(lambda module: transformer_weights_init(module, std_init_range))
+
+        if not self._cfg.decoder.get('pretrained', False):
+            self.decoder.apply(lambda module: transformer_weights_init(module, std_init_range))
+
+        self.log_softmax.apply(lambda module: transformer_weights_init(module, std_init_range))
 
         self.loss_fn = SmoothedCrossEntropyLoss(
             pad_id=self.decoder_tokenizer.pad_id, label_smoothing=cfg.label_smoothing

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -95,7 +95,11 @@ class MTEncDecModel(EncDecNLPModel):
         model_name = encoder_cfg_dict.pop('model_name', None)
         pretrained = encoder_cfg_dict.pop('pretrained', False)
         self.encoder = get_transformer(
-            library=library, model_name=model_name, pretrained=pretrained, config_dict=encoder_cfg_dict, encoder=True
+            library=library,
+            model_name=model_name,
+            pretrained=pretrained,
+            transformer_config=encoder_cfg_dict,
+            encoder=True,
         )
 
         # decoder from NeMo, Megatron-LM, or HuggingFace
@@ -106,7 +110,11 @@ class MTEncDecModel(EncDecNLPModel):
         pretrained = decoder_cfg_dict.pop('pretrained', False)
         decoder_cfg_dict['hidden_size'] = self.encoder.hidden_size
         self.decoder = get_transformer(
-            library=library, model_name=model_name, pretrained=pretrained, config_dict=decoder_cfg_dict, encoder=False
+            library=library,
+            model_name=model_name,
+            pretrained=pretrained,
+            transformer_config=decoder_cfg_dict,
+            encoder=False,
         )
 
         self.log_softmax = TokenClassifier(

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -95,7 +95,7 @@ class MTEncDecModel(EncDecNLPModel):
         model_name = encoder_cfg_dict.pop('model_name', None)
         pretrained = encoder_cfg_dict.pop('pretrained', False)
         self.encoder = get_transformer(
-            library=library, model_name=model_name, pretrained=pretrained, transformer=encoder_cfg_dict, encoder=True,
+            library=library, model_name=model_name, pretrained=pretrained, config_dict=encoder_cfg_dict, encoder=True,
         )
 
         # decoder from NeMo, Megatron-LM, or HuggingFace
@@ -106,7 +106,7 @@ class MTEncDecModel(EncDecNLPModel):
         pretrained = decoder_cfg_dict.pop('pretrained', False)
         decoder_cfg_dict['hidden_size'] = self.encoder.hidden_size
         self.decoder = get_transformer(
-            library=library, model_name=model_name, pretrained=pretrained, transformer=decoder_cfg_dict, encoder=False,
+            library=library, model_name=model_name, pretrained=pretrained, config_dict=decoder_cfg_dict, encoder=False,
         )
 
         self.log_softmax = TokenClassifier(

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -101,6 +101,7 @@ class MTEncDecModel(EncDecNLPModel):
         library = decoder_cfg_dict.pop('library', 'nemo')
         model_name = decoder_cfg_dict.pop('model_name', None)
         pretrained = decoder_cfg_dict.pop('pretrained', False)
+        decoder_cfg_dict['hidden_size'] = self.encoder.hidden_size
         self.decoder = get_transformer(
             library=library, model_name=model_name, pretrained=pretrained, config_dict=decoder_cfg_dict, encoder=False
         )
@@ -132,6 +133,7 @@ class MTEncDecModel(EncDecNLPModel):
 
         # TODO: encoder and decoder with different hidden size?
         std_init_range = 1 / self.encoder.hidden_size ** 0.5
+        # TODO: if using pretrained encoder/decoder we don't need to init weights
         self.apply(lambda module: transformer_weights_init(module, std_init_range))
 
         self.loss_fn = SmoothedCrossEntropyLoss(

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -82,58 +82,24 @@ class MTEncDecModel(EncDecNLPModel):
         # TODO: Why is this base constructor call so late in the game?
         super().__init__(cfg=cfg, trainer=trainer)
 
-        # TODO: use get_encoder function with support for HF and Megatron
+        # encoder from NeMo, Megatron-LM, or HuggingFace
         encoder_cfg_dict = OmegaConf.to_container(cfg.get('encoder'))
         encoder_cfg_dict['vocab_size'] = self.encoder_vocab_size
         library = encoder_cfg_dict.pop('library', 'nemo')
         model_name = encoder_cfg_dict.pop('model_name', None)
         pretrained = encoder_cfg_dict.pop('pretrained', False)
         self.encoder = get_transformer(
-            library=library, model_name=model_name, pretrained=pretrained, config_dict=encoder_cfg_dict
+            library=library, model_name=model_name, pretrained=pretrained, config_dict=encoder_cfg_dict, encoder=True
         )
 
-        # TODO: move to get_nemo_transformer
-        self.encoder = TransformerEncoderNM(
-            vocab_size=self.encoder_vocab_size,
-            hidden_size=cfg.encoder.hidden_size,
-            num_layers=cfg.encoder.num_layers,
-            inner_size=cfg.encoder.inner_size,
-            max_sequence_length=cfg.encoder.max_sequence_length
-            if hasattr(cfg.encoder, 'max_sequence_length')
-            else 512,
-            embedding_dropout=cfg.encoder.embedding_dropout if hasattr(cfg.encoder, 'embedding_dropout') else 0.0,
-            learn_positional_encodings=cfg.encoder.learn_positional_encodings
-            if hasattr(cfg.encoder, 'learn_positional_encodings')
-            else False,
-            num_attention_heads=cfg.encoder.num_attention_heads,
-            ffn_dropout=cfg.encoder.ffn_dropout,
-            attn_score_dropout=cfg.encoder.attn_score_dropout,
-            attn_layer_dropout=cfg.encoder.attn_layer_dropout,
-            hidden_act=cfg.encoder.hidden_act,
-            mask_future=cfg.encoder.mask_future,
-            pre_ln=cfg.encoder.pre_ln,
-        )
-
-        # TODO: user get_decoder function with support for HF and Megatron
-        # TODO: move to get_nemo_transformer
-        self.decoder = TransformerDecoderNM(
-            vocab_size=self.decoder_vocab_size,
-            hidden_size=cfg.decoder.hidden_size,
-            num_layers=cfg.decoder.num_layers,
-            inner_size=cfg.decoder.inner_size,
-            max_sequence_length=cfg.decoder.max_sequence_length
-            if hasattr(cfg.decoder, 'max_sequence_length')
-            else 512,
-            embedding_dropout=cfg.decoder.embedding_dropout if hasattr(cfg.decoder, 'embedding_dropout') else 0.0,
-            learn_positional_encodings=cfg.decoder.learn_positional_encodings
-            if hasattr(cfg.decoder, 'learn_positional_encodings')
-            else False,
-            num_attention_heads=cfg.decoder.num_attention_heads,
-            ffn_dropout=cfg.decoder.ffn_dropout,
-            attn_score_dropout=cfg.decoder.attn_score_dropout,
-            attn_layer_dropout=cfg.decoder.attn_layer_dropout,
-            hidden_act=cfg.decoder.hidden_act,
-            pre_ln=cfg.decoder.pre_ln,
+        # decoder from NeMo, Megatron-LM, or HuggingFace
+        decoder_cfg_dict = OmegaConf.to_container(cfg.get('decoder'))
+        decoder_cfg_dict['vocab_size'] = self.decoder_vocab_size
+        library = decoder_cfg_dict.pop('library', 'nemo')
+        model_name = decoder_cfg_dict.pop('model_name', None)
+        pretrained = decoder_cfg_dict.pop('pretrained', False)
+        self.decoder = get_transformer(
+            library=library, model_name=model_name, pretrained=pretrained, config_dict=encoder_cfg_dict, encoder=False
         )
 
         self.log_softmax = TokenClassifier(

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -69,12 +69,14 @@ class MTEncDecModel(EncDecNLPModel):
         # After this call, ther will be self.encoder_tokenizer and self.decoder_tokenizer
         # Which can convert between tokens and token_ids for SRC and TGT languages correspondingly.
         self.setup_enc_dec_tokenizers(
-            encoder_tokenizer_library=cfg.encoder_tokenizer.get('tokenizer_name', 'yttm'),
+            encoder_tokenizer_library=cfg.encoder_tokenizer.get('tokenizer_library', 'yttm'),
             encoder_tokenizer_model=cfg.encoder_tokenizer.get('tokenizer_model'),
             encoder_bpe_dropout=cfg.encoder_tokenizer.get('bpe_dropout', 0.0),
-            decoder_tokenizer_library=cfg.decoder_tokenizer.get('tokenizer_name', 'yttm'),
+            encoder_model_name=cfg.encoder.get('model_name'),
+            decoder_tokenizer_library=cfg.decoder_tokenizer.get('tokenizer_library', 'yttm'),
             decoder_tokenizer_model=cfg.decoder_tokenizer.tokenizer_model,
             decoder_bpe_dropout=cfg.decoder_tokenizer.get('bpe_dropout', 0.0),
+            decoder_model_name=cfg.decoder.get('model_name'),
         )
 
         # After this call, the model will have  self.source_processor and self.target_processor objects
@@ -254,9 +256,11 @@ class MTEncDecModel(EncDecNLPModel):
         encoder_tokenizer_library=None,
         encoder_tokenizer_model=None,
         encoder_bpe_dropout=0.0,
+        encoder_model_name=None,
         decoder_tokenizer_library=None,
         decoder_tokenizer_model=None,
         decoder_bpe_dropout=0.0,
+        decoder_model_name=None,
     ):
 
         supported_tokenizers = ['yttm', 'huggingface']
@@ -270,11 +274,19 @@ class MTEncDecModel(EncDecNLPModel):
             library=encoder_tokenizer_library,
             tokenizer_model=self.register_artifact("cfg.encoder_tokenizer.tokenizer_model", encoder_tokenizer_model),
             bpe_dropout=encoder_bpe_dropout,
+            model_name=encoder_model_name,
+            vocab_file=None,
+            special_tokens=None,
+            use_fast=False,
         )
         self.decoder_tokenizer = get_nmt_tokenizer(
             library=decoder_tokenizer_library,
             tokenizer_model=self.register_artifact("cfg.decoder_tokenizer.tokenizer_model", decoder_tokenizer_model),
             bpe_dropout=decoder_bpe_dropout,
+            model_name=decoder_model_name,
+            vocab_file=None,
+            special_tokens=None,
+            use_fast=False,
         )
 
     def setup_training_data(self, train_data_config: Optional[DictConfig]):

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -69,11 +69,11 @@ class MTEncDecModel(EncDecNLPModel):
         # After this call, ther will be self.encoder_tokenizer and self.decoder_tokenizer
         # Which can convert between tokens and token_ids for SRC and TGT languages correspondingly.
         self.setup_enc_dec_tokenizers(
-            encoder_tokenizer_library=cfg.encoder_tokenizer.get('tokenizer_library', 'yttm'),
+            encoder_tokenizer_library=cfg.encoder_tokenizer.get('library', 'yttm'),
             encoder_tokenizer_model=cfg.encoder_tokenizer.get('tokenizer_model'),
             encoder_bpe_dropout=cfg.encoder_tokenizer.get('bpe_dropout', 0.0),
             encoder_model_name=cfg.encoder.get('model_name'),
-            decoder_tokenizer_library=cfg.decoder_tokenizer.get('tokenizer_library', 'yttm'),
+            decoder_tokenizer_library=cfg.decoder_tokenizer.get('library', 'yttm'),
             decoder_tokenizer_model=cfg.decoder_tokenizer.tokenizer_model,
             decoder_bpe_dropout=cfg.decoder_tokenizer.get('bpe_dropout', 0.0),
             decoder_model_name=cfg.decoder.get('model_name'),

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import itertools
-from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenizer
-from nemo.collections.nlp.modules.common.lm_utils import get_transformer
 import pickle
 import random
 from pathlib import Path
@@ -38,6 +36,8 @@ from nemo.collections.nlp.data import TarredTranslationDataset, TranslationDatas
 from nemo.collections.nlp.models.enc_dec_nlp_model import EncDecNLPModel
 from nemo.collections.nlp.models.machine_translation.mt_enc_dec_config import MTEncDecModelConfig
 from nemo.collections.nlp.modules.common import TokenClassifier
+from nemo.collections.nlp.modules.common.lm_utils import get_transformer
+from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenizer
 from nemo.collections.nlp.modules.common.transformer import BeamSearchSequenceGenerator
 from nemo.collections.nlp.modules.common.transformer.transformer import TransformerDecoderNM, TransformerEncoderNM
 from nemo.core.classes.common import typecheck

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -102,7 +102,7 @@ class MTEncDecModel(EncDecNLPModel):
         model_name = decoder_cfg_dict.pop('model_name', None)
         pretrained = decoder_cfg_dict.pop('pretrained', False)
         self.decoder = get_transformer(
-            library=library, model_name=model_name, pretrained=pretrained, config_dict=encoder_cfg_dict, encoder=False
+            library=library, model_name=model_name, pretrained=pretrained, config_dict=decoder_cfg_dict, encoder=False
         )
 
         self.log_softmax = TokenClassifier(

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -95,11 +95,7 @@ class MTEncDecModel(EncDecNLPModel):
         model_name = encoder_cfg_dict.pop('model_name', None)
         pretrained = encoder_cfg_dict.pop('pretrained', False)
         self.encoder = get_transformer(
-            library=library,
-            model_name=model_name,
-            pretrained=pretrained,
-            transformer_config=encoder_cfg_dict,
-            encoder=True,
+            library=library, model_name=model_name, pretrained=pretrained, transformer=encoder_cfg_dict, encoder=True,
         )
 
         # decoder from NeMo, Megatron-LM, or HuggingFace
@@ -110,11 +106,7 @@ class MTEncDecModel(EncDecNLPModel):
         pretrained = decoder_cfg_dict.pop('pretrained', False)
         decoder_cfg_dict['hidden_size'] = self.encoder.hidden_size
         self.decoder = get_transformer(
-            library=library,
-            model_name=model_name,
-            pretrained=pretrained,
-            transformer_config=decoder_cfg_dict,
-            encoder=False,
+            library=library, model_name=model_name, pretrained=pretrained, transformer=decoder_cfg_dict, encoder=False,
         )
 
         self.log_softmax = TokenClassifier(

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -39,7 +39,10 @@ from nemo.collections.nlp.modules.common import TokenClassifier
 from nemo.collections.nlp.modules.common.lm_utils import get_transformer
 from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenizer
 from nemo.collections.nlp.modules.common.transformer import BeamSearchSequenceGenerator
-from nemo.collections.nlp.modules.common.transformer.transformer import TransformerDecoderNM, TransformerEncoderNM
+from nemo.collections.nlp.modules.common.transformer.transformer import (
+    NeMoTransformerDecoderNM,
+    NeMoTransformerEncoderNM,
+)
 from nemo.core.classes.common import typecheck
 from nemo.utils import logging, model_utils
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -75,11 +75,11 @@ class MTEncDecModel(EncDecNLPModel):
             encoder_tokenizer_library=cfg.encoder_tokenizer.get('library', 'yttm'),
             encoder_tokenizer_model=cfg.encoder_tokenizer.get('tokenizer_model'),
             encoder_bpe_dropout=cfg.encoder_tokenizer.get('bpe_dropout', 0.0),
-            encoder_model_name=cfg.encoder.get('model_name'),
+            encoder_model_name=cfg.encoder.get('model_name') if hasattr(cfg.encoder, 'model_name') else None,
             decoder_tokenizer_library=cfg.decoder_tokenizer.get('library', 'yttm'),
             decoder_tokenizer_model=cfg.decoder_tokenizer.tokenizer_model,
             decoder_bpe_dropout=cfg.decoder_tokenizer.get('bpe_dropout', 0.0),
-            decoder_model_name=cfg.decoder.get('model_name'),
+            decoder_model_name=cfg.decoder.get('model_name') if hasattr(cfg.decoder, 'model_name') else None,
         )
 
         # After this call, the model will have  self.source_processor and self.target_processor objects

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -153,8 +153,10 @@ class MTEncDecModel(EncDecNLPModel):
 
     @typecheck()
     def forward(self, src, src_mask, tgt, tgt_mask):
-        src_hiddens = self.encoder(src, src_mask)
-        tgt_hiddens = self.decoder(tgt, tgt_mask, src_hiddens, src_mask)
+        src_hiddens = self.encoder(input_ids=src, encoder_mask=src_mask)
+        tgt_hiddens = self.decoder(
+            input_ids=tgt, decoder_mask=tgt_mask, encoder_embeddings=src_hiddens, encoder_mask=src_mask
+        )
         log_probs = self.log_softmax(hidden_states=tgt_hiddens)
         return log_probs
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -39,10 +39,6 @@ from nemo.collections.nlp.modules.common import TokenClassifier
 from nemo.collections.nlp.modules.common.lm_utils import get_transformer
 from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenizer
 from nemo.collections.nlp.modules.common.transformer import BeamSearchSequenceGenerator
-from nemo.collections.nlp.modules.common.transformer.transformer import (
-    NeMoTransformerDecoderNM,
-    NeMoTransformerEncoderNM,
-)
 from nemo.core.classes.common import typecheck
 from nemo.utils import logging, model_utils
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -195,7 +195,7 @@ class MTEncDecModel(EncDecNLPModel):
         _, translations = self.batch_translate(src=src_ids, src_mask=src_mask)
         eval_loss = self.loss_fn(log_probs=log_probs, labels=labels)
         self.eval_loss(loss=eval_loss, num_measurements=log_probs.shape[0] * log_probs.shape[1])
-        np_tgt = tgt_ids.cpu().numpy()
+        np_tgt = tgt_ids.detach()cpu().numpy()
         ground_truths = [self.decoder_tokenizer.ids_to_text(tgt) for tgt in np_tgt]
         ground_truths = [self.target_processor.detokenize(tgt.split(' ')) for tgt in ground_truths]
         num_non_pad_tokens = np.not_equal(np_tgt, self.decoder_tokenizer.pad_id).sum().item()

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -195,7 +195,7 @@ class MTEncDecModel(EncDecNLPModel):
         _, translations = self.batch_translate(src=src_ids, src_mask=src_mask)
         eval_loss = self.loss_fn(log_probs=log_probs, labels=labels)
         self.eval_loss(loss=eval_loss, num_measurements=log_probs.shape[0] * log_probs.shape[1])
-        np_tgt = tgt_ids.detach()cpu().numpy()
+        np_tgt = tgt_ids.detach().cpu().numpy()
         ground_truths = [self.decoder_tokenizer.ids_to_text(tgt) for tgt in np_tgt]
         ground_truths = [self.target_processor.detokenize(tgt.split(' ')) for tgt in ground_truths]
         num_non_pad_tokens = np.not_equal(np_tgt, self.decoder_tokenizer.pad_id).sum().item()

--- a/nemo/collections/nlp/modules/common/decoder_module.py
+++ b/nemo/collections/nlp/modules/common/decoder_module.py
@@ -30,7 +30,7 @@ class DecoderModule(NeuralModule, ABC):
             "input_ids": NeuralType(('B', 'T'), ChannelType()),
             "decoder_mask": NeuralType(('B', 'T'), MaskType(), optional=True),
             "encoder_mask": NeuralType(('B', 'T'), MaskType(), optional=True),
-            "encoder_hidden_states": NeuralType(('B', 'T', 'D'), ChannelType(), optional=True),
+            "encoder_embeddings": NeuralType(('B', 'T', 'D'), ChannelType(), optional=True),
         }
 
     @property

--- a/nemo/collections/nlp/modules/common/encoder_module.py
+++ b/nemo/collections/nlp/modules/common/encoder_module.py
@@ -29,7 +29,7 @@ class EncoderModule(NeuralModule, ABC):
     def input_types(self) -> Optional[Dict[str, NeuralType]]:
         return {
             "input_ids": NeuralType(('B', 'T'), ChannelType()),
-            "encoder_mask": NeuralType(('B', 'T'), MaskType(), optional=True),
+            "encoder_mask": NeuralType(('B', 'T'), MaskType()),
         }
 
     @property

--- a/nemo/collections/nlp/modules/common/encoder_module.py
+++ b/nemo/collections/nlp/modules/common/encoder_module.py
@@ -30,7 +30,6 @@ class EncoderModule(NeuralModule, ABC):
         return {
             "input_ids": NeuralType(('B', 'T'), ChannelType()),
             "encoder_mask": NeuralType(('B', 'T'), MaskType(), optional=True),
-            "token_type_ids": NeuralType(('B', 'T'), ChannelType(), optional=True),
         }
 
     @property

--- a/nemo/collections/nlp/modules/common/huggingface/huggingface_decoder.py
+++ b/nemo/collections/nlp/modules/common/huggingface/huggingface_decoder.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo.collections.nlp.modules.common.decoder_module import DecoderModule
-from nemo.collections.nlp.modules.common.huggingface.huggingface_utils import get_huggingface_pretrained_lm_models_list
 from typing import Optional
-from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
-from nemo.utils import logging
-from transformers import AutoConfig, AutoModel
+
 from hydra.utils import instantiate
+from transformers import AutoConfig, AutoModel
+
+from nemo.collections.nlp.modules.common.decoder_module import DecoderModule
+from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
+from nemo.collections.nlp.modules.common.huggingface.huggingface_utils import get_huggingface_pretrained_lm_models_list
+from nemo.utils import logging
 
 
 class HuggingFaceDecoderModule(DecoderModule):

--- a/nemo/collections/nlp/modules/common/huggingface/huggingface_decoder.py
+++ b/nemo/collections/nlp/modules/common/huggingface/huggingface_decoder.py
@@ -1,0 +1,57 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemo.collections.nlp.modules.common.decoder_module import DecoderModule
+from nemo.collections.nlp.modules.common.huggingface.huggingface_utils import get_huggingface_pretrained_lm_models_list
+from typing import Optional
+from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
+from nemo.utils import logging
+from transformers import AutoConfig, AutoModel
+from hydra.utils import instantiate
+
+
+class HuggingFaceDecoderModule(DecoderModule):
+    """ Class for using HuggingFace encoders in NeMo NLP."""
+
+    def __init__(
+        self,
+        model_name: Optional[str] = None,
+        pretrained: bool = False,
+        config_dict: Optional[dict] = None,
+        checkpoint_file: Optional[str] = None,
+    ):
+        super().__init__()
+        model = None
+        if model_name is not None:
+            if model_name in get_huggingface_pretrained_lm_models_list():
+                if pretrained:
+                    model = AutoModel.from_pretrained(model_name)
+                else:
+                    cfg = AutoConfig.from_pretrained(model_name)
+                    model = AutoModel.from_config(cfg)
+            else:
+                logging.error(f'{model_name} not found in list of HuggingFace pretrained models')
+        else:
+            cfg = instantiate(config_dict)
+            model = AutoModel.from_config(cfg)
+        self._hidden_size = model.config.hidden_size
+        self._vocab_size = model.config.vocab_size
+
+    @property
+    def hidden_size(self) -> Optional[int]:
+        return self._hidden_size
+
+    @property
+    def vocab_size(self) -> Optional[int]:
+        return self._vocab_size

--- a/nemo/collections/nlp/modules/common/huggingface/huggingface_decoder.py
+++ b/nemo/collections/nlp/modules/common/huggingface/huggingface_decoder.py
@@ -18,7 +18,6 @@ from hydra.utils import instantiate
 from transformers import AutoConfig, AutoModel
 
 from nemo.collections.nlp.modules.common.decoder_module import DecoderModule
-from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
 from nemo.collections.nlp.modules.common.huggingface.huggingface_utils import get_huggingface_pretrained_lm_models_list
 from nemo.utils import logging
 

--- a/nemo/collections/nlp/modules/common/huggingface/huggingface_decoder.py
+++ b/nemo/collections/nlp/modules/common/huggingface/huggingface_decoder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -23,7 +23,28 @@ from nemo.utils import logging
 
 
 class HuggingFaceDecoderModule(DecoderModule):
-    """ Class for using HuggingFace encoders in NeMo NLP."""
+    """Gets HuggingFace based model to be used as an Decoder in NeMo NLP.
+    Use the model_name arg to get a named model architecture. 
+    Available model names can be found with get_huggingface_pretrained_lm_models_list() or
+    by going to https://huggingface.co/models.
+    Use the pretrained arg to get the named model architecture with or without pretrained weights.
+
+    If model_name is None, then we can pass in a custom configuration via the config_dict.
+    For example, to instantiate a HuggingFace BERT model with custom configuration we would do:
+        config_dict={
+            '_target_': 'transformers.BertConfig',
+            'hidden_size': 1536
+        } 
+
+
+    Args:
+        model_name (Optional[str]): Named model architecture from HuggingFace. Defaults to None.
+        pretrained (bool): Use True to get pretrained weights. 
+                                    False will use the same architecture but with randomly initialized weights.
+                                    Defaults to False.
+        config_dict (Optional[dict], optional): Use for custom configuration of the HuggingFace model. Defaults to None.
+        checkpoint_file (Optional[str], optional): Provide weights for the transformer from a local checkpoint. Defaults to None.
+    """
 
     def __init__(
         self,

--- a/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
+++ b/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nemo.collections.nlp.modules.common.huggingface.huggingface_utils import get_huggingface_pretrained_lm_models_list
+from typing import Optional
+from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
+from nemo.utils import logging
+from transformers import AutoConfig, AutoModel
+from hydra.utils import instantiate
+
+
+class HuggingFaceEncoderModule(EncoderModule):
+    """ Class for using HuggingFace encoders in NeMo NLP."""
+
+    def __init__(
+        self,
+        model_name: Optional[str] = None,
+        pretrained: bool = False,
+        config_dict: Optional[dict] = None,
+        checkpoint_file: Optional[str] = None,
+    ):
+        super().__init__()
+
+        model = None
+        if model_name is not None:
+            if model_name in get_huggingface_pretrained_lm_models_list():
+                if pretrained:
+                    model = AutoModel.from_pretrained(model_name)
+                else:
+                    cfg = AutoConfig.from_pretrained(model_name)
+                    model = AutoModel.from_config(cfg)
+            else:
+                logging.error(f'{model_name} not found in list of HuggingFace pretrained models')
+        else:
+            cfg = instantiate(config_dict)
+            model = AutoModel.from_config(cfg)
+        self._hidden_size = model.config.hidden_size
+        self._vocab_size = model.config.vocab_size
+
+        self._encoder = model
+
+    # @typecheck()
+    def forward(self, input_ids, encoder_mask):
+        encoder_hidden_states = self._encoder.forward(input_ids=input_ids, attention_mask=encoder_mask)[0]
+        return encoder_hidden_states
+
+    @property
+    def hidden_size(self) -> Optional[int]:
+        return self._hidden_size
+
+    @property
+    def vocab_size(self) -> Optional[int]:
+        return self._vocab_size

--- a/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
+++ b/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
@@ -32,6 +32,8 @@ class HuggingFaceEncoderModule(EncoderModule):
     ):
         super().__init__()
 
+        # TODO: argument correctness checker
+
         model = None
         if model_name is not None:
             if model_name in get_huggingface_pretrained_lm_models_list():

--- a/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
+++ b/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo.collections.nlp.modules.common.huggingface.huggingface_utils import get_huggingface_pretrained_lm_models_list
 from typing import Optional
-from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
-from nemo.utils import logging
-from transformers import AutoConfig, AutoModel
+
 from hydra.utils import instantiate
+from transformers import AutoConfig, AutoModel
+
+from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
+from nemo.collections.nlp.modules.common.huggingface.huggingface_utils import get_huggingface_pretrained_lm_models_list
+from nemo.utils import logging
 
 
 class HuggingFaceEncoderModule(EncoderModule):

--- a/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
+++ b/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo.core.classes.common import typecheck
 from typing import Optional
 
 from hydra.utils import instantiate
@@ -20,6 +19,7 @@ from transformers import AutoConfig, AutoModel
 
 from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
 from nemo.collections.nlp.modules.common.huggingface.huggingface_utils import get_huggingface_pretrained_lm_models_list
+from nemo.core.classes.common import typecheck
 from nemo.utils import logging
 
 

--- a/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
+++ b/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
@@ -34,7 +34,8 @@ class HuggingFaceEncoderModule(EncoderModule):
     ):
         super().__init__()
 
-        # TODO: argument correctness checker
+        if checkpoint_file:
+            raise NotImplementedError('Restoring from checkpoint file not implemented yet.')
 
         model = None
         if model_name is not None:
@@ -52,6 +53,8 @@ class HuggingFaceEncoderModule(EncoderModule):
             else:
                 logging.error(f'{model_name} not found in list of HuggingFace pretrained models')
         else:
+            if pretrained:
+                raise ValueError(f'If not using model_name, then pretrained should be False. Got: {pretrained}.')
             cfg = instantiate(config_dict)
             model = AutoModel.from_config(cfg)
         self._hidden_size = model.config.hidden_size

--- a/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
+++ b/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,6 +32,28 @@ class HuggingFaceEncoderModule(EncoderModule):
         config_dict: Optional[dict] = None,
         checkpoint_file: Optional[str] = None,
     ):
+        """Gets HuggingFace based model to be used as an Encoder in NeMo NLP.
+        Use the model_name arg to get a named model architecture. 
+        Available model names can be found with get_huggingface_pretrained_lm_models_list() or
+        by going to https://huggingface.co/models.
+        Use the pretrained arg to get the named model architecture with or without pretrained weights.
+
+        If model_name is None, then we can pass in a custom configuration via the config_dict.
+        For example, to instantiate a HuggingFace BERT model with custom configuration we would do:
+            config_dict={
+                '_target_': 'transformers.BertConfig',
+                'hidden_size': 1536
+            } 
+
+
+        Args:
+            model_name (Optional[str]): Named model architecture from HuggingFace. Defaults to None.
+            pretrained (bool): Use True to get pretrained weights. 
+                                        False will use the same architecture but with randomly initialized weights.
+                                        Defaults to False.
+            config_dict (Optional[dict], optional): Use for custom configuration of the HuggingFace model. Defaults to None.
+            checkpoint_file (Optional[str], optional): Provide weights for the transformer from a local checkpoint. Defaults to None.
+        """
         super().__init__()
 
         if checkpoint_file:

--- a/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
+++ b/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
@@ -40,6 +40,11 @@ class HuggingFaceEncoderModule(EncoderModule):
         if model_name is not None:
             if model_name in get_huggingface_pretrained_lm_models_list():
                 if pretrained:
+                    config_dict.pop('vocab_size')
+                    if config_dict:
+                        raise ValueError(
+                            f'When using pretrained model, config_dict should be None or empty. Got: {config_dict}'
+                        )
                     model = AutoModel.from_pretrained(model_name)
                 else:
                     cfg = AutoConfig.from_pretrained(model_name)

--- a/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
+++ b/nemo/collections/nlp/modules/common/huggingface/huggingface_encoder.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from nemo.core.classes.common import typecheck
 from typing import Optional
 
 from hydra.utils import instantiate
@@ -84,7 +85,7 @@ class HuggingFaceEncoderModule(EncoderModule):
 
         self._encoder = model
 
-    # @typecheck()
+    @typecheck()
     def forward(self, input_ids, encoder_mask):
         encoder_hidden_states = self._encoder.forward(input_ids=input_ids, attention_mask=encoder_mask)[0]
         return encoder_hidden_states

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -114,7 +114,7 @@ class TransformerConfig:
     library: str = 'nemo'
     model_name: Optional[str] = None
     pretrained: bool = False
-    config_dict: Optional[dict] = None
+    transformer_config: Optional[dict] = None
     checkpoint_file: Optional[str] = None
     encoder: bool = True
 
@@ -123,7 +123,7 @@ def get_transformer(
     library: str = 'nemo',
     model_name: Optional[str] = None,
     pretrained: bool = False,
-    config_dict: Optional[dict] = None,
+    transformer_config: Optional[dict] = None,
     checkpoint_file: Optional[str] = None,
     encoder: bool = True,
 ) -> Union[EncoderModule, DecoderModule]:
@@ -135,7 +135,7 @@ def get_transformer(
        If model_name is None, then we can pass in a custom configuration via the config_dict.
        For example, to instantiate a HuggingFace BERT model with custom configuration we would do:
        encoder = get_transformer(library='huggingface',
-                                 config_dict={
+                                 transformer_config={
                                      '_target_': 'transformers.BertConfig',
                                      'hidden_size': 1536
                                  }) 
@@ -147,7 +147,7 @@ def get_transformer(
         pretrained (bool, optional): Use True to get pretrained weights. 
                                      False will use the same architecture but with randomly initialized weights.
                                      Defaults to False.
-        config_dict (Optional[dict], optional): Use for custom configuration of transformer. Defaults to None.
+        transformer_config (Optional[dict], optional): Use for custom configuration of transformer. Defaults to None.
         checkpoint_file (Optional[str], optional): Provide weights for the transformer from a local checkpoint. Defaults to None.
         encoder (bool, optional): True returns an EncoderModule, False returns a DecoderModule. Defaults to True.
 
@@ -158,10 +158,10 @@ def get_transformer(
     model = None
 
     if library == 'nemo':
-        if isinstance(config_dict, NeMoTransformerConfig):
-            config_dict = asdict(config_dict)
+        if isinstance(transformer_config, NeMoTransformerConfig):
+            transformer_config = asdict(transformer_config)
         model = get_nemo_transformer(
-            model_name=model_name, pretrained=pretrained, config_dict=config_dict, encoder=encoder,
+            model_name=model_name, pretrained=pretrained, config_dict=transformer_config, encoder=encoder,
         )
 
         if checkpoint_file is not None:
@@ -170,7 +170,7 @@ def get_transformer(
 
     elif library == 'huggingface':
         model = get_huggingface_transformer(
-            model_name=model_name, pretrained=pretrained, config_dict=config_dict, encoder=encoder
+            model_name=model_name, pretrained=pretrained, config_dict=transformer_config, encoder=encoder
         )
 
     return model

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -114,7 +114,7 @@ class TransformerConfig:
     library: str = 'nemo'
     model_name: Optional[str] = None
     pretrained: bool = False
-    transformer_config: Optional[dict] = None
+    transformer: Optional[dict] = None
     checkpoint_file: Optional[str] = None
     encoder: bool = True
 
@@ -123,7 +123,7 @@ def get_transformer(
     library: str = 'nemo',
     model_name: Optional[str] = None,
     pretrained: bool = False,
-    transformer_config: Optional[dict] = None,
+    transformer: Optional[dict] = None,
     checkpoint_file: Optional[str] = None,
     encoder: bool = True,
 ) -> Union[EncoderModule, DecoderModule]:
@@ -135,7 +135,7 @@ def get_transformer(
        If model_name is None, then we can pass in a custom configuration via the config_dict.
        For example, to instantiate a HuggingFace BERT model with custom configuration we would do:
        encoder = get_transformer(library='huggingface',
-                                 transformer_config={
+                                 transformer={
                                      '_target_': 'transformers.BertConfig',
                                      'hidden_size': 1536
                                  }) 
@@ -147,7 +147,7 @@ def get_transformer(
         pretrained (bool, optional): Use True to get pretrained weights. 
                                      False will use the same architecture but with randomly initialized weights.
                                      Defaults to False.
-        transformer_config (Optional[dict], optional): Use for custom configuration of transformer. Defaults to None.
+        transformer (Optional[dict], optional): Use for custom configuration of transformer. Defaults to None.
         checkpoint_file (Optional[str], optional): Provide weights for the transformer from a local checkpoint. Defaults to None.
         encoder (bool, optional): True returns an EncoderModule, False returns a DecoderModule. Defaults to True.
 
@@ -158,10 +158,10 @@ def get_transformer(
     model = None
 
     if library == 'nemo':
-        if isinstance(transformer_config, NeMoTransformerConfig):
-            transformer_config = asdict(transformer_config)
+        if isinstance(transformer, NeMoTransformerConfig):
+            transformer = asdict(transformer)
         model = get_nemo_transformer(
-            model_name=model_name, pretrained=pretrained, config_dict=transformer_config, encoder=encoder,
+            model_name=model_name, pretrained=pretrained, config_dict=transformer, encoder=encoder,
         )
 
         if checkpoint_file is not None:
@@ -170,7 +170,7 @@ def get_transformer(
 
     elif library == 'huggingface':
         model = get_huggingface_transformer(
-            model_name=model_name, pretrained=pretrained, config_dict=transformer_config, encoder=encoder
+            model_name=model_name, pretrained=pretrained, config_dict=transformer, encoder=encoder
         )
 
     return model

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -13,13 +13,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from dataclasses import dataclass
-
-from attr import asdict
-from nemo.collections.nlp.modules.common.transformer.transformer import NeMoTransformerConfig
 import os
+from dataclasses import dataclass
 from typing import List, Optional, Union
 
+from attr import asdict
 from hydra.utils import instantiate
 from transformers import AutoConfig, AutoModel
 
@@ -34,6 +32,7 @@ from nemo.collections.nlp.modules.common.megatron.megatron_utils import (
     get_megatron_lm_model,
     get_megatron_lm_models_list,
 )
+from nemo.collections.nlp.modules.common.transformer.transformer import NeMoTransformerConfig
 from nemo.collections.nlp.modules.common.transformer.transformer_utils import (
     get_huggingface_transformer,
     get_nemo_transformer,

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from nemo.collections.nlp.modules.common.transformer.transformer_utils import get_nemo_transformer
 from nemo.collections.nlp.modules.common.decoder_module import DecoderModule
 from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
 import os

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -113,10 +113,6 @@ def get_transformer(
     encoder: bool = True,
 ) -> Union[EncoderModule, DecoderModule]:
 
-    assert model_name is None or (
-        config_dict is None or config_dict == {}
-    ), 'Only one of model_name or config_dict should be used'
-
     model = None
 
     if library == 'nemo':

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from dataclasses import dataclass
 import os
 from typing import List, Optional, Union
 
@@ -106,6 +107,16 @@ def get_lm_model(
     return model
 
 
+@dataclass
+class TransformerConfig:
+    library: str = 'nemo'
+    model_name: Optional[str] = None
+    pretrained: bool = False
+    config_dict: Optional[dict] = None
+    checkpoint_file: Optional[str] = None
+    encoder: bool = True
+
+
 def get_transformer(
     library: str = 'nemo',
     model_name: Optional[str] = None,
@@ -114,6 +125,33 @@ def get_transformer(
     checkpoint_file: Optional[str] = None,
     encoder: bool = True,
 ) -> Union[EncoderModule, DecoderModule]:
+    """Gets Transformer based model to be used as an Encoder or Decoder in NeMo NLP.
+       First choose the library to get the transformer from. This can be huggingface,
+       megatron, or nemo. Use the model_name arg to get a named model architecture
+       and use the pretrained arg to get the named model architecture with pretrained weights.
+
+       If model_name is None, then we can pass in a custom configuration via the config_dict.
+       For example, to instantiate a HuggingFace BERT model with custom configuration we would do:
+       encoder = get_transformer(library='huggingface',
+                                 config_dict={
+                                     '_target_': 'transformers.BertConfig',
+                                     'hidden_size': 1536
+                                 }) 
+
+
+    Args:
+        library (str, optional): Can be 'nemo', 'huggingface', or 'megatron'. Defaults to 'nemo'.
+        model_name (Optional[str], optional): Named model architecture from the chosen library. Defaults to None.
+        pretrained (bool, optional): Use True to get pretrained weights. 
+                                     False will use the same architecture but with randomly initialized weights.
+                                     Defaults to False.
+        config_dict (Optional[dict], optional): Use for custom configuration of transformer. Defaults to None.
+        checkpoint_file (Optional[str], optional): Provide weights for the transformer from a local checkpoint. Defaults to None.
+        encoder (bool, optional): True returns and EncoderModule, False returns a DecoderModule. Defaults to True.
+
+    Returns:
+        Union[EncoderModule, DecoderModule]: Ensures that Encoder/Decoder will work in EncDecNLPModel
+    """
 
     model = None
 

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -13,7 +13,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from nemo.collections.nlp.modules.common.transformer.transformer_utils import get_nemo_transformer
+from nemo.collections.nlp.modules.common.transformer.transformer_utils import (
+    get_huggingface_transformer,
+    get_nemo_transformer,
+)
 from nemo.collections.nlp.modules.common.decoder_module import DecoderModule
 from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
 import os
@@ -125,18 +128,8 @@ def get_transformer(
                 raise ValueError(f'Loading transformer weights from checkpoint file has not been implemented yet.')
 
     elif library == 'huggingface':
-        if model_name is not None:
-            if model_name in get_huggingface_pretrained_lm_models_list():
-                if pretrained:
-                    model = AutoModel.from_pretrained(model_name)
-                else:
-                    cfg = AutoConfig.from_pretrained(model_name)
-                    model = AutoModel.from_config(cfg)
-            else:
-                logging.error(f'{model_name} not found in list of HuggingFace pretrained models')
-        else:
-            cfg = instantiate(config_dict)
-            model = AutoModel.from_config(cfg)
-        model.hidden_size = model.config.hidden_size
+        model = get_huggingface_transformer(
+            model_name=model_name, pretrained=pretrained, config_dict=config_dict, encoder=encoder
+        )
 
     return model

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -13,16 +13,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from nemo.collections.nlp.modules.common.transformer.transformer_utils import (
-    get_huggingface_transformer,
-    get_nemo_transformer,
-)
-from nemo.collections.nlp.modules.common.decoder_module import DecoderModule
-from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
 import os
 from typing import List, Optional, Union
 
+from hydra.utils import instantiate
+from transformers import AutoConfig, AutoModel
+
 from nemo.collections.nlp.modules.common.bert_module import BertModule
+from nemo.collections.nlp.modules.common.decoder_module import DecoderModule
+from nemo.collections.nlp.modules.common.encoder_module import EncoderModule
 from nemo.collections.nlp.modules.common.huggingface.huggingface_utils import (
     get_huggingface_lm_model,
     get_huggingface_pretrained_lm_models_list,
@@ -31,11 +30,11 @@ from nemo.collections.nlp.modules.common.megatron.megatron_utils import (
     get_megatron_lm_model,
     get_megatron_lm_models_list,
 )
+from nemo.collections.nlp.modules.common.transformer.transformer_utils import (
+    get_huggingface_transformer,
+    get_nemo_transformer,
+)
 from nemo.utils import logging
-
-from transformers import AutoConfig, AutoModel
-
-from hydra.utils import instantiate
 
 __all__ = ['get_pretrained_lm_models_list', 'get_lm_model']
 

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -120,17 +120,13 @@ def get_transformer(
     model = None
 
     if library == 'nemo':
-        if model_name is not None:
-            logging.error(f'NeMo transformers cannot be loaded from NGC yet.')
-
-        model = get_nemo_transformer(model_name, config_dict, encoder)
+        model = get_nemo_transformer(
+            model_name=model_name, pretrained=pretrained, config_dict=config_dict, encoder=encoder,
+        )
 
         if checkpoint_file is not None:
             if os.path.isfile(checkpoint_file):
-                logging.info(f'Checkpoint found at {checkpoint_file} will be used to restore weights.')
-                logging.error(f'Loading transformer weights from checkpoint file has not been implemented yet.')
-            else:
-                logging.error(f'Checkpoint not found at {checkpoint_file}.')
+                raise ValueError(f'Loading transformer weights from checkpoint file has not been implemented yet.')
 
     elif library == 'huggingface':
         if model_name is not None:

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -147,7 +147,7 @@ def get_transformer(
                                      Defaults to False.
         config_dict (Optional[dict], optional): Use for custom configuration of transformer. Defaults to None.
         checkpoint_file (Optional[str], optional): Provide weights for the transformer from a local checkpoint. Defaults to None.
-        encoder (bool, optional): True returns and EncoderModule, False returns a DecoderModule. Defaults to True.
+        encoder (bool, optional): True returns an EncoderModule, False returns a DecoderModule. Defaults to True.
 
     Returns:
         Union[EncoderModule, DecoderModule]: Ensures that Encoder/Decoder will work in EncDecNLPModel

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -114,7 +114,7 @@ class TransformerConfig:
     library: str = 'nemo'
     model_name: Optional[str] = None
     pretrained: bool = False
-    transformer: Optional[dict] = None
+    config_dict: Optional[dict] = None
     checkpoint_file: Optional[str] = None
     encoder: bool = True
 
@@ -123,7 +123,7 @@ def get_transformer(
     library: str = 'nemo',
     model_name: Optional[str] = None,
     pretrained: bool = False,
-    transformer: Optional[dict] = None,
+    config_dict: Optional[dict] = None,
     checkpoint_file: Optional[str] = None,
     encoder: bool = True,
 ) -> Union[EncoderModule, DecoderModule]:
@@ -158,10 +158,10 @@ def get_transformer(
     model = None
 
     if library == 'nemo':
-        if isinstance(transformer, NeMoTransformerConfig):
-            transformer = asdict(transformer)
+        if isinstance(config_dict, NeMoTransformerConfig):
+            config_dict = asdict(config_dict)
         model = get_nemo_transformer(
-            model_name=model_name, pretrained=pretrained, config_dict=transformer, encoder=encoder,
+            model_name=model_name, pretrained=pretrained, config_dict=config_dict, encoder=encoder,
         )
 
         if checkpoint_file is not None:
@@ -170,7 +170,7 @@ def get_transformer(
 
     elif library == 'huggingface':
         model = get_huggingface_transformer(
-            model_name=model_name, pretrained=pretrained, config_dict=transformer, encoder=encoder
+            model_name=model_name, pretrained=pretrained, config_dict=config_dict, encoder=encoder
         )
 
     return model

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -14,6 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from dataclasses import dataclass
+
+from attr import asdict
+from nemo.collections.nlp.modules.common.transformer.transformer import NeMoTransformerConfig
 import os
 from typing import List, Optional, Union
 
@@ -156,6 +159,8 @@ def get_transformer(
     model = None
 
     if library == 'nemo':
+        if isinstance(config_dict, NeMoTransformerConfig):
+            config_dict = asdict(config_dict)
         model = get_nemo_transformer(
             model_name=model_name, pretrained=pretrained, config_dict=config_dict, encoder=encoder,
         )

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -109,14 +109,14 @@ def get_lm_model(
     return model
 
 
-@dataclass
-class TransformerConfig:
-    library: str = 'nemo'
-    model_name: Optional[str] = None
-    pretrained: bool = False
-    config_dict: Optional[dict] = None
-    checkpoint_file: Optional[str] = None
-    encoder: bool = True
+# @dataclass
+# class TransformerConfig:
+#     library: str = 'nemo'
+#     model_name: Optional[str] = None
+#     pretrained: bool = False
+#     config_dict: Optional[dict] = None
+#     checkpoint_file: Optional[str] = None
+#     encoder: bool = True
 
 
 def get_transformer(

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -18,8 +18,6 @@ from dataclasses import dataclass
 from typing import List, Optional, Union
 
 from attr import asdict
-from hydra.utils import instantiate
-from transformers import AutoConfig, AutoModel
 
 from nemo.collections.nlp.modules.common.bert_module import BertModule
 from nemo.collections.nlp.modules.common.decoder_module import DecoderModule

--- a/nemo/collections/nlp/modules/common/lm_utils.py
+++ b/nemo/collections/nlp/modules/common/lm_utils.py
@@ -135,7 +135,7 @@ def get_transformer(
        If model_name is None, then we can pass in a custom configuration via the config_dict.
        For example, to instantiate a HuggingFace BERT model with custom configuration we would do:
        encoder = get_transformer(library='huggingface',
-                                 transformer={
+                                 config_dict={
                                      '_target_': 'transformers.BertConfig',
                                      'hidden_size': 1536
                                  }) 
@@ -147,7 +147,7 @@ def get_transformer(
         pretrained (bool, optional): Use True to get pretrained weights. 
                                      False will use the same architecture but with randomly initialized weights.
                                      Defaults to False.
-        transformer (Optional[dict], optional): Use for custom configuration of transformer. Defaults to None.
+        config_dict (Optional[dict], optional): Use for custom configuration of transformer. Defaults to None.
         checkpoint_file (Optional[str], optional): Provide weights for the transformer from a local checkpoint. Defaults to None.
         encoder (bool, optional): True returns an EncoderModule, False returns a DecoderModule. Defaults to True.
 

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -93,3 +93,24 @@ def get_tokenizer(
     return AutoTokenizer(
         pretrained_model_name=tokenizer_name, vocab_file=vocab_file, **special_tokens_dict, use_fast=use_fast
     )
+
+
+def get_nmt_tokenizer(
+    library: str = 'yttm',
+    model_name: Optional[str] = None,
+    tokenizer_model: Optional[str] = None,
+    vocab_file: Optional[str] = None,
+    special_tokens: Optional[Dict[str, str]] = None,
+    use_fast: Optional[bool] = False,
+    bpe_dropout: Optional[float] = 0.0,
+):
+    """
+    Args:
+        model_name: if using a pretrained model from NeMo or HuggingFace
+        tokenizer_model: tokenizer model file of sentencepiece or youtokentome
+        special_tokens: dict of special tokens
+        vocab_file: path to vocab file
+        use_fast: (only for HuggingFace AutoTokenizer) set to True to use fast HuggingFace tokenizer
+    """
+    if library == 'yttm':
+        return YouTokenToMeTokenizer(model_path=tokenizer_model, bpe_dropout=bpe_dropout)

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -40,7 +40,7 @@ def get_tokenizer_list() -> List[str]:
 
 @dataclass
 class TokenizerConfig:
-    tokenizer_name: str = MISSING
+    library: str = MISSING
     tokenizer_model: Optional[str] = None
     vocab_size: Optional[int] = None
     vocab_file: Optional[str] = None
@@ -114,3 +114,14 @@ def get_nmt_tokenizer(
     """
     if library == 'yttm':
         return YouTokenToMeTokenizer(model_path=tokenizer_model, bpe_dropout=bpe_dropout)
+
+    elif library == 'huggingface':
+        if special_tokens is None:
+            special_tokens_dict = {}
+        else:
+            special_tokens_dict = special_tokens
+
+        return AutoTokenizer(
+            pretrained_model_name=model_name, vocab_file=vocab_file, **special_tokens_dict, use_fast=use_fast
+        )
+

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -115,6 +115,7 @@ def get_nmt_tokenizer(
         use_fast: (only for HuggingFace AutoTokenizer) set to True to use fast HuggingFace tokenizer
     """
     if library == 'yttm':
+        logging.info(f'Getting YouTokenToMeTokenizer with model: {tokenizer_model}.')
         return YouTokenToMeTokenizer(model_path=tokenizer_model, bpe_dropout=bpe_dropout)
 
     elif library == 'huggingface':
@@ -122,7 +123,7 @@ def get_nmt_tokenizer(
             special_tokens_dict = {}
         else:
             special_tokens_dict = special_tokens
-        logging.info(f'Instantiating HuggingFace AutoTokenizer with pretrained_model_name: {model_name}')
+        logging.info(f'Getting HuggingFace AutoTokenizer with pretrained_model_name: {model_name}')
         return AutoTokenizer(
             pretrained_model_name=model_name, vocab_file=vocab_file, **special_tokens_dict, use_fast=use_fast
         )

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -25,7 +25,6 @@ from nemo.collections.common.tokenizers.youtokentome_tokenizer import YouTokenTo
 from nemo.collections.nlp.modules.common.huggingface.huggingface_utils import get_huggingface_pretrained_lm_models_list
 from nemo.collections.nlp.modules.common.lm_utils import get_pretrained_lm_models_list
 from nemo.collections.nlp.modules.common.megatron.megatron_utils import get_megatron_tokenizer
-
 from nemo.utils import logging
 
 __all__ = ['get_tokenizer', 'get_tokenizer_list']
@@ -127,4 +126,3 @@ def get_nmt_tokenizer(
         return AutoTokenizer(
             pretrained_model_name=model_name, vocab_file=vocab_file, **special_tokens_dict, use_fast=use_fast
         )
-

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -26,6 +26,8 @@ from nemo.collections.nlp.modules.common.huggingface.huggingface_utils import ge
 from nemo.collections.nlp.modules.common.lm_utils import get_pretrained_lm_models_list
 from nemo.collections.nlp.modules.common.megatron.megatron_utils import get_megatron_tokenizer
 
+from nemo.utils import logging
+
 __all__ = ['get_tokenizer', 'get_tokenizer_list']
 
 
@@ -120,7 +122,7 @@ def get_nmt_tokenizer(
             special_tokens_dict = {}
         else:
             special_tokens_dict = special_tokens
-
+        logging.info(f'Instantiating HuggingFace AutoTokenizer with pretrained_model_name: {model_name}')
         return AutoTokenizer(
             pretrained_model_name=model_name, vocab_file=vocab_file, **special_tokens_dict, use_fast=use_fast
         )

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -126,3 +126,5 @@ def get_nmt_tokenizer(
         return AutoTokenizer(
             pretrained_model_name=model_name, vocab_file=vocab_file, **special_tokens_dict, use_fast=use_fast
         )
+    else:
+        raise NotImplementedError('Currently we only support "yttm" and "huggingface" tokenizer library.')

--- a/nemo/collections/nlp/modules/common/transformer/transformer.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer.py
@@ -27,6 +27,14 @@ from nemo.core.classes.common import typecheck
 from nemo.core.classes.exportable import Exportable
 
 
+# @dataclass
+# class TransformerConfig:
+#     # named model arguments
+#     library: str = 'nemo'
+#     model_name: Optional[str] = None
+#     pretrained: bool = False
+
+
 @dataclass
 class NeMoTransformerConfig:
     # must be configured by the user

--- a/nemo/collections/nlp/modules/common/transformer/transformer.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer.py
@@ -48,6 +48,11 @@ class NeMoTransformerConfig:
     hidden_act: str = 'relu'
     pre_ln: bool = False
 
+    # named model arguments
+    library: str = 'nemo'
+    model_name: str = None
+    pretrained: bool = False
+
 
 @dataclass
 class NeMoTransformerEncoderConfig(NeMoTransformerConfig):

--- a/nemo/collections/nlp/modules/common/transformer/transformer.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer.py
@@ -27,8 +27,9 @@ from nemo.core.classes.exportable import Exportable
 
 
 @dataclass
-class TransformerConfig:
+class NeMoTransformerConfig:
     # must be configured by the user
+    vocab_size: int = MISSING
     hidden_size: int = MISSING
     num_layers: int = MISSING
     inner_size: int = MISSING
@@ -49,7 +50,7 @@ class TransformerConfig:
 
 
 @dataclass
-class TransformerEncoderConfig(TransformerConfig):
+class NeMoTransformerEncoderConfig(NeMoTransformerConfig):
     mask_future: bool = False
 
 

--- a/nemo/collections/nlp/modules/common/transformer/transformer.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer.py
@@ -112,7 +112,7 @@ class TransformerEncoderNM(EncoderModule, Exportable):
             pre_ln=pre_ln,
         )
 
-    # @typecheck
+    # @typecheck()
     def forward(self, input_ids, encoder_mask):
         embeddings = self._embedding(input_ids)
         encoder_hidden_states = self._encoder(embeddings, encoder_mask)
@@ -179,10 +179,15 @@ class TransformerDecoderNM(DecoderModule, Exportable):
             pre_ln=pre_ln,
         )
 
-    # @typecheck
+    @typecheck()
     def forward(self, input_ids, decoder_mask, encoder_embeddings, encoder_mask):
-        decoder_embeddings = self._embedding(input_ids)
-        decoder_hidden_states = self._decoder(decoder_embeddings, decoder_mask, encoder_embeddings, encoder_mask)
+        decoder_embeddings = self._embedding(input_ids=input_ids)
+        decoder_hidden_states = self._decoder(
+            decoder_states=decoder_embeddings,
+            decoder_mask=decoder_mask,
+            encoder_states=encoder_embeddings,
+            encoder_mask=encoder_mask,
+        )
         return decoder_hidden_states
 
     @property

--- a/nemo/collections/nlp/modules/common/transformer/transformer.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass
+from typing import Optional
 
 import torch
 from omegaconf.omegaconf import MISSING
@@ -29,7 +30,6 @@ from nemo.core.classes.exportable import Exportable
 @dataclass
 class NeMoTransformerConfig:
     # must be configured by the user
-    vocab_size: int = MISSING
     hidden_size: int = MISSING
     num_layers: int = MISSING
     inner_size: int = MISSING
@@ -50,7 +50,7 @@ class NeMoTransformerConfig:
 
     # named model arguments
     library: str = 'nemo'
-    model_name: str = None
+    model_name: Optional[str] = None
     pretrained: bool = False
 
 

--- a/nemo/collections/nlp/modules/common/transformer/transformer.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer.py
@@ -112,10 +112,10 @@ class TransformerEncoderNM(EncoderModule, Exportable):
             pre_ln=pre_ln,
         )
 
-    # @typecheck()
+    @typecheck()
     def forward(self, input_ids, encoder_mask):
-        embeddings = self._embedding(input_ids)
-        encoder_hidden_states = self._encoder(embeddings, encoder_mask)
+        embeddings = self._embedding(input_ids=input_ids)
+        encoder_hidden_states = self._encoder(encoder_states=embeddings, encoder_mask=encoder_mask)
         return encoder_hidden_states
 
     @property

--- a/nemo/collections/nlp/modules/common/transformer/transformer.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer.py
@@ -26,7 +26,6 @@ from nemo.collections.nlp.modules.common.transformer.transformer_modules import 
 from nemo.core.classes.common import typecheck
 from nemo.core.classes.exportable import Exportable
 
-
 # @dataclass
 # class TransformerConfig:
 #     # named model arguments

--- a/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
@@ -20,7 +20,10 @@ from omegaconf.dictconfig import DictConfig
 
 from nemo.collections.nlp.modules.common.huggingface.huggingface_decoder import HuggingFaceDecoderModule
 from nemo.collections.nlp.modules.common.huggingface.huggingface_encoder import HuggingFaceEncoderModule
-from nemo.collections.nlp.modules.common.transformer.transformer import TransformerDecoderNM, TransformerEncoderNM
+from nemo.collections.nlp.modules.common.transformer.transformer import (
+    NeMoTransformerDecoderNM,
+    NeMoTransformerEncoderNM,
+)
 from nemo.utils import logging
 
 
@@ -29,7 +32,7 @@ def get_nemo_transformer(
     pretrained: bool = False,
     config_dict: Optional[Union[dict, DictConfig]] = None,
     encoder: bool = True,
-) -> Union[TransformerEncoderNM, TransformerDecoderNM]:
+) -> Union[NeMoTransformerEncoderNM, NeMoTransformerDecoderNM]:
     """Returns NeMo transformer.
     The following configurations are mandatory:
         vocab_size: int
@@ -65,7 +68,7 @@ def get_nemo_transformer(
         cfg = config_dict
 
     if encoder:
-        model = TransformerEncoderNM(
+        model = NeMoTransformerEncoderNM(
             vocab_size=cfg.get('vocab_size'),
             hidden_size=cfg.get('hidden_size'),
             num_layers=cfg.get('num_layers'),
@@ -82,7 +85,7 @@ def get_nemo_transformer(
             pre_ln=cfg.get('pre_ln', False),
         )
     else:
-        model = TransformerDecoderNM(
+        model = NeMoTransformerDecoderNM(
             vocab_size=cfg.get('vocab_size'),
             hidden_size=cfg.get('hidden_size'),
             num_layers=cfg.get('num_layers'),

--- a/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
@@ -13,13 +13,15 @@
 # limitations under the License.
 
 
+import os
+from typing import Optional, Union
+
+from omegaconf.dictconfig import DictConfig
+
 from nemo.collections.nlp.modules.common.huggingface.huggingface_decoder import HuggingFaceDecoderModule
 from nemo.collections.nlp.modules.common.huggingface.huggingface_encoder import HuggingFaceEncoderModule
-import os
-from omegaconf.dictconfig import DictConfig
 from nemo.collections.nlp.modules.common.transformer.transformer import TransformerDecoderNM, TransformerEncoderNM
 from nemo.utils import logging
-from typing import Optional, Union
 
 
 def get_nemo_transformer(

--- a/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 
+from nemo.collections.nlp.modules.common.huggingface.huggingface_decoder import HuggingFaceDecoderModule
+from nemo.collections.nlp.modules.common.huggingface.huggingface_encoder import HuggingFaceEncoderModule
 import os
 from omegaconf.dictconfig import DictConfig
 from nemo.collections.nlp.modules.common.transformer.transformer import TransformerDecoderNM, TransformerEncoderNM
@@ -93,5 +95,19 @@ def get_nemo_transformer(
             hidden_act=cfg.get('hidden_act', 'relu'),
             pre_ln=cfg.get('pre_ln', False),
         )
+
+    return model
+
+
+def get_huggingface_transformer(
+    model_name: Optional[str] = None,
+    pretrained: bool = False,
+    config_dict: Optional[Union[dict, DictConfig]] = None,
+    encoder: bool = True,
+) -> Union[HuggingFaceEncoderModule, HuggingFaceDecoderModule]:
+    if encoder:
+        model = HuggingFaceEncoderModule(model_name, pretrained, config_dict)
+    else:
+        model = HuggingFaceDecoderModule(model_name, pretrained, config_dict)
 
     return model

--- a/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
@@ -45,6 +45,9 @@ def get_nemo_transformer(
     if model_name is not None:
         raise ValueError(f'NeMo transformers cannot be loaded from NGC yet. model_name should be None')
 
+    if pretrained:
+        raise ValueError(f'NeMo transformers cannot be loaded from NGC yet. pretrained should be False')
+
     cfg = None
 
     if config_dict is not None:

--- a/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
@@ -42,6 +42,9 @@ def get_nemo_transformer(
         checkpoint_file (Optional[str], optional): load weights from path to local checkpoint. Defaults to None.
         encoder (bool, optional): True will use EncoderTransformerNM, False will use DecoderTransformerNM. Defaults to True.
     """
+    if model_name is not None:
+        raise ValueError(f'NeMo transformers cannot be loaded from NGC yet. model_name should be None')
+
     cfg = None
 
     if config_dict is not None:
@@ -52,8 +55,8 @@ def get_nemo_transformer(
             and config_dict.get('inner_size') is not None
         ), 'vocab_size, hidden_size, num_layers, and inner_size must are mandatory arguments'
         cfg = config_dict
-    elif model_name is not None:
-        logging.info(f'NeMo transformers cannot be loaded from NGC yet. Using {model_name} with configuration {cfg}.')
+    else:
+        raise ValueError(f'NeMo transformers cannot be loaded from NGC yet. config_dict should not be None')
 
     if encoder:
         model = TransformerEncoderNM(

--- a/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
@@ -21,21 +21,22 @@ from typing import Optional, Union
 
 
 def get_nemo_transformer(
-    pretrained_model_name: Optional[str] = None,
+    model_name: Optional[str] = None,
+    pretrained: bool = False,
     config_dict: Optional[Union[dict, DictConfig]] = None,
     encoder: bool = True,
 ) -> Union[TransformerEncoderNM, TransformerDecoderNM]:
-    """Returns NeMo transformer. Module configuration will be taken in the following order of precedence:
-    config_file > config_dict > pretrained_model_name.
+    """Returns NeMo transformer.
     The following configurations are mandatory:
         vocab_size: int
         hidden_size: int
         num_layers: int
         inner_size: int
-    and must be specified if using config_dict or config_file.
+    and must be specified if using config_dict.
 
     Args:
-        pretrained_model_name (Optional[str]): model name to download from NGC
+        model_name (Optional[str]): model name to download from NGC
+        pretrained: (bool): False will instantiate the named model architecture with random weights.
         config_dict (Optional[dict], optional): model configuration parameters. Defaults to None.
         config_file (Optional[str], optional): path to json file containing model configuration. Defaults to None.
         checkpoint_file (Optional[str], optional): load weights from path to local checkpoint. Defaults to None.
@@ -51,14 +52,41 @@ def get_nemo_transformer(
             and config_dict.get('inner_size') is not None
         ), 'vocab_size, hidden_size, num_layers, and inner_size must are mandatory arguments'
         cfg = config_dict
-    elif pretrained_model_name is not None:
-        logging.info(
-            f'NeMo transformers cannot be loaded from NGC yet. Using {pretrained_model_name} with configuration {cfg}.'
-        )
+    elif model_name is not None:
+        logging.info(f'NeMo transformers cannot be loaded from NGC yet. Using {model_name} with configuration {cfg}.')
 
     if encoder:
-        model = TransformerEncoderNM(**cfg)
+        model = TransformerEncoderNM(
+            vocab_size=cfg.get('vocab_size'),
+            hidden_size=cfg.get('hidden_size'),
+            num_layers=cfg.get('num_layers'),
+            inner_size=cfg.get('inner_size'),
+            max_sequence_length=cfg.get('max_sequence_length', 512),
+            embedding_dropout=cfg.get('embedding_dropout', 0.0),
+            learn_positional_encodings=cfg.get('learn_positional_encodings', False),
+            num_attention_heads=cfg.get('num_attention_heads'),
+            ffn_dropout=cfg.get('ffn_dropout', 0.0),
+            attn_score_dropout=cfg.get('attn_score_dropout', 0.0),
+            attn_layer_dropout=cfg.get('attn_layer_dropout', 0.0),
+            hidden_act=cfg.get('hidden_act', 'relu'),
+            mask_future=cfg.get('mask_future', False),
+            pre_ln=cfg.get('pre_ln', False),
+        )
     else:
-        model = TransformerDecoderNM(**cfg)
+        model = TransformerDecoderNM(
+            vocab_size=cfg.get('vocab_size'),
+            hidden_size=cfg.get('hidden_size'),
+            num_layers=cfg.get('num_layers'),
+            inner_size=cfg.get('inner_size'),
+            max_sequence_length=cfg.get('max_sequence_length', 512),
+            embedding_dropout=cfg.get('embedding_dropout', 0.0),
+            learn_positional_encodings=cfg.get('learn_positional_encodings', False),
+            num_attention_heads=cfg.get('num_attention_heads'),
+            ffn_dropout=cfg.get('ffn_dropout', 0.0),
+            attn_score_dropout=cfg.get('attn_score_dropout', 0.0),
+            attn_layer_dropout=cfg.get('attn_layer_dropout', 0.0),
+            hidden_act=cfg.get('hidden_act', 'relu'),
+            pre_ln=cfg.get('pre_ln', False),
+        )
 
     return model

--- a/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
@@ -50,16 +50,15 @@ def get_nemo_transformer(
 
     cfg = None
 
-    if config_dict is not None:
+    if not pretrained:
         assert (
             config_dict.get('vocab_size') is not None
             and config_dict.get('hidden_size') is not None
             and config_dict.get('num_layers') is not None
             and config_dict.get('inner_size') is not None
-        ), 'vocab_size, hidden_size, num_layers, and inner_size must are mandatory arguments'
+        ), f'Using config_dict: {config_dict}. vocab_size, hidden_size, num_layers, and inner_size must are mandatory arguments'
+
         cfg = config_dict
-    else:
-        raise ValueError(f'NeMo transformers cannot be loaded from NGC yet. config_dict should not be None')
 
     if encoder:
         model = TransformerEncoderNM(

--- a/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
@@ -1,0 +1,64 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+from omegaconf.dictconfig import DictConfig
+from nemo.collections.nlp.modules.common.transformer.transformer import TransformerDecoderNM, TransformerEncoderNM
+from nemo.utils import logging
+from typing import Optional, Union
+
+
+def get_nemo_transformer(
+    pretrained_model_name: Optional[str] = None,
+    config_dict: Optional[Union[dict, DictConfig]] = None,
+    encoder: bool = True,
+) -> Union[TransformerEncoderNM, TransformerDecoderNM]:
+    """Returns NeMo transformer. Module configuration will be taken in the following order of precedence:
+    config_file > config_dict > pretrained_model_name.
+    The following configurations are mandatory:
+        vocab_size: int
+        hidden_size: int
+        num_layers: int
+        inner_size: int
+    and must be specified if using config_dict or config_file.
+
+    Args:
+        pretrained_model_name (Optional[str]): model name to download from NGC
+        config_dict (Optional[dict], optional): model configuration parameters. Defaults to None.
+        config_file (Optional[str], optional): path to json file containing model configuration. Defaults to None.
+        checkpoint_file (Optional[str], optional): load weights from path to local checkpoint. Defaults to None.
+        encoder (bool, optional): True will use EncoderTransformerNM, False will use DecoderTransformerNM. Defaults to True.
+    """
+    cfg = None
+
+    if config_dict is not None:
+        assert (
+            config_dict.get('vocab_size') is not None
+            and config_dict.get('hidden_size') is not None
+            and config_dict.get('num_layers') is not None
+            and config_dict.get('inner_size') is not None
+        ), 'vocab_size, hidden_size, num_layers, and inner_size must are mandatory arguments'
+        cfg = config_dict
+    elif pretrained_model_name is not None:
+        logging.info(
+            f'NeMo transformers cannot be loaded from NGC yet. Using {pretrained_model_name} with configuration {cfg}.'
+        )
+
+    if encoder:
+        model = TransformerEncoderNM(**cfg)
+    else:
+        model = TransformerDecoderNM(**cfg)
+
+    return model

--- a/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
@@ -19,10 +19,7 @@ from omegaconf.dictconfig import DictConfig
 
 from nemo.collections.nlp.modules.common.huggingface.huggingface_decoder import HuggingFaceDecoderModule
 from nemo.collections.nlp.modules.common.huggingface.huggingface_encoder import HuggingFaceEncoderModule
-from nemo.collections.nlp.modules.common.transformer.transformer import (
-    TransformerDecoderNM,
-    TransformerEncoderNM,
-)
+from nemo.collections.nlp.modules.common.transformer.transformer import TransformerDecoderNM, TransformerEncoderNM
 
 
 def get_nemo_transformer(

--- a/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 
-import os
 from typing import Optional, Union
 
 from omegaconf.dictconfig import DictConfig
@@ -24,7 +23,6 @@ from nemo.collections.nlp.modules.common.transformer.transformer import (
     NeMoTransformerDecoderNM,
     NeMoTransformerEncoderNM,
 )
-from nemo.utils import logging
 
 
 def get_nemo_transformer(

--- a/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
+++ b/nemo/collections/nlp/modules/common/transformer/transformer_utils.py
@@ -20,8 +20,8 @@ from omegaconf.dictconfig import DictConfig
 from nemo.collections.nlp.modules.common.huggingface.huggingface_decoder import HuggingFaceDecoderModule
 from nemo.collections.nlp.modules.common.huggingface.huggingface_encoder import HuggingFaceEncoderModule
 from nemo.collections.nlp.modules.common.transformer.transformer import (
-    NeMoTransformerDecoderNM,
-    NeMoTransformerEncoderNM,
+    TransformerDecoderNM,
+    TransformerEncoderNM,
 )
 
 
@@ -30,7 +30,7 @@ def get_nemo_transformer(
     pretrained: bool = False,
     config_dict: Optional[Union[dict, DictConfig]] = None,
     encoder: bool = True,
-) -> Union[NeMoTransformerEncoderNM, NeMoTransformerDecoderNM]:
+) -> Union[TransformerEncoderNM, TransformerDecoderNM]:
     """Returns NeMo transformer.
     The following configurations are mandatory:
         vocab_size: int
@@ -66,7 +66,7 @@ def get_nemo_transformer(
         cfg = config_dict
 
     if encoder:
-        model = NeMoTransformerEncoderNM(
+        model = TransformerEncoderNM(
             vocab_size=cfg.get('vocab_size'),
             hidden_size=cfg.get('hidden_size'),
             num_layers=cfg.get('num_layers'),
@@ -83,7 +83,7 @@ def get_nemo_transformer(
             pre_ln=cfg.get('pre_ln', False),
         )
     else:
-        model = NeMoTransformerDecoderNM(
+        model = TransformerDecoderNM(
             vocab_size=cfg.get('vocab_size'),
             hidden_size=cfg.get('hidden_size'),
             num_layers=cfg.get('num_layers'),


### PR DESCRIPTION
This PR will add HuggingFace Encoder support to NeMo NMT.

When training NeMo NMT models, users can now: 

- Download pretrained model from HF and use it for NMT automatically
- The NMT data preprocessor will automatically use the tokenizer associated with pretrained when preprocessing the data
- The HF encoder can be used with the pretrained weights or with randomly initialized weights
- The HF encoder can be configured from scratch.

# Implementation Details
Since our ultimate goal is to be able to use encoders from HuggingFace, Megatron-LM, and NeMo, we've added some new flags to NMT.

The `library` flag takes values: `huggingface`, `megatron` (when implemented), and `nemo`.
NMT has `library=nemo` by default to maintain backwards compatibility.

The `model_name` flag is used to indicate a _named_ model architecture. From HuggingFace, we have `bert_base_cased` for example.

We've also added the `pretrained` flag. This allows users to decide whether they want to download the named model's pretrained weights `pretrained=True` or simply instantiated the named model architecture with random weights `pretrained=False`.

If a user wants to use a model architecture from a specific library, then they can use `model_name=None` and add the custom configuration under the `encoder` configuration. For example:
```
encoder:
  _target_: transformers.BertConfig
  hidden_size: 1536
```
Also note that `shared_tokenizer` should `False` when using HuggingFace encoders since we do not support HuggingFace Decoders yet.

# Usage
We've provided a config file to use with HuggingFace encoders: examples/nlp/machine_translation/conf/huggingface.yaml

We can use that config file by specifying from the CLI: 
```
--config-path=conf \
--config-name=huggingface
```
## Pretrained HuggingFace Encoder
This will train an NMT model with a pretrained encoder model from HuggingFace and
a randomly initialized decoder from NeMo.
To train the encoder from scratch, set `encoder.pretrained=False`. 
```
MODEL_NAME = bert-base-cased
python examples/nlp/machine_translation/enc_dec_nmt.py \
	--config-path=conf \
	--config-name=huggingface \
        model.src_language=en \
        model.tgt_language=de \
	model.preproc_out_dir=/raid/data/hf_en_de_preproc_${MODEL_NAME} \
	model.shared_tokenizer=false \
	model.encoder_tokenizer.library=huggingface \
	model.encoder.library=huggingface \
	model.encoder.pretrained=true \
	model.encoder.model_name=${MODEL_NAME} \
	model.decoder_tokenizer.library=yttm \
	model.decoder_tokenizer.vocab_size=32000 \
	model.decoder.library=nemo \
	model.decoder.inner_size=4096 \
	model.decoder.num_attention_heads=16 \
	model.decoder.attn_layer_dropout=0.1 \
	model.decoder.ffn_dropout=0.1 \
	model.decoder.num_layers=6 \
        ...
```
## Custom HuggingFace Encoder
This will train an NMT model with a custom encoder model from HuggingFace and
a randomly initialized decoder from NeMo.
Note: we have to use `+` from the CLI if we are not adding the argument to the config file.
```
python examples/nlp/machine_translation/enc_dec_nmt.py \
	--config-path=conf \
	--config-name=huggingface \
        model.src_language=en \
        model.tgt_language=de \
	model.preproc_out_dir=/raid/data/hf_en_de_preproc_custom \
	model.shared_tokenizer=false \
	model.encoder_tokenizer.library=huggingface \
	model.encoder.library=huggingface \ 
        +model.encoder._target_=transformers.BertConfig \
        +model.encoder.hidden_size=1536 \
	model.decoder_tokenizer.library=yttm \
	model.decoder_tokenizer.vocab_size=32000 \
	model.decoder.library=nemo \
	model.decoder.inner_size=4096 \
	model.decoder.num_attention_heads=16 \
	model.decoder.attn_layer_dropout=0.1 \
	model.decoder.ffn_dropout=0.1 \
	model.decoder.num_layers=6 \
        ...
```