### PR TITLE
Add mAES beam search for Transducer models

### DIFF
--- a/examples/asr/conf/contextnet_rnnt/config_rnnt.yaml
+++ b/examples/asr/conf/contextnet_rnnt/config_rnnt.yaml
@@ -188,8 +188,13 @@ model:
     beam:
       beam_size: 2
       score_norm: true
-      tsd_max_sym_exp: 50  # for Time Synchronous Decoding
-      alsd_max_target_len: 2.0  # for Alignment-Length Synchronous Decoding
+      softmax_temperature: 1.0  # scale the logits by some temperature prior to softmax
+      tsd_max_sym_exp: 10  # for Time Synchronous Decoding, int > 0
+      alsd_max_target_len: 5.0  # for Alignment-Length Synchronous Decoding, float > 1.0
+      maes_num_steps: 2  # for modified Adaptive Expansion Search, int > 0
+      maes_prefix_alpha: 1  # for modified Adaptive Expansion Search, int > 0
+      maes_expansion_beta: 2  # for modified Adaptive Expansion Search, int >= 0
+      maes_expansion_gamma: 2.3  # for modified Adaptive Expansion Search, float >= 0
 
   loss:
     loss_name: "default"

--- a/examples/asr/conf/contextnet_rnnt/config_rnnt_bpe.yaml
+++ b/examples/asr/conf/contextnet_rnnt/config_rnnt_bpe.yaml
@@ -189,8 +189,13 @@ model:
     beam:
       beam_size: 2
       score_norm: true
-      tsd_max_sym_exp: 50  # for Time Synchronous Decoding
-      alsd_max_target_len: 2.0  # for Alignment-Length Synchronous Decoding
+      softmax_temperature: 1.0  # scale the logits by some temperature prior to softmax
+      tsd_max_sym_exp: 10  # for Time Synchronous Decoding, int > 0
+      alsd_max_target_len: 5.0  # for Alignment-Length Synchronous Decoding, float > 1.0
+      maes_num_steps: 2  # for modified Adaptive Expansion Search, int > 0
+      maes_prefix_alpha: 1  # for modified Adaptive Expansion Search, int > 0
+      maes_expansion_beta: 2  # for modified Adaptive Expansion Search, int >= 0
+      maes_expansion_gamma: 2.3  # for modified Adaptive Expansion Search, float >= 0
 
   loss:
     loss_name: "default"

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
@@ -415,8 +415,12 @@ model:
       beam_size: 4
       score_norm: true
       return_best_hypothesis: False
-      tsd_max_sym_exp: 10  # for Time Synchronous Decoding
-      alsd_max_target_len: 5.0  # for Alignment-Length Synchronous Decoding
+      tsd_max_sym_exp: 10  # for Time Synchronous Decoding, int > 0
+      alsd_max_target_len: 5.0  # for Alignment-Length Synchronous Decoding, float > 1.0
+      maes_num_steps: 2  # for modified Adaptive Expansion Search, int > 0
+      maes_prefix_alpha: 2  # for modified Adaptive Expansion Search, int > 0
+      maes_expansion_beta: 2  # for modified Adaptive Expansion Search, int >= 0
+      maes_expansion_gamma: 2.3  # for modified Adaptive Expansion Search, float >= 0
 
   # RNNT loss config
   loss:

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
@@ -456,7 +456,7 @@ trainer:
   log_every_n_steps: 100  # Interval of logging.
   val_check_interval: 1.0 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
   check_val_every_n_epoch: 1  # RNNT decoding is slower than CTC, so eval takes longer. Increase value to speed up training slightly.
-  precision: 16  # RNNT requires a lot of memory, so precision 16 is very important. Use very small batch size for precision 32.
+  precision: 32  # RNNT requires a lot of memory, so precision 16 is very important. Use very small batch size for precision 32.
   gradient_clip_val: 1.0  # Gradient norm clip value
   sync_batchnorm: true
   benchmark: false

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
@@ -415,10 +415,11 @@ model:
       beam_size: 4
       score_norm: true
       return_best_hypothesis: False
+      softmax_temperature: 1.0  # scale the logits by some temperature prior to softmax
       tsd_max_sym_exp: 10  # for Time Synchronous Decoding, int > 0
       alsd_max_target_len: 5.0  # for Alignment-Length Synchronous Decoding, float > 1.0
       maes_num_steps: 2  # for modified Adaptive Expansion Search, int > 0
-      maes_prefix_alpha: 2  # for modified Adaptive Expansion Search, int > 0
+      maes_prefix_alpha: 1  # for modified Adaptive Expansion Search, int > 0
       maes_expansion_beta: 2  # for modified Adaptive Expansion Search, int >= 0
       maes_expansion_gamma: 2.3  # for modified Adaptive Expansion Search, float >= 0
 

--- a/nemo/collections/asr/metrics/rnnt_wer.py
+++ b/nemo/collections/asr/metrics/rnnt_wer.py
@@ -85,6 +85,28 @@ class AbstractRNNTDecoding(ABC):
                         By default, a float of 2.0 is used so that a target sequence can be at most twice
                         as long as the acoustic model output length T.
 
+                maes_num_steps: Number of adaptive steps to take. From the paper, 2 steps is generally sufficient,
+                    and can be reduced to 1 to improve decoding speed while sacrificing some accuracy. int > 0.
+
+                maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to keep this as 1
+                    in order to reduce expensive beam search cost later. int >= 0.
+
+                maes_expansion_beta: Maximum number of prefix expansions allowed, in addition to the beam size.
+                    Effectively, the number of hypothesis = beam_size + maes_expansion_beta. Must be an int >= 0,
+                    and affects the speed of inference since large values will perform large beam search in the next step.
+
+                maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when computing the expansions.
+                    The default (2.3) is selected from the paper. It performs a comparison (max_log_prob - gamma <= log_prob[v])
+                    where v is all vocabulary indices in the Vocab set and max_log_prob is the "most" likely token to be
+                    predicted. Gamma therefore provides a margin of additional tokens which can be potential candidates for
+                    expansion apart from the "most likely" candidate.
+                    Lower values will reduce the number of expansions (by increasing pruning-by-value, thereby improving speed
+                    but hurting accuracy). Higher values will increase the number of expansions (by reducing pruning-by-value,
+                    thereby reducing speed but potentially improving accuracy). This is a hyper parameter to be experimentally
+                    tuned on a validation set.
+
+                softmax_temperature: Scales the logits of the joint prior to computing log_softmax.
+
         decoder: The Decoder/Prediction network module.
         joint: The Joint network module.
         blank_id: The id of the RNNT blank token.
@@ -128,6 +150,7 @@ class AbstractRNNTDecoding(ABC):
                 return_best_hypothesis=decoding_cfg.beam.get('return_best_hypothesis', True),
                 search_type='default',
                 score_norm=self.cfg.beam.get('score_norm', True),
+                softmax_temperature=self.cfg.beam.get('softmax_temperature', 1.0),
                 preserve_alignments=self.preserve_alignments,
             )
 
@@ -140,7 +163,8 @@ class AbstractRNNTDecoding(ABC):
                 return_best_hypothesis=decoding_cfg.beam.get('return_best_hypothesis', True),
                 search_type='tsd',
                 score_norm=self.cfg.beam.get('score_norm', True),
-                tsd_max_sym_exp_per_step=self.cfg.beam.get('tsd_max_sym_exp', 50),
+                tsd_max_sym_exp_per_step=self.cfg.beam.get('tsd_max_sym_exp', 10),
+                softmax_temperature=self.cfg.beam.get('softmax_temperature', 1.0),
                 preserve_alignments=self.preserve_alignments,
             )
 
@@ -154,6 +178,7 @@ class AbstractRNNTDecoding(ABC):
                 search_type='alsd',
                 score_norm=self.cfg.beam.get('score_norm', True),
                 alsd_max_target_len=self.cfg.beam.get('alsd_max_target_len', 2),
+                softmax_temperature=self.cfg.beam.get('softmax_temperature', 1.0),
                 preserve_alignments=self.preserve_alignments,
             )
 
@@ -169,13 +194,16 @@ class AbstractRNNTDecoding(ABC):
                 maes_prefix_alpha=self.cfg.beam.get('maes_prefix_alpha', 1),
                 maes_expansion_gamma=self.cfg.beam.get('maes_expansion_gamma', 2.3),
                 maes_expansion_beta=self.cfg.beam.get('maes_expansion_beta', 2.0),
+                softmax_temperature=self.cfg.beam.get('softmax_temperature', 1.0),
                 preserve_alignments=self.preserve_alignments,
             )
 
         else:
 
-            raise ValueError(f"Incorrect decoding strategy supplied. Must be one of {possible_strategies}\n"
-                             f"but was provided {self.cfg.strategy}")
+            raise ValueError(
+                f"Incorrect decoding strategy supplied. Must be one of {possible_strategies}\n"
+                f"but was provided {self.cfg.strategy}"
+            )
 
     def rnnt_decoder_predictions_tensor(
         self, encoder_output: torch.Tensor, encoded_lengths: torch.Tensor, return_hypotheses: bool = False

--- a/nemo/collections/asr/modules/rnnt.py
+++ b/nemo/collections/asr/modules/rnnt.py
@@ -475,6 +475,8 @@ class RNNTDecoder(rnnt_abstract.AbstractRNNTDecoder, Exportable):
                 tokens, state=dec_states, add_sos=False, batch_size=batch
             )  # [B, 1, H], List([L, 1, H])
 
+            dec_states = tuple(state.to(dtype=dtype) for state in dec_states)
+
         # Update done states and cache shared by entire batch.
         j = 0
         for i in range(final_batch):
@@ -518,11 +520,24 @@ class RNNTDecoder(rnnt_abstract.AbstractRNNTDecoder, Exportable):
                ([L x (B, H)], [L x (B, H)])
        """
         # LSTM has 2 states
+        new_states = [[] for _ in range(len(decoder_states[0]))]
         for layer in range(self.pred_rnn_layers):
-            for state_id in range(len(batch_states)):
-                batch_states[state_id][layer] = torch.stack([s[state_id][layer] for s in decoder_states])
+            for state_id in range(len(decoder_states[0])):
+                # batch_states[state_id][layer] = torch.stack([s[state_id][layer] for s in decoder_states])
+                new_state_for_layer = torch.stack([s[state_id][layer] for s in decoder_states])
+                new_states[state_id].append(new_state_for_layer)
 
-        return batch_states
+        for state_id in range(len(decoder_states[0])):
+            new_states[state_id] = torch.stack([state for state in new_states[state_id]])
+
+        return tuple(new_states)
+
+        # Older method avoids extra memory allocation but limits use for prefix_search
+        # for layer in range(self.pred_rnn_layers):
+        #     for state_id in range(len(batch_states)):
+        #         batch_states[state_id][layer] = torch.stack([s[state_id][layer] for s in decoder_states])
+        #
+        # return batch_states
 
     def batch_select_state(self, batch_states: List[torch.Tensor], idx: int) -> List[List[torch.Tensor]]:
         """Get decoder state from batch of states, for given id.

--- a/nemo/collections/asr/modules/rnnt.py
+++ b/nemo/collections/asr/modules/rnnt.py
@@ -530,14 +530,7 @@ class RNNTDecoder(rnnt_abstract.AbstractRNNTDecoder, Exportable):
         for state_id in range(len(decoder_states[0])):
             new_states[state_id] = torch.stack([state for state in new_states[state_id]])
 
-        return tuple(new_states)
-
-        # Older method avoids extra memory allocation but limits use for prefix_search
-        # for layer in range(self.pred_rnn_layers):
-        #     for state_id in range(len(batch_states)):
-        #         batch_states[state_id][layer] = torch.stack([s[state_id][layer] for s in decoder_states])
-        #
-        # return batch_states
+        return new_states
 
     def batch_select_state(self, batch_states: List[torch.Tensor], idx: int) -> List[List[torch.Tensor]]:
         """Get decoder state from batch of states, for given id.

--- a/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
@@ -274,7 +274,7 @@ class BeamRNNTInfer(Typing):
 
                     # Decode every sample in the batch independently.
                     for batch_idx in idx_gen:
-                        inseq = encoder_output[batch_idx : batch_idx + 1, :, :]  # [1, T, D]
+                        inseq = encoder_output[batch_idx : batch_idx + 1, : encoded_lengths[batch_idx], :]  # [1, T, D]
                         logitlen = encoded_lengths[batch_idx]
 
                         if inseq.dtype != dtype:
@@ -866,7 +866,8 @@ class BeamRNNTInfer(Typing):
             )
         ]
 
-        for enc_out_t in h:
+        for t in range(encoded_lengths):
+            enc_out_t = h[t]
             enc_out_t = enc_out_t.unsqueeze(0).unsqueeze(0)
 
             hyps = self.prefix_search(

--- a/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
@@ -814,7 +814,8 @@ class BeamRNNTInfer(Typing):
         beam_state = self.decoder.initialize_state(
             torch.zeros(beam, device=h.device, dtype=h.dtype)
         )  # [L, B, H], [L, B, H] for LSTMS
-        blank_tensor = torch.tensor([self.blank], device=h.device, dtype=torch.long)
+
+        # blank_tensor = torch.tensor([self.blank], device=h.device, dtype=torch.long)
 
         # Precompute some constants for blank position
         ids = list(range(self.vocab_size + 1))
@@ -838,8 +839,7 @@ class BeamRNNTInfer(Typing):
 
         cache = {}
 
-        beam_dec_out, beam_state, beam_lm_tokens = self.decoder.batch_score_hypothesis(init_tokens, cache, beam_state,)
-
+        beam_dec_out, beam_state, beam_lm_tokens = self.decoder.batch_score_hypothesis(init_tokens, cache, beam_state)
         state = self.decoder.batch_select_state(beam_state, 0)
 
         if self.language_model is not None:
@@ -903,7 +903,7 @@ class BeamRNNTInfer(Typing):
                             lm_scores=hyp.lm_scores,
                         )
 
-                        if k == 0:  # self.blank
+                        if k == self.blank:
                             list_b.append(new_hyp)
                         else:
                             new_hyp.y_sequence.append(int(k))
@@ -921,7 +921,6 @@ class BeamRNNTInfer(Typing):
 
                     break
                 else:
-                    x = [hyp.dec_state for hyp in list_exp]
                     beam_state = self.decoder.batch_initialize_states(
                         beam_state,
                         [hyp.dec_state for hyp in list_exp],

--- a/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
@@ -876,7 +876,7 @@ class BeamRNNTInfer(Typing):
             )  # type: List[Hypothesis]
             kept_hyps = []
 
-            beam_enc_out = enc_out_t  # .unsqueeze(0).unsqueeze(0)
+            beam_enc_out = enc_out_t
 
             list_b = []
             for n in range(self.maes_num_steps):

--- a/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
@@ -804,4 +804,6 @@ class BeamRNNTInferConfig:
     alsd_max_target_len: float = 1.0
     nsc_max_timesteps_expansion: int = 1
     nsc_prefix_alpha: int = 1
+    language_model: Optional[Dict[str, Any]] = None
+    softmax_temperature: float = 1.0
     preserve_alignments: bool = False

--- a/nemo/collections/asr/parts/utils/rnnt_utils.py
+++ b/nemo/collections/asr/parts/utils/rnnt_utils.py
@@ -27,7 +27,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Union, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import torch
 

--- a/nemo/collections/asr/parts/utils/rnnt_utils.py
+++ b/nemo/collections/asr/parts/utils/rnnt_utils.py
@@ -91,10 +91,15 @@ class NBestHypotheses:
 
 
 def is_prefix(x: List[int], pref: List[int]) -> bool:
-    """Check if pref is a prefix of x.
+    """
+    Obtained from https://github.com/espnet/espnet.
+
+    Check if pref is a prefix of x.
+
     Args:
         x: Label ID sequence.
         pref: Prefix label ID sequence.
+
     Returns:
         : Whether pref is a prefix of x.
     """
@@ -109,21 +114,22 @@ def is_prefix(x: List[int], pref: List[int]) -> bool:
 
 
 def select_k_expansions(
-    hyps: List[Hypothesis],
-    logps: torch.Tensor,
-    beam_size: int,
-    gamma: float,
-    beta: int,
+    hyps: List[Hypothesis], logps: torch.Tensor, beam_size: int, gamma: float, beta: int,
 ) -> List[Tuple[int, Hypothesis]]:
-    """Return K hypotheses candidates for expansion from a list of hypothesis.
+    """
+    Obtained from https://github.com/espnet/espnet
+
+    Return K hypotheses candidates for expansion from a list of hypothesis.
     K candidates are selected according to the extended hypotheses probabilities
     and a prune-by-value method. Where K is equal to beam_size + beta.
+
     Args:
         hyps: Hypotheses.
         beam_logp: Log-probabilities for hypotheses expansions.
         beam_size: Beam size.
         gamma: Allowed logp difference for prune-by-value method.
         beta: Number of additional candidates to store.
+
     Return:
         k_expansions: Best K expansion hypotheses candidates.
     """
@@ -131,13 +137,18 @@ def select_k_expansions(
 
     for i, hyp in enumerate(hyps):
         hyp_i = [(int(k), hyp.score + float(logp)) for k, logp in enumerate(logps[i])]
-        k_best_exp = max(hyp_i, key=lambda x: x[1])[1]
+        k_best_exp_val = max(hyp_i, key=lambda x: x[1])
 
-        k_expansions.append(
-            sorted(
-                filter(lambda x: (k_best_exp - gamma) <= x[1], hyp_i),
-                key=lambda x: x[1],
-            )[: beam_size + beta]
-        )
+        k_best_exp_idx = k_best_exp_val[0]
+        k_best_exp = k_best_exp_val[1]
+
+        expansions = sorted(filter(lambda x: (k_best_exp - gamma) <= x[1], hyp_i), key=lambda x: x[1],)[
+            : beam_size + beta
+        ]
+
+        if len(expansions) > 0:
+            k_expansions.append(expansions)
+        else:
+            k_expansions.append([(k_best_exp_idx, k_best_exp)])
 
     return k_expansions

--- a/nemo/collections/asr/parts/utils/rnnt_utils.py
+++ b/nemo/collections/asr/parts/utils/rnnt_utils.py
@@ -71,8 +71,9 @@ class Hypothesis:
 
     score: float
     y_sequence: Union[List[int], torch.Tensor]
-    dec_state: Optional[Union[List[List[torch.Tensor]], List[torch.Tensor]]] = None
     text: Optional[str] = None
+    dec_out: Optional[List[torch.Tensor]] = None
+    dec_state: Optional[Union[List[List[torch.Tensor]], List[torch.Tensor]]] = None
     timestep: Union[List[int], torch.Tensor] = field(default_factory=list)
     alignments: Optional[Union[List[int], List[List[int]]]] = None
     length: int = 0
@@ -87,3 +88,21 @@ class NBestHypotheses:
     """List of N best hypotheses"""
 
     n_best_hypotheses: Optional[List[Hypothesis]]
+
+
+def is_prefix(x: List[int], pref: List[int]) -> bool:
+    """Check if pref is a prefix of x.
+    Args:
+        x: Label ID sequence.
+        pref: Prefix label ID sequence.
+    Returns:
+        : Whether pref is a prefix of x.
+    """
+    if len(pref) >= len(x):
+        return False
+
+    for i in range(len(pref)):
+        if pref[i] != x[i]:
+            return False
+
+    return True


### PR DESCRIPTION
# Changelog
- Add mAES Transducer algorithm for further improved WER at the cost of speed of execution. 
- Update configs with new decoding scheme
- Begin adding hooks for external LM rescoring

# References
- [Accelerating RNN Transducer Inference via Adaptive Expansion Search](https://ieeexplore.ieee.org/document/9250505)

Ported from ESPNet v1