### PR TITLE
[BUGFIX] Only process tarfile artifacts when model was restored from tarfile

### DIFF
--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -272,7 +272,7 @@ class ModelPT(LightningModule, Model):
 
         # Process current tarfile artifacts by unpacking the previous tarfile and extract the artifacts
         # that are currently required.
-        if len(tarfile_artifacts) > 0 and self._is_model_being_restored():
+        if len(tarfile_artifacts) > 0 and app_state.model_restore_path is not None:
             # Need to step into nemo archive to extract file
             # Get path where the command is executed - the artifacts will be "retrieved" there
             # (original .nemo behavior)

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -272,7 +272,7 @@ class ModelPT(LightningModule, Model):
 
         # Process current tarfile artifacts by unpacking the previous tarfile and extract the artifacts
         # that are currently required.
-        if len(tarfile_artifacts) > 0:
+        if len(tarfile_artifacts) > 0 and self._is_model_being_restored():
             # Need to step into nemo archive to extract file
             # Get path where the command is executed - the artifacts will be "retrieved" there
             # (original .nemo behavior)


### PR DESCRIPTION
NLP models are having tarfile artifacts when calling save_to. This is causing tarfile artifacts to be processed even though the model was not restored from a tarfile.