### PR TITLE
[CORE] Upgrade Jenkins to NGC PyTorch 21.03 Container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,13 @@ pipeline {
     stage('PyTorch version') {
       steps {
         sh 'python -c "import torch; print(torch.__version__)"'
-        sh 'python -c "import torchtext; print(torchtext.__version__)"'
         sh 'python -c "import torchvision; print(torchvision.__version__)"'
+      }
+    }
+
+    stage('Uninstall torchtext') {
+      steps {
+        sh 'pip uninstall -y torchtext'
       }
     }
 

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -2,7 +2,6 @@ boto3
 h5py
 matplotlib>=3.3.2
 sentencepiece
-torchtext
 unidecode
 youtokentome
 numpy

--- a/setup.py
+++ b/setup.py
@@ -91,43 +91,6 @@ extras_require['tts'] = list(chain([extras_require['tts'], extras_require['asr']
 
 tests_requirements = extras_require["test"]
 
-########################## VERSION MISMATCH PATCH #############################
-# REMOVE AFTER 21.03 Container is released !
-
-try:
-    import torch
-
-    version = torch.__version__
-    SUPPORTED_TORCH_VERSION = f"torch=={version}"
-
-    if 'a' in version or 'b' in version:
-        # It is githash release, force to supported Pytorch Lightning branch
-        SUPPORTED_PYTORCH_LIGHTNING = "pytorch-lightning==1.2.2"
-    else:
-        SUPPORTED_PYTORCH_LIGHTNING = "pytorch-lightning>=1.2.3"
-except (ImportError, ModuleNotFoundError):
-    # Since no torch is installed, pip install torch will install latest torch and latest pytorch lightning
-    SUPPORTED_TORCH_VERSION = "torch"
-    SUPPORTED_PYTORCH_LIGHTNING = "pytorch-lightning>=1.2.3"
-
-install_requires_buffer = []
-for ix, line in enumerate(install_requires):
-    if 'lightning' in line:
-        install_requires_buffer.append(SUPPORTED_PYTORCH_LIGHTNING)
-    elif 'torch' in line:
-        install_requires_buffer.append(SUPPORTED_TORCH_VERSION)
-
-        # Pytorch 1.7.1 must use torchtext==0.8.0, torchaudio==0.7.2 and torchvision==0.8.2
-        if SUPPORTED_TORCH_VERSION == "torch<=1.7.1":
-            install_requires_buffer.append("torchvision==0.8.2")
-            install_requires_buffer.append("torchaudio==0.7.2")
-            install_requires_buffer.append("torchtext==0.8.0")
-
-    else:
-        install_requires_buffer.append(line)
-
-# override install requires
-install_requires = install_requires_buffer
 
 ###############################################################################
 #                            Code style checkers                              #


### PR DESCRIPTION
Uninstalling torchtext and removing torchtext from nlp requirements due to incompatibility with PTL install inside 21.03 container.

Removed setup.py version logic.