### PR TITLE
Actually install NeMo requirements in Docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,7 +73,7 @@ RUN pip uninstall -y sacrebleu
 # install nemo dependencies
 WORKDIR /tmp/nemo
 COPY requirements .
-RUN for f in $(ls requirements/*.txt); do pip install --disable-pip-version-check --no-cache-dir -r $f; done
+RUN for f in $(ls requirements*.txt); do pip install --disable-pip-version-check --no-cache-dir -r $f; done
 
 #install TRT tools: PT quantization support and ONNX graph optimizer
 WORKDIR /tmp/trt_build


### PR DESCRIPTION
When building docker container locally: 
```
#17 [nemo-deps 10/12] RUN for f in $(ls requirements/*.txt); do pip install ...
#17 0.515 ls: cannot access 'requirements/*.txt': No such file or directory
#17 DONE 0.6s

```

The files are copied not into a separate `/tmp/nemo/requirements/` folder but directly into `/tmp/nemo/`, so we either have to create new directory first or install directly from where we copied.




Signed-off-by: Aleksei Kalinov <alekseia@nvidia.com>