### PR TITLE
Fixed wrong tgt_length for timing

### DIFF
--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -896,7 +896,7 @@ class MTEncDecModel(EncDecNLPModel):
         if log_timing:
             timing = timer.export()
             timing["mean_src_length"] = src_mask.sum().cpu().item() / src_mask.shape[0]
-            tgt, tgt_mask = self.prepare_inference_batch(best_translations, prepend_ids)
+            tgt, tgt_mask = self.prepare_inference_batch(best_translations, prepend_ids, target=True)
             timing["mean_tgt_length"] = tgt_mask.sum().cpu().item() / tgt_mask.shape[0]
 
             if type(return_val) is tuple:


### PR DESCRIPTION
This PR fixes tgt_length to use the decoder tokenizer instead of the encoder tokenizer.