### PR TITLE
get embedding for a single file

### DIFF
--- a/nemo/collections/asr/models/label_models.py
+++ b/nemo/collections/asr/models/label_models.py
@@ -341,8 +341,9 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
     @torch.no_grad()
     def get_embedding(self, path2audio_file):
         audio, sr = librosa.load(path2audio_file, sr=None)
-        if sr != 16000:
-            audio = librosa.core.resample(audio, sr, 16000)
+        target_sr = self._cfg.train_ds.get('sample_rate', 16000)
+        if sr != target_sr:
+            audio = librosa.core.resample(audio, sr, target_sr)
         audio_length = audio.shape[0]
         device = self.device
         audio_signal, audio_signal_len = (

--- a/nemo/collections/asr/models/label_models.py
+++ b/nemo/collections/asr/models/label_models.py
@@ -342,7 +342,7 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
     def get_embedding(self, path2audio_file):
         audio, sr = librosa.load(path2audio_file, sr=None)
         if sr != 16000:
-            raise ValueError("Make sure input audio has sample rate of 16Khz")
+            audio = librosa.core.resample(audio, sr, 16000)
         audio_length = audio.shape[0]
         device = self.device
         audio_signal, audio_signal_len = (
@@ -352,7 +352,7 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
         self.eval()
         self.freeze()
         _, embs = self.forward(input_signal=audio_signal, input_signal_length=audio_signal_len)
-
+        del audio_signal, audio_signal_len
         return embs
 
 

--- a/nemo/collections/asr/models/label_models.py
+++ b/nemo/collections/asr/models/label_models.py
@@ -350,9 +350,14 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
             torch.tensor([audio], device=device),
             torch.tensor([audio_length], device=device),
         )
-        self.eval()
+        mode = self.training
         self.freeze()
+
         _, embs = self.forward(input_signal=audio_signal, input_signal_length=audio_signal_len)
+
+        self.train(mode=mode)
+        if mode is True:
+            self.unfreeze()
         del audio_signal, audio_signal_len
         return embs
 


### PR DESCRIPTION
Signed-off-by: nithinraok <nithinrao.koluguri@gmail.com>

Usage:
`speaker_model = ExtractSpeakerEmbeddingsModel.from_pretrained(model_name="speakerverification_speakernet")`
` embs = speaker_model.get_embedding('audio_path')`