### PR TITLE
Support multiple models being instantiated in same execution scope

### DIFF
--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -422,7 +422,7 @@ class NLPModel(ModelPT, Exportable):
             restored_model = cls._default_restore_from(
                 restore_path, override_config_path, map_location, strict, return_config
             )
-            restored_model._trainer = trainer
+            restored_model.set_trainer(trainer)
             return restored_model
         else:
             return super().restore_from(restore_path, override_config_path, map_location, strict, return_config)

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -1295,8 +1295,17 @@ class ModelPT(LightningModule, Model):
 
     def _set_model_guid(self):
         if not hasattr(self, 'model_guid'):
+            appstate = AppState()
+
+            # Generate a unique uuid for the instance
+            # also determine if the model is being restored or not, and preserve the path
             self.model_guid = str(uuid.uuid4())
-            AppState().register_model_guid(self.model_guid)
+            if self._is_model_being_restored():
+                restore_path = appstate.model_restore_path
+            else:
+                restore_path = None
+
+            appstate.register_model_guid(self.model_guid, model_restore_path=restore_path)
 
     @staticmethod
     def _is_restore_type_tarfile() -> bool:

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -338,6 +338,8 @@ class ModelPT(LightningModule, Model):
             torch.save(self.state_dict(), model_weights)
             self._make_nemo_file_from_folder(filename=save_path, source_dir=tmpdir)
 
+            AppState().register_model_guid(self.model_guid, restoration_path=save_path)
+
     @rank_zero_only
     def save_to(self, save_path: str):
         """
@@ -1305,7 +1307,7 @@ class ModelPT(LightningModule, Model):
             else:
                 restore_path = None
 
-            appstate.register_model_guid(self.model_guid, model_restore_path=restore_path)
+            appstate.register_model_guid(self.model_guid, restoration_path=restore_path)
 
     @staticmethod
     def _is_restore_type_tarfile() -> bool:

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -273,14 +273,13 @@ class ModelPT(LightningModule, Model):
 
         # Process current tarfile artifacts by unpacking the previous tarfile and extract the artifacts
         # that are currently required.
-        if len(tarfile_artifacts) > 0 and app_state.model_restore_path is not None:
+        model_metadata = app_state.get_model_metadata_from_guid(self.model_guid)
+        if len(tarfile_artifacts) > 0 and model_metadata.restoration_path is not None:
             # Need to step into nemo archive to extract file
             # Get path where the command is executed - the artifacts will be "retrieved" there
             # (original .nemo behavior)
             cwd = os.getcwd()
             try:
-                model_metadata = app_state.get_model_metadata_from_guid(self.model_guid)
-
                 # Step into the nemo archive to try and find the file
                 with tempfile.TemporaryDirectory() as archive_dir:
                     self._unpack_nemo_file(path2file=model_metadata.restoration_path, out_folder=archive_dir)

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -29,7 +29,7 @@ class ModelMetadataRegistry:
 class AppState(metaclass=Singleton):
     def __init__(self):
         # method call lock
-        self._lock = Lock()
+        self.__lock = Lock()
 
         # TODO: should we store global config in hydra_runner?
         self._app_cfg = None
@@ -362,21 +362,19 @@ class AppState(metaclass=Singleton):
 
     @model_restore_path.setter
     def model_restore_path(self, path):
-        with self._lock:
+        with self.__lock:
             self._model_restore_path = path
+            self._all_model_restore_paths.append(path)
 
-            if path not in self._all_model_restore_paths:
-                self._all_model_restore_paths.append(path)
-
-    def register_model_guid(self, guid):
+    def register_model_guid(self, guid: str, model_restore_path: str):
         # Maps a guid to its restore path (None or last absolute path)
-        with self._lock:
+        with self.__lock:
             idx = len(self._model_guid_map)
-            self._model_guid_map[guid] = ModelMetadataRegistry(guid, idx, restoration_path=self.model_restore_path)
+            self._model_guid_map[guid] = ModelMetadataRegistry(guid, idx, restoration_path=model_restore_path)
 
     def reset_model_guid_registry(self):
         # Reset the guid mapping
-        with self._lock:
+        with self.__lock:
             self._model_guid_map.clear()
 
     def get_model_metadata_from_guid(self, guid):

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -14,7 +14,7 @@
 
 from dataclasses import dataclass
 from threading import Lock
-from typing import Optional
+from typing import Dict, Optional
 
 from nemo.utils.metaclasses import Singleton
 
@@ -64,7 +64,7 @@ class AppState(metaclass=Singleton):
         self._model_weights_ckpt = "model_weights.ckpt"
         self._model_restore_path = None
         self._all_model_restore_paths = []
-        self._model_guid_map = {}
+        self._model_guid_map = {}  # type: Dict[str, ModelMetadataRegistry]
 
     @property
     def device_id(self):
@@ -369,7 +369,10 @@ class AppState(metaclass=Singleton):
     def register_model_guid(self, guid: str, restoration_path: Optional[str] = None):
         # Maps a guid to its restore path (None or last absolute path)
         with self.__lock:
-            idx = len(self._model_guid_map)
+            if guid in self._model_guid_map:
+                idx = self._model_guid_map[guid].gidx
+            else:
+                idx = len(self._model_guid_map)
             self._model_guid_map[guid] = ModelMetadataRegistry(guid, idx, restoration_path=restoration_path)
 
     def reset_model_guid_registry(self):

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -357,8 +357,7 @@ class AppState(metaclass=Singleton):
 
     @property
     def model_restore_path(self):
-        with self._lock:
-            restore_path = self._all_model_restore_paths[-1] if len(self._all_model_restore_paths) > 0 else None
+        restore_path = self._all_model_restore_paths[-1] if len(self._all_model_restore_paths) > 0 else None
         return restore_path
 
     @model_restore_path.setter
@@ -382,6 +381,5 @@ class AppState(metaclass=Singleton):
 
     def get_model_metadata_from_guid(self, guid):
         # Returns the global model idx and restoration path
-        with self._lock:
-            metadata = self._model_guid_map[guid]
+        metadata = self._model_guid_map[guid]
         return metadata

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -366,18 +366,18 @@ class AppState(metaclass=Singleton):
             self._model_restore_path = path
             self._all_model_restore_paths.append(path)
 
-    def register_model_guid(self, guid: str, model_restore_path: str):
+    def register_model_guid(self, guid: str, restoration_path: Optional[str] = None):
         # Maps a guid to its restore path (None or last absolute path)
         with self.__lock:
             idx = len(self._model_guid_map)
-            self._model_guid_map[guid] = ModelMetadataRegistry(guid, idx, restoration_path=model_restore_path)
+            self._model_guid_map[guid] = ModelMetadataRegistry(guid, idx, restoration_path=restoration_path)
 
     def reset_model_guid_registry(self):
         # Reset the guid mapping
         with self.__lock:
             self._model_guid_map.clear()
 
-    def get_model_metadata_from_guid(self, guid):
+    def get_model_metadata_from_guid(self, guid) -> ModelMetadataRegistry:
         # Returns the global model idx and restoration path
         metadata = self._model_guid_map[guid]
         return metadata

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -46,6 +46,7 @@ class ArtifactPathType(Enum):
 class ArtifactItem:
     path: str
     path_type: ArtifactPathType
+    hashed_path: Optional[str] = None
 
 
 def resolve_dataset_name_from_cfg(cfg: DictConfig) -> str:

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -46,6 +46,7 @@ class ArtifactPathType(Enum):
 class ArtifactItem:
     path: str
     path_type: ArtifactPathType
+    model_guid: str
 
 
 def resolve_dataset_name_from_cfg(cfg: DictConfig) -> str:

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -46,7 +46,6 @@ class ArtifactPathType(Enum):
 class ArtifactItem:
     path: str
     path_type: ArtifactPathType
-    model_guid: str
 
 
 def resolve_dataset_name_from_cfg(cfg: DictConfig) -> str:

--- a/tests/core/test_save_restore.py
+++ b/tests/core/test_save_restore.py
@@ -170,7 +170,6 @@ class TestSaveRestore:
 
             # Save test
             model_copy = self.__test_restore_elsewhere(model, map_location='cpu')
-            # assert filecmp.cmp(model.temp_file, model_copy.temp_file)
 
         # Restore test
         diff = model.w.weight - model_copy.w.weight
@@ -229,7 +228,6 @@ class TestSaveRestore:
 
             # Save test (with overriden config as OmegaConf object)
             model_copy = self.__test_restore_elsewhere(model, map_location='cpu', override_config_path=cfg)
-            assert filecmp.cmp(model.temp_file, model_copy.temp_file)
 
         # Restore test
         diff = model.w.weight - model_copy.w.weight
@@ -271,7 +269,6 @@ class TestSaveRestore:
             # Restore test
             diff = model.w.weight - model_copy.w.weight
             assert diff.mean() <= 1e-9
-            # assert os.path.basename(model.temp_file) == model_copy.temp_file
             assert filecmp.cmp(model.temp_file, model_copy.temp_file)
             assert model_copy.temp_data == ["*****\n"]
 
@@ -339,7 +336,6 @@ class TestSaveRestore:
             # Save test
             model_copy = self.__test_restore_elsewhere(model, map_location='cpu')
             model2_copy = self.__test_restore_elsewhere(model2, map_location='cpu')
-            # assert filecmp.cmp(model.temp_file, model_copy.temp_file)
 
         # Restore test
         assert model_copy.temp_data == ["*****\n"]
@@ -372,7 +368,6 @@ class TestSaveRestore:
             # Save test (inverted order)
             model2_copy = self.__test_restore_elsewhere(model2, map_location='cpu')
             model_copy = self.__test_restore_elsewhere(model, map_location='cpu')
-            # assert filecmp.cmp(model.temp_file, model_copy.temp_file)
 
         # Restore test
         assert model_copy.temp_data == ["*****\n"]

--- a/tests/core/test_save_restore.py
+++ b/tests/core/test_save_restore.py
@@ -316,8 +316,8 @@ class TestSaveRestore:
     def test_mock_save_to_restore_from_multiple_models(self):
         appstate = AppState()
         # reset appstate cache of model guid and restoration paths from previous tests
-        appstate.reset_model_guid_registry()
-        appstate._all_model_restore_paths = []
+        # appstate.reset_model_guid_registry()
+        # appstate._all_model_restore_paths = []
 
         with tempfile.NamedTemporaryFile('w') as empty_file, tempfile.NamedTemporaryFile('w') as empty_file2:
             # Write some data
@@ -349,11 +349,3 @@ class TestSaveRestore:
         # Restore test
         assert model_copy.temp_data == ["*****\n"]
         assert model2_copy.temp_data == ['+++++\n']
-
-        # AppState tests
-        assert len(appstate._model_guid_map) == 4  # (2 original, 2 copies)
-        assert len(appstate._all_model_restore_paths) == 2  # (paths of 2 restored copies)
-        assert (
-            appstate.model_restore_path
-            == appstate.get_model_metadata_from_guid(model2_copy.model_guid).restoration_path
-        )

--- a/tests/core/test_save_restore.py
+++ b/tests/core/test_save_restore.py
@@ -424,3 +424,25 @@ class TestSaveRestore:
         metadata = appstate.get_model_metadata_from_guid(model_copy.model_guid)
         assert metadata.guid != model.model_guid
         assert metadata.restoration_path == path
+
+    @pytest.mark.unit
+    def test_mock_save_to_multiple_times(self):
+        with tempfile.NamedTemporaryFile('w') as empty_file, tempfile.TemporaryDirectory() as tmpdir:
+            # Write some data
+            empty_file.writelines(["*****\n"])
+            empty_file.flush()
+
+            # Update config
+            cfg = _mock_model_config()
+            cfg.model.temp_file = empty_file.name
+
+            # Create model
+            model = MockModel(cfg=cfg.model, trainer=None)  # type: MockModel
+            model = model.to('cpu')
+
+            assert model.temp_file == empty_file.name
+
+            # Save test
+            model.save_to(os.path.join(tmpdir, 'save_0.nemo'))
+            model.save_to(os.path.join(tmpdir, 'save_1.nemo'))
+            model.save_to(os.path.join(tmpdir, 'save_2.nemo'))


### PR DESCRIPTION
# Changelog
- Model's are now attached with a one off global unique id (guid) which is registered into the global AppState for maintanence.
- AppState tracks whether the model was restored via a nemo file or via constructor and monitors an ever growing list of model restoration paths (If the model constructor was used, its restoration path is None).
- During registration of artifacts, each model registers its own copy of artifacts (via self)
- During save to, the restoration path is retrieved from AppState and artifacts are copied from the restoration file. If restoration path is None, assume local path artifacts
- During restore from, the restoration path is first registered in an ever growing list. Then the model is constructed (which allocates a GUID and registers this GUID with the restoration path).

# Bugfix
- Fixes a bug which prevents a model constructed via constructor to call save_to multiple times.

Signed-off-by: smajumdar <titu1994@gmail.com>