### PR TITLE
Remove data augmentation for decoder + Increase default max_epochs

### DIFF
--- a/docs/source/nlp/text_normalization.rst
+++ b/docs/source/nlp/text_normalization.rst
@@ -130,16 +130,6 @@ then we will simply append the prefix ``tn`` to it and so the final input to our
 be ``tn I live in tn 123 King Ave``. Similarly, for the ITN problem, we just append the prefix ``itn``
 to the input.
 
-To improve the robustness of the decoder, we also apply a simple data augmentation technique during training the decoder.
-
-Data Augmentation for Training DuplexDecoderModel
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Since the tagger may not be perfect, the inputs to the decoder may not all be semiotic spans. Therefore, to make the decoder become more robust against the tagger's potential errors,
-we train the decoder with not only semiotic spans but also with some other more "noisy" spans. This way even if the tagger makes some errors, there will still be some chance that the
-final output is still correct.
-
-The argument ``data.train_ds.decoder_data_augmentation`` in the config file controls whether this data augmentation will be enabled or not.
-
 References
 ----------
 

--- a/examples/nlp/duplex_text_normalization/conf/duplex_tn_config.yaml
+++ b/examples/nlp/duplex_text_normalization/conf/duplex_tn_config.yaml
@@ -59,7 +59,7 @@ tagger_exp_manager:
 decoder_trainer:
   gpus: 1 # the number of gpus, 0 for CPU
   num_nodes: 1
-  max_epochs: 3  # the number of training epochs
+  max_epochs: 5  # the number of training epochs
   checkpoint_callback: false  # provided by exp_manager
   logger: false  # provided by exp_manager
   accumulate_grad_batches: 1 # accumulates grads every k batches
@@ -123,7 +123,6 @@ data:
     max_decoder_len: 80
     mode: ${mode}
     max_insts: -1 # Maximum number of instances (-1 means no limit)
-    decoder_data_augmentation: true # Refer to the text_normalization doc for more information about data augmentation
     use_cache: ${data.use_cache}
 
   validation_ds:

--- a/nemo/collections/nlp/data/text_normalization/decoder_dataset.py
+++ b/nemo/collections/nlp/data/text_normalization/decoder_dataset.py
@@ -43,7 +43,6 @@ class TextNormalizationDecoderDataset(Dataset):
         tokenizer_name: name of the tokenizer,
         mode: should be one of the values ['tn', 'itn', 'joint'].  `tn` mode is for TN only. `itn` mode is for ITN only. `joint` is for training a system that can do both TN and ITN at the same time.
         max_len: maximum length of sequence in tokens. The code will discard any training instance whose input or output is longer than the specified max_len.
-        decoder_data_augmentation (bool): a flag indicates whether to augment the dataset with additional data instances that may help the decoder become more robust against the tagger's errors. Refer to the doc for more info.
         lang: language of the dataset
         do_basic_tokenize: a flag indicates whether to do some basic tokenization for the inputs
         use_cache: Enables caching to use pickle format to store and read data from
@@ -57,7 +56,6 @@ class TextNormalizationDecoderDataset(Dataset):
         tokenizer_name: str,
         mode: str,
         max_len: int,
-        decoder_data_augmentation: bool,
         lang: str,
         do_basic_tokenize: bool,
         use_cache: bool = False,
@@ -113,19 +111,6 @@ class TextNormalizationDecoderDataset(Dataset):
                             do_basic_tokenize=do_basic_tokenize,
                         )
                         insts.append(inst)
-                        if decoder_data_augmentation:
-                            noise_left = random.randint(1, 2)
-                            noise_right = random.randint(1, 2)
-                            inst = DecoderDataInstance(
-                                w_words,
-                                s_words,
-                                inst_dir,
-                                start_idx=ix - noise_left,
-                                end_idx=ix + 1 + noise_right,
-                                lang=self.lang,
-                                do_basic_tokenize=do_basic_tokenize,
-                            )
-                            insts.append(inst)
 
             self.insts = insts
             inputs = [inst.input_str for inst in insts]

--- a/nemo/collections/nlp/data/text_normalization/decoder_dataset.py
+++ b/nemo/collections/nlp/data/text_normalization/decoder_dataset.py
@@ -14,7 +14,6 @@
 
 import os
 import pickle
-import random
 
 from tqdm import tqdm
 from transformers import PreTrainedTokenizerBase

--- a/nemo/collections/nlp/models/duplex_text_normalization/duplex_decoder.py
+++ b/nemo/collections/nlp/models/duplex_text_normalization/duplex_decoder.py
@@ -320,7 +320,6 @@ class DuplexDecoderModel(NLPModel):
             self.transformer_name,
             cfg.mode,
             cfg.get('max_decoder_len', tokenizer.model_max_length),
-            cfg.get('decoder_data_augmentation', False),
             cfg.lang,
             cfg.do_basic_tokenize,
             cfg.get('use_cache', False),


### PR DESCRIPTION
Increasing the number of epochs by roughly two times can get the same performance as data augmentation.

@yzhang123 @ekmb 