### PR TITLE
update spectral clustering method

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,7 +255,7 @@ pipeline {
         stage('Speaker Diarization Inference') {
           steps {
             sh 'python examples/speaker_recognition/speaker_diarize.py \
-            diarizer.oracle_num_speakers \
+            diarizer.oracle_num_speakers=2 \
             diarizer.paths2audio_files=/home/TestData/an4_diarizer/audio_files.scp \
             diarizer.path2groundtruth_rttm_files=/home/TestData/an4_diarizer/rttm_files.scp \
             diarizer.speaker_embeddings.model_path=/home/TestData/an4_diarizer/spkr.nemo \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,6 +255,7 @@ pipeline {
         stage('Speaker Diarization Inference') {
           steps {
             sh 'python examples/speaker_recognition/speaker_diarize.py \
+            diarizer.oracle_num_speakers \
             diarizer.paths2audio_files=/home/TestData/an4_diarizer/audio_files.scp \
             diarizer.path2groundtruth_rttm_files=/home/TestData/an4_diarizer/rttm_files.scp \
             diarizer.speaker_embeddings.model_path=/home/TestData/an4_diarizer/spkr.nemo \

--- a/docs/source/asr/speaker_diarization/configs.rst
+++ b/docs/source/asr/speaker_diarization/configs.rst
@@ -28,9 +28,10 @@ An example Speaker Diarization dataset configuration could look like:
 .. code-block:: yaml
 
   diarizer:
-    num_speakers: 2 # for each recording
+    oracle_num_speakers: ??? # if number of speakers is known input it or pass null if not known. Accepts int or path to file containing uniq-id and num of speakers of that session
+    max_num_speakers: 8 # max number of speakers for each recording. If oracle num speakers is passed this value is ignored
     out_dir: ??? 
-    paths2audio_files: null # either list of audio file paths or file containing paths to audio files for which we need to perform diarization.
+    paths2audio_files: ??? # either list of audio file paths or file containing paths to audio files for which we need to perform diarization.
     path2groundtruth_rttm_files: null # (Optional) either list of rttm file paths or file containing paths to rttm files (this can be passed if we need to calculate DER rate based on our ground truth rttm files).
     ...
     
@@ -58,7 +59,7 @@ Diarizer Architecture Configurations
     speaker_embeddings:
       oracle_vad_manifest: null # leave it null if to perform diarization with above VAD model else path to manifest file genrerated as shown in Datasets section
       model_path: ??? #.nemo local model path or pretrained model name
-      window_length_in_sec: 1.5
-      shift_length_in_sec: 0.75
+      window_length_in_sec: 1.5 # for better performace try with 3 sec and 1.5 sec
+      shift_length_in_sec: 0.75 # for better performace try with 1.5 sec and 0.75 sec
 
 

--- a/docs/source/asr/speaker_diarization/configs.rst
+++ b/docs/source/asr/speaker_diarization/configs.rst
@@ -31,7 +31,7 @@ An example Speaker Diarization dataset configuration could look like:
     oracle_num_speakers: ??? # if number of speakers is known input it or pass null if not known. Accepts int or path to file containing uniq-id and num of speakers of that session
     max_num_speakers: 8 # max number of speakers for each recording. If oracle num speakers is passed this value is ignored
     out_dir: ??? 
-    paths2audio_files: ??? # file containing paths to audio files for diarzation inference
+    paths2audio_files: ??? # file containing paths to audio files for diarzation
     path2groundtruth_rttm_files: null # (Optional) file containing paths to rttm files (this can be passed if we need to calculate DER rate based on ground truth rttm files).
     ...
     

--- a/docs/source/asr/speaker_diarization/configs.rst
+++ b/docs/source/asr/speaker_diarization/configs.rst
@@ -31,8 +31,8 @@ An example Speaker Diarization dataset configuration could look like:
     oracle_num_speakers: ??? # if number of speakers is known input it or pass null if not known. Accepts int or path to file containing uniq-id and num of speakers of that session
     max_num_speakers: 8 # max number of speakers for each recording. If oracle num speakers is passed this value is ignored
     out_dir: ??? 
-    paths2audio_files: ??? # either list of audio file paths or file containing paths to audio files for which we need to perform diarization.
-    path2groundtruth_rttm_files: null # (Optional) either list of rttm file paths or file containing paths to rttm files (this can be passed if we need to calculate DER rate based on our ground truth rttm files).
+    paths2audio_files: ??? # file containing paths to audio files for diarzation inference
+    path2groundtruth_rttm_files: null # (Optional) file containing paths to rttm files (this can be passed if we need to calculate DER rate based on ground truth rttm files).
     ...
     
 .. note::

--- a/docs/source/asr/speaker_diarization/datasets.rst
+++ b/docs/source/asr/speaker_diarization/datasets.rst
@@ -3,7 +3,7 @@ Datasets
 Check out page :doc:`Speech Classification Datasets <../speech_classification/datasets>` and :doc:`Speaker Recogniton Datasets <../speaker_recognition/datasets>` 
 for preparing datasets for training and validating VAD and speaker embedding models respectively.
 
-For Speaker Diarization inference, ``diarizer`` expects following arguments, which needs to be created by user depending on dataset:
+For Speaker Diarization inference, ``diarizer`` expects following arguments :
 
   - paths2audio_files
   - oracle_num_speakers
@@ -12,13 +12,13 @@ For Speaker Diarization inference, ``diarizer`` expects following arguments, whi
 
 paths2audio_files:
   - a file containing absolute paths to audio files or list of paths to audio files. 
-  For generating a file that contains paths to audio files (which we call as ``scp file``), you can simply use ``find`` bash command as shown below:
+  For generating a file that contains paths to audio files, you can simply use ``find`` bash command as shown below:
 .. code-block:: bash
 
-  find $PWD/{data_dir} -iname '*.wav' > path_to_audiofiles.scp
+  find $PWD/{data_dir} -iname '*.wav' > path_to_audiofiles.txt
 
 .. note::
-  We expect audio and the corresponding RTTM to have the same base name and the name should be unique (uniq-id).
+  We expect audio and the corresponding RTTM files to have the same base name and the name should be unique (uniq-id).
 
 oracle_num_speakers:
   - if number of speakers is known input it or pass null if not known. Accepts int or path to file containing uniq-id with num of speakers of that session 
@@ -28,7 +28,7 @@ oracle_num_speakers:
     iaaa 2
 
 path2groundtruth_rttm_files [Optional]:
-  - To evaluate the diarizer system with known rttm files, One needs to provide an scp like file (path2groundtruth_rttm_files) for groundtruth label files.
+  - To evaluate the diarizer system with known rttm files, One needs to provide a txt file (path2groundtruth_rttm_files) for groundtruth label files.
   use above mentioned ``find`` command to get all reference rttm files (use '*.rttm' as search pattern)
 
 Each groundtruth label file should be in NIST Rich Transcription Time Marked (RTTM) format. Take one line from a RTTM file for example:
@@ -45,7 +45,7 @@ To prepare an oracle manifest file, use the script from ``scripts`` folder as sh
 
 .. code-block:: bash
 
-  python $NeMo/scripts/ --paths2rttm_files=<path2groundtruth_rttm_files.scp> --paths2audio_files=<paths2audio_files.scp> --manifest_file=<output_oracle_manifest_file.json>
+  python $NeMo/scripts/ --paths2rttm_files=<path2groundtruth_rttm_files.txt> --paths2audio_files=<paths2audio_files.txt> --manifest_file=<output_oracle_manifest_file.json>
 
 Here ``paths2audio_files`` and ``path2groundtruth_rttm_files`` are files containing paths to audio files as shown above.
 

--- a/docs/source/asr/speaker_diarization/datasets.rst
+++ b/docs/source/asr/speaker_diarization/datasets.rst
@@ -38,8 +38,8 @@ Each groundtruth label file should be in NIST Rich Transcription Time Marked (RT
   SPEAKER TS3012d.Mix-Headset 1 331.573 0.671 <NA> <NA> MTD046ID <NA> <NA>
 
 
-oracle_vad_manifest [Optional but suggested for good performace. This avoids FPR and TPR]:
-  - To perform just oracle diarization, that is taking speech activity time stamps from groundtruths or another VAD from wild instead from NeMo VAD output, ``diarizer`` expects an orcale manifest json file that contains paths to audio files with offset for start time and duration of segment.
+oracle_vad_manifest [Optional but suggested for good performace. This reduces FPR and TPR]:
+  - To perform just oracle diarization, that is taking speech activity time stamps from groundtruth RTTMs or another VAD from wild instead of NeMo VAD output, ``diarizer`` expects an oracle manifest json file that contains paths to audio files with offset for start time and duration of segment.
 
 To prepare an oracle manifest file, use the script from ``scripts`` folder as shown below:
 
@@ -52,8 +52,8 @@ Here ``paths2audio_files`` and ``path2groundtruth_rttm_files`` are files contain
 AMI Meeting Corpus
 ------------------
 
-The following are the suggested arguments and considerations we took for getting Speaker Error Rate (SER) of 4.1% on AMI Lapel test set corpus:
-  - diarizer.oracle_num_speakers = 4 (since there are exactly 4 speakers per each lapel test set session)
+The following are the suggested parameters for getting Speaker Error Rate (SER) of 4.1% on AMI Lapel test set corpus:
+  - diarizer.oracle_num_speakers = 4 (since there are exactly 4 speakers per each Lapel test set session)
   - diarizer.speaker_embeddings.model_path = ``speakerverification_speakernet`` (This model is trained on voxceleb dataset. ``Use this model for simialr non-telephonic speech datasets``)
   - diarizer.speaker_embeddings.window_length_in_sec = 3 
   - diarizer.speaker_embeddings.shift_length_in_sec = 1.5 
@@ -63,7 +63,7 @@ Input paths2audio_files, paths2rttm_files and oracle_vad_manifest by following s
 CallHome LDC97S42 (CH109)
 -------------------------
 
-The following are the suggested arguments and considerations we took for getting Speaker Error Rate (SER) of 5.4% on CH109 set:
+The following are the suggested parameters for getting Speaker Error Rate (SER) of 5.4% on CH109 set:
   - diarizer.oracle_num_speakers = 2 (since there are exactly 2 speakers per each ch109 session)
   - diarizer.speaker_embeddings.model_path = ``speakerdiarization_speakernet`` (This model is trained on voxceleb and telephonic speech Fisher and SWBD. ``Use this model for similar telephonic speech datasets``)
   - diarizer.speaker_embeddings.window_length_in_sec = 1.5

--- a/docs/source/asr/speaker_diarization/datasets.rst
+++ b/docs/source/asr/speaker_diarization/datasets.rst
@@ -3,19 +3,34 @@ Datasets
 Check out page :doc:`Speech Classification Datasets <../speech_classification/datasets>` and :doc:`Speaker Recogniton Datasets <../speaker_recognition/datasets>` 
 for preparing datasets for training and validating VAD and speaker embedding models respectively.
 
-For Speaker Diarization inference, ``diarizer`` expects either list of paths to audio files or a file containing absolute paths to audio files. 
+For Speaker Diarization inference, ``diarizer`` expects following arguments, which needs to be created by user depending on dataset:
 
-For generating a file that contains paths to audio files (which we call as ``scp file``), you can simply use ``find`` bash command as shown below:
+  - paths2audio_files
+  - oracle_num_speakers
+  - path2groundtruth_rttm_files [Optional]
+  - oracle_vad_manifest (if vad/rttm files are known)[Optional but suggested for good performace. This avoids FPR and TPR]
 
+paths2audio_files:
+  - a file containing absolute paths to audio files or list of paths to audio files. 
+  For generating a file that contains paths to audio files (which we call as ``scp file``), you can simply use ``find`` bash command as shown below:
 .. code-block:: bash
 
   find $PWD/{data_dir} -iname '*.wav' > path_to_audiofiles.scp
 
+.. note::
+  We expect audio and the corresponding RTTM to have the same base name and the name should be unique (uniq-id).
 
-Preparing Evaluation Dataset
-----------------------------
+oracle_num_speakers:
+  - if number of speakers is known input it or pass null if not known. Accepts int or path to file containing uniq-id with num of speakers of that session 
 
-To score with a diarizer model, we need to provide an scp like file for groundtruth label file.
+  Sample line (uniq-id `iaaa` session has 2 unique speakers )::
+    
+    iaaa 2
+
+path2groundtruth_rttm_files [Optional]:
+  - To evaluate the diarizer system with known rttm files, One needs to provide an scp like file (path2groundtruth_rttm_files) for groundtruth label files.
+  use above mentioned ``find`` command to get all reference rttm files (use '*.rttm' as search pattern)
+
 Each groundtruth label file should be in NIST Rich Transcription Time Marked (RTTM) format. Take one line from a RTTM file for example:
 
 .. code-block:: bash
@@ -23,21 +38,35 @@ Each groundtruth label file should be in NIST Rich Transcription Time Marked (RT
   SPEAKER TS3012d.Mix-Headset 1 331.573 0.671 <NA> <NA> MTD046ID <NA> <NA>
 
 
-Prepraing ORACLE manifest
+oracle_vad_manifest [Optional but suggested for good performace. This avoids FPR and TPR]:
+  - To perform just oracle diarization, that is taking speech activity time stamps from groundtruths or another VAD from wild instead from NeMo VAD output, ``diarizer`` expects an orcale manifest json file that contains paths to audio files with offset for start time and duration of segment.
+
+To prepare an oracle manifest file, use the script from ``scripts`` folder as shown below:
+
+.. code-block:: bash
+
+  python $NeMo/scripts/ --paths2rttm_files=<path2groundtruth_rttm_files.scp> --paths2audio_files=<paths2audio_files.scp> --manifest_file=<output_oracle_manifest_file.json>
+
+Here ``paths2audio_files`` and ``path2groundtruth_rttm_files`` are files containing paths to audio files as shown above.
+
+AMI Meeting Corpus
+------------------
+
+The following are the suggested arguments and considerations we took for getting Speaker Error Rate (SER) of 4.1% on AMI Lapel test set corpus:
+  - diarizer.oracle_num_speakers = 4 (since there are exactly 4 speakers per each lapel test set session)
+  - diarizer.speaker_embeddings.model_path = ``speakerverification_speakernet`` (This model is trained on voxceleb dataset. ``Use this model for simialr non-telephonic speech datasets``)
+  - diarizer.speaker_embeddings.window_length_in_sec = 3 
+  - diarizer.speaker_embeddings.shift_length_in_sec = 1.5 
+
+Input paths2audio_files, paths2rttm_files and oracle_vad_manifest by following steps as shown above
+
+CallHome LDC97S42 (CH109)
 -------------------------
 
-To perform just oracle diarization, that is taking speech activity time stamps from groundtruths instead from VAD output, ``diarizer`` expects 
-an orcale manifest file that contains paths to audio files with offset for start time and duration of segment.
+The following are the suggested arguments and considerations we took for getting Speaker Error Rate (SER) of 5.4% on CH109 set:
+  - diarizer.oracle_num_speakers = 2 (since there are exactly 2 speakers per each ch109 session)
+  - diarizer.speaker_embeddings.model_path = ``speakerdiarization_speakernet`` (This model is trained on voxceleb and telephonic speech Fisher and SWBD. ``Use this model for similar telephonic speech datasets``)
+  - diarizer.speaker_embeddings.window_length_in_sec = 1.5
+  - diarizer.speaker_embeddings.shift_length_in_sec = 0.75
 
-To prepare an oracle manifest file, use the helper function from ``speaker_utils`` as shown below:
-
-.. code-block:: python
-
-    from nemo.collections.asr.parts.speaker_utils import write_rttm2manifest
-
-    oracle_manifest = os.path.join(os.getcwd(),'oracle_manifest.json')
-    write_rttm2manifest(paths2audio_files=paths2audio_files,
-                    paths2rttm_files=path2groundtruth_rttm_files,
-                    manifest_file=oracle_manifest)  
-
-Here ``paths2audio_files`` and ``path2groundtruth_rttm_files`` are lists containing paths to audio files.
+Input paths2audio_files, paths2rttm_files and oracle_vad_manifest by following steps as shown above

--- a/examples/speaker_recognition/conf/speaker_diarization.yaml
+++ b/examples/speaker_recognition/conf/speaker_diarization.yaml
@@ -23,5 +23,5 @@ diarizer:
   speaker_embeddings:
     oracle_vad_manifest: null
     model_path: ??? #.nemo local model path or pretrained model name (speakerverification_speakernet or speakerdiarization_speakernet)
-    window_length_in_sec: 3.0 # for performace try with 3 sec and 1.5 sec
-    shift_length_in_sec: 1.5 # for performace try with 1.5 sec and 0.75 sec
+    window_length_in_sec: 1.5 # for performace try with 3 sec and 1.5 sec
+    shift_length_in_sec: 0.75 # for performace try with 1.5 sec and 0.75 sec

--- a/examples/speaker_recognition/conf/speaker_diarization.yaml
+++ b/examples/speaker_recognition/conf/speaker_diarization.yaml
@@ -4,10 +4,11 @@ num_workers: 4
 sample_rate: &sample_rate 16000
 
 diarizer:
-  num_speakers: 2 # max number of speakers for each recording
+  oracle_num_speakers: ??? # if number of speakers is known input it or pass null if not known. Accepts int or path to file containing uniq-id and num of speakers of that session
+  max_num_speakers: 8 # max number of speakers for each recording. If oracle num speakers is passed this value is ignored
   out_dir: ???
-  paths2audio_files: null #file containing paths to audio files for inference
-  path2groundtruth_rttm_files: null #file containing paths to ground truth rttm files for score computation
+  paths2audio_files: ??? #file containing paths to audio files for inference
+  path2groundtruth_rttm_files: null #file containing paths to ground truth rttm files for score computation or null if no reference rttms are present
 
   vad:
     model_path: null #.nemo local model path or pretrained model name or none
@@ -21,6 +22,6 @@ diarizer:
 
   speaker_embeddings:
     oracle_vad_manifest: null
-    model_path: ??? #.nemo local model path or pretrained model name
-    window_length_in_sec: 1.5
-    shift_length_in_sec: 0.75
+    model_path: ??? #.nemo local model path or pretrained model name (speakerverification_speakernet or speakerdiarization_speakernet)
+    window_length_in_sec: 3.0 # for performace try with 3 sec and 1.5 sec
+    shift_length_in_sec: 1.5 # for performace try with 1.5 sec and 0.75 sec

--- a/examples/speaker_recognition/conf/speaker_diarization.yaml
+++ b/examples/speaker_recognition/conf/speaker_diarization.yaml
@@ -4,8 +4,8 @@ num_workers: 4
 sample_rate: &sample_rate 16000
 
 diarizer:
-  oracle_num_speakers: ??? # if number of speakers is known input it or pass null if not known. Accepts int or path to file containing uniq-id and num of speakers of that session
-  max_num_speakers: 8 # max number of speakers for each recording. If oracle num speakers is passed this value is ignored
+  oracle_num_speakers: ??? # oracle number of speakers or pass null if not known. [int or path to file containing uniq-id with num of speakers of that session]
+  max_num_speakers: 8 # max number of speakers for each recording. If oracle num speakers is passed this value is ignored.
   out_dir: ???
   paths2audio_files: ??? #file containing paths to audio files for inference
   path2groundtruth_rttm_files: null #file containing paths to ground truth rttm files for score computation or null if no reference rttms are present

--- a/examples/speaker_recognition/conf/speaker_diarization.yaml
+++ b/examples/speaker_recognition/conf/speaker_diarization.yaml
@@ -23,5 +23,5 @@ diarizer:
   speaker_embeddings:
     oracle_vad_manifest: null
     model_path: ??? #.nemo local model path or pretrained model name (speakerverification_speakernet or speakerdiarization_speakernet)
-    window_length_in_sec: 1.5 # for performace try with 3 sec and 1.5 sec
-    shift_length_in_sec: 0.75 # for performace try with 1.5 sec and 0.75 sec
+    window_length_in_sec: 1.5 # window length in sec for speaker embedding extraction
+    shift_length_in_sec: 0.75 # shift length in sec for speaker embedding extraction

--- a/nemo/collections/asr/models/clustering_diarizer.py
+++ b/nemo/collections/asr/models/clustering_diarizer.py
@@ -90,8 +90,17 @@ class ClusteringDiarizer(Model, DiarizationMixin):
 
         # init speaker model
         self._init_speaker_model()
-        self._num_speakers = self._cfg.diarizer.oracle_num_speakers
-        self.max_num_speakers = self._cfg.diarizer.max_num_speakers
+
+        if self._cfg.diarizer.get('num_speakers', None):
+            self._num_speakers = self._cfg.diarizer.num_speakers
+            logging.warning("in next release num_speakers will be changed to oracle_num_speakers")
+        else:
+            self._num_speakers = self._cfg.diarizer.oracle_num_speakers
+
+        if self._cfg.diarizer.get('max_num_speakers', None):
+            self.max_num_speakers = self._cfg.diarizer.max_num_speakers
+        else:
+            self.max_num_speakers = 8
 
         self._device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 

--- a/nemo/collections/asr/models/clustering_diarizer.py
+++ b/nemo/collections/asr/models/clustering_diarizer.py
@@ -90,7 +90,8 @@ class ClusteringDiarizer(Model, DiarizationMixin):
 
         # init speaker model
         self._init_speaker_model()
-        self._num_speakers = self._cfg.diarizer.num_speakers
+        self._num_speakers = self._cfg.diarizer.oracle_num_speakers
+        self.max_num_speakers = self._cfg.diarizer.max_num_speakers
 
         self._device = torch.device("cuda:0" if torch.cuda.is_available() else "cpu")
 
@@ -252,8 +253,8 @@ class ClusteringDiarizer(Model, DiarizationMixin):
             with autocast():
                 _, embs = self._speaker_model.forward(input_signal=audio_signal, input_signal_length=audio_signal_len)
                 emb_shape = embs.shape[-1]
-                embs = embs.type(torch.float32)
-                embs = embs.view(-1, emb_shape).cpu().detach().numpy()
+                embs = embs.view(-1, emb_shape).type(torch.float32)
+                embs = embs.cpu().detach().numpy()
                 out_embeddings[uniq_names[i]].extend(embs)
             del test_batch
 
@@ -346,6 +347,7 @@ class ClusteringDiarizer(Model, DiarizationMixin):
             shift=self._cfg.diarizer.speaker_embeddings.shift_length_in_sec,
             audio_rttm_map=self.AUDIO_RTTM_MAP,
             out_rttm_dir=out_rttm_dir,
+            max_num_speakers=self.max_num_speakers,
         )
 
     @staticmethod

--- a/nemo/collections/asr/parts/nmse_clustering.py
+++ b/nemo/collections/asr/parts/nmse_clustering.py
@@ -12,7 +12,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This file is part of https://github.com/tango4j/Auto-Tuning-Spectral-Clustering.
+# Copyright (c) 2007-2020 The scikit-learn developers.
+
+# BSD 3-Clause License
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This file is part of https://github.com/scikit-learn/scikit-learn/blob/114616d9f6ce9eba7c1aacd3d4a254f868010e25/sklearn/manifold/_spectral_embedding.py and
+# https://github.com/tango4j/Auto-Tuning-Spectral-Clustering.
+
 
 import numpy as np
 import scipy
@@ -41,6 +58,17 @@ def get_X_conn_from_dist(X_dist_raw, p_neighbors):
 
 
 def isFullyConnected(X_conn_from_dist):
+    """ Return whether the graph is connected (True) or Not (False).
+    Parameters
+    ----------
+    graph : {array-like, sparse matrix} of shape (n_samples, n_samples)
+        Adjacency matrix of the graph, non-zero weight means an edge
+        between the nodes.
+    Returns
+    -------
+    is_connected : bool
+        True means the graph is fully connected and False means not.
+    """
     gC = _graph_connected_component(X_conn_from_dist, 0).sum() == X_conn_from_dist.shape[0]
     return gC
 
@@ -59,6 +87,22 @@ def gc_thres_min_gc(mat, max_n, n_list):
 
 
 def _graph_connected_component(graph, node_id):
+    """Find the largest graph connected components that contains one
+    given node.
+    Parameters
+    ----------
+    graph : array-like of shape (n_samples, n_samples)
+        Adjacency matrix of the graph, non-zero weight means an edge
+        between the nodes.
+    node_id : int
+        The index of the query node of the graph.
+    Returns
+    -------
+    connected_components_matrix : array-like of shape (n_samples,)
+        An array of bool value indicating the indexes of the nodes
+        belonging to the largest connected components of the given query
+        node.
+    """
     n_node = graph.shape[0]
     if sparse.issparse(graph):
         graph = graph.tocsr()

--- a/nemo/collections/asr/parts/nmse_clustering.py
+++ b/nemo/collections/asr/parts/nmse_clustering.py
@@ -1,0 +1,221 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file is part of https://github.com/tango4j/Auto-Tuning-Spectral-Clustering.
+
+import numpy as np
+import scipy
+from scipy import sparse
+from sklearn.cluster import SpectralClustering as sklearn_SpectralClustering
+from sklearn.metrics.pairwise import cosine_similarity
+from sklearn.preprocessing import MinMaxScaler
+
+scaler = MinMaxScaler(feature_range=(0, 1))
+
+
+def get_kneighbors_conn(X_dist, p_neighbors):
+    X_dist_out = np.zeros_like(X_dist)
+    for i, line in enumerate(X_dist):
+        sorted_idx = np.argsort(line)
+        sorted_idx = sorted_idx[::-1]
+        indices = sorted_idx[:p_neighbors]
+        X_dist_out[indices, i] = 1
+    return X_dist_out
+
+
+def get_X_conn_from_dist(X_dist_raw, p_neighbors):
+    X_r = get_kneighbors_conn(X_dist_raw, p_neighbors)
+    X_conn_from_dist = 0.5 * (X_r + X_r.T)
+    return X_conn_from_dist
+
+
+def isFullyConnected(X_conn_from_dist):
+    gC = _graph_connected_component(X_conn_from_dist, 0).sum() == X_conn_from_dist.shape[0]
+    return gC
+
+
+def gc_thres_min_gc(mat, max_n, n_list):
+    p_neighbors, index = 1, 0
+    X_conn_from_dist = get_X_conn_from_dist(mat, p_neighbors)
+    fully_connected = isFullyConnected(X_conn_from_dist)
+    for i, p_neighbors in enumerate(n_list):
+        fully_connected = isFullyConnected(X_conn_from_dist)
+        X_conn_from_dist = get_X_conn_from_dist(mat, p_neighbors)
+        if fully_connected or p_neighbors > max_n:
+            break
+
+    return X_conn_from_dist, p_neighbors
+
+
+def _graph_connected_component(graph, node_id):
+    n_node = graph.shape[0]
+    if sparse.issparse(graph):
+        graph = graph.tocsr()
+    connected_nodes = np.zeros(n_node, dtype=np.bool)
+    nodes_to_explore = np.zeros(n_node, dtype=np.bool)
+    nodes_to_explore[node_id] = True
+    for _ in range(n_node):
+        last_num_component = connected_nodes.sum()
+        np.logical_or(connected_nodes, nodes_to_explore, out=connected_nodes)
+        if last_num_component >= connected_nodes.sum():
+            break
+        indices = np.where(nodes_to_explore)[0]
+        nodes_to_explore.fill(False)
+        for i in indices:
+            if sparse.issparse(graph):
+                neighbors = graph[i].toarray().ravel()
+            else:
+                neighbors = graph[i]
+            np.logical_or(nodes_to_explore, neighbors, out=nodes_to_explore)
+    return connected_nodes
+
+
+def getLaplacian(X):
+    """
+    returns laplacian matrix of X
+    """
+    X[np.diag_indices(X.shape[0])] = 0
+    A = X
+    D = np.sum(np.abs(A), axis=1)
+    D = np.diag(D)
+    L = D - A
+    return L
+
+
+def eig_decompose(L, k):
+    try:
+        lambdas, eig_vecs = scipy.linalg.eigh(L)
+    except:
+        try:
+            lambdas = scipy.linalg.eigvals(L)
+            eig_vecs = None
+        except:
+            lambdas, eig_vecs = scipy.sparse.linalg.eigsh(L)  ### Inaccurate results
+    return lambdas, eig_vecs
+
+
+def getLamdaGaplist(lambdas):
+    lambda_gap_list = []
+    for i in range(len(lambdas) - 1):
+        lambda_gap_list.append(float(lambdas[i + 1]) - float(lambdas[i]))
+    return lambda_gap_list
+
+
+def estimate_num_of_spkrs(X_conn, SPK_MAX):
+    """
+    Estimate number of speakers using eigen decompose on Laplacian Matrix
+    """
+    L = getLaplacian(X_conn)
+    lambdas, eig_vals = eig_decompose(L, k=X_conn.shape[0])
+    lambdas = np.sort(lambdas)
+    lambda_gap_list = getLamdaGaplist(lambdas)
+    num_of_spk = np.argmax(lambda_gap_list[: min(SPK_MAX, len(lambda_gap_list))]) + 1
+    return num_of_spk, lambdas, lambda_gap_list
+
+
+def NMEanalysis(mat, SPK_MAX, max_rp_threshold=0.250, sparse_search=True, search_p_volume=20, fixed_thres=None):
+    """
+    Normalized Eigengap analysis to get p_neighbours and estimated num of speakers
+    """
+    eps = 1e-10
+    eig_ratio_list = []
+    if fixed_thres:
+        p_neighbors_list = [int(mat.shape[0] * fixed_thres)]
+        max_N = p_neighbors_list[0]
+    else:
+        max_N = int(mat.shape[0] * max_rp_threshold)
+        if sparse_search:
+            N = min(max_N, search_p_volume)
+            p_neighbors_list = list(np.linspace(1, max_N, N, endpoint=True).astype(int))
+        else:
+            p_neighbors_list = list(range(1, max_N))
+
+    est_spk_n_dict = {}
+    for p_neighbors in p_neighbors_list:
+        X_conn_from_dist = get_X_conn_from_dist(mat, p_neighbors)
+        est_num_of_spk, lambdas, lambda_gap_list = estimate_num_of_spkrs(X_conn_from_dist, SPK_MAX)
+        est_spk_n_dict[p_neighbors] = (est_num_of_spk, lambdas)
+        arg_sorted_idx = np.argsort(lambda_gap_list[:SPK_MAX])[::-1]
+        max_key = arg_sorted_idx[0]
+        max_eig_gap = lambda_gap_list[max_key] / (max(lambdas) + eps)
+        eig_ratio_value = (p_neighbors / mat.shape[0]) / (max_eig_gap + eps)
+        eig_ratio_list.append(eig_ratio_value)
+
+    index_nn = np.argmin(eig_ratio_list)
+    rp_p_neighbors = p_neighbors_list[index_nn]
+    X_conn_from_dist = get_X_conn_from_dist(mat, rp_p_neighbors)
+    if not isFullyConnected(X_conn_from_dist):
+        X_conn_from_dist, rp_p_neighbors = gc_thres_min_gc(mat, max_N, p_neighbors_list)
+
+    return (
+        X_conn_from_dist,
+        float(rp_p_neighbors / mat.shape[0]),
+        est_spk_n_dict[rp_p_neighbors][0],
+        est_spk_n_dict[rp_p_neighbors][1],
+        rp_p_neighbors,
+    )
+
+
+def get_eigen_matrix(emb):
+    """
+    input
+    emb: embedding
+    
+    output
+    similarity matrix
+    """
+    sim_d = cosine_similarity(emb)
+    scaler.fit(sim_d)
+    sim_d = scaler.transform(sim_d)
+
+    return sim_d
+
+
+def COSclustering(key, emb, oracle_num_speakers=None, max_num_speaker=8):
+    """
+    input:
+    key (str): speaker uniq name
+    emb (np array): speaker embedding
+    oracle_num_speaker (int or None): oracle number of speakers if known else None
+    max_num_speakers (int): maximum number of clusters to consider for each session
+    output:
+    Y (List[int]): speaker labels
+    """
+    est_num_spks_out_list = []
+    mat = get_eigen_matrix(emb)
+
+    if oracle_num_speakers:
+        max_num_speaker = oracle_num_speakers
+
+    X_conn_spkcount, rp_thres_spkcount, est_num_of_spk, lambdas, p_neigh = NMEanalysis(mat, max_num_speaker)
+    X_conn_from_dist = get_X_conn_from_dist(mat, p_neigh)
+
+    if oracle_num_speakers:
+        est_num_of_spk = oracle_num_speakers
+
+    est_num_spks_out_list.append([key, str(est_num_of_spk)])
+
+    # Perform spectral clustering
+    spectral_model = sklearn_SpectralClustering(
+        affinity='precomputed',
+        eigen_solver='amg',
+        random_state=0,
+        n_jobs=-1,
+        n_clusters=est_num_of_spk,
+        eigen_tol=1e-10,
+    )
+
+    Y = spectral_model.fit_predict(X_conn_from_dist)
+
+    return Y

--- a/nemo/collections/asr/parts/nmse_clustering.py
+++ b/nemo/collections/asr/parts/nmse_clustering.py
@@ -171,6 +171,7 @@ def estimate_num_of_spkrs(X_conn, SPK_MAX):
 def NMEanalysis(mat, SPK_MAX, max_rp_threshold=0.250, sparse_search=True, search_p_volume=20, fixed_thres=None):
     """
     Normalized Eigengap analysis to get p_neighbours and estimated num of speakers
+    Reference: https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8937487&tag=1 
     """
     eps = 1e-10
     eig_ratio_list = []

--- a/requirements/requirements_asr.txt
+++ b/requirements/requirements_asr.txt
@@ -18,5 +18,5 @@ g2p_en
 pydub
 pyannote.core
 pyannote.metrics
-spectralcluster
+pyamg
 torch-stft


### PR DESCRIPTION
This PR :
* Adds new NMSE spectral clustering method
* Updates Docs to include dataset creation for any dataset, with special mentions for AMI and CH109. 
* Adds ability to diarize for unknown number of speakers/session with very good accuracies 
* Replace SpectralCluster from requirements with pyamg (math computing repo) 

Signed-off-by: nithinraok <nithinrao.koluguri@gmail.com>