### PR TITLE
Make ITN tests optional (run only on change)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,6 +76,18 @@ pipeline {
       }
     }
 
+    stage('L0: ITN Tests CPU') {
+      when {
+        anyOf {
+          changeset glob: "nemo_text_processing/*"
+        }
+      }
+      steps {
+        sh 'CUDA_VISIBLE_DEVICES="" pytest tests/nemo_text_processing/ -m "not pleasefixme" --cpu'
+      }
+    }
+
+
     stage('L0: Computer Vision Integration') {
       when {
         anyOf {
@@ -370,7 +382,7 @@ pipeline {
         stage('Speech to Text - RNNT') {
           steps {
             sh 'STRICT_NUMBA_COMPAT_CHECK=false python examples/asr/speech_to_text_rnnt.py \
-            --config-path="conf/contextnet_rnnt/" --config-name="config_rnnt.yaml" \
+            --config-path="experimental/contextnet_rnnt/" --config-name="config_rnnt.yaml" \
             model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json \
             model.validation_ds.manifest_filepath=/home/TestData/an4_dataset/an4_val.json \
             model.train_ds.batch_size=2 \
@@ -384,7 +396,7 @@ pipeline {
         stage('L2: Speech to Text RNNT WPE') {
           steps {
             sh 'STRICT_NUMBA_COMPAT_CHECK=false python examples/asr/speech_to_text_rnnt_bpe.py \
-            --config-path="conf/contextnet_rnnt/" --config-name="config_rnnt_bpe.yaml" \
+            --config-path="experimental/contextnet_rnnt/" --config-name="config_rnnt_bpe.yaml" \
             model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json \
             model.validation_ds.manifest_filepath=/home/TestData/an4_dataset/an4_val.json \
             model.train_ds.batch_size=2 \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -382,7 +382,7 @@ pipeline {
         stage('Speech to Text - RNNT') {
           steps {
             sh 'STRICT_NUMBA_COMPAT_CHECK=false python examples/asr/speech_to_text_rnnt.py \
-            --config-path="experimental/contextnet_rnnt/" --config-name="config_rnnt.yaml" \
+            --config-path="conf/contextnet_rnnt/" --config-name="config_rnnt.yaml" \
             model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json \
             model.validation_ds.manifest_filepath=/home/TestData/an4_dataset/an4_val.json \
             model.train_ds.batch_size=2 \
@@ -396,7 +396,7 @@ pipeline {
         stage('L2: Speech to Text RNNT WPE') {
           steps {
             sh 'STRICT_NUMBA_COMPAT_CHECK=false python examples/asr/speech_to_text_rnnt_bpe.py \
-            --config-path="experimental/contextnet_rnnt/" --config-name="config_rnnt_bpe.yaml" \
+            --config-path="conf/contextnet_rnnt/" --config-name="config_rnnt_bpe.yaml" \
             model.train_ds.manifest_filepath=/home/TestData/an4_dataset/an4_train.json \
             model.validation_ds.manifest_filepath=/home/TestData/an4_dataset/an4_val.json \
             model.train_ds.batch_size=2 \

--- a/nemo/core/utils/numba_utils.py
+++ b/nemo/core/utils/numba_utils.py
@@ -82,6 +82,25 @@ def with_numba_compat_strictness(strict: bool):
     set_numba_compat_strictness(strict=initial_strictness)
 
 
+def numba_cpu_is_supported(min_version: str) -> bool:
+    """
+    Tests if an appropriate version of numba is installed.
+
+    Args:
+        min_version: The minimum version of numba that is required.
+
+    Returns:
+        bool, whether numba CPU supported with this current installation or not.
+    """
+    module_available, msg = model_utils.check_lib_version('numba', checked_version=min_version, operator=operator.ge)
+
+    # If numba is not installed
+    if module_available is None:
+        return False
+    else:
+        return True
+
+
 def numba_cuda_is_supported(min_version: str) -> bool:
     """
     Tests if an appropriate version of numba is installed, and if it is,
@@ -93,7 +112,7 @@ def numba_cuda_is_supported(min_version: str) -> bool:
     Returns:
         bool, whether cuda is supported with this current installation or not.
     """
-    module_available, msg = model_utils.check_lib_version('numba', checked_version=min_version, operator=operator.ge)
+    module_available = numba_cpu_is_supported(min_version)
 
     # If numba is not installed
     if module_available is None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,8 @@ test=pytest
 # -vv will also display tests with durration = 0.00s
 [tool:pytest]
 addopts = --verbose --pyargs --durations=0
+testpaths = tests
+norecursedirs = nemo nemo_text_processing external examples docs scripts tools tutorials *.egg .* _darcs build CVS dist venv {arch}
 markers =
     unit: marks unit test, i.e. testing a single, well isolated functionality (deselect with '-m "not unit"')
     integration: marks test checking the elements when integrated into subsystems (deselect with '-m "not integration"')

--- a/tests/collections/asr/numba/rnnt_loss/test_rnnt_pytorch.py
+++ b/tests/collections/asr/numba/rnnt_loss/test_rnnt_pytorch.py
@@ -57,7 +57,8 @@ class TestRNNTLossPytorch:
     @pytest.mark.unit
     @pytest.mark.parametrize('device', DEVICES)
     def test_case_small(self, device):
-        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+        if device == 'cuda':
+            numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         acts = np.array(
             [
@@ -102,7 +103,8 @@ class TestRNNTLossPytorch:
     @pytest.mark.unit
     @pytest.mark.parametrize('device', DEVICES)
     def test_case_small_random(self, device):
-        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+        if device == 'cuda':
+            numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         rng = np.random.RandomState(0)
         acts = rng.randn(1, 4, 3, 3)
@@ -121,7 +123,8 @@ class TestRNNTLossPytorch:
     @pytest.mark.parametrize('device', DEVICES)
     @pytest.mark.parametrize('fastemit_lambda', [1.0, 0.01, 0.00001])
     def test_case_small_random_fastemit_reg(self, device, fastemit_lambda):
-        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+        if device == 'cuda':
+            numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         rng = np.random.RandomState(0)
         acts = rng.randn(1, 4, 3, 3)
@@ -139,7 +142,8 @@ class TestRNNTLossPytorch:
     @pytest.mark.unit
     @pytest.mark.parametrize('device', DEVICES)
     def big_test(self, device):
-        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+        if device == 'cuda':
+            numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         # minibatch x T x U x alphabet_size
         activations = [
@@ -255,7 +259,8 @@ class TestRNNTLossPytorch:
     @pytest.mark.unit
     @pytest.mark.parametrize('device', DEVICES)
     def test_case_large_random(self, device):
-        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+        if device == 'cuda':
+            numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         rng = np.random.RandomState(0)
         acts = rng.randn(4, 8, 11, 5)

--- a/tests/collections/asr/test_asr_rnnt_encdec_model.py
+++ b/tests/collections/asr/test_asr_rnnt_encdec_model.py
@@ -24,7 +24,9 @@ from nemo.core.utils import numba_utils
 from nemo.core.utils.numba_utils import __NUMBA_MINIMUM_VERSION__
 from nemo.utils.config_utils import assert_dataclass_signature_match
 
-NUMBA_RNNT_LOSS_AVAILABLE = numba_utils.numba_cuda_is_supported(__NUMBA_MINIMUM_VERSION__)
+NUMBA_RNNT_LOSS_AVAILABLE = numba_utils.numba_cpu_is_supported(
+    __NUMBA_MINIMUM_VERSION__
+) or numba_utils.numba_cuda_is_supported(__NUMBA_MINIMUM_VERSION__)
 
 
 @pytest.fixture()

--- a/tests/collections/asr/test_asr_rnnt_encoder_model_bpe.py
+++ b/tests/collections/asr/test_asr_rnnt_encoder_model_bpe.py
@@ -27,7 +27,9 @@ from nemo.collections.common import tokenizers
 from nemo.core.utils import numba_utils
 from nemo.core.utils.numba_utils import __NUMBA_MINIMUM_VERSION__
 
-NUMBA_RNNT_LOSS_AVAILABLE = numba_utils.numba_cuda_is_supported(__NUMBA_MINIMUM_VERSION__)
+NUMBA_RNNT_LOSS_AVAILABLE = numba_utils.numba_cpu_is_supported(
+    __NUMBA_MINIMUM_VERSION__
+) or numba_utils.numba_cuda_is_supported(__NUMBA_MINIMUM_VERSION__)
 
 
 @pytest.fixture()


### PR DESCRIPTION
# Changelog
- Run ITN tests only when `nemo_text_processing/*` files are changed
- Split numba checks into CPU level and GPU level tests
- Make certain RNNT tests runnable on CPU only devices

Signed-off-by: smajumdar <titu1994@gmail.com>