### PR TITLE
Add back tagger data augmentation + Fixes for analyze_errors.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,6 +60,7 @@ Key Features
     * `Information retrieval <https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/nlp/information_retrieval.html>`_
     * `Entity Linking <https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/nlp/entity_linking.html>`_
     * `Dialogue State Tracking <https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/nlp/sgd_qa.html>`_
+    * `Neural Duplex Text Normalization <https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/nlp/text_normalization.html>`_
     * `NGC collection of pre-trained NLP models. <https://ngc.nvidia.com/catalog/collections/nvidia:nemo_nlp>`_
 * `Speech synthesis (TTS) <https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/tts/intro.html#>`_
     * Spectrogram generation: Tacotron2, GlowTTS, FastSpeech2, FastPitch, FastSpeech2

--- a/docs/source/nlp/text_normalization.rst
+++ b/docs/source/nlp/text_normalization.rst
@@ -130,9 +130,21 @@ then we will simply append the prefix ``tn`` to it and so the final input to our
 be ``tn I live in tn 123 King Ave``. Similarly, for the ITN problem, we just append the prefix ``itn``
 to the input.
 
-To improve the robustness of the decoder, we also apply a simple data augmentation technique during training the decoder.
+To improve the effectiveness and robustness of our models, we also experiment with some simple data
+augmentation techniques during training.
 
-Data Augmentation for Training DuplexDecoderModel
+Data Augmentation for Training DuplexTaggerModel (Set to be False by defalt)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+In the Google English TN training data, about 93% of the tokens are not in any semiotic span. In other words, the ground-truth tags of most tokens are of trivial types (i.e., ``SAME`` and ``PUNCT``). To alleviate this class imbalance problem,
+for each original instance with several semiotic spans, we create a new instance by simply concatenating all the semiotic spans together. For example, considering the following ITN instance:
+
+Original instance: ``[The|SAME] [revenues|SAME] [grew|SAME] [a|SAME] [lot|SAME] [between|SAME] [two|B-TRANSFORM] [thousand|I-TRANSFORM] [two|I-TRANSFORM] [and|SAME] [two|B-TRANSFORM] [thousand|I-TRANSFORM] [five|I-TRANSFORM] [.|PUNCT]``
+
+Augmented instance: ``[two|B-TRANSFORM] [thousand|I-TRANSFORM] [two|I-TRANSFORM] [two|B-TRANSFORM] [thousand|I-TRANSFORM] [five|I-TRANSFORM]``
+
+The argument ``data.train_ds.tagger_data_augmentation`` in the config file controls whether this data augmentation will be enabled or not.
+
+Data Augmentation for Training DuplexDecoderModel (Set to be True by defalt)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Since the tagger may not be perfect, the inputs to the decoder may not all be semiotic spans. Therefore, to make the decoder become more robust against the tagger's potential errors,
 we train the decoder with not only semiotic spans but also with some other more "noisy" spans. This way even if the tagger makes some errors, there will still be some chance that the

--- a/docs/source/nlp/text_normalization.rst
+++ b/docs/source/nlp/text_normalization.rst
@@ -133,7 +133,7 @@ to the input.
 To improve the effectiveness and robustness of our models, we also experiment with some simple data
 augmentation techniques during training.
 
-Data Augmentation for Training DuplexTaggerModel (Set to be False by defalt)
+Data Augmentation for Training DuplexTaggerModel (Set to be False by default)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 In the Google English TN training data, about 93% of the tokens are not in any semiotic span. In other words, the ground-truth tags of most tokens are of trivial types (i.e., ``SAME`` and ``PUNCT``). To alleviate this class imbalance problem,
 for each original instance with several semiotic spans, we create a new instance by simply concatenating all the semiotic spans together. For example, considering the following ITN instance:
@@ -144,7 +144,7 @@ Augmented instance: ``[two|B-TRANSFORM] [thousand|I-TRANSFORM] [two|I-TRANSFORM]
 
 The argument ``data.train_ds.tagger_data_augmentation`` in the config file controls whether this data augmentation will be enabled or not.
 
-Data Augmentation for Training DuplexDecoderModel (Set to be True by defalt)
+Data Augmentation for Training DuplexDecoderModel (Set to be True by default)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Since the tagger may not be perfect, the inputs to the decoder may not all be semiotic spans. Therefore, to make the decoder become more robust against the tagger's potential errors,
 we train the decoder with not only semiotic spans but also with some other more "noisy" spans. This way even if the tagger makes some errors, there will still be some chance that the

--- a/examples/nlp/duplex_text_normalization/analyze_errors.py
+++ b/examples/nlp/duplex_text_normalization/analyze_errors.py
@@ -26,6 +26,7 @@ USAGE Example:
 """
 
 from argparse import ArgumentParser
+from typing import List
 
 from nemo.collections.nlp.data.text_normalization import constants
 
@@ -284,8 +285,8 @@ def analyze(errors_log_fp: str, visualization_fp: str):
 if __name__ == '__main__':
     # Parse argument
     parser = ArgumentParser()
-    parser.add_argument('--errors_log_fp', type='str', help='Path to the error log file', required=True)
-    parser.add_argument('--visualization_fp', type='str', help='Path to the output visualization file', required=True)
+    parser.add_argument('--errors_log_fp', help='Path to the error log file', required=True)
+    parser.add_argument('--visualization_fp', help='Path to the output visualization file', required=True)
     args = parser.parse_args()
 
     analyze(args.errors_log_fp, args.visualization_fp)

--- a/examples/nlp/duplex_text_normalization/conf/duplex_tn_config.yaml
+++ b/examples/nlp/duplex_text_normalization/conf/duplex_tn_config.yaml
@@ -123,7 +123,9 @@ data:
     max_decoder_len: 80
     mode: ${mode}
     max_insts: -1 # Maximum number of instances (-1 means no limit)
-    decoder_data_augmentation: true # Refer to the text_normalization doc for more information about data augmentation
+    # Refer to the text_normalization doc for more information about data augmentation
+    tagger_data_augmentation: false
+    decoder_data_augmentation: true
     use_cache: ${data.use_cache}
 
   validation_ds:

--- a/nemo/collections/nlp/data/text_normalization/tagger_dataset.py
+++ b/nemo/collections/nlp/data/text_normalization/tagger_dataset.py
@@ -42,6 +42,7 @@ class TextNormalizationTaggerDataset(Dataset):
         tokenizer_name: name of the tokenizer,
         mode: should be one of the values ['tn', 'itn', 'joint'].  `tn` mode is for TN only. `itn` mode is for ITN only. `joint` is for training a system that can do both TN and ITN at the same time.
         do_basic_tokenize: a flag indicates whether to do some basic tokenization before using the tokenizer of the model
+        tagger_data_augmentation (bool): a flag indicates whether to augment the dataset with additional data instances
         lang: language of the dataset
         use_cache: Enables caching to use pickle format to store and read data from,
         max_insts: Maximum number of instances (-1 means no limit)
@@ -54,6 +55,7 @@ class TextNormalizationTaggerDataset(Dataset):
         tokenizer_name: str,
         mode: str,
         do_basic_tokenize: bool,
+        tagger_data_augmentation: bool,
         lang: str,
         use_cache: bool = False,
         max_insts: int = -1,
@@ -97,6 +99,16 @@ class TextNormalizationTaggerDataset(Dataset):
                     # Create a new TaggerDataInstance
                     inst = TaggerDataInstance(w_words, s_words, inst_dir, do_basic_tokenize)
                     insts.append(inst)
+                    # Data Augmentation (if enabled)
+                    if tagger_data_augmentation:
+                        filtered_w_words, filtered_s_words = [], []
+                        for ix, (w, s) in enumerate(zip(w_words, s_words)):
+                            if not s in constants.SPECIAL_WORDS:
+                                filtered_w_words.append(w)
+                                filtered_s_words.append(s)
+                        if len(filtered_s_words) > 1:
+                            inst = TaggerDataInstance(filtered_w_words, filtered_s_words, inst_dir)
+                            insts.append(inst)
 
             self.insts = insts
             texts = [inst.input_words for inst in insts]

--- a/nemo/collections/nlp/models/duplex_text_normalization/duplex_tagger.py
+++ b/nemo/collections/nlp/models/duplex_text_normalization/duplex_tagger.py
@@ -282,12 +282,14 @@ class DuplexTaggerModel(NLPModel):
         start_time = perf_counter()
         logging.info(f'Creating {mode} dataset')
         input_file = cfg.data_path
+        tagger_data_augmentation = cfg.get('tagger_data_augmentation', False)
         dataset = TextNormalizationTaggerDataset(
             input_file,
             self._tokenizer,
             self.transformer_name,
             cfg.mode,
             cfg.do_basic_tokenize,
+            tagger_data_augmentation,
             cfg.lang,
             cfg.get('use_cache', False),
             cfg.get('max_insts', -1),


### PR DESCRIPTION
Changes:

- Add back tagger data augmentation (but default to be False)
- Fixes for analyze_errors.py
- Add duplex tn to README

@yzhang123 