### PR TITLE
 resolved MisconfigurationException

### DIFF
--- a/nemo/collections/tts/models/glow_tts.py
+++ b/nemo/collections/tts/models/glow_tts.py
@@ -206,6 +206,7 @@ class GlowTTSModel(SpectrogramGenerator):
             )
             log_audio_to_tb(tb_logger, outputs[0]['y'][0], "true_audio_gf", self.global_step)
             log_audio_to_tb(tb_logger, outputs[0]['y_gen'][0], "generated_audio_gf", self.global_step)
+        self.log('val_loss', avg_loss)
         return {'val_loss': avg_loss, 'log': tensorboard_logs}
 
     def _setup_dataloader_from_config(self, cfg: DictConfig):


### PR DESCRIPTION
end of epoch will throw execption:

pytorch_lightning.utilities.exceptions.MisconfigurationException: ModelCheckpoint(monitor='val_loss') not found in the returned metrics: ['loss', 'l_mle', 'l_length', 'logdet']. HINT: Did you call self.log('val_loss', value) in the LightningModule?


Signed-off-by: Qiliang <xiaoqlster@gmail.com>