### PR TITLE
[BUGFIX] Update jenkins test for tarred dataset creation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1302,7 +1302,7 @@ pipeline {
               python create_tarred_parallel_dataset.py \
               --src_fname /home/TestData/nlp/nmt/toy_data/wmt14-de-en.src \
               --tgt_fname /home/TestData/nlp/nmt/toy_data/wmt14-de-en.ref \
-              --out_dir $PWD/preproc_out_dir \
+              --out_dir $PWD/out_dir \
               --encoder_tokenizer_vocab_size=2000 \
               --decoder_tokenizer_vocab_size=2000 \
               --tokens_in_batch=1000 \


### PR DESCRIPTION
Two tests in parallel were outputting to the same directory.