### PR TITLE
Replace model names in VAD tutorials

### DIFF
--- a/tutorials/asr/06_Voice_Activiy_Detection.ipynb
+++ b/tutorials/asr/06_Voice_Activiy_Detection.ipynb
@@ -246,9 +246,9 @@
    "source": [
     "# Training - Preparation\n",
     "\n",
-    "We will be training a MatchboxNet model from paper \"[MatchboxNet: 1D Time-Channel Separable Convolutional Neural Network Architecture for Speech Commands Recognition](https://arxiv.org/abs/2004.08531)\" evolved from [QuartzNet](https://arxiv.org/pdf/1910.10261.pdf) model. The benefit of QuartzNet over JASPER models is that they use Separable Convolutions, which greatly reduce the number of parameters required to get good model accuracy.\n",
+    "We will be training a MarbleNet model from paper \"[MarbleNet: Deep 1D Time-Channel Separable Convolutional Neural Network for Voice Activity Detection](https://arxiv.org/abs/2010.13886)\", evolved from [QuartzNet](https://arxiv.org/pdf/1910.10261.pdf) and [MatchboxNet](https://arxiv.org/abs/2004.08531) model. The benefit of QuartzNet over JASPER models is that they use Separable Convolutions, which greatly reduce the number of parameters required to get good model accuracy.\n",
     "\n",
-    "MatchboxNet models generally follow the model definition pattern QuartzNet-[BxRXC], where B is the number of blocks, R is the number of convolutional sub-blocks, and C is the number of channels in these blocks. Each sub-block contains a 1-D masked convolution, batch normalization, ReLU, and dropout.\n"
+    "MarbleNet models generally follow the model definition pattern QuartzNet-[BxRXC], where B is the number of blocks, R is the number of convolutional sub-blocks, and C is the number of channels in these blocks. Each sub-block contains a 1-D masked convolution, batch normalization, ReLU, and dropout.\n"
    ]
   },
   {
@@ -276,7 +276,7 @@
    },
    "source": [
     "## Model Configuration\n",
-    "The MatchboxNet Model is defined in a config file which declares multiple important sections.\n",
+    "The MarbleNet Model is defined in a config file which declares multiple important sections.\n",
     "\n",
     "They are:\n",
     "\n",
@@ -308,7 +308,7 @@
    },
    "outputs": [],
    "source": [
-    "# This line will print the entire config of the MatchboxNet model\n",
+    "# This line will print the entire config of the MarbleNet model\n",
     "config_path = f\"configs/{MODEL_CONFIG}\"\n",
     "config = OmegaConf.load(config_path)\n",
     "print(config.pretty())"
@@ -521,9 +521,9 @@
     "id": "t0zz-vHH7Uuh"
    },
    "source": [
-    "## Building the MatchboxNet Model\n",
+    "## Building the MarbleNet Model\n",
     "\n",
-    "MatchboxNet is an ASR model with a classification task - it generates one label for the entire provided audio stream. Therefore we encapsulate it inside the `EncDecClassificationModel` as follows."
+    "MarbleNet is an ASR model with a classification task - it generates one label for the entire provided audio stream. Therefore we encapsulate it inside the `EncDecClassificationModel` as follows."
    ]
   },
   {
@@ -547,9 +547,9 @@
     "id": "jA9UND-Q_oyw"
    },
    "source": [
-    "# Training a MatchboxNet Model\n",
+    "# Training a MarbleNet Model\n",
     "\n",
-    "As MatchboxNet is inherently a PyTorch Lightning Model, it can easily be trained in a single line - `trainer.fit(model)` !\n",
+    "As MarbleNet is inherently a PyTorch Lightning Model, it can easily be trained in a single line - `trainer.fit(model)` !\n",
     "\n",
     "\n",
     "# Training the model\n",

--- a/tutorials/asr/07_Online_Offline_Microphone_VAD_Demo.ipynb
+++ b/tutorials/asr/07_Online_Offline_Microphone_VAD_Demo.ipynb
@@ -68,7 +68,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This notebook requires the `torchaudio` library to be installed for MatchboxNet. Please follow the instructions available at the [torchaudio Github page](https://github.com/pytorch/audio#installation) to install the appropriate version of torchaudio.\n",
+    "This notebook requires the `torchaudio` library to be installed for MarbleNet. Please follow the instructions available at the [torchaudio Github page](https://github.com/pytorch/audio#installation) to install the appropriate version of torchaudio.\n",
     "\n",
     "If you would like to install the latest version, please run the following command to install it:\n",
     "\n",


### PR DESCRIPTION
Fix some model names (MatchboxNet -> MarbleNet) in VAD tutorials.
(Thought I've fixed all of them before but it's still there hmm) 