### PR TITLE
Corrects support for subclass overriding "target" in Serialization

### DIFF
--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -449,6 +449,11 @@ class Serialization(ABC):
 
                 # try instantiating model with target class
                 if imported_cls is not None:
+                    # if calling class (cls) is subclass of imported class,
+                    # use subclass instead
+                    if issubclass(cls, imported_cls):
+                        imported_cls = cls
+
                     try:
                         instance = imported_cls(cfg=config)
                     except Exception:

--- a/tests/core/test_serialization.py
+++ b/tests/core/test_serialization.py
@@ -20,6 +20,20 @@ from nemo.collections.asr.modules import SpectrogramAugmentation
 from nemo.core.classes.common import Serialization
 
 
+def get_class_path(cls):
+    return f"{cls.__module__}.{cls.__name__}"
+
+
+class MockSerializationImpl(Serialization):
+    def __init__(self, cfg: DictConfig):
+        self.cfg = cfg
+        self.value = self.__class__.__name__
+
+
+class MockSerializationImplV2(MockSerializationImpl):
+    pass
+
+
 class TestSerialization:
     @pytest.mark.unit
     def test_from_config_dict_with_cls(self):
@@ -119,3 +133,33 @@ class TestSerialization:
         assert 'params' not in new_config
         assert 'cls' not in new_config
         assert '_target_' in new_config
+
+    @pytest.mark.unit
+    def test_base_class_instantiation(self):
+        # Target class is V2 impl, calling class is Serialization (base class)
+        config = DictConfig({'target': get_class_path(MockSerializationImplV2)})
+        obj = Serialization.from_config_dict(config=config)
+        new_config = obj.to_config_dict()
+        assert config == new_config
+        assert isinstance(obj, MockSerializationImplV2)
+        assert obj.value == "MockSerializationImplV2"
+
+    @pytest.mark.unit
+    def test_self_class_instantiation(self):
+        # Target class is V1 impl, calling class is V1 (same class)
+        config = DictConfig({'target': get_class_path(MockSerializationImpl)})
+        obj = MockSerializationImpl.from_config_dict(config=config)  # Serialization is base class
+        new_config = obj.to_config_dict()
+        assert config == new_config
+        assert isinstance(obj, MockSerializationImpl)
+        assert obj.value == "MockSerializationImpl"
+
+    @pytest.mark.unit
+    def test_sub_class_instantiation(self):
+        # Target class is V1 impl, calling class is V2 (sub class)
+        config = DictConfig({'target': get_class_path(MockSerializationImpl)})
+        obj = MockSerializationImplV2.from_config_dict(config=config)  # Serialization is base class
+        new_config = obj.to_config_dict()
+        assert config == new_config
+        assert isinstance(obj, MockSerializationImplV2)
+        assert obj.value == "MockSerializationImplV2"


### PR DESCRIPTION
# Changelog
- After class resolution of `target`, if calling `cls` is subclass of resolved `imported_cls`, then defer to subclass `cls` instantiation instead of the imported target class.
- Add tests to check these scenarios

Signed-off-by: smajumdar <titu1994@gmail.com>