### PR TITLE
Fixed Hydra-core configuration

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -8,7 +8,7 @@ wrapt
 ruamel.yaml
 scikit-learn
 omegaconf>=2.0.5,<2.1.0
-hydra-core>=1.0.4
+hydra-core==1.0.6
 transformers>=4.0.1
 sentencepiece<1.0.0
 webdataset>=0.1.48


### PR DESCRIPTION
Hydra-core version 1.1.0  was released on 11th June 2021, and it requires OmegaConf == 2.1.\*, while Nemo requires OmegaConf >=2.0.5 & <2.1.*. Therefore, the existing tutorial notebooks( can be found [here](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/starthere/tutorials.html), on importing the models, reported a configuration error. This pull request changed the specified version of hydra-core, specified in the requirements, from >=1.0.4 to ==1.0.6, which supports OmegaConf <2.1.0, and the tutorial notebooks run correctly, without any error