### PR TITLE
Improve efficiency of dataloaders for transcribe()

### DIFF
--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -275,6 +275,9 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
             'sample_rate': self.preprocessor._sample_rate,
             'batch_size': min(config['batch_size'], len(config['paths2audio_files'])),
             'shuffle': False,
+            'num_workers': os.cpu_count() - 1,
+            'pin_memory': True,
+            'use_start_end_token': self.cfg.validation_ds.get('use_start_end_token', False),
         }
 
         temporary_datalayer = self._setup_dataloader_from_config(config=DictConfig(dl_config))

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -655,8 +655,10 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
             'sample_rate': self.preprocessor._sample_rate,
             'labels': self.decoder.vocabulary,
             'batch_size': min(config['batch_size'], len(config['paths2audio_files'])),
-            'trim_silence': True,
+            'trim_silence': False,
             'shuffle': False,
+            'num_workers': os.cpu_count() - 1,
+            'pin_memory': True,
         }
 
         temporary_datalayer = self._setup_dataloader_from_config(config=DictConfig(dl_config))

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -354,6 +354,9 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
             'sample_rate': self.preprocessor._sample_rate,
             'batch_size': min(config['batch_size'], len(config['paths2audio_files'])),
             'shuffle': False,
+            'num_workers': os.cpu_count() - 1,
+            'pin_memory': True,
+            'use_start_end_token': self.cfg.validation_ds.get('use_start_end_token', False),
         }
 
         temporary_datalayer = self._setup_dataloader_from_config(config=DictConfig(dl_config))

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -807,8 +807,10 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecJointModel):
             'sample_rate': self.preprocessor._sample_rate,
             'labels': self.joint.vocabulary,
             'batch_size': min(config['batch_size'], len(config['paths2audio_files'])),
-            'trim_silence': True,
+            'trim_silence': False,
             'shuffle': False,
+            'num_workers': os.cpu_count() - 1,
+            'pin_memory': True,
         }
 
         temporary_datalayer = self._setup_dataloader_from_config(config=DictConfig(dl_config))


### PR DESCRIPTION
# Changelog
- Add num_workers and pin_memory to data loaders
- Add missing flag for use start end token in transcribe data loaders for BPE models

# Bugfix
- Remove trim_silence = True as default is now False

Signed-off-by: smajumdar <titu1994@gmail.com>