### PR TITLE
[NMT] Add support for multiple validation and test dataloaders

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1049,6 +1049,27 @@ pipeline {
             }
         }
 
+        stage('L2: NMT Multi-Validation') {
+            steps {
+              sh 'cd examples/nlp/machine_translation && \
+              python enc_dec_nmt.py \
+              --config-path=conf \
+              --config-name=aayn_base \
+              model.train_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-en-de.src \
+              model.train_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-en-de.ref \
+              model.validation_ds.src_file_name=[/home/TestData/nlp/nmt/toy_data/wmt13-en-de.src,/home/TestData/nlp/nmt/toy_data/wmt14-en-de.src] \
+              model.validation_ds.tgt_file_name=[/home/TestData/nlp/nmt/toy_data/wmt13-en-de.ref,/home/TestData/nlp/nmt/toy_data/wmt14-en-de.ref] \
+              model.test_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-en-de.src \
+              model.test_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-en-de.ref \
+              model.encoder_tokenizer.tokenizer_model=/home/TestData/nlp/nmt/toy_data/tt_tokenizer.BPE.4096.model \
+              model.decoder_tokenizer.tokenizer_model=/home/TestData/nlp/nmt/toy_data/tt_tokenizer.BPE.4096.model \
+              trainer.gpus=[0] \
+              +trainer.fast_dev_run=true \
+              exp_manager=null \
+              '
+            }
+        }
+
         stage('L2: NMT Inference') {
             steps {
               sh 'cd examples/nlp/machine_translation && \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1011,6 +1011,7 @@ pipeline {
               python enc_dec_nmt.py \
               --config-path=conf \
               --config-name=aayn_base \
+              do_testing=true \
               model.train_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
               model.train_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.ref \
               model.validation_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
@@ -1021,6 +1022,7 @@ pipeline {
               model.decoder_tokenizer.tokenizer_model=/home/TestData/nlp/nmt/toy_data/tt_tokenizer.BPE.4096.model \
               trainer.gpus=[0] \
               +trainer.fast_dev_run=true \
+              +trainer.limit_test_batches=2 \
               exp_manager=null \
               '
             }
@@ -1032,6 +1034,7 @@ pipeline {
               python enc_dec_nmt.py \
               --config-path=conf \
               --config-name=aayn_base \
+              do_testing=true \
               model.train_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
               model.train_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.ref \
               model.validation_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
@@ -1044,6 +1047,7 @@ pipeline {
               model.decoder.pre_ln=true \
               trainer.gpus=[1] \
               +trainer.fast_dev_run=true \
+              +trainer.limit_test_batches=2 \
               exp_manager=null \
               '
             }
@@ -1055,16 +1059,18 @@ pipeline {
               python enc_dec_nmt.py \
               --config-path=conf \
               --config-name=aayn_base \
+              do_testing=true \
               model.train_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-en-de.src \
               model.train_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-en-de.ref \
               model.validation_ds.src_file_name=[/home/TestData/nlp/nmt/toy_data/wmt13-en-de.src,/home/TestData/nlp/nmt/toy_data/wmt14-en-de.src] \
               model.validation_ds.tgt_file_name=[/home/TestData/nlp/nmt/toy_data/wmt13-en-de.ref,/home/TestData/nlp/nmt/toy_data/wmt14-en-de.ref] \
-              model.test_ds.src_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-en-de.src \
-              model.test_ds.tgt_file_name=/home/TestData/nlp/nmt/toy_data/wmt14-en-de.ref \
+              model.test_ds.src_file_name=[/home/TestData/nlp/nmt/toy_data/wmt13-en-de.src,/home/TestData/nlp/nmt/toy_data/wmt14-en-de.src] \
+              model.test_ds.tgt_file_name=[/home/TestData/nlp/nmt/toy_data/wmt13-en-de.ref,/home/TestData/nlp/nmt/toy_data/wmt14-en-de.ref] \
               model.encoder_tokenizer.tokenizer_model=/home/TestData/nlp/nmt/toy_data/tt_tokenizer.BPE.4096.model \
               model.decoder_tokenizer.tokenizer_model=/home/TestData/nlp/nmt/toy_data/tt_tokenizer.BPE.4096.model \
               trainer.gpus=[0] \
               +trainer.fast_dev_run=true \
+              +trainer.limit_test_batches=2 \
               exp_manager=null \
               '
             }

--- a/examples/nlp/machine_translation/conf/aayn_base.yaml
+++ b/examples/nlp/machine_translation/conf/aayn_base.yaml
@@ -1,5 +1,6 @@
 name: AttentionIsAllYouNeed
 do_training: True # set to False if only preprocessing data
+do_testing: False # set to True to run evaluation on test data after training
 
 model:
   beam_size: 4

--- a/examples/nlp/machine_translation/conf/huggingface.yaml
+++ b/examples/nlp/machine_translation/conf/huggingface.yaml
@@ -1,5 +1,6 @@
 name: HuggingFaceEncoder
-do_training: true
+do_training: True # set to False if only preprocessing data
+do_testing: False # set to True to run evaluation on test data after training
 
 model:
   beam_size: 4

--- a/examples/nlp/machine_translation/enc_dec_nmt.py
+++ b/examples/nlp/machine_translation/enc_dec_nmt.py
@@ -92,6 +92,7 @@ Usage:
 class MTEncDecConfig(NemoConfig):
     name: Optional[str] = 'MTEncDec'
     do_training: bool = True
+    do_testing: bool = False
     model: MTEncDecModelConfig = MTEncDecModelConfig()
     trainer: Optional[TrainerConfig] = TrainerConfig()
     exp_manager: Optional[ExpManagerConfig] = ExpManagerConfig(name='MTEncDec', files_to_copy=[])
@@ -113,19 +114,22 @@ def main(cfg: MTEncDecConfig) -> None:
     if cfg.model.preproc_out_dir is not None:
         MTDataPreproc(cfg=cfg.model, trainer=trainer)
 
+    # experiment logs, checkpoints, and auto-resume are managed by exp_manager and PyTorch Lightning
+    exp_manager(trainer, cfg.exp_manager)
+
+    # everything needed to train translation models is encapsulated in the NeMo MTEncdDecModel
+    mt_model = MTEncDecModel(cfg.model, trainer=trainer)
+
+    logging.info("\n\n************** Model parameters and their sizes ***********")
+    for name, param in mt_model.named_parameters():
+        print(name, param.size())
+    logging.info("***********************************************************\n\n")
+
     if cfg.do_training:
-        # experiment logs, checkpoints, and auto-resume are managed by exp_manager and PyTorch Lightning
-        exp_manager(trainer, cfg.exp_manager)
-
-        # everything needed to train translation models is encapsulated in the NeMo MTEncdDecModel
-        mt_model = MTEncDecModel(cfg.model, trainer=trainer)
-
-        logging.info("\n\n************** Model parameters and their sizes ***********")
-        for name, param in mt_model.named_parameters():
-            print(name, param.size())
-        logging.info("***********************************************************\n\n")
-
         trainer.fit(mt_model)
+
+    if cfg.do_testing:
+        trainer.test(mt_model)
 
 
 if __name__ == '__main__':

--- a/nemo/collections/nlp/data/machine_translation/machine_translation_dataset.py
+++ b/nemo/collections/nlp/data/machine_translation/machine_translation_dataset.py
@@ -19,7 +19,7 @@ import json
 import pickle
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Optional
+from typing import Optional, Any
 
 import braceexpand
 import numpy as np
@@ -35,8 +35,8 @@ __all__ = ['TranslationDataset', 'TarredTranslationDataset']
 
 @dataclass
 class TranslationDataConfig:
-    src_file_name: Optional[str] = None
-    tgt_file_name: Optional[str] = None
+    src_file_name: Optional[Any] = None  # Any = str or List[str]
+    tgt_file_name: Optional[Any] = None  # Any = str or List[str]
     use_tarred_dataset: bool = False
     tar_files: Optional[str] = None
     metadata_file: Optional[str] = None

--- a/nemo/collections/nlp/data/machine_translation/machine_translation_dataset.py
+++ b/nemo/collections/nlp/data/machine_translation/machine_translation_dataset.py
@@ -19,7 +19,7 @@ import json
 import pickle
 from collections import OrderedDict
 from dataclasses import dataclass
-from typing import Optional, Any
+from typing import Any, Optional
 
 import braceexpand
 import numpy as np

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -358,6 +358,9 @@ class MTEncDecModel(EncDecNLPModel):
     def setup_multiple_validation_data(self, val_data_config: Union[DictConfig, Dict]):
         self.setup_validation_data(self._cfg.get('validation_ds'))
 
+    def setup_multiple_test_data(self, val_data_config: Union[DictConfig, Dict]):
+        self.setup_test_data(self._cfg.get('validation_ds'))
+
     def setup_validation_data(self, val_data_config: Optional[DictConfig]):
         self._validation_dl = self._setup_eval_dataloader_from_config(cfg=val_data_config)
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -295,6 +295,8 @@ class MTEncDecModel(EncDecNLPModel):
             self.log(f"{mode}_loss_dl_index_{dataloader_idx}", eval_loss, sync_dist=True)
             self.log(f"{mode}_sacreBLEU_dl_index_{dataloader_idx}", sb_score, sync_dist=True)
 
+            getattr(self, f'eval_loss_{dataloader_idx}').reset()
+
         self.log(f'{mode}_sacreBLEU', sum(sb_scores) / len(sb_scores), sync_dist=True)
         self.log(f'{mode}_loss', sum(eval_losses) / len(eval_losses), sync_dist=True)
 
@@ -304,7 +306,6 @@ class MTEncDecModel(EncDecNLPModel):
         :param outputs: list of individual outputs of each validation step.
         """
         self.eval_epoch_end(outputs, 'val')
-        self.eval_loss.reset()
 
     def test_epoch_end(self, outputs):
         return self.eval_epoch_end(outputs, 'test')

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -214,8 +214,8 @@ class MTEncDecModel(EncDecNLPModel):
             'num_non_pad_tokens': num_non_pad_tokens,
         }
 
-    def test_step(self, batch, batch_idx):
-        return self.eval_step(batch, batch_idx, 'test')
+    def test_step(self, batch, batch_idx, dataloader_idx=0):
+        return self.eval_step(batch, batch_idx, 'test', dataloader_idx)
 
     @rank_zero_only
     def log_param_stats(self):
@@ -359,11 +359,10 @@ class MTEncDecModel(EncDecNLPModel):
         self.setup_validation_data(self._cfg.get('validation_ds'))
 
     def setup_validation_data(self, val_data_config: Optional[DictConfig]):
-        # self._validation_dl = self._setup_dataloader_from_config(cfg=val_data_config)
-        self._validation_dl = self._setup_val_dataloader_from_config(cfg=val_data_config)
+        self._validation_dl = self._setup_eval_dataloader_from_config(cfg=val_data_config)
 
     def setup_test_data(self, test_data_config: Optional[DictConfig]):
-        self._test_dl = self._setup_dataloader_from_config(cfg=test_data_config)
+        self._test_dl = self._setup_eval_dataloader_from_config(cfg=test_data_config)
 
     def _setup_dataloader_from_config(self, cfg: DictConfig):
         if cfg.get("load_from_cached_dataset", False):
@@ -439,7 +438,7 @@ class MTEncDecModel(EncDecNLPModel):
             drop_last=cfg.get("drop_last", False),
         )
 
-    def _setup_val_dataloader_from_config(self, cfg: DictConfig):
+    def _setup_eval_dataloader_from_config(self, cfg: DictConfig):
         src_file_name = cfg.get('src_file_name')
         tgt_file_name = cfg.get('tgt_file_name')
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -190,7 +190,7 @@ class MTEncDecModel(EncDecNLPModel):
         }
         return {'loss': train_loss, 'log': tensorboard_logs}
 
-    def eval_step(self, batch, batch_idx, mode, dataloader_idx):
+    def eval_step(self, batch, batch_idx, mode, dataloader_idx=0):
         for i in range(len(batch)):
             if batch[i].ndim == 3:
                 # Dataset returns already batched data and the first dimension of size 1 added by DataLoader
@@ -229,7 +229,7 @@ class MTEncDecModel(EncDecNLPModel):
                     global_step=self.global_step,
                 )
 
-    def validation_step(self, batch, batch_idx, dataloader_idx):
+    def validation_step(self, batch, batch_idx, dataloader_idx=0):
         """
         Lightning calls this inside the validation loop with the data from the validation dataloader
         passed in as `batch`.
@@ -277,6 +277,7 @@ class MTEncDecModel(EncDecNLPModel):
                 logging.info(
                     f"Dataset name: {dataset_name}, Dataloader index: {dataloader_idx}, Val Loss = {eval_loss}"
                 )
+                # TODO: log average sb_score
                 logging.info(
                     f"Dataset name: {dataset_name}, Dataloader index: {dataloader_idx}, Sacre BLEU = {sb_score}"
                 )
@@ -297,6 +298,7 @@ class MTEncDecModel(EncDecNLPModel):
 
             getattr(self, f'eval_loss_{dataloader_idx}').reset()
 
+        # TODO: change default to dl index 0 for sacreBLEU and loss
         self.log(f'{mode}_sacreBLEU', sum(sb_scores) / len(sb_scores), sync_dist=True)
         self.log(f'{mode}_loss', sum(eval_losses) / len(eval_losses), sync_dist=True)
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -358,8 +358,8 @@ class MTEncDecModel(EncDecNLPModel):
     def setup_multiple_validation_data(self, val_data_config: Union[DictConfig, Dict]):
         self.setup_validation_data(self._cfg.get('validation_ds'))
 
-    def setup_multiple_test_data(self, val_data_config: Union[DictConfig, Dict]):
-        self.setup_test_data(self._cfg.get('validation_ds'))
+    def setup_multiple_test_data(self, test_data_config: Union[DictConfig, Dict]):
+        self.setup_test_data(self._cfg.get('test_ds'))
 
     def setup_validation_data(self, val_data_config: Optional[DictConfig]):
         self._validation_dl = self._setup_eval_dataloader_from_config(cfg=val_data_config)

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -209,7 +209,6 @@ class MTEncDecModel(EncDecNLPModel):
         ground_truths = [self.target_processor.detokenize(tgt.split(' ')) for tgt in ground_truths]
         num_non_pad_tokens = np.not_equal(np_tgt, self.decoder_tokenizer.pad_id).sum().item()
         return {
-            'dataloader_idx': dataloader_idx,
             'translations': translations,
             'ground_truths': ground_truths,
             'num_non_pad_tokens': num_non_pad_tokens,

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -281,8 +281,8 @@ class MTEncDecModel(EncDecNLPModel):
                 sb_score = 0.0
 
             sb_scores.append(sb_score)
-            self.log(f"dataloader_index_{dataloader_idx}_{mode}_loss", eval_loss, sync_dist=True)
-            self.log(f"dataloader_index_{dataloader_idx}_{mode}_sacreBLEU", sb_score, sync_dist=True)
+            self.log(f"{mode}_loss_dl_index_{dataloader_idx}", eval_loss, sync_dist=True)
+            self.log(f"{mode}_sacreBLEU_dl_index_{dataloader_idx}", sb_score, sync_dist=True)
 
         self.log(f'{mode}_sacreBLEU', sum(sb_scores) / len(sb_scores), sync_dist=True)
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -14,9 +14,9 @@
 
 import itertools
 import json
-from multiprocessing import Value
 import pickle
 import random
+from multiprocessing import Value
 from pathlib import Path
 from typing import Dict, List, Optional, Union
 
@@ -24,7 +24,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 import torch.utils.data as pt_data
-from omegaconf import DictConfig, OmegaConf, ListConfig
+from omegaconf import DictConfig, ListConfig, OmegaConf
 from pytorch_lightning import Trainer
 from pytorch_lightning.utilities import rank_zero_only
 from sacrebleu import corpus_bleu

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -238,6 +238,9 @@ class MTEncDecModel(EncDecNLPModel):
     def eval_epoch_end(self, outputs, mode):
         dl_0_sb_score = 0  # log dl_0 by default to preserve backward compatibility
         dl_0_eval_loss = 0
+        # if user specifies one validation dataloader, then PTL reverts to giving a list of dictionary instead of a list of list of dictionary
+        if isinstance(outputs[0], dict):
+            outputs = [outputs]
         for dataloader_idx, output in enumerate(outputs):
             eval_loss = getattr(self, f'eval_loss_{dataloader_idx}').compute()
             if dataloader_idx == 0:

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -284,7 +284,7 @@ class MTEncDecModel(EncDecNLPModel):
             self.log(f"dataloader_index_{dataloader_idx}_{mode}_loss", eval_loss, sync_dist=True)
             self.log(f"dataloader_index_{dataloader_idx}_{mode}_sacreBLEU", sb_score, sync_dist=True)
 
-        self.log(f'{mode}_sacreBLEU', sum(sb_scores) / len(sb_scores))
+        self.log(f'{mode}_sacreBLEU', sum(sb_scores) / len(sb_scores), sync_dist=True)
 
     def validation_epoch_end(self, outputs):
         """


### PR DESCRIPTION
Specify multiple validation (or test) dataloaders by inputting a list of src (tgt) files.

# Usage
Replace `src_file_name` and `tgt_file_name` with a list of file paths.
```
    model.validation_ds.src_file_name=/data/wmt14-en-de.src \
    model.validation_ds.tgt_file_name=/data/wmt14-en-de.ref \
```
Becomes:
```
    model.validation_ds.src_file_name=[/data/wmt13-en-de.src,/data/wmt14-en-de.src] \
    model.validation_ds.tgt_file_name=[/data/wmt13-en-de.ref,/data/wmt14-en-de.ref] \
```
When using `val_loss` or `val_sacreBLEU` for the `exp_manager.checkpoint_callback_params.monitor` then the 0th indexed dataloader will be used as the monitor. This ensures backwards compatibility.

Additionally, any validation dataloader can now be used as a monitor by appending the index as below:
```
    exp_manager.checkpoint_callback_params.monitor=val_sacreBLEU_dl_index_1
```
Multiple test datasets works exactly the same way as validation datasets, simply replace `validation_ds` by `test_ds` in the above examples.
