### PR TITLE
Preserve the tokenizer config for ASR

### DIFF
--- a/nemo/collections/asr/parts/mixins.py
+++ b/nemo/collections/asr/parts/mixins.py
@@ -112,6 +112,12 @@ class ASRBPEMixin(ABC):
             )
         )
 
+        # Preserve config
+        if hasattr(self, 'cfg') and hasattr(self.cfg, 'tokenizer'):
+            OmegaConf.set_struct(self.cfg.tokenizer, False)
+            self.cfg.tokenizer = tokenizer_cfg
+            OmegaConf.set_struct(self.cfg.tokenizer, True)
+
 
 class DiarizationMixin(ABC):
     @abstractmethod


### PR DESCRIPTION
# Bugfix
- ASR BPE models did not correctly preserve the new tokenizer config after changing vocabulary

Signed-off-by: smajumdar <titu1994@gmail.com>