### PR TITLE
Fix bug in SpecCutout

### DIFF
--- a/nemo/collections/asr/parts/spectr_augment.py
+++ b/nemo/collections/asr/parts/spectr_augment.py
@@ -55,7 +55,7 @@ class SpecAugment(nn.Module):
             self.adaptive_temporal_width = False
         else:
             if time_width > 1.0 or time_width < 0.0:
-                raise ValueError('If `time_width` is a float value, must be in range [0, 1]')
+                raise ValueError("If `time_width` is a float value, must be in range [0, 1]")
 
             self.adaptive_temporal_width = True
 
@@ -115,8 +115,8 @@ class SpecCutout(nn.Module):
                 rect_x = self._rng.randint(0, sh[1] - self.rect_freq)
                 rect_y = self._rng.randint(0, sh[2] - self.rect_time)
 
-                w_x = self._rng.randint(0, self.rect_time)
-                w_y = self._rng.randint(0, self.rect_freq)
+                w_x = self._rng.randint(0, self.rect_freq)
+                w_y = self._rng.randint(0, self.rect_time)
 
                 x[idx, rect_x : rect_x + w_x, rect_y : rect_y + w_y] = 0.0
 


### PR DESCRIPTION
[Colab notebook demonstrating bug and fix](https://colab.research.google.com/drive/1Tksb-RXAeLSkBW72KDgm1DYUaPAnHXBx?usp=sharing)

There is a bug in the NeMo implementation of SpecCutout that causes the dimensions of masks to be transposed so that `rect_freq` is the size of the mask in the time dimension and `rect_time` is the size of the mask in the frequency dimension. This also causes the placement of the masks to be limited to the lowest frequency bins.

![image](https://user-images.githubusercontent.com/47190785/118002089-49df7b00-b315-11eb-9828-10436e84a674.png)

Output after fix:
![image](https://user-images.githubusercontent.com/47190785/118003342-7e076b80-b316-11eb-9ddc-17af39e6b9da.png)
