### PR TITLE
Fix window_stride calculation in DALI pipeline & Fix dither generation

### DIFF
--- a/nemo/collections/asr/data/audio_to_text_dali.py
+++ b/nemo/collections/asr/data/audio_to_text_dali.py
@@ -41,7 +41,7 @@ __all__ = [
 ]
 
 """
-Below minimum version is required to access the "read_idxs" argument in 
+Below minimum version is required to access the "read_idxs" argument in
 dali.fn.readers.nemo_asr
 """
 __DALI_MINIMUM_VERSION__ = "1.4"
@@ -222,7 +222,7 @@ class _AudioTextDALIDataset(Iterator):
             self.window_stride_sec = params['window_stride'] if 'window_stride' in params else 0.01
             self.sample_rate = params['sample_rate'] if 'sample_rate' in params else sample_rate
             self.window_size = int(self.window_size_sec * self.sample_rate)
-            self.window_stride = int(self.window_size_sec * self.sample_rate)
+            self.window_stride = int(self.window_stride_sec * self.sample_rate)
 
             normalize = params['normalize'] if 'normalize' in params else 'per_feature'
             if normalize == 'per_feature':  # Each freq channel independently
@@ -345,7 +345,7 @@ class _AudioTextDALIDataset(Iterator):
             else:
                 # Additive gaussian noise (dither)
                 if self.dither > 0.0:
-                    gaussian_noise = dali.fn.normal_distribution(device=self.device)
+                    gaussian_noise = dali.fn.normal_distribution(audio)
                     audio = audio + self.dither * gaussian_noise
 
                 # Preemphasis filter


### PR DESCRIPTION
Fixes a bug in the calculation of the window stride uses for spectrogram calculation in the DALI implementation.
Fixes a bug in the generation of gaussian noise (dither). Generate noise with the shape of the audio, instead of a single sample (bug)

Signed-off-by: Joaquin Anton <janton@nvidia.com>