### PR TITLE
Update requirements.txt to include tqdm and pandas as deps for SDE and plotly

### DIFF
--- a/tools/speech_data_explorer/requirements.txt
+++ b/tools/speech_data_explorer/requirements.txt
@@ -8,3 +8,4 @@ dash_table
 numpy
 diff_match_patch
 editdistance
+tqdm

--- a/tools/speech_data_explorer/requirements.txt
+++ b/tools/speech_data_explorer/requirements.txt
@@ -9,3 +9,4 @@ numpy
 diff_match_patch
 editdistance
 tqdm
+pandas


### PR DESCRIPTION
This PR adds `tqdm` as a dependency for the Speech Dataset Explorer; it fails as below without it. 

```
✔ ~/NeMo/tools/speech_data_explorer [main|✔] 
23:02 $ python3 data_explorer.py 
Traceback (most recent call last):
  File "data_explorer.py", line 37, in <module>
    import tqdm
ModuleNotFoundError: No module named 'tqdm'
✘-1 ~/NeMo/tools/speech_data_explorer [main|✔] 
23:02 $ pip install tqdm
Defaulting to user installation because normal site-packages is not writeable
Collecting tqdm
  Downloading tqdm-4.61.2-py2.py3-none-any.whl (76 kB)
     |████████████████████████████████| 76 kB 325 kB/s 
Installing collected packages: tqdm
Successfully installed tqdm-4.61.2
```