### PR TITLE
vad_infer.py. Change the type of an argument "num_workers" from float to int.

### DIFF
--- a/examples/asr/vad_infer.py
+++ b/examples/asr/vad_infer.py
@@ -69,7 +69,7 @@ def main():
     parser.add_argument("--time_length", type=float, default=0.63)
     parser.add_argument("--shift_length", type=float, default=0.01)
     parser.add_argument("--normalize_audio", type=bool, default=False)
-    parser.add_argument("--num_workers", type=float, default=20)
+    parser.add_argument("--num_workers", type=int, default=20)
     parser.add_argument("--split_duration", type=float, default=400)
     parser.add_argument(
         "--dont_auto_split",


### PR DESCRIPTION
num_workers' type must be int, not float.
It induces TypeError even when using additional input as `--num_workers=20`

```
>>> python vad_infer.py  --dataset=manifest.json --num_workers=20

Traceback (most recent call last):
  File "vad_infer.py", line 171, in <module>
    main()
  File "vad_infer.py", line 106, in main
    manifest_vad_input = prepare_manifest(config)
  File "/workspace/NeMo/nemo/collections/asr/parts/utils/vad_utils.py", line 48, in prepare_manifest
    p = Pool(processes=config['num_workers'])
  File "/opt/conda/lib/python3.8/multiprocessing/context.py", line 119, in Pool
    return Pool(processes, initializer, initargs, maxtasksperchild,
  File "/opt/conda/lib/python3.8/multiprocessing/pool.py", line 212, in __init__
    self._repopulate_pool()
  File "/opt/conda/lib/python3.8/multiprocessing/pool.py", line 303, in _repopulate_pool
    return self._repopulate_pool_static(self._ctx, self.Process,
  File "/opt/conda/lib/python3.8/multiprocessing/pool.py", line 318, in _repopulate_pool_static
    for i in range(processes - len(pool)):
TypeError: 'float' object cannot be interpreted as an integer
```