### PR TITLE
change tensor interface to B,T,D between mel generator and vocoder 

### DIFF
--- a/nemo/collections/tts/models/base.py
+++ b/nemo/collections/tts/models/base.py
@@ -181,7 +181,7 @@ class GlowVocoder(Vocoder):
         self.check_children_attributes()  # Ensure stft parameters are defined
 
         with self.nemo_infer():
-            spect = torch.zeros((1, self.n_mel, 88)).to(self.device)
+            spect = torch.zeros((1, 88, self.n_mel)).to(self.device)
             bias_audio = self.convert_spectrogram_to_audio(spec=spect, sigma=0.0, denoise=False)
             bias_spect, _ = self.stft(bias_audio)
             self.bias_spect = bias_spect[..., 0][..., None]

--- a/nemo/collections/tts/models/fastpitch.py
+++ b/nemo/collections/tts/models/fastpitch.py
@@ -115,11 +115,11 @@ class FastPitchModel(SpectrogramGenerator):
     def forward(self, *, text, durs=None, pitch=None, speaker=0, pace=1.0):
         return self.fastpitch(text=text, durs=durs, pitch=pitch, speaker=speaker, pace=pace)
 
-    @typecheck(output_types={"spect": NeuralType(('B', 'C', 'T'), MelSpectrogramType())})
+    @typecheck(output_types={"spect": NeuralType(('B', 'T', 'D'), MelSpectrogramType())})
     def generate_spectrogram(self, tokens: 'torch.tensor', speaker: int = 0, pace: float = 1.0) -> torch.tensor:
         self.eval()
         spect, *_ = self(text=tokens, durs=None, pitch=None, speaker=speaker, pace=pace)
-        return spect.transpose(1, 2)
+        return spect
 
     def training_step(self, batch, batch_idx):
         audio, audio_lens, text, text_lens, durs, pitch, speakers = batch

--- a/nemo/collections/tts/models/fastspeech2.py
+++ b/nemo/collections/tts/models/fastspeech2.py
@@ -243,13 +243,13 @@ class FastSpeech2Model(SpectrogramGenerator):
         x = torch.tensor(tokens).unsqueeze_(0).long().to(self.device)
         return x
 
-    @typecheck(output_types={"spect": NeuralType(('B', 'C', 'T'), MelSpectrogramType())})
+    @typecheck(output_types={"spect": NeuralType(('B', 'T', 'D'), MelSpectrogramType())})
     def generate_spectrogram(self, tokens: torch.Tensor) -> torch.Tensor:
         self.eval()
         token_len = torch.tensor([tokens.shape[1]]).to(self.device)
         spect, *_ = self(text=tokens, text_length=token_len)
 
-        return spect.transpose(1, 2)
+        return spect
 
     def __setup_dataloader_from_config(self, cfg, shuffle_should_be: bool = True, name: str = "train"):
         if "dataset" not in cfg or not isinstance(cfg.dataset, DictConfig):

--- a/nemo/collections/tts/models/glow_tts.py
+++ b/nemo/collections/tts/models/glow_tts.py
@@ -249,6 +249,7 @@ class GlowTTSModel(SpectrogramGenerator):
     def setup_test_data(self, test_data_config: Optional[DictConfig]):
         self._test_dl = self._setup_dataloader_from_config(cfg=test_data_config)
 
+    @typecheck(output_types={"spect": NeuralType(('B', 'T', 'D'), MelSpectrogramType())})
     def generate_spectrogram(
         self, tokens: 'torch.tensor', noise_scale: float = 0.0, length_scale: float = 1.0
     ) -> torch.tensor:
@@ -258,7 +259,7 @@ class GlowTTSModel(SpectrogramGenerator):
         token_len = torch.tensor([tokens.shape[1]]).to(self.device)
         spect, _ = self(x=tokens, x_lengths=token_len, gen=True, noise_scale=noise_scale, length_scale=length_scale)
 
-        return spect
+        return spect.tranpose(1, 2)
 
     @classmethod
     def list_available_models(cls) -> 'List[PretrainedModelInfo]':

--- a/nemo/collections/tts/models/hifigan.py
+++ b/nemo/collections/tts/models/hifigan.py
@@ -117,10 +117,11 @@ class HifiGanModel(Vocoder, Exportable):
         return self.generator(x=spec)
 
     @typecheck(
-        input_types={"spec": NeuralType(('B', 'C', 'T'), MelSpectrogramType())},
+        input_types={"spec": NeuralType(('B', 'T', 'C'), MelSpectrogramType())},
         output_types={"audio": NeuralType(('B', 'T'), AudioSignal())},
     )
     def convert_spectrogram_to_audio(self, spec: 'torch.tensor') -> 'torch.tensor':
+        spec = spec.transpose(1, 2)
         return self(spec=spec).squeeze(1)
 
     def training_step(self, batch, batch_idx, optimizer_idx):

--- a/nemo/collections/tts/models/melgan.py
+++ b/nemo/collections/tts/models/melgan.py
@@ -90,8 +90,12 @@ class MelGanModel(Vocoder):
         """
         return self.generator(spec=spec)
 
-    @typecheck(output_types={"audio": NeuralType(('B', 'T'), AudioSignal())})
+    @typecheck(
+        output_types={"audio": NeuralType(('B', 'T'), AudioSignal())},
+        input_types={"spec": NeuralType(('B', 'T', 'C'), MelSpectrogramType())},
+    )
     def convert_spectrogram_to_audio(self, spec: 'torch.tensor') -> 'torch.tensor':
+        spec = spec.transpose(1, 2)
         return self(spec=spec).squeeze(1)
 
     def training_step(self, batch, batch_idx, optimizer_idx):

--- a/nemo/collections/tts/models/squeezewave.py
+++ b/nemo/collections/tts/models/squeezewave.py
@@ -119,7 +119,7 @@ class SqueezeWaveModel(GlowVocoder):
 
     @typecheck(
         input_types={
-            "spec": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
+            "spec": NeuralType(('B', 'T', 'D'), MelSpectrogramType()),
             "sigma": NeuralType(optional=True),
             "denoise": NeuralType(optional=True),
             "denoiser_strength": NeuralType(optional=True),
@@ -129,6 +129,7 @@ class SqueezeWaveModel(GlowVocoder):
     def convert_spectrogram_to_audio(
         self, spec: torch.Tensor, sigma: bool = 1.0, denoise: bool = True, denoiser_strength: float = 0.01
     ) -> torch.Tensor:
+        spec = spec.transpose(1, 2)
         with self.nemo_infer():
             audio = self.squeezewave(spec=spec, run_inverse=True, audio=None, sigma=sigma)
             if denoise:

--- a/nemo/collections/tts/models/tacotron2.py
+++ b/nemo/collections/tts/models/tacotron2.py
@@ -194,7 +194,7 @@ class Tacotron2Model(SpectrogramGenerator):
 
     @typecheck(
         input_types={"tokens": NeuralType(('B', 'T'), EmbeddedTextType())},
-        output_types={"spec": NeuralType(('B', 'D', 'T'), MelSpectrogramType())},
+        output_types={"spec": NeuralType(('B', 'T', 'D'), MelSpectrogramType())},
     )
     def generate_spectrogram(self, *, tokens):
         self.eval()
@@ -210,7 +210,7 @@ class Tacotron2Model(SpectrogramGenerator):
             mask = mask.permute(1, 0, 2)
             spectrogram_pred.data.masked_fill_(mask, self.pad_value)
 
-        return spectrogram_pred
+        return spectrogram_pred.transpose(2, 1)
 
     def training_step(self, batch, batch_idx):
         audio, audio_len, tokens, token_len = batch

--- a/nemo/collections/tts/models/talknet.py
+++ b/nemo/collections/tts/models/talknet.py
@@ -311,6 +311,7 @@ class TalkNetSpectModel(SpectrogramGenerator, Exportable):
     def parse(self, text: str, **kwargs) -> torch.Tensor:
         return torch.tensor(self.vocab.encode(text)).long().unsqueeze(0).to(self.device)
 
+    @typecheck(output_types={"spec": NeuralType(('B', 'T', 'D'), MelSpectrogramType())})
     def generate_spectrogram(self, tokens: torch.Tensor, **kwargs) -> torch.Tensor:
         assert hasattr(self, '_durs_model') and hasattr(self, '_pitch_model')
 
@@ -338,7 +339,7 @@ class TalkNetSpectModel(SpectrogramGenerator, Exportable):
         # Spect
         mel = self(tokens, text_len, durs, f0)
 
-        return mel
+        return mel.tranpose(1, 2)
 
     def forward_for_export(self, tokens: torch.Tensor, text_len: torch.Tensor):
         durs = self._durs_model(tokens, text_len)

--- a/nemo/collections/tts/models/two_stages.py
+++ b/nemo/collections/tts/models/two_stages.py
@@ -159,6 +159,7 @@ class TwoStagesModel(Vocoder):
         pass
 
     def convert_spectrogram_to_audio(self, spec: torch.Tensor, **kwargs) -> torch.Tensor:
+
         self.eval()
         try:
             self.mel2spec.mode = OperationMode.infer

--- a/nemo/collections/tts/models/uniglow.py
+++ b/nemo/collections/tts/models/uniglow.py
@@ -129,7 +129,7 @@ class UniGlowModel(GlowVocoder):
 
     @typecheck(
         input_types={
-            "spec": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
+            "spec": NeuralType(('B', 'T', 'D'), MelSpectrogramType()),
             "sigma": NeuralType(optional=True),
             "denoise": NeuralType(optional=True),
             "denoiser_strength": NeuralType(optional=True),
@@ -139,6 +139,7 @@ class UniGlowModel(GlowVocoder):
     def convert_spectrogram_to_audio(
         self, spec: torch.Tensor, sigma: bool = 1.0, denoise: bool = True, denoiser_strength: float = 0.01
     ) -> torch.Tensor:
+        spec = spec.transpose(1, 2)
         if not self.removed_weightnorm:
             self.model.remove_weightnorm()
             self.removed_weightnorm = True

--- a/nemo/collections/tts/models/waveglow.py
+++ b/nemo/collections/tts/models/waveglow.py
@@ -119,7 +119,7 @@ class WaveGlowModel(GlowVocoder, Exportable):
 
     @typecheck(
         input_types={
-            "spec": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
+            "spec": NeuralType(('B', 'T', 'D'), MelSpectrogramType()),
             "sigma": NeuralType(optional=True),
             "denoise": NeuralType(optional=True),
             "denoiser_strength": NeuralType(optional=True),
@@ -129,6 +129,7 @@ class WaveGlowModel(GlowVocoder, Exportable):
     def convert_spectrogram_to_audio(
         self, spec: torch.Tensor, sigma: float = 1.0, denoise: bool = True, denoiser_strength: float = 0.01
     ) -> torch.Tensor:
+        spec = spec.transpose(1, 2)
         with self.nemo_infer():
             self.waveglow.remove_weightnorm()
             audio = self.waveglow(

--- a/nemo_text_processing/inverse_text_normalization/data/quarter_time.tsv
+++ b/nemo_text_processing/inverse_text_normalization/data/quarter_time.tsv
@@ -1,0 +1,12 @@
+one 	12
+two 	1
+three 	2
+four 	3
+five 	4
+six 	5
+seven 	6
+eight 	7
+nine 	8
+ten 	9
+eleven 	10
+twelve 	11

--- a/tools/text_processing_deployment/export_grammars.sh
+++ b/tools/text_processing_deployment/export_grammars.sh
@@ -15,15 +15,13 @@
 
 #!/bin/bash
 
-# This script compiles and exports WFST-grammars from nemo_text_processing, builds C++ production backend Sparrowhawk (https://github.com/google/sparrowhawk) in docker, 
+# This script compiles and exports WFST-grammars from nemo_tools inverse text normalization, builds C++ production backend Sparrowhawk (https://github.com/google/sparrowhawk) in docker, 
 # plugs grammars into Sparrowhawk and returns prompt inside docker.
-# For inverse text normalization run:
+# To run inverse text normalization, run e.g.
 #       echo "two dollars fifty" | ../../src/bin/normalizer_main --config=sparrowhawk_configuration.ascii_proto
-# For text normalization run:
-#       echo "\$2.5" | ../../src/bin/normalizer_main --config=sparrowhawk_configuration.ascii_proto
 
 GRAMMARS=${1:-"itn_grammars"} # tn_grammars
-INPUT_CASE=${2:-"cased"} # lower_cased, only for tn_grammars
+INPUT_CASE=${2:-"cased"}
 python pynini_export.py --output_dir=. --grammars=${GRAMMARS} --input_case=${INPUT_CASE}
 find . -name "Makefile" -type f -delete
 bash docker/build.sh 


### PR DESCRIPTION
updates for  TTS models to generate mels with output of type B, T, D and all vocoders to take as input B,T,D shapes to enable continues memory when grabbing chunks of spectrogram at inference time.