### PR TITLE
Bugfix adaptive spec augment time masking

### DIFF
--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -434,7 +434,7 @@ class SpectrogramAugmentation(NeuralModule):
         """
         return {
             "input_spec": NeuralType(('B', 'D', 'T'), SpectrogramType()),
-            "length": NeuralType(tuple('B'), LengthsType(), optional=True),
+            "length": NeuralType(tuple('B'), LengthsType()),
         }
 
     @property
@@ -474,7 +474,7 @@ class SpectrogramAugmentation(NeuralModule):
                 mask_value=mask_value,
             )
         else:
-            self.spec_augment = lambda input_spec: input_spec
+            self.spec_augment = lambda input_spec, length: input_spec
 
         # Check if numba is supported, and use a Numba kernel if it is
         if use_numba_spec_augment and numba_utils.numba_cuda_is_supported(__NUMBA_MINIMUM_VERSION__):
@@ -490,7 +490,7 @@ class SpectrogramAugmentation(NeuralModule):
             self.spec_augment_numba = None
 
     @typecheck()
-    def forward(self, input_spec, length=None):
+    def forward(self, input_spec, length):
         augmented_spec = self.spec_cutout(input_spec=input_spec)
 
         # To run the Numba kernel, correct numba version is required as well as
@@ -498,7 +498,7 @@ class SpectrogramAugmentation(NeuralModule):
         if self.spec_augment_numba is not None and spec_augment_launch_heuristics(augmented_spec, length):
             augmented_spec = self.spec_augment_numba(input_spec=augmented_spec, length=length)
         else:
-            augmented_spec = self.spec_augment(input_spec=augmented_spec)
+            augmented_spec = self.spec_augment(input_spec=augmented_spec, length=length)
         return augmented_spec
 
 

--- a/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
+++ b/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
@@ -267,7 +267,6 @@ class SpecAugmentNumba(nn.Module, Typing):
             else:
                 time_width = (
                     torch.tensor(self.time_width, dtype=torch.int32, device=input_spec.device)
-                    .clamp(min=1)
                     .unsqueeze(0)
                     .repeat(sh[0])
                 )

--- a/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
+++ b/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
@@ -254,7 +254,7 @@ class SpecAugmentNumba(nn.Module, Typing):
         # Construct the freq and time masks as well as start positions
         if self.freq_masks > 0:
             freq_starts = torch.randint(
-                0, sh[1] - self.freq_width, size=[bs, self.freq_masks], device=input_spec.device
+                0, sh[1] - self.freq_width + 1, size=[bs, self.freq_masks], device=input_spec.device
             )
             freq_lengths = torch.randint(0, self.freq_width + 1, size=[bs, self.freq_masks], device=input_spec.device)
         else:

--- a/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
+++ b/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
@@ -251,15 +251,10 @@ class SpecAugmentNumba(nn.Module, Typing):
         sh = input_spec.shape
         bs = sh[0]
 
-        if self.adaptive_temporal_width:
-            time_width = max(1, int(sh[2] * self.time_width))
-        else:
-            time_width = self.time_width
-
         # Construct the freq and time masks as well as start positions
         if self.freq_masks > 0:
             freq_starts = torch.randint(
-                0, sh[1] - self.freq_width + 1, size=[bs, self.freq_masks], device=input_spec.device
+                0, max(1, sh[1] - self.freq_width), size=[bs, self.freq_masks], device=input_spec.device
             )
             freq_lengths = torch.randint(0, self.freq_width + 1, size=[bs, self.freq_masks], device=input_spec.device)
         else:
@@ -267,10 +262,31 @@ class SpecAugmentNumba(nn.Module, Typing):
             freq_lengths = torch.zeros([bs, 1], dtype=torch.int64, device=input_spec.device)
 
         if self.time_masks > 0:
-            time_starts = torch.randint(
-                0, sh[2] - time_width + 1, size=[bs, self.time_masks], device=input_spec.device
-            )
-            time_lengths = torch.randint(0, time_width + 1, size=[bs, self.time_masks], device=input_spec.device)
+            if self.adaptive_temporal_width:
+                time_width = (length * self.time_width).int().clamp(min=1)
+            else:
+                time_width = (
+                    torch.tensor(self.time_width, dtype=torch.int32, device=input_spec.device)
+                    .clamp(min=1)
+                    .unsqueeze(0)
+                    .repeat(sh[0])
+                )
+
+            time_starts = []
+            time_lengths = []
+            for idx in range(sh[0]):
+                time_starts.append(
+                    torch.randint(
+                        0, max(1, length[idx] - time_width[idx]), size=[1, self.time_masks], device=input_spec.device
+                    )
+                )
+                time_lengths.append(
+                    torch.randint(0, time_width[idx] + 1, size=[1, self.time_masks], device=input_spec.device)
+                )
+
+            time_starts = torch.cat(time_lengths, 0)
+            time_lengths = torch.cat(time_lengths, 0)
+
         else:
             time_starts = torch.zeros([bs, 1], dtype=torch.int64, device=input_spec.device)
             time_lengths = torch.zeros([bs, 1], dtype=torch.int64, device=input_spec.device)

--- a/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
+++ b/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
@@ -254,7 +254,7 @@ class SpecAugmentNumba(nn.Module, Typing):
         # Construct the freq and time masks as well as start positions
         if self.freq_masks > 0:
             freq_starts = torch.randint(
-                0, max(1, sh[1] - self.freq_width), size=[bs, self.freq_masks], device=input_spec.device
+                0, sh[1] - self.freq_width, size=[bs, self.freq_masks], device=input_spec.device
             )
             freq_lengths = torch.randint(0, self.freq_width + 1, size=[bs, self.freq_masks], device=input_spec.device)
         else:

--- a/tests/collections/asr/numba/spec_augment/test_spec_aug_numba.py
+++ b/tests/collections/asr/numba/spec_augment/test_spec_aug_numba.py
@@ -61,7 +61,7 @@ def prepare_data(b, f, t, device='cuda', freq_masks=0, time_masks=0, freq_width=
 
     # Construct the freq and time masks as well as start positions
     if freq_masks > 0:
-        freq_starts = torch.randint(0, sh[1] - freq_width, size=[bs, freq_masks], device=x.device)
+        freq_starts = torch.randint(0, sh[1] - freq_width + 1, size=[bs, freq_masks], device=x.device)
         freq_lengths = torch.randint(0, freq_width + 1, size=[bs, freq_masks], device=x.device)
     else:
         freq_starts = torch.zeros([bs, 1], dtype=torch.int64, device=x.device)

--- a/tests/collections/asr/numba/spec_augment/test_spec_aug_numba.py
+++ b/tests/collections/asr/numba/spec_augment/test_spec_aug_numba.py
@@ -61,7 +61,7 @@ def prepare_data(b, f, t, device='cuda', freq_masks=0, time_masks=0, freq_width=
 
     # Construct the freq and time masks as well as start positions
     if freq_masks > 0:
-        freq_starts = torch.randint(0, max(1, sh[1] - freq_width), size=[bs, freq_masks], device=x.device)
+        freq_starts = torch.randint(0, sh[1] - freq_width, size=[bs, freq_masks], device=x.device)
         freq_lengths = torch.randint(0, freq_width + 1, size=[bs, freq_masks], device=x.device)
     else:
         freq_starts = torch.zeros([bs, 1], dtype=torch.int64, device=x.device)

--- a/tests/collections/asr/numba/spec_augment/test_spec_aug_numba.py
+++ b/tests/collections/asr/numba/spec_augment/test_spec_aug_numba.py
@@ -73,7 +73,6 @@ def prepare_data(b, f, t, device='cuda', freq_masks=0, time_masks=0, freq_width=
         else:
             time_width = (
                     torch.tensor(orginal_time_width, dtype=torch.int32, device=x.device)
-                    .clamp(min=1)
                     .unsqueeze(0)
                     .repeat(sh[0])
                 )

--- a/tests/collections/asr/numba/spec_augment/test_spec_aug_numba.py
+++ b/tests/collections/asr/numba/spec_augment/test_spec_aug_numba.py
@@ -57,22 +57,41 @@ def prepare_data(b, f, t, device='cuda', freq_masks=0, time_masks=0, freq_width=
 
         adaptive_temporal_width = True
 
-    if adaptive_temporal_width:
-        time_width = max(1, int(sh[2] * time_width))
-    else:
-        time_width = time_width
+    orginal_time_width = time_width
 
     # Construct the freq and time masks as well as start positions
     if freq_masks > 0:
-        freq_starts = torch.randint(0, sh[1] - freq_width + 1, size=[bs, freq_masks], device=x.device)
+        freq_starts = torch.randint(0, max(1, sh[1] - freq_width), size=[bs, freq_masks], device=x.device)
         freq_lengths = torch.randint(0, freq_width + 1, size=[bs, freq_masks], device=x.device)
     else:
         freq_starts = torch.zeros([bs, 1], dtype=torch.int64, device=x.device)
         freq_lengths = torch.zeros([bs, 1], dtype=torch.int64, device=x.device)
 
     if time_masks > 0:
-        time_starts = torch.randint(0, sh[2] - time_width + 1, size=[bs, time_masks], device=x.device)
-        time_lengths = torch.randint(0, time_width + 1, size=[bs, time_masks], device=x.device)
+        if adaptive_temporal_width:
+            time_width = (x_len * orginal_time_width).int().clamp(min=1)
+        else:
+            time_width = (
+                    torch.tensor(orginal_time_width, dtype=torch.int32, device=x.device)
+                    .clamp(min=1)
+                    .unsqueeze(0)
+                    .repeat(sh[0])
+                )
+
+        time_starts = []
+        time_lengths = []
+        for idx in range(sh[0]):
+            time_starts.append(
+                torch.randint(
+                    0, max(1, x_len[idx] - time_width[idx]), size=[1, time_masks], device=x.device
+                )
+            )
+            time_lengths.append(
+                torch.randint(0, time_width[idx] + 1, size=[1, time_masks], device=x.device)
+            )
+
+        time_starts = torch.cat(time_lengths, 0)
+        time_lengths = torch.cat(time_lengths, 0)
     else:
         time_starts = torch.zeros([bs, 1], dtype=torch.int64, device=x.device)
         time_lengths = torch.zeros([bs, 1], dtype=torch.int64, device=x.device)

--- a/tests/collections/asr/test_asr_modules.py
+++ b/tests/collections/asr/test_asr_modules.py
@@ -125,7 +125,7 @@ class TestASRModulesBasicTests:
         input_signal = torch.randn(size=(4, 512))
         length = torch.randint(low=161, high=500, size=[4])
         res0 = instance0(input_signal=input_signal, length=length)
-        res = instance1(input_spec=res0[0])
+        res = instance1(input_spec=res0[0], length=length)
 
         assert res.shape == res0[0].shape
 


### PR DESCRIPTION
# Bugfix
- Fix a bug in adaptive time masking where the mask start index could begin in a padded region, therefore making the mask useless (ASR losses dont access masked sections when computing loss).
- In effect, augmentation was reduced.