### PR TITLE
Fix numba spec augment for cases where batch size > MAX_THREAD_BUFFER

### DIFF
--- a/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
+++ b/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
@@ -57,12 +57,12 @@ def spec_augment_kernel(
     # For all samples in the batch, apply the freq mask
     for bidx in range(0, x.shape[0], threads_per_block):
         # Resolve the index of the batch (case where more masks than MAX_THREAD_BUFFER)
-        bm_idx = bidx * threads_per_block + tid
+        bm_idx = bidx + tid
 
-        # For `len_f` number of freq masks that must be applied
-        for fidx in range(0, len_f):
-            # If resolved freq mask index < total number of freq masks
-            if fidx < len_f:
+        # Access mask only if valid sample id in batch
+        if bm_idx < x.shape[0]:
+            # For `len_f` number of freq masks that must be applied
+            for fidx in range(0, len_f):
                 # Access the start index and width of this freq mask
                 f_start = freq_starts[bm_idx, fidx]
                 f_width = freq_widths[bm_idx, fidx]
@@ -76,12 +76,12 @@ def spec_augment_kernel(
     # For all samples in the batch, apply the time mask
     for b_idx in range(0, x.shape[0], threads_per_block):
         # Resolve the index of the batch (case where more masks than MAX_THREAD_BUFFER)
-        bm_idx = bidx * threads_per_block + tid
+        bm_idx = b_idx + tid
 
-        # For `len_t` number of freq masks that must be applied
-        for tidx in range(0, len_t):
-            # If resolved time mask index < total number of time masks
-            if tidx < len_t:
+        # Access mask only if valid sample id in batch
+        if bm_idx < x.shape[0]:
+            # For `len_t` number of freq masks that must be applied
+            for tidx in range(0, len_t):
                 # Access the start index and width of this time mask
                 t_start = time_starts[bm_idx, tidx]
                 t_width = time_widths[bm_idx, tidx]

--- a/tests/collections/asr/numba/spec_augment/test_spec_aug_numba.py
+++ b/tests/collections/asr/numba/spec_augment/test_spec_aug_numba.py
@@ -21,13 +21,13 @@ from nemo.core.utils import numba_utils
 from nemo.core.utils.numba_utils import __NUMBA_MINIMUM_VERSION__
 
 
-def get_cfg(seed=0, dtype='float32'):
+def get_cfg(seed=0, dtype='float32', **kwargs):
     # fmt: off
-    cfg = OmegaConf.create(
-        dict(b=2, f=80, t=20, device='cuda',
-             freq_masks=2, time_masks=2, freq_width=27, time_width=0.05, mask_value=0.0,
-             seed=seed, dtype=dtype)
-    )
+    default = dict(b=2, f=80, t=20, device='cuda',
+                  freq_masks=2, time_masks=2, freq_width=27, time_width=0.05, mask_value=0.0,
+                  seed=seed, dtype=dtype)
+    default.update(**kwargs)
+    cfg = OmegaConf.create(default)
     # fmt: on
     return cfg
 
@@ -124,6 +124,8 @@ def freq_mask_check(x, x_len, f_start, f_len, mask_value, bidx):
     check_result = True
     for fidx in range(f_start, f_start + f_len):
         if not (x[bidx, fidx, :] == mask_value).all():
+            print(bidx, fidx)
+            print(x[bidx, fidx, :])
             check_result = False
             break
     assert check_result
@@ -163,10 +165,37 @@ class TestSpecAugmentNumba:
             for f_start, f_len in zip(data['freq_starts'][bidx], data['freq_lengths'][bidx]):
                 freq_mask_check(x, x_len, f_start, f_len, mask_value=cfg.mask_value, bidx=bidx)
 
+    @pytest.mark.unit
+    @pytest.mark.run_only_on('GPU')
+    @pytest.mark.parametrize('dtype', ['float16', 'float32'])
+    def test_spec_aug_kernel_large_batch(self, dtype):
+        numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
+
+        # Change max threads per block temporarily
+        original_buffer = spec_aug_numba.MAX_THREAD_BUFFER
+        spec_aug_numba.MAX_THREAD_BUFFER = 4
+
+        cfg = get_cfg(seed=0, dtype=dtype)
+        cfg.freq_masks = 2
+        cfg.time_masks = 10
+        cfg.b = spec_aug_numba.MAX_THREAD_BUFFER + 1
+
+        data = prepare_data(**cfg)
+
+        launch_kernel(data, cfg)
+        x, x_len, sh = data['x'], data['x_len'], data['sh']
+
+        # Assert freq masks are correct
+        for bidx in range(sh[0]):
+            for f_start, f_len in zip(data['freq_starts'][bidx], data['freq_lengths'][bidx]):
+                freq_mask_check(x, x_len, f_start, f_len, mask_value=cfg.mask_value, bidx=bidx)
+
         # Assert time masks are correct
         for bidx in range(sh[0]):
             for t_start, t_len in zip(data['time_starts'][bidx], data['time_lengths'][bidx]):
                 time_mask_check(x, x_len, t_start, t_len, mask_value=cfg.mask_value, bidx=bidx)
+
+        spec_aug_numba.MAX_THREAD_BUFFER = original_buffer
 
     @pytest.mark.unit
     @pytest.mark.run_only_on('GPU')

--- a/tests/collections/asr/numba/spec_augment/test_spec_aug_numba.py
+++ b/tests/collections/asr/numba/spec_augment/test_spec_aug_numba.py
@@ -124,8 +124,6 @@ def freq_mask_check(x, x_len, f_start, f_len, mask_value, bidx):
     check_result = True
     for fidx in range(f_start, f_start + f_len):
         if not (x[bidx, fidx, :] == mask_value).all():
-            print(bidx, fidx)
-            print(x[bidx, fidx, :])
             check_result = False
             break
     assert check_result


### PR DESCRIPTION
# Bugfix
- Fix an issue where numba spec augment will throw cryptic CUDA error if batch size > MAX_THREAD_BUFFER

Closes https://github.com/NVIDIA/NeMo/issues/2916

Signed-off-by: smajumdar <titu1994@gmail.com>