### PR TITLE
Alias Swish to SiLU 

### DIFF
--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -127,6 +127,11 @@ class ConvASREncoder(NeuralModule, Exportable):
             jasper = OmegaConf.to_container(jasper)
 
         activation = jasper_activations[activation]()
+
+        # If the activation can be executed in place, do so.
+        if hasattr(activation, 'inplace'):
+            activation.inplace = True
+
         feat_in = feat_in * frame_splicing
 
         self._feat_in = feat_in

--- a/nemo/collections/asr/parts/activations.py
+++ b/nemo/collections/asr/parts/activations.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
 import torch.nn as nn
 
 __all__ = ['Swish']

--- a/nemo/collections/asr/parts/activations.py
+++ b/nemo/collections/asr/parts/activations.py
@@ -18,10 +18,8 @@ import torch.nn as nn
 __all__ = ['Swish']
 
 
-class Swish(nn.Module):
+class Swish(nn.SiLU):
     """
     Swish activation function introduced in 'https://arxiv.org/abs/1710.05941'
+    Mathematically identical to SiLU. See note in nn.SiLU for references.
     """
-
-    def forward(self, x):
-        return x * torch.sigmoid(x)

--- a/nemo/collections/asr/parts/jasper.py
+++ b/nemo/collections/asr/parts/jasper.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     PYTORCH_QUANTIZATION_AVAILABLE = False
 
-jasper_activations = {"hardtanh": nn.Hardtanh, "relu": nn.ReLU, "selu": nn.SELU, "swish": Swish}
+jasper_activations = {"hardtanh": nn.Hardtanh, "relu": nn.ReLU, "selu": nn.SELU, "swish": Swish, "silu": nn.SiLU}
 
 
 def tds_uniform_(tensor, mode='fan_in'):


### PR DESCRIPTION
# Changelog
- Alias `Swish` activation to `nn.SiLU` which is mathematically identical
- Update activations to inplace execution if possible for `ConvASREncoder`

Signed-off-by: smajumdar <titu1994@gmail.com>