### PR TITLE
NMT input ID validity test for negative values

### DIFF
--- a/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
+++ b/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
@@ -43,6 +43,16 @@ class SentencePieceTokenizer(TokenizerSpec):
             raise ValueError(f"model_path: {model_path} is invalid")
         self.tokenizer = sentencepiece.SentencePieceProcessor()
         self.tokenizer.Load(model_path)
+        # validate no token is negative
+        negative_tokens = []
+        for n in ["eos_id", "bos_id", "unk_id", "pad_id"]:
+            v = getattr(self.tokenizer, n)()
+            if v < 0:
+                negative_tokens.append(f"{n}={v}")
+
+        if negative_tokens:
+            raise ValueError(f"sentencepiece has invalid negative special tokens = {negative_tokens}")
+
         self.original_vocab_size = self.tokenizer.get_piece_size()
         self.vocab_size = self.tokenizer.get_piece_size()
         self.legacy = legacy

--- a/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
+++ b/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
@@ -43,15 +43,6 @@ class SentencePieceTokenizer(TokenizerSpec):
             raise ValueError(f"model_path: {model_path} is invalid")
         self.tokenizer = sentencepiece.SentencePieceProcessor()
         self.tokenizer.Load(model_path)
-        # validate no token is negative
-        negative_tokens = []
-        for n in ["eos_id", "bos_id", "unk_id", "pad_id"]:
-            v = getattr(self.tokenizer, n)()
-            if v < 0:
-                negative_tokens.append(f"{n}={v}")
-
-        if negative_tokens:
-            raise ValueError(f"sentencepiece has invalid negative special tokens = {negative_tokens}")
 
         self.original_vocab_size = self.tokenizer.get_piece_size()
         self.vocab_size = self.tokenizer.get_piece_size()

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_bottleneck_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_bottleneck_model.py
@@ -257,9 +257,10 @@ class MTBottleneckModel(MTEncDecModel):
         return_info - if True, returns loss, info_dict with additional information
                       regarding the loss that can be logged
         """
-        # test src/tgt for id range (i.e., hellp in catching wrong tokenizer)
-        self.test_encoder_ids(src, raise_error=True)
-        self.test_decoder_ids(tgt, raise_error=True)
+        if self.validate_input_ids:
+            # test src/tgt for id range (i.e., hellp in catching wrong tokenizer)
+            self.test_encoder_ids(src, raise_error=True)
+            self.test_decoder_ids(tgt, raise_error=True)
 
         enc_hiddens, enc_mask = self.encoder(input_ids=src, encoder_mask=src_mask, return_mask=True,)
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -75,7 +75,7 @@ class MTEncDecModel(EncDecNLPModel):
         self.encoder_tokenizer_library = cfg.encoder_tokenizer.get('library', 'yttm')
         self.decoder_tokenizer_library = cfg.decoder_tokenizer.get('library', 'yttm')
 
-        self.validate_input_ids =  = cfg.get("validate_input_ids", True)
+        self.validate_input_ids = cfg.get("validate_input_ids", True)
 
 
         # Instantiates tokenizers and register to be saved with NeMo Model archive

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -212,7 +212,10 @@ class MTEncDecModel(EncDecNLPModel):
         return ids
 
     def test_encoder_ids(self, ids, raise_error=False):
-        invalid_ids = (ids >= self.encoder_tokenizer.vocab_size).any()
+        invalid_ids = torch.logical_or(
+            (ids >= self.encoder_tokenizer.vocab_size).any(),
+            (ids < 0).any(),
+        )
 
         if raise_error and invalid_ids:
             raise ValueError("Encoder ids are out of range (tip: check encoder tokenizer)")
@@ -220,7 +223,10 @@ class MTEncDecModel(EncDecNLPModel):
         return not invalid_ids
 
     def test_decoder_ids(self, ids, raise_error=False):
-        invalid_ids = (ids >= self.decoder_tokenizer.vocab_size).any()
+        invalid_ids = torch.logical_or(
+            (ids >= self.decoder_tokenizer.vocab_size).any(),
+            (ids < 0).any(),
+        )
 
         if raise_error and invalid_ids:
             raise ValueError("Decoder ids are out of range (tip: check decoder tokenizer)")
@@ -710,14 +716,14 @@ class MTEncDecModel(EncDecNLPModel):
 
     @torch.no_grad()
     def batch_translate(self, src: torch.LongTensor, src_mask: torch.LongTensor, return_beam_scores: bool = False):
-        """	
-        Translates a minibatch of inputs from source language to target language.	
-        Args:	
-            src: minibatch of inputs in the src language (batch x seq_len)	
-            src_mask: mask tensor indicating elements to be ignored (batch x seq_len)	
-        Returns:	
-            translations: a list strings containing detokenized translations	
-            inputs: a list of string containing detokenized inputs	
+        """
+        Translates a minibatch of inputs from source language to target language.
+        Args:
+            src: minibatch of inputs in the src language (batch x seq_len)
+            src_mask: mask tensor indicating elements to be ignored (batch x seq_len)
+        Returns:
+            translations: a list strings containing detokenized translations
+            inputs: a list of string containing detokenized inputs
         """
         mode = self.training
         try:

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -75,6 +75,9 @@ class MTEncDecModel(EncDecNLPModel):
         self.encoder_tokenizer_library = cfg.encoder_tokenizer.get('library', 'yttm')
         self.decoder_tokenizer_library = cfg.decoder_tokenizer.get('library', 'yttm')
 
+        self.validate_input_ids =  = cfg.get("validate_input_ids", True)
+
+
         # Instantiates tokenizers and register to be saved with NeMo Model archive
         # After this call, ther will be self.encoder_tokenizer and self.decoder_tokenizer
         # Which can convert between tokens and token_ids for SRC and TGT languages correspondingly.
@@ -229,9 +232,10 @@ class MTEncDecModel(EncDecNLPModel):
 
     @typecheck()
     def forward(self, src, src_mask, tgt, tgt_mask):
-        # test src/tgt for id range (i.e., hellp in catching wrong tokenizer)
-        self.test_encoder_ids(src, raise_error=True)
-        self.test_decoder_ids(tgt, raise_error=True)
+        if self.validate_input_ids:
+            # test src/tgt for id range (i.e., hellp in catching wrong tokenizer)
+            self.test_encoder_ids(src, raise_error=True)
+            self.test_decoder_ids(tgt, raise_error=True)
 
         src_hiddens = self.encoder(input_ids=src, encoder_mask=src_mask)
         tgt_hiddens = self.decoder(

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -77,7 +77,6 @@ class MTEncDecModel(EncDecNLPModel):
 
         self.validate_input_ids = cfg.get("validate_input_ids", True)
 
-
         # Instantiates tokenizers and register to be saved with NeMo Model archive
         # After this call, ther will be self.encoder_tokenizer and self.decoder_tokenizer
         # Which can convert between tokens and token_ids for SRC and TGT languages correspondingly.
@@ -450,7 +449,7 @@ class MTEncDecModel(EncDecNLPModel):
         for tok_name, tok_library, tok_model in [
             ("encoder_tokenizer", encoder_tokenizer_library, self.encoder_tokenizer),
             ("decoder_tokenizer", decoder_tokenizer_library, self.decoder_tokenizer),
-            ]:
+        ]:
             if tok_library == 'sentencepiece':
                 negative_tokens = []
                 for n in ["eos_id", "bos_id", "unk_id", "pad_id"]:
@@ -459,8 +458,9 @@ class MTEncDecModel(EncDecNLPModel):
                         negative_tokens.append(f"{n}={v}")
 
                 if negative_tokens:
-                    raise ValueError(f"{tok_name}=sentencepiece has invalid negative special tokens = {negative_tokens}")
-
+                    raise ValueError(
+                        f"{tok_name}=sentencepiece has invalid negative special tokens = {negative_tokens}"
+                    )
 
     def setup_training_data(self, train_data_config: Optional[DictConfig]):
         self._train_dl = self._setup_dataloader_from_config(cfg=train_data_config)

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -446,6 +446,22 @@ class MTEncDecModel(EncDecNLPModel):
             r2l=decoder_r2l,
         )
 
+        # validate no token is negative for sentencepiece tokenizers
+        for tok_name, tok_library, tok_model in zip([
+            ("encoder_tokenizer", encoder_tokenizer_library, self.encoder_tokenizer),
+            ("decoder_tokenizer", decoder_tokenizer_library, self.decoder_tokenizer),
+            ]):
+            if tok_library == 'sentencepiece':
+                negative_tokens = []
+                for n in ["eos_id", "bos_id", "unk_id", "pad_id"]:
+                    v = getattr(tok_model.tokenizer, n)()
+                    if v < 0:
+                        negative_tokens.append(f"{n}={v}")
+
+                if negative_tokens:
+                    raise ValueError(f"{tok_name}=sentencepiece has invalid negative special tokens = {negative_tokens}")
+
+
     def setup_training_data(self, train_data_config: Optional[DictConfig]):
         self._train_dl = self._setup_dataloader_from_config(cfg=train_data_config)
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -212,10 +212,7 @@ class MTEncDecModel(EncDecNLPModel):
         return ids
 
     def test_encoder_ids(self, ids, raise_error=False):
-        invalid_ids = torch.logical_or(
-            (ids >= self.encoder_tokenizer.vocab_size).any(),
-            (ids < 0).any(),
-        )
+        invalid_ids = torch.logical_or((ids >= self.encoder_tokenizer.vocab_size).any(), (ids < 0).any(),)
 
         if raise_error and invalid_ids:
             raise ValueError("Encoder ids are out of range (tip: check encoder tokenizer)")
@@ -223,10 +220,7 @@ class MTEncDecModel(EncDecNLPModel):
         return not invalid_ids
 
     def test_decoder_ids(self, ids, raise_error=False):
-        invalid_ids = torch.logical_or(
-            (ids >= self.decoder_tokenizer.vocab_size).any(),
-            (ids < 0).any(),
-        )
+        invalid_ids = torch.logical_or((ids >= self.decoder_tokenizer.vocab_size).any(), (ids < 0).any(),)
 
         if raise_error and invalid_ids:
             raise ValueError("Decoder ids are out of range (tip: check decoder tokenizer)")

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -447,10 +447,10 @@ class MTEncDecModel(EncDecNLPModel):
         )
 
         # validate no token is negative for sentencepiece tokenizers
-        for tok_name, tok_library, tok_model in zip([
+        for tok_name, tok_library, tok_model in [
             ("encoder_tokenizer", encoder_tokenizer_library, self.encoder_tokenizer),
             ("decoder_tokenizer", decoder_tokenizer_library, self.decoder_tokenizer),
-            ]):
+            ]:
             if tok_library == 'sentencepiece':
                 negative_tokens = []
                 for n in ["eos_id", "bos_id", "unk_id", "pad_id"]:


### PR DESCRIPTION
This PR extends validity checks of src/tgt input IDs:

1. Added a test for special tokens being valid (i.e., non-negative) for Sentencepiece tokenizer.
2. Extended MTEncDecModel id validity test to include non-negativity.
3. Added `model.validate_input_ids` to `MTEncDecModel` config to allow disabling id validity (`true` by default).
