### PR TITLE
Add FastEmit support for RNNT Losses

### DIFF
--- a/examples/asr/experimental/contextnet_rnnt/config_rnnt.yaml
+++ b/examples/asr/experimental/contextnet_rnnt/config_rnnt.yaml
@@ -191,6 +191,11 @@ model:
       tsd_max_sym_exp: 50  # for Time Synchronous Decoding
       alsd_max_target_len: 2.0  # for Alignment-Length Synchronous Decoding
 
+  loss:
+    loss_name: "default"
+    warprnnt_numba_kwargs:
+      fastemit_lambda: 0.0
+
   optim:
     name: adam
     # _target_: nemo.core.optim.optimizers.Adam

--- a/examples/asr/experimental/contextnet_rnnt/config_rnnt_bpe.yaml
+++ b/examples/asr/experimental/contextnet_rnnt/config_rnnt_bpe.yaml
@@ -192,6 +192,11 @@ model:
       tsd_max_sym_exp: 50  # for Time Synchronous Decoding
       alsd_max_target_len: 2.0  # for Alignment-Length Synchronous Decoding
 
+  loss:
+    loss_name: "default"
+    warprnnt_numba_kwargs:
+      fastemit_lambda: 0.0
+
   optim:
     name: adam
     # _target_: nemo.core.optim.optimizers.Adam

--- a/nemo/collections/asr/losses/rnnt.py
+++ b/nemo/collections/asr/losses/rnnt.py
@@ -32,6 +32,7 @@ from dataclasses import dataclass
 from typing import Optional
 
 import torch
+from omegaconf import DictConfig, OmegaConf
 
 from nemo.core.classes import Loss, typecheck
 from nemo.core.neural_types import LabelsType, LengthsType, LogprobsType, LossType, NeuralType
@@ -144,6 +145,9 @@ def resolve_rnnt_loss(loss_name: str, blank_idx: int, loss_kwargs: dict = None) 
     # Resolve loss functions sequentially
     loss_kwargs = {} if loss_kwargs is None else loss_kwargs
 
+    if isinstance(loss_kwargs, DictConfig):
+        loss_kwargs = OmegaConf.to_container(loss_kwargs, resolve=True)
+
     # Get actual loss name for `default`
     if loss_name == 'default':
         loss_name = loss_config.loss_name
@@ -156,7 +160,8 @@ def resolve_rnnt_loss(loss_name: str, blank_idx: int, loss_kwargs: dict = None) 
         _warn_unused_additional_kwargs(loss_name, loss_kwargs)
 
     elif loss_name == 'warprnnt_numba':
-        loss_func = RNNTLossNumba(blank=blank_idx, reduction='none')
+        fastemit_lambda = loss_kwargs.pop('fastemit_lambda', 0.0)
+        loss_func = RNNTLossNumba(blank=blank_idx, reduction='none', fastemit_lambda=fastemit_lambda)
         _warn_unused_additional_kwargs(loss_name, loss_kwargs)
 
     else:
@@ -194,7 +199,19 @@ class RNNTLoss(Loss):
         albiet there is a small speed penalty for JIT numba compile.
 
         Note:
-            Requires the pytorch bindings to be installed prior to calling this class.
+            Requires Numba 0.53.0 or later to be installed to use this loss function.
+
+        Losses can be selected via the config, and optionally be passed keyword arguments as follows.
+
+        Examples:
+            .. code-block:: yaml
+
+                model:  # RNNT Model config
+                    ...
+                    loss:
+                        loss_name: "warprnnt_numba"
+                        warprnnt_numba_kwargs:
+                            fastemit_lambda: 0.0
 
         Warning:
             In the case that GPU memory is exhausted in order to compute RNNTLoss, it might cause

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt.py
@@ -44,6 +44,7 @@ def rnnt_loss_cpu(
     costs: torch.Tensor,
     grads: torch.Tensor,
     blank_label: int,
+    fastemit_lambda: float,
     num_threads: int,
 ):
     """
@@ -59,6 +60,8 @@ def rnnt_loss_cpu(
         costs: Zero vector of length [B] in which costs will be set.
         grads: Zero tensor of shape [B, T, U, V+1] where the gradient will be set.
         blank_label: Index of the blank token in the vocabulary.
+        fastemit_lambda: Float scaling factor for FastEmit regularization. Refer to
+            FastEmit: Low-latency Streaming ASR with Sequence-level Emission Regularization.
         num_threads: Number of threads for OpenMP.
     """
     # aliases
@@ -92,6 +95,7 @@ def rnnt_loss_cpu(
         alphabet_size=alphabet_size,
         workspace=cpu_workspace,
         blank=blank_label,
+        fastemit_lambda=fastemit_lambda,
         num_threads=num_threads,
         batch_first=True,
     )
@@ -136,6 +140,7 @@ def rnnt_loss_gpu(
     costs: torch.Tensor,
     grads: torch.Tensor,
     blank_label: int,
+    fastemit_lambda: float,
     num_threads: int,
 ):
     """
@@ -151,6 +156,8 @@ def rnnt_loss_gpu(
         costs: Zero vector of length [B] in which costs will be set.
         grads: Zero tensor of shape [B, T, U, V+1] where the gradient will be set.
         blank_label: Index of the blank token in the vocabulary.
+        fastemit_lambda: Float scaling factor for FastEmit regularization. Refer to
+            FastEmit: Low-latency Streaming ASR with Sequence-level Emission Regularization.
         num_threads: Number of threads for OpenMP.
     """
     minibatch_size = acts.shape[0]
@@ -189,6 +196,7 @@ def rnnt_loss_gpu(
         alphabet_size=alphabet_size,
         workspace=gpu_workspace,
         blank=blank_label,
+        fastemit_lambda=fastemit_lambda,
         num_threads=num_threads,
         stream=stream,
     )

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_numpy.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_numpy.py
@@ -186,6 +186,8 @@ def compute_gradient(log_probs, alphas, betas, labels, blank, fastemit_lambda):
         for u, l in enumerate(labels):
             grads[:, u, l] = (1.0 + fastemit_lambda) * grads[:, u, l]
 
+    print("numpy", alphas[0, 0], betas[1, 0], log_probs[0, 0, 0], log_like, "final ", grads[0, 0, 0])
+
     return grads
 
 

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_numpy.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_numpy.py
@@ -33,6 +33,57 @@ from torch.autograd import Function, Variable
 from torch.nn import Module
 
 
+def check_type(var, t, name):
+    if var.dtype is not t:
+        raise TypeError("{} must be {}".format(name, t))
+
+
+def check_contiguous(var, name):
+    if not var.is_contiguous():
+        raise ValueError("{} must be contiguous".format(name))
+
+
+def check_dim(var, dim, name):
+    if len(var.shape) != dim:
+        raise ValueError("{} must be {}D".format(name, dim))
+
+
+def certify_inputs(log_probs, labels, lengths, label_lengths):
+    # check_type(log_probs, torch.float32, "log_probs")
+    check_type(labels, torch.int32, "labels")
+    check_type(label_lengths, torch.int32, "label_lengths")
+    check_type(lengths, torch.int32, "lengths")
+    check_contiguous(log_probs, "log_probs")
+    check_contiguous(labels, "labels")
+    check_contiguous(label_lengths, "label_lengths")
+    check_contiguous(lengths, "lengths")
+
+    if lengths.shape[0] != log_probs.shape[0]:
+        raise ValueError(
+            f"Must have a length per example. "
+            f"Given lengths dim: {lengths.shape[0]}, "
+            f"Log probs dim : {log_probs.shape[0]}"
+        )
+    if label_lengths.shape[0] != log_probs.shape[0]:
+        raise ValueError(
+            "Must have a label length per example. "
+            f"Given label lengths dim : {label_lengths.shape[0]}, "
+            f"Log probs dim : {log_probs.shape[0]}"
+        )
+
+    check_dim(log_probs, 4, "log_probs")
+    check_dim(labels, 2, "labels")
+    check_dim(lengths, 1, "lenghts")
+    check_dim(label_lengths, 1, "label_lenghts")
+    max_T = torch.max(lengths)
+    max_U = torch.max(label_lengths)
+    T, U = log_probs.shape[1:3]
+    if T != max_T:
+        raise ValueError(f"Input length mismatch! Given T: {T}, Expected max T from input lengths: {max_T}")
+    if U != max_U + 1:
+        raise ValueError(f"Output length mismatch! Given U: {U}, Expected max U from target lengths: {max_U} + 1")
+
+
 def _assert_no_grad(tensor):
     assert not tensor.requires_grad, (
         "gradients only computed for log_probs - please " "mark other tensors as not requiring gradients"
@@ -102,7 +153,7 @@ def backward_pass(log_probs, labels, blank):
     return betas, betas[0, 0]
 
 
-def compute_gradient(log_probs, alphas, betas, labels, blank):
+def compute_gradient(log_probs, alphas, betas, labels, blank, fastemit_lambda):
     """
     Computes the gradients of the log_probs with respect to the log probability of this step occuring.
 
@@ -129,10 +180,52 @@ def compute_gradient(log_probs, alphas, betas, labels, blank):
         grads[:, u, l] = alphas[:, u] + betas[:, u + 1]
 
     grads = -np.exp(grads + log_probs - log_like)
+
+    if fastemit_lambda > 0.0:
+        for u, l in enumerate(labels):
+            grads[:, u, l] = (1.0 + fastemit_lambda) * grads[:, u, l]
+
     return grads
 
 
-def transduce(log_probs, labels, blank=0):
+def fastemit_regularization(log_probs, labels, alphas, betas, blank, fastemit_lambda):
+    """
+    Computes probability of the forward variable alpha.
+
+    Args:
+        log_probs: Tensor of shape [T, U, V+1]
+        labels: Labels of shape [B, U]
+        blank: Index of the blank token.
+
+    Returns:
+        A tuple of the forward variable probabilities - alpha of shape [T, U]
+        and the log likelihood of this forward step.
+    """
+    T, U, _ = log_probs.shape
+    alignment = np.zeros((T, U), dtype='f')
+
+    for u in range(U):
+        for n in range(0, T + U):
+            t = n - u
+
+
+
+    # log_like = betas[0, 0]
+
+    # // grad to last blank transition
+    # grads[T - 1, U - 1, blank] = alphas[T - 1, U - 1]
+    #
+    # grads[: T - 1, :, blank] = alphas[: T - 1, :] + betas[1:, :]
+    # for u, l in enumerate(labels):
+    #     grads[:, u, l] = alphas[:, u] + betas[:, u + 1]
+    #
+    # grads = -np.exp(grads + log_probs - log_like)
+
+    loglike = alphas[T - 1, U - 1] + log_probs[T - 1, U - 1, blank]
+    return alphas, loglike
+
+
+def transduce(log_probs, labels, blank=0, fastemit_lambda=0.0):
     """
     Args:
         log_probs: 3D array with shape
@@ -145,11 +238,11 @@ def transduce(log_probs, labels, blank=0):
     """
     alphas, ll_forward = forward_pass(log_probs, labels, blank)
     betas, ll_backward = backward_pass(log_probs, labels, blank)
-    grads = compute_gradient(log_probs, alphas, betas, labels, blank)
-    return -ll_forward, grads
+    grads = compute_gradient(log_probs, alphas, betas, labels, blank, fastemit_lambda)
+    return -ll_forward, grads, alphas, betas
 
 
-def transduce_batch(log_probs, labels, flen, glen, blank=0):
+def transduce_batch(log_probs, labels, flen, glen, blank=0, fastemit_lambda=0.0):
     """
     Compute the transducer loss of the batch.
 
@@ -168,17 +261,25 @@ def transduce_batch(log_probs, labels, flen, glen, blank=0):
     for b in range(log_probs.shape[0]):
         t = int(flen[b])
         u = int(glen[b]) + 1
-        ll, g = transduce(log_probs[b, :t, :u, :], labels[b, : u - 1], blank)
+        ll, g, alphas, betas = transduce(log_probs[b, :t, :u, :], labels[b, : u - 1], blank, fastemit_lambda)
         grads[b, :t, :u, :] = g
+
+        _ = fastemit_regularization(log_probs[b, :t, :u, :], labels[b, : u - 1], alphas, betas, blank, fastemit_lambda)
+
         costs.append(ll)
     return costs, grads
 
 
 class _RNNT(Function):
     @staticmethod
-    def forward(ctx, acts, labels, act_lens, label_lens, blank):
+    def forward(ctx, acts, labels, act_lens, label_lens, blank, fastemit_lambda):
         costs, grads = transduce_batch(
-            acts.detach().cpu().numpy(), labels.cpu().numpy(), act_lens.cpu().numpy(), label_lens.cpu().numpy(), blank,
+            acts.detach().cpu().numpy(),
+            labels.cpu().numpy(),
+            act_lens.cpu().numpy(),
+            label_lens.cpu().numpy(),
+            blank,
+            fastemit_lambda,
         )
 
         costs = torch.FloatTensor([sum(costs)])
@@ -189,7 +290,7 @@ class _RNNT(Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        return ctx.grads, None, None, None, None
+        return ctx.grads, None, None, None, None, None
 
 
 class RNNTLoss(Module):
@@ -198,9 +299,10 @@ class RNNTLoss(Module):
         `blank_label` (int): default 0 - label index of blank token
     """
 
-    def __init__(self, blank: int = 0):
+    def __init__(self, blank: int = 0, fastemit_lambda: float = 0.0):
         super(RNNTLoss, self).__init__()
         self.blank = blank
+        self.fastemit_lambda = fastemit_lambda
         self.rnnt = _RNNT.apply
 
     def forward(self, acts, labels, act_lens, label_lens):
@@ -208,6 +310,18 @@ class RNNTLoss(Module):
         _assert_no_grad(labels)
         _assert_no_grad(act_lens)
         _assert_no_grad(label_lens)
+        certify_inputs(acts, labels, act_lens, label_lens)
 
         acts = torch.nn.functional.log_softmax(acts, -1)
-        return self.rnnt(acts, labels, act_lens, label_lens, self.blank)
+        return self.rnnt(acts, labels, act_lens, label_lens, self.blank, self.fastemit_lambda)
+
+
+if __name__ == '__main__':
+    loss = RNNTLoss(fastemit_lambda=0.01)
+
+    acts = torch.randn(1, 10, 11, 3)
+    labels = torch.tensor([[0, 1, 1, 2, 1, 1, 2, 1, 1, 2]], dtype=torch.int32)
+    act_lens = torch.tensor([10], dtype=torch.int32)
+    label_lens = torch.tensor([len(labels[0])], dtype=torch.int32)
+
+    loss_val = loss(acts, labels, act_lens, label_lens)

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_numpy.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_numpy.py
@@ -295,7 +295,7 @@ class _RNNT(Function):
         costs = torch.FloatTensor([sum(costs)])
         grads = torch.Tensor(grads).to(acts)
 
-        ctx.grads = Variable(grads)
+        ctx.grads = grads
         return costs
 
     @staticmethod

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_numpy.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_numpy.py
@@ -186,8 +186,6 @@ def compute_gradient(log_probs, alphas, betas, labels, blank, fastemit_lambda):
         for u, l in enumerate(labels):
             grads[:, u, l] = (1.0 + fastemit_lambda) * grads[:, u, l]
 
-    print("numpy", alphas[0, 0], betas[1, 0], log_probs[0, 0, 0], log_like, "final ", grads[0, 0, 0])
-
     return grads
 
 
@@ -274,7 +272,9 @@ def transduce_batch(log_probs, labels, flen, glen, blank=0, fastemit_lambda=0.0)
         ll, g, alphas, betas = transduce(log_probs[b, :t, :u, :], labels[b, : u - 1], blank, fastemit_lambda)
         grads[b, :t, :u, :] = g
 
-        reg = fastemit_regularization(log_probs[b, :t, :u, :], labels[b, : u - 1], alphas, betas, blank, fastemit_lambda)
+        reg = fastemit_regularization(
+            log_probs[b, :t, :u, :], labels[b, : u - 1], alphas, betas, blank, fastemit_lambda
+        )
         ll += reg
         costs.append(ll)
     return costs, grads

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
@@ -76,6 +76,7 @@ class _RNNTNumba(Function):
                 if grads is not None:
                     grads /= minibatch_size
 
+        print("final cuda grad", grads[0, 0, 0, 0])
         # costs = costs.to(log_probs.device)
         ctx.grads = grads
 

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
@@ -38,12 +38,14 @@ __all__ = ['rnnt_loss', 'RNNTLossNumba']
 
 class _RNNTNumba(Function):
     @staticmethod
-    def forward(ctx, acts, labels, act_lens, label_lens, blank, reduction):
+    def forward(ctx, acts, labels, act_lens, label_lens, blank, reduction, fastemit_lambda):
         """
         log_probs: Tensor of (batch x seqLength x labelLength x outputDim) containing output from network
         labels: 2 dimensional Tensor containing all the targets of the batch with zero padded
         act_lens: Tensor of size (batch) containing size of each output sequence from the network
         label_lens: Tensor of (batch) containing label length of each example
+        fastemit_lambda: Float scaling factor for FastEmit regularization. Refer to
+            FastEmit: Low-latency Streaming ASR with Sequence-level Emission Regularization.
         """
         is_cuda = acts.is_cuda
 
@@ -62,6 +64,7 @@ class _RNNTNumba(Function):
             costs=costs,
             grads=grads,
             blank_label=blank,
+            fastemit_lambda=fastemit_lambda,
             num_threads=0,
         )
 
@@ -82,7 +85,7 @@ class _RNNTNumba(Function):
     def backward(ctx, grad_output):
         if grad_output is not None and ctx.grads is not None:
             grad_output = grad_output.view(-1, 1, 1, 1).to(ctx.grads)
-            return ctx.grads.mul_(grad_output), None, None, None, None, None
+            return ctx.grads.mul_(grad_output), None, None, None, None, None, None
 
 
 def rnnt_loss(acts, labels, act_lens, label_lens, blank=0, reduction='mean'):
@@ -114,9 +117,10 @@ class RNNTLossNumba(Module):
             then the mean over the batch is taken. Default: 'mean'
     """
 
-    def __init__(self, blank=0, reduction='mean'):
+    def __init__(self, blank=0, reduction='mean', fastemit_lambda: float = 0.0):
         super(RNNTLossNumba, self).__init__()
         self.blank = blank
+        self.fastemit_lambda = fastemit_lambda
         self.reduction = reduction
         self.loss = _RNNTNumba.apply
 
@@ -132,7 +136,7 @@ class RNNTLossNumba(Module):
             # log_softmax is computed within GPU version.
             acts = torch.nn.functional.log_softmax(acts, -1)
 
-        return self.loss(acts, labels, act_lens, label_lens, self.blank, self.reduction)
+        return self.loss(acts, labels, act_lens, label_lens, self.blank, self.reduction, self.fastemit_lambda)
 
 
 def check_type(var, t, name):

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
@@ -76,8 +76,6 @@ class _RNNTNumba(Function):
                 if grads is not None:
                     grads /= minibatch_size
 
-        print("final cuda grad", grads[0, 0, 0, 0])
-        # costs = costs.to(log_probs.device)
         ctx.grads = grads
 
         return costs

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/cpu_utils/cpu_rnnt.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/cpu_utils/cpu_rnnt.py
@@ -146,6 +146,7 @@ class CPURNNT:
         alphabet_size: int,
         workspace: torch.Tensor,
         blank: int,
+        fastemit_lambda: float,
         num_threads: int,
         batch_first: bool,
     ):
@@ -160,6 +161,8 @@ class CPURNNT:
             workspace: An allocated chunk of memory that will be sliced off and reshaped into required
                 blocks used as working memory.
             blank: Index of the RNNT blank token in the vocabulary. Generally the first or last token in the vocab.
+            fastemit_lambda: Float scaling factor for FastEmit regularization. Refer to
+                FastEmit: Low-latency Streaming ASR with Sequence-level Emission Regularization.
             num_threads: Number of OMP threads to launch.
             batch_first: Bool that decides if batch dimension is first or third.
         """
@@ -169,6 +172,7 @@ class CPURNNT:
         self.alphabet_size_ = alphabet_size
         self.workspace = workspace  # a flat vector of floatX numbers that represents allocated memory slices
         self.blank_ = blank
+        self.fastemit_lambda_ = fastemit_lambda
         self.num_threads_ = num_threads
         self.batch_first = batch_first
 
@@ -198,6 +202,10 @@ class CPURNNT:
         llBackward = self.compute_betas_and_grads(
             grad, rnntm.log_probs2, T, U, rnntm.alphas, rnntm.betas, labels, llForward
         )
+
+        # Scale llForward by FastEmit lambda
+        llForward *= (1.0 + self.fastemit_lambda_)
+        llBackward *= (1.0 + self.fastemit_lambda_)
 
         diff = (llForward - llBackward).abs()
         if diff > 0.1:
@@ -291,7 +299,9 @@ class CPURNNT:
 
                 if u < U - 1:
                     g = alphas[idx(t, u)] + betas[idx(t, u + 1)]
-                    grad[idx(t, u, labels[u])] = -torch.exp(log_probs[idx(t, u) * 2 + 1] + g - loglike)
+                    grad[idx(t, u, labels[u])] = -torch.exp(
+                        math.log1p(self.fastemit_lambda_) + log_probs[idx(t, u) * 2 + 1] + g - loglike
+                    )
 
         # // gradient to the last blank transition
         grad[idx(T - 1, U - 1, self.blank_)] = -torch.exp(

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/cpu_utils/cpu_rnnt.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/cpu_utils/cpu_rnnt.py
@@ -204,8 +204,8 @@ class CPURNNT:
         )
 
         # Scale llForward by FastEmit lambda
-        llForward *= (1.0 + self.fastemit_lambda_)
-        llBackward *= (1.0 + self.fastemit_lambda_)
+        llForward *= 1.0 + self.fastemit_lambda_
+        llBackward *= 1.0 + self.fastemit_lambda_
 
         diff = (llForward - llBackward).abs()
         if diff > 0.1:

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt.py
@@ -229,7 +229,8 @@ class GPURNNT:
         # compute negative log likelihood.
         for mb in range(self.minibatch_):
             # Scale llForward by FastEmit lambda
-            costs[mb] = (1.0 + self.fastemit_lambda_) * -costs[mb]
+            costs[mb] = -costs[mb]
+            costs[mb] = (1.0 + self.fastemit_lambda_) * costs[mb]
 
         return global_constants.RNNTStatus.RNNT_STATUS_SUCCESS
 

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt.py
@@ -39,7 +39,16 @@ from nemo.collections.asr.parts.numba.rnnt_loss.utils.cuda_utils import gpu_rnnt
 
 class GPURNNT:
     def __init__(
-        self, minibatch: int, maxT: int, maxU: int, alphabet_size: int, workspace, blank: int, num_threads: int, stream
+        self,
+        minibatch: int,
+        maxT: int,
+        maxU: int,
+        alphabet_size: int,
+        workspace,
+        blank: int,
+        fastemit_lambda,
+        num_threads: int,
+        stream,
     ):
         """
         Helper class to launch the CUDA Kernels to compute the Transducer Loss.
@@ -52,6 +61,8 @@ class GPURNNT:
             workspace: An allocated chunk of memory that will be sliced off and reshaped into required
                 blocks used as working memory.
             blank: Index of the RNNT blank token in the vocabulary. Generally the first or last token in the vocab.
+            fastemit_lambda: Float scaling factor for FastEmit regularization. Refer to
+                FastEmit: Low-latency Streaming ASR with Sequence-level Emission Regularization.
             num_threads: Number of OMP threads to launch.
             stream: Numba Cuda Stream.
         """
@@ -63,6 +74,7 @@ class GPURNNT:
             workspace
         )  # a flat vector of floatX numbers that represents allocated memory slices
         self.blank_ = blank
+        self.fastemit_lambda_ = fastemit_lambda
         self.num_threads_ = num_threads
         self.stream_ = stream  # type: cuda.cudadrv.driver.Stream
 
@@ -207,6 +219,7 @@ class GPURNNT:
                 self.maxU_,
                 self.alphabet_size_,
                 self.blank_,
+                self.fastemit_lambda_,
             )
 
         # // cost
@@ -215,7 +228,8 @@ class GPURNNT:
 
         # compute negative log likelihood.
         for mb in range(self.minibatch_):
-            costs[mb] = -costs[mb]
+            # Scale llForward by FastEmit lambda
+            costs[mb] = (1.0 + self.fastemit_lambda_) * -costs[mb]
 
         return global_constants.RNNTStatus.RNNT_STATUS_SUCCESS
 

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt_kernel.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt_kernel.py
@@ -99,8 +99,6 @@ def compute_alphas_kernel(
         maxU: The maximum possible target sequence length. Represents U in the logprobs tensor.
         alphabet_size: The vocabulary dimension V+1 (inclusive of RNNT blank).
         blank_: Index of the RNNT blank token in the vocabulary. Generally the first or last token in the vocab.
-        fastemit_lambda: Float scaling factor for FastEmit regularization. Refer to
-            FastEmit: Low-latency Streaming ASR with Sequence-level Emission Regularization.
 
     Updates:
         Kernel inplace updates the following inputs:
@@ -371,7 +369,9 @@ def compute_grad_kernel(
                 #     print(mb, t, u, idx, "init u grad", grad)
 
                 # math.log1p(fastemit_lambda) +
-                grad -= math.exp(math.log1p(fastemit_lambda) + alphas[col] + logpk - logll[mb] + betas[col + 1])
+                grad -= math.exp(alphas[col] + logpk - logll[mb] + betas[col + 1])
+
+                # print("LABEL", mb, t, u, idx, "label", labels[u], "grad", grad)
 
                 # if mb == 0 and t == 0 and u == 0:
                 #     print(mb, t, u, idx, "final u grad", grad)

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt_kernel.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt_kernel.py
@@ -349,22 +349,23 @@ def compute_grad_kernel(
                 if u < U - 1:
                     fastemit_grad = fastemit_lambda * math.exp(
                         alphas[col]
+                        + (denom[col] + acts[col * alphabet_size + labels[u]])
                         + betas[col + 1]
                         + logpk
                         - logll[mb]
-                        + logp(denom, acts, maxT, maxU, alphabet_size, mb, t, u, u + 1)
                     )
                 else:
                     fastemit_grad = 0.0
             else:
                 fastemit_grad = 0.0
 
+            if mb == 0 and t == 0 and u == 1:
+                print(mb, t, u, idx, "grad", grad, "fastemit grad", fastemit_grad)
+
             # // grad to last blank transition
             # grad[b, T-1, U-1, v=blank] -= exp(alphas[b, t, u) + logpk - logll[b])
             if (idx == blank_) and (t == T - 1) and (u == U - 1):
-
                 grad -= math.exp(alphas[col] + logpk - logll[mb])
-                pass
 
             # grad of blank across t < T;
             # grad[b, t<T-1, u, v=blank] -= exp(alphas[b, t, u] + logpk - logll[b] betas[b, t + 1, u])
@@ -377,6 +378,9 @@ def compute_grad_kernel(
                 # grad -= fastemit_lambda * (math.exp(alphas[col] + betas[col + 1] + logpk - logll[mb]))
                 grad += fastemit_grad
                 grad -= math.exp(alphas[col] + logpk - logll[mb] + betas[col + maxU])
+
+                if mb == 0 and t == 0 and u == 1:
+                    print(mb, t, u, idx, " final t grad", grad)
 
                 # if mb == 0 and t == 0 and u == 0 and idx == 0:
                 #     print("cuda", alphas[col], betas[col + maxU], logpk, logll[mb], "final ", grad)
@@ -395,6 +399,9 @@ def compute_grad_kernel(
                 # math.log1p(fastemit_lambda) +
                 grad += fastemit_grad
                 grad -= math.exp(math.log1p(fastemit_lambda) + alphas[col] + logpk - logll[mb] + betas[col + 1])
+
+                if mb == 0 and t == 0 and u == 1:
+                    print(mb, t, u, idx, " final u grad", grad)
 
                 # print("LABEL", mb, t, u, idx, "label", labels[u], "grad", grad)
 

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt_kernel.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/cuda_utils/gpu_rnnt_kernel.py
@@ -349,6 +349,7 @@ def compute_grad_kernel(
             # grad[b, T-1, U-1, v=blank] -= exp(alphas[b, t, u) + logpk - logll[b])
             if (idx == blank_) and (t == T - 1) and (u == U - 1):
                 grad -= math.exp(alphas[col] + logpk - logll[mb])
+                pass
 
             # grad of blank across t < T;
             # grad[b, t<T-1, u, v=blank] -= exp(alphas[b, t, u] + logpk - logll[b] betas[b, t + 1, u])
@@ -356,7 +357,12 @@ def compute_grad_kernel(
                 # if mb == 0 and t == 0 and u == 0 and idx == 0:
                 #     print(mb, t, u, idx, "init t grad", grad)
 
-                grad -= math.exp(alphas[col] + logpk - logll[mb] + betas[col + maxU])
+                grad_t = math.exp(alphas[col] + logpk - logll[mb] + betas[col + maxU])
+                grad += -grad_t
+
+                if mb == 0 and t == 0 and u == 0 and idx == 0:
+                    print("cuda", alphas[col], betas[col + maxU], logpk, logll[mb], "final ", grad)
+                    # print("cuda check",  -math.exp(alphas[col] + logpk - logll[mb] + betas[col + maxU]))
 
                 # if mb == 0 and t == 0 and u == 0 and idx == 0:
                 #     print(mb, t, u, idx, "init t grad", grad)

--- a/tests/collections/asr/numba/rnnt_loss/test_rnnt_pytorch.py
+++ b/tests/collections/asr/numba/rnnt_loss/test_rnnt_pytorch.py
@@ -119,10 +119,9 @@ class TestRNNTLossPytorch:
 
     @pytest.mark.unit
     @pytest.mark.parametrize('device', DEVICES)
-    def test_case_small_random_fastemit_reg(self, device):
+    @pytest.mark.parametrize('fastemit_lambda', [1.0, 0.01, 0.00001])
+    def test_case_small_random_fastemit_reg(self, device, fastemit_lambda):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
-
-        fastemit_lambda = 1.0
 
         rng = np.random.RandomState(0)
         acts = rng.randn(1, 4, 3, 3)
@@ -133,11 +132,6 @@ class TestRNNTLossPytorch:
 
         fn_np = RNNTLoss_Numpy(fastemit_lambda=fastemit_lambda)
         np_cost, np_grads = wrap_and_call(fn_np, acts, labels, device)
-
-        if device == 'cuda':
-            print("pt grad\n", pt_grads)
-            print("np grad\n", np_grads)
-            print('diff\n', np.abs(pt_grads - np_grads))
 
         assert np.allclose(pt_cost, np_cost, rtol=1e-6), "small_random_test costs mismatch."
         assert np.allclose(pt_grads, np_grads, atol=1e-5, rtol=1e-5), "small_random_test gradient mismatch."

--- a/tests/collections/asr/numba/rnnt_loss/test_rnnt_pytorch.py
+++ b/tests/collections/asr/numba/rnnt_loss/test_rnnt_pytorch.py
@@ -92,6 +92,7 @@ class TestRNNTLossPytorch:
                 ]
             ]
         )
+
         assert np.allclose(pt_cost, expected_cost, rtol=1e-6), "small_test costs mismatch."
         assert np.allclose(pt_grads, expected_grads), "small_test gradient mismatch."
 
@@ -121,7 +122,7 @@ class TestRNNTLossPytorch:
     def test_case_small_random_fastemit_reg(self, device):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
-        fastemit_lambda = 10.0
+        fastemit_lambda = 1.0
 
         rng = np.random.RandomState(0)
         acts = rng.randn(1, 4, 3, 3)

--- a/tests/collections/asr/test_asr_rnnt_encdec_model.py
+++ b/tests/collections/asr/test_asr_rnnt_encdec_model.py
@@ -76,6 +76,8 @@ def asr_model():
 
     decoding = {'strategy': 'greedy_batch', 'greedy': {'max_symbols': 30}}
 
+    loss = {'loss_name': 'default', 'warprnnt_numba_kwargs': {'fastemit_lambda': 0.001}}
+
     modelConfig = DictConfig(
         {
             'labels': ListConfig(labels),
@@ -85,6 +87,7 @@ def asr_model():
             'decoder': DictConfig(decoder),
             'joint': DictConfig(joint),
             'decoding': DictConfig(decoding),
+            'loss': DictConfig(loss),
         }
     )
 

--- a/tests/collections/asr/test_asr_rnnt_encoder_model_bpe.py
+++ b/tests/collections/asr/test_asr_rnnt_encoder_model_bpe.py
@@ -73,6 +73,8 @@ def asr_model(test_data_dir):
 
     tokenizer = {'dir': os.path.join(test_data_dir, "asr", "tokenizers", "an4_wpe_128"), 'type': 'wpe'}
 
+    loss = {'loss_name': 'default', 'warprnnt_numba_kwargs': {'fastemit_lambda': 0.001}}
+
     modelConfig = DictConfig(
         {
             'preprocessor': DictConfig(preprocessor),
@@ -82,6 +84,7 @@ def asr_model(test_data_dir):
             'joint': DictConfig(joint),
             'tokenizer': DictConfig(tokenizer),
             'decoding': DictConfig(decoding),
+            'loss': DictConfig(loss),
         }
     )
 


### PR DESCRIPTION
# Changelog
- Adds Numpy + CPU + Numba CUDA support for FastEmit regularization from the paper [FastEmit: Low-latency Streaming ASR with Sequence-level Emission Regularization](https://arxiv.org/abs/2010.11148)

# Usage

```yaml
model:  # RNNT Model config
  ...
  loss:
    loss_name: "warprnnt_numba"
    warprnnt_numba_kwargs:
      fastemit_lambda: 0.0
```