### PR TITLE
Change Jarvis to Riva in export.rst

### DIFF
--- a/docs/source/core/export.rst
+++ b/docs/source/core/export.rst
@@ -4,7 +4,7 @@ Exporting NeMo Models
 Exporting Models
 ----------------
 
-Most of the NeMo models can be exported to ONNX or TorchScript to be deployed for inference in optimized execution environments, such as Jarvis or Triton Inference Server.  
+Most of the NeMo models can be exported to ONNX or TorchScript to be deployed for inference in optimized execution environments, such as Riva or Triton Inference Server.  
 Export interface is provided by the ``Exportable`` mix-in class. If a model extends ``Exportable``, it can be exported by:
 
 .. code-block:: Python


### PR DESCRIPTION
Changing the product name from Jarvis to Riva in a nemo doc file export.rst that was not committed in the previous update.