### PR TITLE
Evaluate the performance of the decoder for each semiotic class

### DIFF
--- a/examples/nlp/duplex_text_normalization/class_based_decoding_evaluation.py
+++ b/examples/nlp/duplex_text_normalization/class_based_decoding_evaluation.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This script can be used to evaluate the accuracy of a trained decoder model
+for each semiotic class (DATE, CARDINAL, LETTERS, ...).
+
+USAGE Example:
+python class_based_decoding_evaluation.py
+        decoder_pretrained_model=PATH_TO_TRAINED_DECODER
+        data.test_ds.data_path=PATH_TO_TEST_FILE
+        mode={tn,itn,joint}
+        lang={en,ru,de}
+"""
+
+from math import ceil
+
+import numpy as np
+from helpers import DECODER_MODEL, instantiate_model_and_trainer
+from omegaconf import DictConfig, OmegaConf
+from tqdm import tqdm
+
+from nemo.collections.nlp.data.text_normalization import TextNormalizationTestDataset, constants
+from nemo.collections.nlp.data.text_normalization.utils import basic_tokenize, read_data_file
+from nemo.collections.nlp.models.duplex_text_normalization.utils import get_formatted_string
+from nemo.core.config import hydra_runner
+from nemo.utils import logging
+
+
+def print_class_based_stats(class2stats):
+    """ Print statistics of class-based evaluation results """
+    for class_name in class2stats:
+        correct_count = np.sum(class2stats[class_name])
+        total_count = len(class2stats[class_name])
+        class_acc = np.average(class2stats[class_name])
+        class_acc = str(round(class_acc, 3)) + f'% ({correct_count}/{total_count})'
+        formatted_str = get_formatted_string((class_name, class_acc), str_max_len=20)
+        print(formatted_str)
+    print()
+
+
+@hydra_runner(config_path="conf", config_name="duplex_tn_config")
+def main(cfg: DictConfig) -> None:
+    logging.info(f'Config Params: {OmegaConf.to_yaml(cfg)}')
+    lang = cfg.lang
+    batch_size = cfg.data.test_ds.batch_size
+
+    # Load the decoder and its tokenizer
+    print('Evaluating the decoder')
+    decoder_model = instantiate_model_and_trainer(cfg, DECODER_MODEL, False)[1]
+    transformer_model, tokenizer = decoder_model.model, decoder_model._tokenizer
+    try:
+        model_max_len = transformer_model.config.n_positions
+    except AttributeError:
+        model_max_len = 512
+    # Load the test dataset
+    decoder_model.setup_test_data(cfg.data.test_ds)
+    test_dataset, test_dl = decoder_model.test_dataset, decoder_model._test_dl
+    # Inference
+    itn_class2stats, tn_class2stats = {}, {}
+    for ix, examples in tqdm(enumerate(test_dl)):
+        # Extract infos of the current batch
+        start_idx = ix * batch_size
+        end_idx = min((ix + 1) * batch_size, len(test_dataset))
+        batch_insts = test_dataset.insts[start_idx:end_idx]
+        batch_input_centers = [inst.input_center_str for inst in batch_insts]
+        batch_targets = [inst.output_str for inst in batch_insts]
+        batch_dirs = [inst.direction for inst in batch_insts]
+        batch_classes = [inst.semiotic_class for inst in batch_insts]
+        # Inference
+        input_ids = examples['input_ids'].to(decoder_model.device)
+        generated_ids = transformer_model.generate(input_ids, max_length=model_max_len)
+        batch_preds = tokenizer.batch_decode(generated_ids, skip_special_tokens=True)
+        batch_preds = decoder_model.postprocess_output_spans(batch_input_centers, batch_preds, batch_dirs)
+        # Update itn_class2stats and tn_class2stats
+        for direction, _class, pred, target in zip(batch_dirs, batch_classes, batch_preds, batch_targets):
+            correct = TextNormalizationTestDataset.is_same(pred, target, direction, lang)
+            stats = itn_class2stats if direction == constants.INST_BACKWARD else tn_class2stats
+            if not _class in stats:
+                stats[_class] = []
+            stats[_class].append(int(correct))
+
+    # Print out stats
+    print('ITN (Backward Direction)')
+    print_class_based_stats(itn_class2stats)
+    print('TN (Forward Direction)')
+    print_class_based_stats(tn_class2stats)
+
+
+if __name__ == '__main__':
+    main()

--- a/examples/nlp/duplex_text_normalization/class_based_decoding_evaluation.py
+++ b/examples/nlp/duplex_text_normalization/class_based_decoding_evaluation.py
@@ -24,15 +24,12 @@ python class_based_decoding_evaluation.py
         lang={en,ru,de}
 """
 
-from math import ceil
-
 import numpy as np
 from helpers import DECODER_MODEL, instantiate_model_and_trainer
 from omegaconf import DictConfig, OmegaConf
 from tqdm import tqdm
 
 from nemo.collections.nlp.data.text_normalization import TextNormalizationTestDataset, constants
-from nemo.collections.nlp.data.text_normalization.utils import basic_tokenize, read_data_file
 from nemo.collections.nlp.models.duplex_text_normalization.utils import get_formatted_string
 from nemo.core.config import hydra_runner
 from nemo.utils import logging

--- a/examples/nlp/duplex_text_normalization/combine_processed_datasets.py
+++ b/examples/nlp/duplex_text_normalization/combine_processed_datasets.py
@@ -12,6 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+This script can be used to combine multiple datasets produced by the script google_data_preprocessing.py
+into one single dataset. A potential usecase is to combine multiple datasets of different languages into
+one single dataset for multilingual training.
+
+USAGE Example:
+python combine_processed_datasets.py
+        --input_dirs=PATH_TO_ENGLISH_DATASET_FOLDER
+        --input_dirs=PATH_TO_RUSSIAN_DATASET_FOLDER
+        --output_dir=PATH_TO_COMBINED_DATASET_FOLDER
+"""
+
 from argparse import ArgumentParser
 from os import mkdir
 from os.path import isdir, join

--- a/nemo/collections/nlp/data/text_normalization/decoder_dataset.py
+++ b/nemo/collections/nlp/data/text_normalization/decoder_dataset.py
@@ -235,13 +235,16 @@ class DecoderDataInstance:
         w_input = w_left + [extra_id_0] + c_w_words + [extra_id_1] + w_right
         s_input = s_left + [extra_id_0] + c_s_words + [extra_id_1] + s_right
         if inst_dir == constants.INST_BACKWARD:
+            input_center_words = c_s_words
             input_words = [constants.ITN_PREFIX] + s_input
             output_words = c_w_words
         if inst_dir == constants.INST_FORWARD:
+            input_center_words = c_w_words
             input_words = [constants.TN_PREFIX] + w_input
             output_words = c_s_words
         # Finalize
         self.input_str = ' '.join(input_words)
+        self.input_center_str = ' '.join(input_center_words)
         self.output_str = ' '.join(output_words)
         self.direction = inst_dir
         self.semiotic_class = semiotic_class

--- a/nemo/collections/nlp/models/duplex_text_normalization/duplex_decoder.py
+++ b/nemo/collections/nlp/models/duplex_text_normalization/duplex_decoder.py
@@ -193,6 +193,7 @@ class DuplexDecoderModel(NLPModel):
         return final_texts
 
     def postprocess_output_spans(self, input_centers, output_spans, input_dirs):
+        en_greek_writtens = list(constants.EN_GREEK_TO_SPOKEN.keys())
         en_greek_spokens = list(constants.EN_GREEK_TO_SPOKEN.values())
         for ix, (_input, _output) in enumerate(zip(input_centers, output_spans)):
             if self.lang == constants.ENGLISH:
@@ -201,6 +202,9 @@ class DuplexDecoderModel(NLPModel):
                     output_spans[ix] = ' '.join(wordninja.split(_output))
                     continue
                 # Greek letters
+                if _input in en_greek_writtens:
+                    if input_dirs[ix] == constants.INST_FORWARD:
+                        output_spans[ix] = constants.EN_GREEK_TO_SPOKEN[_input]
                 if _input in en_greek_spokens:
                     if input_dirs[ix] == constants.INST_FORWARD:
                         output_spans[ix] = _input
@@ -214,27 +218,29 @@ class DuplexDecoderModel(NLPModel):
             logging.info(
                 f"Dataloader config or file_path for the train is missing, so no data loader for train is created!"
             )
-            self._train_dl = None
+            self.train_dataset, self._train_dl = None, None
             return
-        self._train_dl = self._setup_dataloader_from_config(cfg=train_data_config, mode="train")
+        self.train_dataset, self._train_dl = self._setup_dataloader_from_config(cfg=train_data_config, mode="train")
 
     def setup_validation_data(self, val_data_config: Optional[DictConfig]):
         if not val_data_config or not val_data_config.data_path:
             logging.info(
                 f"Dataloader config or file_path for the validation is missing, so no data loader for validation is created!"
             )
-            self._validation_dl = None
+            self.validation_dataset, self._validation_dl = None, None
             return
-        self._validation_dl = self._setup_dataloader_from_config(cfg=val_data_config, mode="val")
+        self.validation_dataset, self._validation_dl = self._setup_dataloader_from_config(
+            cfg=val_data_config, mode="val"
+        )
 
     def setup_test_data(self, test_data_config: Optional[DictConfig]):
         if not test_data_config or test_data_config.data_path is None:
             logging.info(
                 f"Dataloader config or file_path for the test is missing, so no data loader for test is created!"
             )
-            self._test_dl = None
+            self.test_dataset, self._test_dl = None, None
             return
-        self._test_dl = self._setup_dataloader_from_config(cfg=test_data_config, mode="test")
+        self.test_dataset, self._test_dl = self._setup_dataloader_from_config(cfg=test_data_config, mode="test")
 
     def _setup_dataloader_from_config(self, cfg: DictConfig, mode: str):
         tokenizer, model = self._tokenizer, self.model
@@ -260,7 +266,7 @@ class DuplexDecoderModel(NLPModel):
         )
         running_time = perf_counter() - start_time
         logging.info(f'Took {running_time} seconds')
-        return dl
+        return dataset, dl
 
     @classmethod
     def list_available_models(cls) -> Optional[PretrainedModelInfo]:

--- a/nemo/collections/nlp/models/duplex_text_normalization/duplex_tagger.py
+++ b/nemo/collections/nlp/models/duplex_text_normalization/duplex_tagger.py
@@ -53,7 +53,10 @@ class DuplexTaggerModel(NLPModel):
         self.loss_fct = nn.CrossEntropyLoss(ignore_index=constants.LABEL_PAD_TOKEN_ID)
 
         # setup to track metrics
-        self.classification_report = ClassificationReport(self.num_labels, mode='micro', dist_sync_on_step=True)
+        label_ids = {l: idx for idx, l in enumerate(constants.ALL_TAG_LABELS)}
+        self.classification_report = ClassificationReport(
+            self.num_labels, label_ids, mode='micro', dist_sync_on_step=True
+        )
 
         # Language
         self.lang = cfg.get('lang', None)


### PR DESCRIPTION
@yzhang123 

For the `english-joint` model, these are the evaluation results:
```
TN (Forward Direction)
DATE                  0.999% (2829/2832)
CARDINAL              0.994% (1031/1037)
LETTERS               0.996% (1345/1350)
PLAIN                 0.997% (352/353)
VERBATIM              1.0% (302/302)
MEASURE               0.993% (141/142)
DECIMAL               1.0% (92/92)
FRACTION              0.875% (14/16)
ORDINAL               0.99% (102/103)
TELEPHONE             0.919% (34/37)
MONEY                 0.973% (36/37)
ELECTRONIC            0.735% (36/49)
DIGIT                 0.886% (39/44)
TIME                  1.0% (8/8)
ADDRESS               1.0% (4/4)
```

I don't add a new script for evaluating the tagger because it can be simply evaluated as follows:
```
tagger_trainer, tagger_model = instantiate_model_and_trainer(cfg, TAGGER_MODEL, False)
tagger_model.setup_test_data(cfg.data.test_ds)
tagger_trainer.test(model=tagger_model , verbose=False)
```