### PR TITLE
Update container to 21.04

### DIFF
--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -110,7 +110,8 @@ class ModelPT(LightningModule, Model):
         self._test_dl = None
         self._optimizer = None
         self._scheduler = None
-        self._trainer = trainer
+        self.trainer = trainer  # reference required for self.*_rank
+        self._trainer = self.trainer  # alias for backward compatibility
 
         # Set device_id in AppState
         if torch.cuda.is_available() and torch.cuda.current_device() is not None:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 numpy>=1.18.2
 onnx>=1.7.0
-pytorch-lightning>=1.2.3
+pytorch-lightning>=1.2.8
 python-dateutil
 torch
 wget


### PR DESCRIPTION
# Bugfix
- Correct DDP initialization (single/multi node) for datasets that depend on self.global_rank, self.local_rank, self.node_rank.

Signed-off-by: smajumdar <titu1994@gmail.com>