### PR TITLE
Adding complete method to MegatronGPTModel

### DIFF
--- a/examples/nlp/language_modeling/megatron_gpt_eval.py
+++ b/examples/nlp/language_modeling/megatron_gpt_eval.py
@@ -1,0 +1,56 @@
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from pytorch_lightning.trainer import trainer
+import nemo.collections.nlp as nemo_nlp
+from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel
+from pytorch_lightning.trainer.trainer import Trainer
+from nemo.utils import  logging
+from argparse import ArgumentParser
+
+import torch
+
+from nemo.collections.asr.metrics.wer import WER, word_error_rate
+from nemo.collections.asr.models import EncDecCTCModel
+from nemo.utils import logging
+
+
+assert torch.cuda.is_available()
+
+
+def main():
+    parser = ArgumentParser()
+    parser.add_argument("--model_file", type=str, default="", required=True, help="Pass path to model's .nemo file")
+    parser.add_argument("--prompt", type=str, default="", required=True, help="Prompt for the model (a text to complete)")
+    parser.add_argument("--tokens_to_generate", type=int, default="64", required=True, help="How many tokens to add to prompt")
+    parser.add_argument("--stop_after_sentence", type=bool, default="True", required=False, help="True/False: whether to stop after full sentence has been generated.")
+
+    args = parser.parse_args()
+    torch.set_grad_enabled(False)
+
+    # TODO: not sure why we require PTL for restoring
+    trainer = Trainer()    
+    model = MegatronGPTModel.restore_from(restore_path=args.model_file, trainer=trainer)
+    res = model.complete({"prompt": args.prompt,
+                          "tokens_to_generate": args.tokens_to_generate,
+                          "stop_after_sentence": args.stop_after_sentence})
+    print("***************************")
+    print(res['completion']['text'])
+    print("***************************")
+    logging.info(f"Generation stopped because: {res['completion']['stop reason']}")
+
+
+if __name__ == '__main__':
+    main()  # noqa pylint: disable=no-value-for-parameter

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Dict
 import torch
 from apex import mpu
 from omegaconf.dictconfig import DictConfig
@@ -292,6 +293,63 @@ class MegatronGPTModel(NLPModel):
             clip_grad_norm_fp32(parameters=parameters, max_norm=clip_val)
         else:
             return
+
+
+    def complete(self, request: Dict):
+        """
+            Autoregressively invokes language model in the inference mode
+        Args:	
+            request: Dictionary with the following fields
+                * prompt: a string which text the model should complete.
+                * tokens_to_generate: how many tokens to generate while doing prompt completion.
+                * stop_after_sentence: (default True) whether to stop generation once sentence end is reached.
+        Returns:	
+            response: A python dictionary with the following fields
+                * prompt: original text of the prompt
+                * tokenized_prompt: list of (str) tokens from prompt
+                * completion: a python dictionary with the following subfields:
+                    * tokens: a list of triples (token, token_id, log_prob) comprising completion
+                    * stop reason: either 'eos', 'sentence_end' or 'limit' indicating why generation stopped
+                    * text: completion text (as a single string)
+                
+        """
+        response = {}
+        self.eval()
+        tokenized_prompt = self.tokenizer.text_to_tokens(request['prompt'])
+        response["tokenized_prompt"] = tokenized_prompt     
+        tokens = self.tokenizer.text_to_ids(request['prompt'])
+        # How will this look in model parallel setting?
+        tokens = torch.tensor(tokens, device=self.device)
+        # naive greedy slow loop
+        # TODO: rewrite me with BeamSearchDecoder          
+        response['prompt'] = request['prompt']
+        response['completion'] = {}
+        response['completion']['stop reason'] = 'limit' 
+        for i in range(request.get("tokens_to_generate", 1024)):            
+            attention_mask, _, position_ids = get_ltor_masks_and_position_ids(
+                data=torch.unsqueeze(tokens, 0), 
+                eod_token=self.tokenizer.eos_id,
+                reset_position_ids=self.cfg.get('reset_position_ids', False),
+                reset_attention_mask=self.cfg.get('reset_attention_mask', False),
+                eod_mask_loss=self.cfg.get('eod_mask_loss', False),
+            )
+            # No labels during inference. Still need masks to not attend to the right
+            output_tensor = self(torch.unsqueeze(tokens, 0), position_ids, attention_mask, labels=None)            
+            log_probs, token_ids = torch.max(output_tensor, dim=-1)
+            reached_eos = token_ids[0, -1].item() == self.tokenizer.eos_id            
+            # TODO: CURRENT log_probs are probably NOT correct!!!!            
+            tokens = torch.cat([tokens, token_ids[:,-1]])
+            response['completion']["tokens"] = list(zip(self.tokenizer.ids_to_tokens(tokens), tokens.tolist(), log_probs.tolist()[0]))
+            completion_text = self.tokenizer.ids_to_text(x[1] for x in response['completion']["tokens"])
+            if reached_eos: # Will it actually ever reach that?
+                response['completion']['stop reason'] = 'eos'
+                break
+            elif request.get("stop_after_sentence", True) and completion_text.endswith(('.', '!', '?')):
+                response['completion']['stop reason'] = 'sentence_end'
+                break
+        response['completion']["text"] = self.tokenizer.ids_to_text(x[1] for x in response['completion']["tokens"])                  
+        return response
+
 
     def list_available_models():
         pass


### PR DESCRIPTION
This PR adds the following method ```response=MegatronGPTModel.complete(request)``` and example how to use it.
Example usage:
```
python examples/nlp/language_modeling/megatron_gpt_eval.py --model_file megatron_gpt.nemo \
--prompt "How to fix gpu memory? A: " --tokens_to_generate 256
```
With a somewhat good converged model you should be getting completion like this:
```
How to fix gpu memory? A: 

You can use the gpu_mem_info() function to get the information about the memory.
```