### PR TITLE
Resets the state of GlobalAverageLossMetric on validation_epoch_end

### DIFF
--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -258,6 +258,7 @@ class MTEncDecModel(EncDecNLPModel):
         :param outputs: list of individual outputs of each validation step.
         """
         self.log_dict(self.eval_epoch_end(outputs, 'val'), sync_dist=True)
+        self.eval_loss.reset()
 
     def test_epoch_end(self, outputs):
         return self.eval_epoch_end(outputs, 'test')


### PR DESCRIPTION
Resets the state of GlobalAverageLossMetric on validation_epoch_end. This used to be done by PTL earlier but is not anymore after an API change.