### PR TITLE
Fix ipywidgets error in asr notebook

### DIFF
--- a/requirements/requirements_asr.txt
+++ b/requirements/requirements_asr.txt
@@ -20,3 +20,4 @@ pyannote.core
 pyannote.metrics
 pyamg
 torch-stft
+ipywidgets


### PR DESCRIPTION
Added `ipywidgets` to avoid `ImportError: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html` error.