### PR TITLE
Make Text processing installation optional via reinstall.sh

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -30,6 +30,6 @@ else
 fi
 
 echo 'Installing additional nemo_text_processing conda dependency'
-bash nemo_text_processing/setup.sh > /dev/null 2>&1 && echo "nemo_text_processing installed"
+bash nemo_text_processing/setup.sh > /dev/null 2>&1 && echo "nemo_text_processing installed!" || echo "nemo_text_processing could not be installed!"
 
 echo 'All done!'

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -30,6 +30,6 @@ else
 fi
 
 echo 'Installing additional nemo_text_processing conda dependency'
-bash nemo_text_processing/setup.sh
+bash nemo_text_processing/setup.sh > /dev/null 2>&1 && echo "nemo_text_processing installed"
 
 echo 'All done!'


### PR DESCRIPTION
# Changelog
- Make text normalization installation step optional (if in a non-conda environment and user attempts reinstall.sh).

Signed-off-by: smajumdar <titu1994@gmail.com>