### PR TITLE
Support symlinked files

### DIFF
--- a/scripts/speech_recognition/convert_to_tarred_audio_dataset.py
+++ b/scripts/speech_recognition/convert_to_tarred_audio_dataset.py
@@ -462,7 +462,7 @@ class ASRTarredDatasetBuilder:
         """Creates a tarball containing the audio files from `entries`.
         """
         new_entries = []
-        tar = tarfile.open(os.path.join(target_dir, f'audio_{shard_id}.tar'), mode='w')
+        tar = tarfile.open(os.path.join(target_dir, f'audio_{shard_id}.tar'), mode='w', dereference=True)
 
         count = dict()
         for entry in entries:


### PR DESCRIPTION
To preserve disk space on my machine, I generally use symlinks to create different splits of my data.
The tarred audio dataset script doesn't follow symlinks, so simply pass `dereference=True` to the `tarfile.open()` method. 

See more info in the python docs: https://docs.python.org/3/library/tarfile.html#tarfile.TarFile