### PR TITLE
fixed the num_samples of text classification model.

### DIFF
--- a/nemo/collections/nlp/data/text_classification/text_classification_dataset.py
+++ b/nemo/collections/nlp/data/text_classification/text_classification_dataset.py
@@ -116,8 +116,13 @@ class TextClassificationDataset(Dataset):
                     )
                 else:
                     with open(input_file, "r") as f:
-                        lines = f.readlines(num_samples)
+                        lines = f.readlines()
                         logging.info(f'Read {len(lines)} examples from {input_file}.')
+                        if num_samples > 0:
+                            lines = lines[:num_samples]
+                            logging.warning(
+                                f"Parameter 'num_samples' is set, so just the first {len(lines)} examples are kept."
+                            )
 
                         if shuffle:
                             random.shuffle(lines)


### PR DESCRIPTION
Parameter num_samples was considered as number of bytes instead of number of lines in the text classification dataset.