### PR TITLE
Force fastpitch output to fp32

### DIFF
--- a/nemo/collections/tts/models/fastpitch.py
+++ b/nemo/collections/tts/models/fastpitch.py
@@ -401,7 +401,7 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
             attn_hard_dur,
             pitch,
         ) = self.fastpitch(text=text)
-        return spect, num_frames, durs_predicted, log_durs_predicted, pitch_predicted
+        return spect.to(torch.float), num_frames, durs_predicted, log_durs_predicted, pitch_predicted
 
     @property
     def disabled_deployment_input_names(self):


### PR DESCRIPTION
This enables a much simpler deployment when doing mixed precision inference.

Signed-off-by: Ryan Leary <rleary@nvidia.com>