### PR TITLE
Fix Nemo eval nondeterminism

### DIFF
--- a/nemo/collections/asr/parts/features.py
+++ b/nemo/collections/asr/parts/features.py
@@ -371,8 +371,8 @@ class FilterbankFeatures(nn.Module):
                 x.unsqueeze(1), (self.stft_pad_amount, self.stft_pad_amount), "reflect"
             ).squeeze(1)
 
-        # dither
-        if self.dither > 0:
+        # dither (only in training mode for eval determinism)
+        if self.training and self.dither > 0:
             x += self.dither * torch.randn_like(x)
 
         # do preemphasis


### PR DESCRIPTION
In the eval mode the model should be deterministic (return the same value for the same input).

I find it strange that this was not fixed before - this makes exports and evaluation non-deterministic.