### PR TITLE
Update ASR scripts for tokenizer building and tarred dataset building

### DIFF
--- a/examples/asr/asr_webapp/Dockerfile
+++ b/examples/asr/asr_webapp/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG BASE_IMAGE=nvcr.io/nvidia/nemo:1.0.0rc1
+ARG BASE_IMAGE=nvcr.io/nvidia/nemo:1.0.1
 
 # build an image that includes only the nemo dependencies, ensures that dependencies
 # are included first for optimal caching, and useful for building a development

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -128,6 +128,13 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
         results.append(model)
 
         model = PretrainedModelInfo(
+            pretrained_model_name="stt_zh_citrinet_1024_gamma_0_25",
+            description="For details about this model, please visit https://ngc.nvidia.com/catalog/models/nvidia:nemo:stt_zh_citrinet_1024_gamma_0_25",
+            location="https://api.ngc.nvidia.com/v2/models/nvidia/nemo/stt_zh_citrinet_1024_gamma_0_25/versions/1.0.0/files/stt_zh_citrinet_1024_gamma_0_25.nemo",
+        )
+        results.append(model)
+
+        model = PretrainedModelInfo(
             pretrained_model_name="asr_talknet_aligner",
             description="For details about this model, please visit https://ngc.nvidia.com/catalog/models/nvidia:nemo:asr_talknet_aligner",
             location="https://api.ngc.nvidia.com/v2/models/nvidia/nemo/asr_talknet_aligner/versions/1.0.0rc1/files/qn5x5_libri_tts_phonemes.nemo",

--- a/scripts/speech_recognition/convert_to_tarred_audio_dataset.py
+++ b/scripts/speech_recognition/convert_to_tarred_audio_dataset.py
@@ -107,8 +107,9 @@ parser.add_argument(
 parser.add_argument(
     '--max_duration',
     default=None,
+    required=True,
     type=float,
-    help='Maximum duration of audio clip in the dataset. By default, it is None and will not filter files.',
+    help='Maximum duration of audio clip in the dataset. By default, it is None and is required to be set.',
 )
 parser.add_argument(
     '--min_duration',

--- a/scripts/tokenizers/process_asr_text_tokenizer.py
+++ b/scripts/tokenizers/process_asr_text_tokenizer.py
@@ -106,6 +106,9 @@ parser.add_argument(
     help="Character coverage percentage for SentencePiece tokenization. For languages "
     "with large vocabulary, should be close to 0.9995, otherwise kept as 1.0",
 )
+parser.add_argument('--spe_bos', action='store_true', help='Add <s> token to SentencePiece Tokenizer.')
+parser.add_argument('--spe_eos', action='store_true', help='Add </s> token to SentencePiece Tokenizer.')
+parser.add_argument('--spe_pad', action='store_true', help='Add <pad> token to SentencePiece Tokenizer.')
 parser.add_argument(
     '--spe_sample_size',
     type=int,
@@ -173,6 +176,9 @@ def __process_data(
     spe_train_extremely_large_corpus: bool,
     spe_sample_size: int,
     spe_max_sentencepiece_length: int,
+    spe_bos: bool,
+    spe_eos: bool,
+    spe_pad: bool,
     lower_case: bool,
 ):
     """
@@ -191,6 +197,9 @@ def __process_data(
             this flag can be set to try to trained the tokenizer. Will silently fail if it runs out of RAM.
         spe_max_sentencepiece_length: Limits the maximum length of the SentencePiece subword that can be constructed.
             By default, no limit is placed.
+        spe_bos: Bool flag, whether to add <s> to SentencePiece tokenizer vocabulary.
+        spe_eos: Bool flag, whether to add </s> to SentencePiece tokenizer vocabulary.
+        spe_pad: Bool flag, whether to add <pad> to SentencePiece tokenizer vocabulary.
         lower_case: whether to tokenize with lower case character set only (for english)
 
     Returns:
@@ -222,6 +231,9 @@ def __process_data(
             character_coverage=spe_character_coverage,
             train_extremely_large_corpus=spe_train_extremely_large_corpus,
             max_sentencepiece_length=spe_max_sentencepiece_length,
+            bos=spe_bos,
+            eos=spe_eos,
+            pad=spe_pad,
         )
 
     else:
@@ -249,6 +261,7 @@ def main():
     spe_sample_size = args.spe_sample_size
     spe_train_extremely_large_corpus = args.spe_train_extremely_large_corpus
     spe_max_sentencepiece_length = args.spe_max_sentencepiece_length
+    spe_bos, spe_eos, spe_pad = args.spe_bos, args.spe_eos, args.spe_pad
     lower_case = args.lower_case
 
     if not os.path.exists(data_root):
@@ -272,6 +285,9 @@ def main():
         spe_sample_size=spe_sample_size,
         spe_train_extremely_large_corpus=spe_train_extremely_large_corpus,
         spe_max_sentencepiece_length=spe_max_sentencepiece_length,
+        spe_bos=spe_bos,
+        spe_eos=spe_eos,
+        spe_pad=spe_pad,
     )
 
     print("Serialized tokenizer at location :", tokenizer_path)

--- a/tutorials/tools/label-studio/setup-asr-preannotations.ipynb
+++ b/tutorials/tools/label-studio/setup-asr-preannotations.ipynb
@@ -25,7 +25,7 @@
    "source": [
     "!docker run --gpus all -it --rm --shm-size=8g \\\n",
     "-p 8888:8888 -p 6006:6006 -p 8080:8080 --ulimit memlock=-1 --ulimit \\\n",
-    "stack=67108864 --device=/dev/snd nvcr.io/nvidia/nemo:1.0.0rc1"
+    "stack=67108864 --device=/dev/snd nvcr.io/nvidia/nemo:1.0.1"
    ]
   },
   {


### PR DESCRIPTION
# Changelog
- Update docker container to nemo:1.0.1 
- Add Citrinet 1024 Gamma 0.25 model card for Mandarin to CTC char models
- Update tokenizer scripts to support adding bos, eos and pad tokens to SentencePiece tokenizers via `--spe_bos`, `--spe_eos` and `--spe_pad` flags.
- Update dataset building script to always provide a max length when building tarred datasets.

Signed-off-by: smajumdar <titu1994@gmail.com>