### PR TITLE
Fix loading and resample audio in get_samples

### DIFF
--- a/nemo/collections/asr/parts/utils/streaming_utils.py
+++ b/nemo/collections/asr/parts/utils/streaming_utils.py
@@ -16,6 +16,7 @@ import copy
 
 import numpy as np
 import soundfile as sf
+import librosa
 import torch
 from omegaconf import OmegaConf
 from torch.utils.data import DataLoader
@@ -125,12 +126,11 @@ class AudioBuffersDataLayer(IterableDataset):
 
 def get_samples(audio_file, target_sr=16000):
     with sf.SoundFile(audio_file, 'r') as f:
-        dtype = 'int16'
+        dtype = 'float32'
         sample_rate = f.samplerate
         samples = f.read(dtype=dtype)
         if sample_rate != target_sr:
             samples = librosa.core.resample(samples, sample_rate, target_sr)
-        samples = samples.astype('float32') / 32768
         samples = samples.transpose()
         return samples
 


### PR DESCRIPTION
There are several bugs in this file:
1. librosa library is not imported.
2. librosa.core.resample is expecting float32 array and not int.
3. librosa.core.resample returns float32 array, so no need to re-convert it.