### PR TITLE
[docs] variable name error in text to sound example in docs

### DIFF
--- a/docs/source/tts/intro.rst
+++ b/docs/source/tts/intro.rst
@@ -17,9 +17,9 @@ Quick Start:
     vocoder = Vocoder.from_pretrained("tts_waveglow_88m")
 
     # All spectrogram generators start by parsing raw strings to a tokenized version of the string
-    parsed = spec_gen.parse("You can type your sentence here to get nemo to produce speech.")
+    parsed = spec_generator.parse("You can type your sentence here to get nemo to produce speech.")
     # They then take the tokenized string and produce a spectrogram
-    spectrogram = spec_gen.generate_spectrogram(tokens=parsed)
+    spectrogram = spec_generator.generate_spectrogram(tokens=parsed)
     # Finally, a vocoder converts the spectrogram to audio
     audio = vocoder.convert_spectrogram_to_audio(spec=spectrogram)
 


### PR DESCRIPTION
variable name `spec_gen` was used for parsing text and creating spectogram, which should be `spec_generator`