### PR TITLE
[BUGFIX] OmegaConf forward compatibility

### DIFF
--- a/examples/asr/experimental/wav2vec/wav2vec_pretrain.py
+++ b/examples/asr/experimental/wav2vec/wav2vec_pretrain.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import pytorch_lightning as pl
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from nemo.collections.asr.models.wav2vec.wav2vec_model import Wav2VecEncoderModel
 from nemo.core.config import hydra_runner
@@ -84,7 +84,7 @@ Override optimizer entirely
 
 @hydra_runner(config_path="configs", config_name="wav2vec_pretrain")
 def main(cfg: DictConfig):
-    logging.info("Application config\n" + cfg.pretty())
+    logging.info("Application config\n" + OmegaConf.to_yaml(cfg))
 
     trainer = pl.Trainer(**cfg.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))

--- a/examples/cv/mnist_lenet5_image_classification_pure_lightning.py
+++ b/examples/cv/mnist_lenet5_image_classification_pure_lightning.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass
 
 # from hydra.utils import instantiate
 import pytorch_lightning as ptl
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from nemo.collections.cv.models import MNISTLeNet5, MNISTLeNet5Config
 from nemo.core.config import Config, TrainerConfig, hydra_runner
@@ -42,7 +42,7 @@ class AppConfig(Config):
 @hydra_runner(schema=AppConfig, config_name="AppConfig")
 def main(cfg: DictConfig):
     # Show configuration - user can modify every parameter from command line!
-    logging.info("Application config\n" + cfg.pretty())
+    logging.info("Application config\n" + OmegaConf.to_yaml(cfg))
 
     # The "model" - with dataloader/dataset inside of it.
     lenet5 = MNISTLeNet5(cfg.model)

--- a/examples/nlp/dialogue_state_tracking/sgd_qa.py
+++ b/examples/nlp/dialogue_state_tracking/sgd_qa.py
@@ -110,7 +110,7 @@ from nemo.utils.exp_manager import exp_manager
 
 @hydra_runner(config_path="conf", config_name="sgdqa_config")
 def main(cfg: DictConfig) -> None:
-    logging.info(f'Config: {cfg.pretty()}')
+    logging.info(f'Config: {OmegaConf.to_yaml(cfg)}')
     trainer = pl.Trainer(**cfg.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))
 

--- a/examples/nlp/entity_linking/self_alignment_pretraining.py
+++ b/examples/nlp/entity_linking/self_alignment_pretraining.py
@@ -16,7 +16,7 @@
 # Please see tutorial at Nemo/tutorials/nlp/Entity_Linking_Medical.ipynb for
 # more information on entity linking and self alignment pretraining.
 
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 from pytorch_lightning import Trainer
 
 from nemo.collections.nlp.models import EntityLinkingModel
@@ -27,7 +27,7 @@ from nemo.utils.exp_manager import exp_manager
 
 @hydra_runner(config_path="conf", config_name="umls_medical_entity_linking_config.yaml")
 def main(cfg: DictConfig) -> None:
-    logging.info(f"\nConfig Params:\n{cfg.pretty()}")
+    logging.info(f"\nConfig Params:\n{OmegaConf.to_yaml(cfg)}")
     trainer = Trainer(**cfg.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))
 

--- a/examples/nlp/glue_benchmark/glue_benchmark.py
+++ b/examples/nlp/glue_benchmark/glue_benchmark.py
@@ -36,7 +36,7 @@ Note, MNLI task includes both matched and mismatched dev sets
 import os
 
 import pytorch_lightning as pl
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from nemo.collections.nlp.models import GLUEModel
 from nemo.core.config import hydra_runner
@@ -46,7 +46,7 @@ from nemo.utils.exp_manager import exp_manager
 
 @hydra_runner(config_name="glue_benchmark_config")
 def main(cfg: DictConfig) -> None:
-    logging.info(f'Config: {cfg.pretty()}')
+    logging.info(f'Config: {OmegaConf.to_yaml(cfg)}')
     trainer = pl.Trainer(**cfg.trainer)
     exp_manager_cfg = cfg.get("exp_manager", None)
 

--- a/examples/nlp/information_retrieval/bert_dpr.py
+++ b/examples/nlp/information_retrieval/bert_dpr.py
@@ -14,7 +14,7 @@
 
 
 import pytorch_lightning as pl
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from nemo.collections.nlp.models import BertDPRModel
 from nemo.core.config import hydra_runner
@@ -24,7 +24,7 @@ from nemo.utils.exp_manager import exp_manager
 
 @hydra_runner(config_path="conf", config_name="bert_ir_config")
 def main(cfg: DictConfig) -> None:
-    logging.info(f'Config: {cfg.pretty()}')
+    logging.info(f'Config: {OmegaConf.to_yaml(cfg)}')
     trainer = pl.Trainer(**cfg.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))
     bert_dpr_model = BertDPRModel(cfg.model, trainer=trainer)

--- a/examples/nlp/information_retrieval/bert_joint_ir.py
+++ b/examples/nlp/information_retrieval/bert_joint_ir.py
@@ -14,7 +14,7 @@
 
 
 import pytorch_lightning as pl
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from nemo.collections.nlp.models import BertJointIRModel
 from nemo.core.config import hydra_runner
@@ -24,7 +24,7 @@ from nemo.utils.exp_manager import exp_manager
 
 @hydra_runner(config_path="conf", config_name="bert_ir_config")
 def main(cfg: DictConfig) -> None:
-    logging.info(f'Config: {cfg.pretty()}')
+    logging.info(f'Config: {OmegaConf.to_yaml(cfg)}')
     trainer = pl.Trainer(**cfg.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))
     bert_joint_ir_model = BertJointIRModel(cfg.model, trainer=trainer)

--- a/examples/nlp/language_modeling/bert_pretraining.py
+++ b/examples/nlp/language_modeling/bert_pretraining.py
@@ -14,7 +14,7 @@
 
 
 import pytorch_lightning as pl
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 from pytorch_lightning.plugins import DDPPlugin
 
 from nemo.collections.nlp.models.language_modeling import BERTLMModel
@@ -25,7 +25,7 @@ from nemo.utils.exp_manager import exp_manager
 
 @hydra_runner(config_path="conf", config_name="bert_pretraining_from_text_config")
 def main(cfg: DictConfig) -> None:
-    logging.info(f'Config:\n {cfg.pretty()}')
+    logging.info(f'Config:\n {OmegaConf.to_yaml(cfg)}')
     trainer = pl.Trainer(plugins=[DDPPlugin(find_unused_parameters=True)], **cfg.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))
     bert_model = BERTLMModel(cfg.model, trainer=trainer)

--- a/examples/nlp/language_modeling/transformer_lm.py
+++ b/examples/nlp/language_modeling/transformer_lm.py
@@ -14,7 +14,7 @@
 
 
 import pytorch_lightning as pl
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from nemo.collections.nlp.models.language_modeling import TransformerLMModel
 from nemo.core.config import hydra_runner
@@ -24,7 +24,7 @@ from nemo.utils.exp_manager import exp_manager
 
 @hydra_runner(config_path="conf", config_name="transformer_lm_config")
 def main(cfg: DictConfig) -> None:
-    logging.info(f'Config: {cfg.pretty()}')
+    logging.info(f'Config: {OmegaConf.to_yaml(cfg)}')
     trainer = pl.Trainer(**cfg.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))
     transformer_lm = TransformerLMModel(cfg.model, trainer=trainer)

--- a/examples/nlp/machine_translation/enc_dec_nmt.py
+++ b/examples/nlp/machine_translation/enc_dec_nmt.py
@@ -15,6 +15,7 @@
 from dataclasses import dataclass
 from typing import Optional
 
+from omegaconf import OmegaConf
 from pytorch_lightning import Trainer
 
 from nemo.collections.nlp.data.machine_translation.preproc_mt_data import MTDataPreproc
@@ -104,7 +105,7 @@ def main(cfg: MTEncDecConfig) -> None:
     default_cfg = MTEncDecConfig()
     cfg = update_model_config(default_cfg, cfg)
     logging.info("\n\n************** Experiment configuration ***********")
-    logging.info(f'Config: {cfg.pretty()}')
+    logging.info(f'Config: {OmegaConf.to_yaml(cfg)}')
 
     # training is managed by PyTorch Lightning
     trainer = Trainer(**cfg.trainer)

--- a/examples/nlp/question_answering/question_answering_squad.py
+++ b/examples/nlp/question_answering/question_answering_squad.py
@@ -91,7 +91,7 @@ from nemo.utils.exp_manager import exp_manager
 
 @hydra_runner(config_path="conf", config_name="question_answering_squad_config")
 def main(cfg: DictConfig) -> None:
-    logging.info(f'Config: {cfg.pretty()}')
+    logging.info(f'Config: {OmegaConf.to_yaml(cfg)}')
     trainer = pl.Trainer(**cfg.trainer)
     exp_dir = exp_manager(trainer, cfg.get("exp_manager", None))
 

--- a/examples/nlp/text2sparql/evaluate_text2sparql.py
+++ b/examples/nlp/text2sparql/evaluate_text2sparql.py
@@ -40,7 +40,7 @@ python evaluate_text2sparql.py \
 import os
 
 import pytorch_lightning as pl
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from nemo.collections.nlp.models.neural_machine_translation import NeuralMachineTranslationModel
 from nemo.core.config import hydra_runner
@@ -49,7 +49,7 @@ from nemo.utils import logging
 
 @hydra_runner(config_path="conf", config_name="text2sparql_config")
 def main(cfg: DictConfig) -> None:
-    logging.info(f"Config:\n {cfg.pretty()}")
+    logging.info(f"Config:\n {OmegaConf.to_yaml(cfg)}")
     trainer = pl.Trainer(gpus=cfg.trainer.gpus)
     nmt_model = NeuralMachineTranslationModel.restore_from(restore_path=cfg.model.nemo_path)
     nmt_model.setup_test_data(cfg.model.test_ds)

--- a/examples/nlp/text2sparql/text2sparql.py
+++ b/examples/nlp/text2sparql/text2sparql.py
@@ -89,7 +89,7 @@ python text2sparql.py \
 """
 
 import pytorch_lightning as pl
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from nemo.collections.nlp.models.neural_machine_translation import NeuralMachineTranslationModel
 from nemo.core.config import hydra_runner
@@ -99,7 +99,7 @@ from nemo.utils.exp_manager import exp_manager
 
 @hydra_runner(config_path="conf", config_name="text2sparql_config")
 def main(cfg: DictConfig) -> None:
-    logging.info(f"Config:\n {cfg.pretty()}")
+    logging.info(f"Config:\n {OmegaConf.to_yaml(cfg)}")
     trainer = pl.Trainer(**cfg.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))
     nmt_model = NeuralMachineTranslationModel(cfg.model, trainer=trainer)

--- a/examples/nlp/text_classification/model_parallel_text_classification_evaluation.py
+++ b/examples/nlp/text_classification/model_parallel_text_classification_evaluation.py
@@ -16,7 +16,7 @@
 This script runs model parallel text classification evaluation.
 """
 import pytorch_lightning as pl
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from nemo.collections.nlp.models.text_classification import TextClassificationModel
 from nemo.collections.nlp.parts.nlp_overrides import NLPDDPPlugin
@@ -27,7 +27,7 @@ from nemo.utils.exp_manager import exp_manager
 
 @hydra_runner(config_path="conf", config_name="text_classification_config")
 def main(cfg: DictConfig) -> None:
-    logging.info(f'\nConfig Params:\n{cfg.pretty()}')
+    logging.info(f'\nConfig Params:\n{OmegaConf.to_yaml(cfg)}')
     trainer = pl.Trainer(plugins=[NLPDDPPlugin()], **cfg.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))
     # TODO: can we drop strict=False

--- a/examples/nlp/text_classification/text_classification_with_bert.py
+++ b/examples/nlp/text_classification/text_classification_with_bert.py
@@ -96,7 +96,7 @@ You may restore the saved model like this:
     eval_trainer.test(model=eval_model, verbose=False)
 """
 import pytorch_lightning as pl
-from omegaconf import DictConfig
+from omegaconf import DictConfig, OmegaConf
 
 from nemo.collections.nlp.models.text_classification import TextClassificationModel
 from nemo.collections.nlp.parts.nlp_overrides import NLPDDPPlugin
@@ -107,7 +107,7 @@ from nemo.utils.exp_manager import exp_manager
 
 @hydra_runner(config_path="conf", config_name="text_classification_config")
 def main(cfg: DictConfig) -> None:
-    logging.info(f'\nConfig Params:\n{cfg.pretty()}')
+    logging.info(f'\nConfig Params:\n{OmegaConf.to_yaml(cfg)}')
     trainer = pl.Trainer(plugins=[NLPDDPPlugin()], **cfg.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))
 

--- a/examples/speaker_recognition/speaker_diarize.py
+++ b/examples/speaker_recognition/speaker_diarize.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from omegaconf import OmegaConf
 from pytorch_lightning import seed_everything
 
 from nemo.collections.asr.models import ClusteringDiarizer
@@ -39,7 +40,7 @@ seed_everything(42)
 @hydra_runner(config_path="conf", config_name="speaker_diarization.yaml")
 def main(cfg):
 
-    logging.info(f'Hydra config: {cfg.pretty()}')
+    logging.info(f'Hydra config: {OmegaConf.to_yaml(cfg)}')
     sd_model = ClusteringDiarizer(cfg=cfg)
     sd_model.diarize()
 

--- a/examples/speaker_recognition/speaker_reco.py
+++ b/examples/speaker_recognition/speaker_reco.py
@@ -15,7 +15,7 @@
 import os
 
 import pytorch_lightning as pl
-from omegaconf.listconfig import ListConfig
+from omegaconf import ListConfig, OmegaConf
 from pytorch_lightning import seed_everything
 
 from nemo.collections.asr.models import EncDecSpeakerLabelModel
@@ -53,7 +53,7 @@ seed_everything(42)
 @hydra_runner(config_path="conf", config_name="SpeakerNet_recognition_3x2x512.yaml")
 def main(cfg):
 
-    logging.info(f'Hydra config: {cfg.pretty()}')
+    logging.info(f'Hydra config: {OmegaConf.to_yaml(cfg)}')
     trainer = pl.Trainer(**cfg.trainer)
     log_dir = exp_manager(trainer, cfg.get("exp_manager", None))
     speaker_model = EncDecSpeakerLabelModel(cfg=cfg.model, trainer=trainer)

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -308,9 +308,9 @@ class ModelPT(LightningModule, Model):
             conf = OmegaConf.load(path2yaml_file)
             for conf_path, item in self.artifacts.items():
                 if item.hashed_path is None:
-                    OmegaConf.update_node(conf, conf_path, item.path)
+                    OmegaConf.update(conf, conf_path, item.path)
                 else:
-                    OmegaConf.update_node(conf, conf_path, item.hashed_path)
+                    OmegaConf.update(conf, conf_path, item.hashed_path)
             with open(path2yaml_file, 'w') as fout:
                 OmegaConf.save(config=conf, f=fout, resolve=True)
 

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -307,7 +307,10 @@ class ModelPT(LightningModule, Model):
         if self.artifacts is not None and len(self.artifacts) > 0:
             conf = OmegaConf.load(path2yaml_file)
             for conf_path, item in self.artifacts.items():
-                OmegaConf.update(conf, conf_path, item.path)
+                if item.hashed_path is None:
+                    OmegaConf.update_node(conf, conf_path, item.path)
+                else:
+                    OmegaConf.update_node(conf, conf_path, item.hashed_path)
             with open(path2yaml_file, 'w') as fout:
                 OmegaConf.save(config=conf, f=fout, resolve=True)
 

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -307,10 +307,7 @@ class ModelPT(LightningModule, Model):
         if self.artifacts is not None and len(self.artifacts) > 0:
             conf = OmegaConf.load(path2yaml_file)
             for conf_path, item in self.artifacts.items():
-                if item.hashed_path is None:
-                    conf.update_node(conf_path, item.path)
-                else:
-                    conf.update_node(conf_path, item.hashed_path)
+                OmegaConf.update(conf, conf_path, item.path)
             with open(path2yaml_file, 'w') as fout:
                 OmegaConf.save(config=conf, f=fout, resolve=True)
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -7,7 +7,7 @@ wget
 wrapt
 ruamel.yaml
 scikit-learn
-omegaconf>=2.0.5
+omegaconf>=2.0.5,<2.1.0
 hydra-core>=1.0.4
 transformers>=4.0.1
 sentencepiece<1.0.0

--- a/tutorials/asr/03_Speech_Commands.ipynb
+++ b/tutorials/asr/03_Speech_Commands.ipynb
@@ -1333,7 +1333,7 @@
     "    log_every_n_steps=1,  # Interval of logging.\n",
     "    val_check_interval=1.0,  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations\n",
     "))\n",
-    "print(trainer_config.pretty())"
+    "print(OmegaConf.to_yaml(trainer_config))"
    ],
    "execution_count": null,
    "outputs": []
@@ -1441,7 +1441,7 @@
     "# Set \"min_lr\" to lower value\n",
     "optim_sched_cfg.sched.min_lr = 1e-4\n",
     "\n",
-    "print(optim_sched_cfg.pretty())"
+    "print(OmegaConf.to_yaml(optim_sched_cfg))"
    ],
    "execution_count": null,
    "outputs": []

--- a/tutorials/asr/05_Online_Noise_Augmentation.ipynb
+++ b/tutorials/asr/05_Online_Noise_Augmentation.ipynb
@@ -1140,7 +1140,7 @@
    "outputs": [],
    "source": [
     "# Has `augmentor`\n",
-    "print(config.model.train_ds.pretty())"
+    "print(OmegaConf.to_yaml(config.model.train_ds))"
    ]
   },
   {
@@ -1154,7 +1154,7 @@
    "outputs": [],
    "source": [
     "# Does not have `augmentor`\n",
-    "print(config.model.test_ds.pretty())"
+    "print(OmegaConf.to_yaml(config.model.test_ds))"
    ]
   },
   {

--- a/tutorials/asr/06_Voice_Activiy_Detection.ipynb
+++ b/tutorials/asr/06_Voice_Activiy_Detection.ipynb
@@ -314,7 +314,7 @@
     "config = OmegaConf.to_container(config, resolve=True)\n",
     "config = OmegaConf.create(config)\n",
     "\n",
-    "print(config.pretty())"
+    "print(OmegaConf.to_yaml(config))"
    ]
   },
   {
@@ -355,7 +355,7 @@
    },
    "outputs": [],
    "source": [
-    "print(config.model.train_ds.pretty())"
+    "print(OmegaConf.to_yaml(config.model.train_ds))"
    ]
   },
   {
@@ -426,7 +426,7 @@
    "outputs": [],
    "source": [
     "print(\"Trainer config - \\n\")\n",
-    "print(config.trainer.pretty())"
+    "print(OmegaConf.to_yaml(config.trainer))"
    ]
   },
   {
@@ -576,8 +576,8 @@
    "outputs": [],
    "source": [
     "# Noise augmentation\n",
-    "print(config.model.train_ds.augmentor.pretty()) # noise augmentation\n",
-    "print(config.model.spec_augment.pretty()) # SpecAug data augmentation"
+    "print(OmegaConf.to_yaml(config.model.train_ds.augmentor)) # noise augmentation\n",
+    "print(OmegaConf.to_yaml(config.model.spec_augment)) # SpecAug data augmentation"
    ]
   },
   {


### PR DESCRIPTION
Apply updates where OmegaConf is breaking with 2.1.0.

See #2316 for the original PR to v1.0.0.

Note, we have to upper bound OmegaConf as Hydra 1.0.6 is not compatible with OmegaConf 2.1.0. When the new version of Hydra is released we should remove the upper bound.