### PR TITLE
Make numba dynamically checked and remove hard dependency in requirements.txt

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN apt-get update && \
 
 # build torchaudio (change latest release version to match pytorch)
 WORKDIR /tmp/torchaudio_build
-RUN git clone --depth 1 --branch release/0.6 https://github.com/pytorch/audio.git && \
+RUN git clone --depth 1 --branch release/0.7 https://github.com/pytorch/audio.git && \
     cd audio && \
     BUILD_SOX=1 python setup.py install && \
     cd .. && rm -r audio
@@ -96,7 +96,14 @@ ARG NEMO_VERSION=1.0.0rc1
 RUN /usr/bin/test -n "$NEMO_VERSION" && \
     /bin/echo "export NEMO_VERSION=${NEMO_VERSION}" >> /root/.bashrc && \
     /bin/echo "export BASE_IMAGE=${BASE_IMAGE}" >> /root/.bashrc
-RUN --mount=from=nemo-src,target=/tmp/nemo cd /tmp/nemo && pip install ".[all]"
+RUN --mount=from=nemo-src,target=/tmp/nemo cd /tmp/nemo && pip install ".[all]" && \
+    python -c "import nemo.collections.asr as nemo_asr" && \
+    python -c "import nemo.collections.nlp as nemo_nlp" && \
+    python -c "import nemo.collections.tts as nemo_tts"
+
+# TODO: Remove once 20.04 container is base container
+# install latest numba version
+RUN conda update -c numba numba -y
 
 # copy scripts/examples/tests into container for end user
 WORKDIR /workspace/nemo

--- a/nemo/collections/asr/parts/numba/__init__.py
+++ b/nemo/collections/asr/parts/numba/__init__.py
@@ -12,4 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from nemo.collections.asr.parts.numba.numba_utils import numba_cuda_is_supported
 from nemo.collections.asr.parts.numba.rnnt_loss.rnnt_pytorch import RNNTLossNumba
+
+__NUMBA_MINIMUM_VERSION__ = "0.53.0"

--- a/nemo/collections/asr/parts/numba/numba_utils.py
+++ b/nemo/collections/asr/parts/numba/numba_utils.py
@@ -17,8 +17,18 @@ import operator
 from nemo.utils import model_utils
 
 
-def numba_cuda_is_supported(version) -> bool:
-    module_available, msg = model_utils.check_lib_version('numba', checked_version=version, operator=operator.ge)
+def numba_cuda_is_supported(min_version: str) -> bool:
+    """
+    Tests if an appropriate version of numba is installed, and if it is,
+    if cuda is supported properly within it.
+    
+    Args:
+        min_version: The minimum version of numba that is required.
+
+    Returns:
+        bool, whether cuda is supported with this current installation or not.
+    """
+    module_available, msg = model_utils.check_lib_version('numba', checked_version=min_version, operator=operator.ge)
 
     # If numba is not installed
     if module_available is None:
@@ -39,9 +49,15 @@ def numba_cuda_is_supported(version) -> bool:
         return False
 
 
-def skip_numba_cuda_test_if_unsupported(version):
-    numba_cuda_support = numba_cuda_is_supported(version)
+def skip_numba_cuda_test_if_unsupported(min_version: str):
+    """
+    Helper method to skip pytest test case if numba cuda is not supported.
+    
+    Args:
+        min_version: The minimum version of numba that is required.
+    """
+    numba_cuda_support = numba_cuda_is_supported(min_version)
     if not numba_cuda_support:
         import pytest
 
-        pytest.skip(f"Numba cuda test is being skipped. Minimum version required : {version}")
+        pytest.skip(f"Numba cuda test is being skipped. Minimum version required : {min_version}")

--- a/nemo/collections/asr/parts/numba/numba_utils.py
+++ b/nemo/collections/asr/parts/numba/numba_utils.py
@@ -1,0 +1,47 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import operator
+
+from nemo.utils import model_utils
+
+
+def numba_cuda_is_supported(version) -> bool:
+    module_available, msg = model_utils.check_lib_version('numba', checked_version=version, operator=operator.ge)
+
+    # If numba is not installed
+    if module_available is None:
+        return False
+
+    # If numba version is installed and available
+    if module_available is True:
+        from numba import cuda
+
+        # this method first arrived in 0.53, and that's the minimum version required
+        if hasattr(cuda, 'is_supported_version'):
+            return cuda.is_supported_version()
+        else:
+            # assume cuda is supported, but it may fail due to CUDA incompatibility
+            return False
+
+    else:
+        return False
+
+
+def skip_numba_cuda_test_if_unsupported(version):
+    numba_cuda_support = numba_cuda_is_supported(version)
+    if not numba_cuda_support:
+        import pytest
+
+        pytest.skip(f"Numba cuda test is being skipped. Minimum version required : {version}")

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -23,6 +23,7 @@ import pytorch_lightning as pl
 import wrapt
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from omegaconf import errors as omegaconf_errors
+from packaging import version
 
 from nemo.utils import logging
 
@@ -465,3 +466,53 @@ def resolve_subclass_pretrained_model_info(base_class) -> List['PretrainedModelI
 
     list_of_models = list(sorted(list_of_models))
     return list_of_models
+
+
+def check_lib_version(lib_name: str, checked_version: str, operator) -> (Optional[bool], str):
+    """
+    Checks if a library is installed, and if it is, checks the operator(lib.__version__, version) as a result.
+    This bool result along with a string analysis of result is returned.
+
+    If the library is not installed at all, then returns None instead, along with a string explaining
+    that the library is not installed
+
+    Args:
+        lib_name: lower case str name of the library that must be imported.
+        checked_version: semver string that is compared against lib.__version__.
+        operator: binary callable function func(a, b) -> bool; that compares lib.__version__ against version in
+            some manner. Must return a boolean.
+
+    Returns:
+        A tuple of results:
+        -   Bool or None. Bool if the library could be imported, and the result of
+            operator(lib.__version__, version) or False if __version__ is not implemented in lib.
+            None is passed if the library is not installed at all.
+        -   A string analysis of the check.
+    """
+    try:
+        mod = __import__(lib_name)
+
+        if hasattr(mod, '__version__'):
+            lib_ver = version.Version(mod.__version__)
+            match_ver = version.Version(checked_version)
+
+            if operator(lib_ver, match_ver):
+                msg = f"Lib {lib_name} version is satisfied !"
+                return True, msg
+            else:
+                msg = (
+                    f"Lib {lib_name} version ({lib_ver}) is not {operator.__name__} than required version {checked_version}.\n"
+                    f"Please upgrade the lib using either pip or conda to the latest version."
+                )
+                return False, msg
+        else:
+            msg = (
+                f"Lib {lib_name} does not implement __version__ in its init file. "
+                f"Could not check version compatibility."
+            )
+            return False, msg
+    except (ImportError, ModuleNotFoundError):
+        pass
+
+    msg = f"Lib {lib_name} has not been installed. Please use pip or conda to install this package."
+    return None, msg

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -470,7 +470,7 @@ def resolve_subclass_pretrained_model_info(base_class) -> List['PretrainedModelI
 
 def check_lib_version(lib_name: str, checked_version: str, operator) -> (Optional[bool], str):
     """
-    Checks if a library is installed, and if it is, checks the operator(lib.__version__, version) as a result.
+    Checks if a library is installed, and if it is, checks the operator(lib.__version__, checked_version) as a result.
     This bool result along with a string analysis of result is returned.
 
     If the library is not installed at all, then returns None instead, along with a string explaining
@@ -485,7 +485,7 @@ def check_lib_version(lib_name: str, checked_version: str, operator) -> (Optiona
     Returns:
         A tuple of results:
         -   Bool or None. Bool if the library could be imported, and the result of
-            operator(lib.__version__, version) or False if __version__ is not implemented in lib.
+            operator(lib.__version__, checked_version) or False if __version__ is not implemented in lib.
             None is passed if the library is not installed at all.
         -   A string analysis of the check.
     """

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -16,4 +16,4 @@ tqdm>=4.41.0
 opencc
 pangu
 jieba
-numba>=0.53.0
+numba

--- a/tests/collections/asr/numba/rnnt_loss/test_rnnt_pytorch.py
+++ b/tests/collections/asr/numba/rnnt_loss/test_rnnt_pytorch.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 import torch
 
+from nemo.collections.asr.parts.numba import __NUMBA_MINIMUM_VERSION__, numba_utils
 from nemo.collections.asr.parts.numba.rnnt_loss.rnnt_numpy import RNNTLoss as RNNTLoss_Numpy
 from nemo.collections.asr.parts.numba.rnnt_loss.rnnt_pytorch import RNNTLossNumba
 
@@ -51,6 +52,9 @@ class TestRNNTLossPytorch:
     @pytest.mark.unit
     @pytest.mark.parametrize('device', DEVICES)
     def test_case_small(self, device):
+        if device == 'cuda':
+            numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         acts = np.array(
             [
                 [
@@ -93,6 +97,9 @@ class TestRNNTLossPytorch:
     @pytest.mark.unit
     @pytest.mark.parametrize('device', DEVICES)
     def test_case_small_random(self, device):
+        if device == 'cuda':
+            numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         rng = np.random.RandomState(0)
         acts = rng.randn(1, 4, 3, 3)
         labels = [[1, 2]]
@@ -109,6 +116,8 @@ class TestRNNTLossPytorch:
     @pytest.mark.unit
     @pytest.mark.parametrize('device', DEVICES)
     def big_test(self, device):
+        if device == 'cuda':
+            numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         # minibatch x T x U x alphabet_size
         activations = [
@@ -224,6 +233,9 @@ class TestRNNTLossPytorch:
     @pytest.mark.unit
     @pytest.mark.parametrize('device', DEVICES)
     def test_case_large_random(self, device):
+        if device == 'cuda':
+            numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         rng = np.random.RandomState(0)
         acts = rng.randn(4, 8, 11, 5)
         labels = [

--- a/tests/collections/asr/numba/rnnt_loss/utils/test_gpu_rnnt_kernel.py
+++ b/tests/collections/asr/numba/rnnt_loss/utils/test_gpu_rnnt_kernel.py
@@ -17,6 +17,7 @@ import pytest
 import torch
 from numba import cuda
 
+from nemo.collections.asr.parts.numba import __NUMBA_MINIMUM_VERSION__, numba_utils
 from nemo.collections.asr.parts.numba.rnnt_loss import rnnt_numpy
 from nemo.collections.asr.parts.numba.rnnt_loss.rnnt_pytorch import certify_inputs
 from nemo.collections.asr.parts.numba.rnnt_loss.utils.cuda_utils import gpu_rnnt_kernel, reduce
@@ -33,6 +34,8 @@ class TestRNNTCUDAKernels:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Reductions can only be run when CUDA is available")
     @pytest.mark.unit
     def test_compute_alphas_kernel(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         random = np.random.RandomState(0)
         original_shape = [1, 5, 11, 3]
         B, T, U, V = original_shape
@@ -99,6 +102,8 @@ class TestRNNTCUDAKernels:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Reductions can only be run when CUDA is available")
     @pytest.mark.unit
     def test_compute_betas_kernel(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         random = np.random.RandomState(0)
         original_shape = [1, 5, 11, 3]
         B, T, U, V = original_shape

--- a/tests/collections/asr/numba/rnnt_loss/utils/test_reduce.py
+++ b/tests/collections/asr/numba/rnnt_loss/utils/test_reduce.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 from numba import cuda
 
+from nemo.collections.asr.parts.numba import __NUMBA_MINIMUM_VERSION__, numba_utils
 from nemo.collections.asr.parts.numba.rnnt_loss.utils.cuda_utils import reduce
 
 
@@ -23,6 +24,8 @@ class TestRNNTCUDAReductions:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Reductions can only be run when CUDA is available")
     @pytest.mark.unit
     def test_reduce_max(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         random = np.random.RandomState(0)
         original_shape = [1, 5, 4, 3]
         x = random.randn(*original_shape).reshape([-1])
@@ -50,6 +53,8 @@ class TestRNNTCUDAReductions:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Reductions can only be run when CUDA is available")
     @pytest.mark.unit
     def test_reduce_exp(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         random = np.random.RandomState(0)
         original_shape = [1, 5, 4, 2]
         x = random.randn(*original_shape).reshape([-1])

--- a/tests/collections/asr/numba/rnnt_loss/utils/test_rnnt_helper.py
+++ b/tests/collections/asr/numba/rnnt_loss/utils/test_rnnt_helper.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 from numba import cuda
 
+from nemo.collections.asr.parts.numba import __NUMBA_MINIMUM_VERSION__, numba_utils
 from nemo.collections.asr.parts.numba.rnnt_loss.utils import global_constants, rnnt_helper
 
 
@@ -23,6 +24,8 @@ class TestRNNTHelper:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
     def test_log_sum_exp(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         # wrapper kernel for device function that is tested
         @cuda.jit
         def _kernel(x, y):
@@ -53,6 +56,8 @@ class TestRNNTHelper:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
     def test_log_sum_exp_neg_inf(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         # wrapper kernel for device function that is tested
         @cuda.jit
         def _kernel(x, y):
@@ -83,6 +88,8 @@ class TestRNNTHelper:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
     def test_div_up(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         # wrapper kernel for device function that is tested
         @cuda.jit
         def _kernel(x, y):
@@ -114,6 +121,8 @@ class TestRNNTHelper:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
     def test_add(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         # wrapper kernel for device function that is tested
         @cuda.jit
         def _kernel(x, y):
@@ -145,6 +154,8 @@ class TestRNNTHelper:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
     def test_maximum(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         # wrapper kernel for device function that is tested
         @cuda.jit
         def _kernel(x, y):
@@ -176,6 +187,8 @@ class TestRNNTHelper:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
     def test_identity(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         # wrapper kernel for device function that is tested
         @cuda.jit
         def _kernel(x):
@@ -205,6 +218,8 @@ class TestRNNTHelper:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
     def test_negate(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         # wrapper kernel for device function that is tested
         @cuda.jit
         def _kernel(x):
@@ -234,6 +249,8 @@ class TestRNNTHelper:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
     def test_exponential(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         # wrapper kernel for device function that is tested
         @cuda.jit
         def _kernel(x):
@@ -264,6 +281,8 @@ class TestRNNTHelper:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
     def test_log_plus(self):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
         # wrapper kernel for device function that is tested
         @cuda.jit
         def _kernel(x, y):


### PR DESCRIPTION
# Changelog
- Remove hard numba version requirements
- Dynamically check for version at runtime when it is required
- Update tests to dynamically switch off for cuda if version is incompatible (either due to numba version itself, or due to mismatch between supported CUDA version and actual CUDA version installed).
- Update docker file to forcibly update numba temporarily (to be removed at 20.04 release)
- Update docker file to preemptively import the domains to download whatever is necessary.
- Patch a bug in dynamic resolution of numba losses

Signed-off-by: smajumdar <titu1994@gmail.com>