### PR TITLE
Ptl upgrade r1.5.0 fixes

### DIFF
--- a/examples/asr/conf/carnelinet/carnelinet_384.yaml
+++ b/examples/asr/conf/carnelinet/carnelinet_384.yaml
@@ -228,7 +228,8 @@ trainer:
   max_epochs: 100
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: false  # Provided by exp_manager
   logger: false  # Provided by exp_manager

--- a/examples/asr/conf/citrinet/citrinet_384.yaml
+++ b/examples/asr/conf/citrinet/citrinet_384.yaml
@@ -392,7 +392,8 @@ trainer:
   max_epochs: 100
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: false  # Provided by exp_manager
   logger: false  # Provided by exp_manager

--- a/examples/asr/conf/citrinet/citrinet_512.yaml
+++ b/examples/asr/conf/citrinet/citrinet_512.yaml
@@ -392,7 +392,8 @@ trainer:
   max_epochs: 100
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: false  # Provided by exp_manager
   logger: false  # Provided by exp_manager

--- a/examples/asr/conf/citrinet/config_bpe.yaml
+++ b/examples/asr/conf/citrinet/config_bpe.yaml
@@ -158,7 +158,8 @@ trainer:
   max_epochs: 5
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -162,7 +162,8 @@ trainer:
   max_epochs: 5
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/asr/conf/conformer/conformer_ctc_bpe.yaml
+++ b/examples/asr/conf/conformer/conformer_ctc_bpe.yaml
@@ -153,7 +153,8 @@ trainer:
   max_epochs: 1000
   max_steps: null # computed at runtime if not set
   val_check_interval: 1.0 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   gradient_clip_val: 0.0
   precision: 32 # Should be set to 16 for O1 and O2 to enable the AMP.

--- a/examples/asr/conf/conformer/conformer_ctc_char.yaml
+++ b/examples/asr/conf/conformer/conformer_ctc_char.yaml
@@ -128,7 +128,8 @@ trainer:
   max_epochs: 1000
   max_steps: null # computed at runtime if not set
   val_check_interval: 1.0 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   gradient_clip_val: 0.0
   precision: 32 # Should be set to 16 for O1 and O2 to enable the AMP.

--- a/examples/asr/conf/conformer/conformer_transducer_bpe.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_bpe.yaml
@@ -203,7 +203,8 @@ trainer:
   max_epochs: 1000
   max_steps: null # computed at runtime if not set
   val_check_interval: 1.0 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   gradient_clip_val: 0.0
   precision: 32 # Should be set to 16 for O1 and O2 to enable the AMP.

--- a/examples/asr/conf/conformer/conformer_transducer_char.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_char.yaml
@@ -198,7 +198,8 @@ trainer:
   max_epochs: 1000
   max_steps: null # computed at runtime if not set
   val_check_interval: 1.0 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   gradient_clip_val: 0.0
   precision: 32 # Should be set to 16 for O1 and O2 to enable the AMP.

--- a/examples/asr/conf/contextnet_rnnt/config_rnnt.yaml
+++ b/examples/asr/conf/contextnet_rnnt/config_rnnt.yaml
@@ -225,7 +225,8 @@ trainer:
   max_epochs: 5
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   precision: 32
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager

--- a/examples/asr/conf/contextnet_rnnt/config_rnnt_bpe.yaml
+++ b/examples/asr/conf/contextnet_rnnt/config_rnnt_bpe.yaml
@@ -226,7 +226,8 @@ trainer:
   max_epochs: 5
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   precision: 32
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
@@ -471,7 +471,8 @@ trainer:
   max_epochs: 100
   max_steps: null # computed at runtime if not set
   num_nodes: 1  # Should be set via SLURM variable `SLURM_JOB_NUM_NODES`
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: false  # Provided by exp_manager
   logger: false  # Provided by exp_manager

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_char.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_char.yaml
@@ -472,7 +472,8 @@ trainer:
   max_epochs: 100
   max_steps: null # computed at runtime if not set
   num_nodes: 1  # Should be set via SLURM variable `SLURM_JOB_NUM_NODES`
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: false  # Provided by exp_manager
   logger: false  # Provided by exp_manager

--- a/examples/asr/conf/jasper/jasper_10x5dr.yaml
+++ b/examples/asr/conf/jasper/jasper_10x5dr.yaml
@@ -183,7 +183,8 @@ trainer:
   max_epochs: 5
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/asr/conf/marblenet/marblenet_3x2x64.yaml
+++ b/examples/asr/conf/marblenet/marblenet_3x2x64.yaml
@@ -155,7 +155,8 @@ trainer:
   max_epochs: 150
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v1.yaml
+++ b/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v1.yaml
@@ -168,7 +168,8 @@ trainer:
   max_epochs: 200
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v2.yaml
+++ b/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v2.yaml
@@ -168,7 +168,8 @@ trainer:
   max_epochs: 200
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/asr/conf/quartznet/quartznet_15x5.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5.yaml
@@ -253,7 +253,8 @@ trainer:
   max_epochs: 5
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/asr/conf/quartznet/quartznet_15x5_zh.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5_zh.yaml
@@ -455,7 +455,8 @@ trainer:
   max_epochs: 5
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/asr/experimental/quartznet/quartznet_15x5_aug.yaml
+++ b/examples/asr/experimental/quartznet/quartznet_15x5_aug.yaml
@@ -265,7 +265,8 @@ trainer:
   max_epochs: 5
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/asr/experimental/structured/conf/quartznet_15x5.yaml
+++ b/examples/asr/experimental/structured/conf/quartznet_15x5.yaml
@@ -226,7 +226,8 @@ trainer:
   gpus: 0 # number of gpus
   max_epochs: 5
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations

--- a/examples/asr/experimental/wav2vec/configs/wav2vec_pretrain.yaml
+++ b/examples/asr/experimental/wav2vec/configs/wav2vec_pretrain.yaml
@@ -97,7 +97,8 @@ trainer:
   max_epochs: 100
   max_steps: null # computed at runtime if not set
   val_check_interval: 0.5 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   gradient_clip_val: 0.0
   precision: 32 # Should be set to 16 for O1 and O2 to enable the AMP.

--- a/examples/asr/experimental/wav2vec/configs/wav2vec_pretrain_large.yaml
+++ b/examples/asr/experimental/wav2vec/configs/wav2vec_pretrain_large.yaml
@@ -97,7 +97,8 @@ trainer:
   max_epochs: 100
   max_steps: null # computed at runtime if not set
   val_check_interval: 0.5 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   gradient_clip_val: 0.0
   precision: 32 # Should be set to 16 for O1 and O2 to enable the AMP.

--- a/examples/asr/speech_to_label.py
+++ b/examples/asr/speech_to_label.py
@@ -34,7 +34,8 @@ python speech_to_label.py \
     model.train_ds.manifest_filepath="<path to train manifest>" \
     model.validation_ds.manifest_filepath=["<path to val manifest>","<path to test manifest>"] \
     trainer.gpus=2 \
-    trainer.accelerator="ddp" \
+    trainer.accelerator="gpu" \
+    trainer.strategy="ddp" \
     trainer.max_epochs=200 \
     exp_manager.create_wandb_logger=True \
     exp_manager.wandb_logger_kwargs.name="MatchboxNet-3x1x64-v1" \
@@ -67,7 +68,8 @@ python speech_to_label.py \
     model.train_ds.manifest_filepath="<path to train manifest>" \
     model.validation_ds.manifest_filepath=["<path to val manifest>","<path to test manifest>"] \
     trainer.gpus=2 \
-    trainer.accelerator="ddp" \
+    trainer.accelerator="gpu" \
+    trainer.strategy="ddp" \
     trainer.max_epochs=200 \
     exp_manager.create_wandb_logger=True \
     exp_manager.wandb_logger_kwargs.name="MatchboxNet-3x1x64-vad" \
@@ -94,7 +96,8 @@ python speech_to_label.py \
     +model.train_ds.num_worker=<num_shards used generating tarred dataset> \
     model.validation_ds.manifest_filepath=<path to validation audio_manifest.json>\
     trainer.gpus=2 \
-    trainer.accelerator="ddp" \
+    trainer.accelerator="gpu" \
+    trainer.strategy="ddp" \
     trainer.max_epochs=200 \
     exp_manager.create_wandb_logger=True \
     exp_manager.wandb_logger_kwargs.name="MatchboxNet-3x1x64-vad" \

--- a/examples/asr/speech_to_text_bpe.py
+++ b/examples/asr/speech_to_text_bpe.py
@@ -39,7 +39,8 @@ python speech_to_text_bpe.py \
     model.tokenizer.dir=<path to directory of tokenizer (not full path to the vocab file!)> \
     model.tokenizer.type=<either bpe or wpe> \
     trainer.gpus=-1 \
-    trainer.accelerator="ddp" \
+    trainer.accelerator="gpu" \
+    trainer.strategy="ddp" \
     trainer.max_epochs=100 \
     model.optim.name="adamw" \
     model.optim.lr=0.001 \

--- a/examples/asr/speech_to_text_rnnt_bpe.py
+++ b/examples/asr/speech_to_text_rnnt_bpe.py
@@ -39,7 +39,7 @@ python speech_to_text_rnnt_bpe.py \
     model.tokenizer.dir=<path to directory of tokenizer (not full path to the vocab file!)> \
     model.tokenizer.type=<either bpe or wpe> \
     trainer.gpus=-1 \
-    trainer.accelerator="ddp" \
+    trainer.accelerator="gpu" \
     trainer.max_epochs=100 \
     model.optim.name="adamw" \
     model.optim.lr=0.001 \

--- a/examples/cv/mnist_lenet5_image_classification_pure_lightning.py
+++ b/examples/cv/mnist_lenet5_image_classification_pure_lightning.py
@@ -35,7 +35,7 @@ class AppConfig(Config):
     """
 
     name: str = "Training of a LeNet-5 Model using a pure PyTorchLightning approach - using DDP on 2 GPUs."
-    trainer: TrainerConfig = TrainerConfig(gpus=2, accelerator="ddp")
+    trainer: TrainerConfig = TrainerConfig(gpus=2, accelerator="gpu", strategy="ddp")
     model: MNISTLeNet5Config = MNISTLeNet5Config()
 
 

--- a/examples/nlp/dialogue_state_tracking/conf/sgdqa_config.yaml
+++ b/examples/nlp/dialogue_state_tracking/conf/sgdqa_config.yaml
@@ -23,7 +23,8 @@ trainer:
   accumulate_grad_batches: 1 # accumulates grads every k batches
   gradient_clip_val: 1.0
   precision: 16 # Should be set to 16 for O1 and O2 to enable the AMP.
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   log_every_n_steps: 5  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
   resume_from_checkpoint: null # The path to a checkpoint file to continue the training, restores the whole state including the epoch, step, LR schedulers, apex, etc.

--- a/examples/nlp/duplex_text_normalization/conf/duplex_tn_config.yaml
+++ b/examples/nlp/duplex_text_normalization/conf/duplex_tn_config.yaml
@@ -16,7 +16,8 @@ tagger_trainer:
   accumulate_grad_batches: 1 # accumulates grads every k batches
   gradient_clip_val: 0.0
   precision: 32 # Should be set to 16 for O1 and O2 to enable the AMP.
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
 
 tagger_model:
   do_training: true
@@ -66,7 +67,8 @@ decoder_trainer:
   accumulate_grad_batches: 1 # accumulates grads every k batches
   gradient_clip_val: 0.0
   precision: 32 # Should be set to 16 for O1 and O2 to enable the AMP.
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
   resume_from_checkpoint: null # The path to a checkpoint file to continue the training, restores the whole state including the epoch, step, LR schedulers, apex, etc.

--- a/examples/nlp/entity_linking/conf/tiny_example_entity_linking_config.yaml
+++ b/examples/nlp/entity_linking/conf/tiny_example_entity_linking_config.yaml
@@ -7,7 +7,8 @@ trainer:
   max_steps: null
   accumulate_grad_batches: 1
   precision: 16
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   gradient_clip_val: 0.0
   log_every_n_steps: 1
   val_check_interval: 2

--- a/examples/nlp/entity_linking/conf/umls_medical_entity_linking_config.yaml
+++ b/examples/nlp/entity_linking/conf/umls_medical_entity_linking_config.yaml
@@ -7,7 +7,8 @@ trainer:
   max_steps: null
   accumulate_grad_batches: 1
   precision: 16
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   gradient_clip_val: 0.0
   log_every_n_steps: 1
   val_check_interval: 1000

--- a/examples/nlp/glue_benchmark/glue_benchmark_config.yaml
+++ b/examples/nlp/glue_benchmark/glue_benchmark_config.yaml
@@ -8,7 +8,8 @@ trainer:
   max_steps: null # precedence over max_epochs
   accumulate_grad_batches: 1 # accumulates grads every k batches
   precision: 16
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
 

--- a/examples/nlp/information_retrieval/conf/bert_ir_config.yaml
+++ b/examples/nlp/information_retrieval/conf/bert_ir_config.yaml
@@ -7,7 +7,8 @@ trainer:
   max_steps: null # precedence over max_epochs
   accumulate_grad_batches: 1 # accumulates grads every k batches
   precision: 16 # 16 to use AMP
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 0.05  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
   checkpoint_callback: false  # provided by exp_manager

--- a/examples/nlp/intent_slot_classification/conf/intent_slot_classification_config.yaml
+++ b/examples/nlp/intent_slot_classification/conf/intent_slot_classification_config.yaml
@@ -7,7 +7,8 @@ trainer:
   max_steps: null # precedence over max_epochs
   accumulate_grad_batches: 1 # accumulates grads every k batches
   precision: 32 # Should be set to 16 for O1 and O2 amp_level to enable the AMP.
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
   resume_from_checkpoint: null # The path to a checkpoint file to continue the training, restores the whole state including the epoch, step, LR schedulers, apex, etc.

--- a/examples/nlp/language_modeling/conf/bert_pretraining_from_preprocessed_config.yaml
+++ b/examples/nlp/language_modeling/conf/bert_pretraining_from_preprocessed_config.yaml
@@ -8,7 +8,8 @@ trainer:
   replace_sampler_ddp: false # needed for bert pretraining from preproc
   accumulate_grad_batches: 1 # accumulates grads every k batches
   precision: 16 # 16 to use AMP
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   gradient_clip_val: 1.0
   log_every_n_steps: 1
   val_check_interval: 1.0 # check once per epoch .25 for 4 times per epoch

--- a/examples/nlp/language_modeling/conf/bert_pretraining_from_text_config.yaml
+++ b/examples/nlp/language_modeling/conf/bert_pretraining_from_text_config.yaml
@@ -7,7 +7,8 @@ trainer:
   max_steps: null # precedence over max_epochs
   accumulate_grad_batches: 1 # accumulates grads every k batches
   precision: 16 # 16 to use AMP
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   gradient_clip_val: 0.0
   log_every_n_steps: 1
   val_check_interval: 1.0 # check once per epoch .25 for 4 times per epoch

--- a/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml
@@ -4,7 +4,8 @@ restore_from_path: null # used when starting from a .nemo file
 trainer:
   gpus: 1
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   precision: 16
   logger: False # logger provided by exp_manager
   checkpoint_callback: False

--- a/examples/nlp/language_modeling/conf/transformer_lm_config.yaml
+++ b/examples/nlp/language_modeling/conf/transformer_lm_config.yaml
@@ -89,7 +89,8 @@ trainer:
   num_nodes: 1
   max_epochs: 200
   precision: 16 # Should be set to 16 for O1 and O2, default is 16 as PT ignores it when am_level is O0
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   checkpoint_callback: False
   logger: False
   log_every_n_steps: 50  # Interval of logging.

--- a/examples/nlp/machine_translation/conf/aayn_base.yaml
+++ b/examples/nlp/machine_translation/conf/aayn_base.yaml
@@ -146,7 +146,8 @@ trainer:
   num_nodes: 1
   max_epochs: 200
   precision: 16 # Should be set to 16 for O1 and O2, default is 16 as PT ignores it when am_level is O0
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   checkpoint_callback: False
   logger: False
   log_every_n_steps: 50  # Interval of logging.

--- a/examples/nlp/machine_translation/conf/aayn_bottleneck.yaml
+++ b/examples/nlp/machine_translation/conf/aayn_bottleneck.yaml
@@ -173,7 +173,8 @@ trainer:
   num_nodes: 1
   max_epochs: 200
   precision: 16 # Should be set to 16 for O1 and O2, default is 16 as PT ignores it when am_level is O0
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   checkpoint_callback: False
   logger: False
   log_every_n_steps: 50  # Interval of logging.

--- a/examples/nlp/machine_translation/conf/huggingface.yaml
+++ b/examples/nlp/machine_translation/conf/huggingface.yaml
@@ -120,7 +120,8 @@ trainer:
   num_nodes: 1
   max_epochs: 200
   precision: 16 # Should be set to 16 for O1 and O2, default is 16 as PT ignores it when am_level is O0
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   checkpoint_callback: False
   logger: False
   log_every_n_steps: 50  # Interval of logging.

--- a/examples/nlp/machine_translation/conf/megatron.yaml
+++ b/examples/nlp/machine_translation/conf/megatron.yaml
@@ -148,7 +148,8 @@ trainer:
   num_nodes: 1
   max_epochs: 200
   precision: 16 # Should be set to 16 for O1 and O2, default is 16 as PT ignores it when am_level is O0
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   checkpoint_callback: False
   logger: False
   log_every_n_steps: 50  # Interval of logging.

--- a/examples/nlp/question_answering/conf/question_answering_squad_config.yaml
+++ b/examples/nlp/question_answering/conf/question_answering_squad_config.yaml
@@ -10,7 +10,8 @@ trainer:
   max_steps: null # precedence over max_epochs
   accumulate_grad_batches: 1 # accumulates grads every k batches
   precision: 16 # 16 to use AMP
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   gradient_clip_val: 0.0
   val_check_interval: 1.0 # check once per epoch .25 for 4 times per epoch
   checkpoint_callback: false # provided by exp_manager

--- a/examples/nlp/text2sparql/conf/text2sparql_config.yaml
+++ b/examples/nlp/text2sparql/conf/text2sparql_config.yaml
@@ -8,7 +8,8 @@ trainer:
   max_epochs: 2 # the number of training epochs
   max_steps: null # precedence over max_epochs
   accumulate_grad_batches: 1 # accumulates grads every k batches
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   gradient_clip_val: 0.0
   log_every_n_steps: 1
   val_check_interval: 1.0 # check once per epoch .25 for 4 times per epoch

--- a/examples/nlp/text_classification/conf/text_classification_config.yaml
+++ b/examples/nlp/text_classification/conf/text_classification_config.yaml
@@ -22,7 +22,8 @@ trainer:
   accumulate_grad_batches: 1 # accumulates grads every k batches
   gradient_clip_val: 0.0
   precision: 32 # Should be set to 16 for O1 and O2 to enable the AMP.
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
   resume_from_checkpoint: null # The path to a checkpoint file to continue the training, restores the whole state including the epoch, step, LR schedulers, apex, etc.

--- a/examples/nlp/token_classification/conf/punctuation_capitalization_config.yaml
+++ b/examples/nlp/token_classification/conf/punctuation_capitalization_config.yaml
@@ -25,7 +25,8 @@ trainer:
   accumulate_grad_batches: 1 # accumulates grads every k batches
   gradient_clip_val: 0.0
   precision: 16 # Should be set to 16 for O1 and O2, default is 16 as PT ignores it when am_level is O0
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   checkpoint_callback: false  # Provided by exp_manager
   logger: false  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.

--- a/examples/nlp/token_classification/conf/token_classification_config.yaml
+++ b/examples/nlp/token_classification/conf/token_classification_config.yaml
@@ -24,7 +24,8 @@ trainer:
   accumulate_grad_batches: 1 # accumulates grads every k batches
   gradient_clip_val: 0.0
   precision: 16 # Should be set to 16 for O1 and O2, default is 16 as PT ignores it when am_level is O0
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.

--- a/examples/nlp/zero_shot_intent_recognition/conf/zero_shot_intent_config.yaml
+++ b/examples/nlp/zero_shot_intent_recognition/conf/zero_shot_intent_config.yaml
@@ -20,7 +20,8 @@ trainer:
   max_steps: null # precedence over max_epochs
   accumulate_grad_batches: 1 # accumulates grads every k batches
   precision: 16
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
   resume_from_checkpoint: null # The path to a checkpoint file to continue the training, restores the whole state including the epoch, step, LR schedulers, apex, etc.

--- a/examples/speaker_tasks/recognition/conf/SpeakerNet_recognition_3x2x512.yaml
+++ b/examples/speaker_tasks/recognition/conf/SpeakerNet_recognition_3x2x512.yaml
@@ -141,7 +141,8 @@ trainer:
   max_epochs: 200
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   deterministic: True
   checkpoint_callback: False

--- a/examples/speaker_tasks/recognition/conf/SpeakerNet_verification_3x2x256.yaml
+++ b/examples/speaker_tasks/recognition/conf/SpeakerNet_verification_3x2x256.yaml
@@ -129,7 +129,8 @@ trainer:
   max_epochs: 200
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   deterministic: True
   checkpoint_callback: False

--- a/examples/speaker_tasks/recognition/conf/ecapa_tdnn.yaml
+++ b/examples/speaker_tasks/recognition/conf/ecapa_tdnn.yaml
@@ -91,7 +91,8 @@ trainer:
   max_epochs: 250
   max_steps: null # computed at runtime if not set
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   deterministic: False
   checkpoint_callback: False

--- a/examples/tts/conf/aligner.yaml
+++ b/examples/tts/conf/aligner.yaml
@@ -104,7 +104,8 @@ trainer:
   gpus: 1
   max_epochs: ???
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False
   logger: False

--- a/examples/tts/conf/degli.yaml
+++ b/examples/tts/conf/degli.yaml
@@ -90,7 +90,8 @@ trainer:
   gpus: 1 # number of gpus
   max_epochs: 200
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/ed_mel2spec.yaml
+++ b/examples/tts/conf/ed_mel2spec.yaml
@@ -86,7 +86,8 @@ trainer:
   gpus: 1 # number of gpus
   max_epochs: 200
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/fastpitch.yaml
+++ b/examples/tts/conf/fastpitch.yaml
@@ -128,7 +128,8 @@ trainer:
   gpus: -1 # number of gpus
   max_epochs: 1500
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/fastpitch_align.yaml
+++ b/examples/tts/conf/fastpitch_align.yaml
@@ -167,7 +167,8 @@ trainer:
   gpus: -1 # number of gpus
   max_epochs: 1500
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/fastpitch_align_44100.yaml
+++ b/examples/tts/conf/fastpitch_align_44100.yaml
@@ -170,7 +170,8 @@ trainer:
   gpus: -1 # number of gpus
   max_epochs: 1500
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/fastpitch_hifigan_e2e.yaml
+++ b/examples/tts/conf/fastpitch_hifigan_e2e.yaml
@@ -121,7 +121,8 @@ trainer:
   gpus: -1 # number of gpus
   max_epochs: 1500
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/fastspeech2.yaml
+++ b/examples/tts/conf/fastspeech2.yaml
@@ -129,7 +129,8 @@ trainer:
   gpus: 1 # number of gpus
   max_epochs: ???
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/fastspeech2_hifigan_e2e.yaml
+++ b/examples/tts/conf/fastspeech2_hifigan_e2e.yaml
@@ -120,7 +120,8 @@ trainer:
   gpus: 1 # number of gpus
   max_epochs: ???
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/glow_tts.yaml
+++ b/examples/tts/conf/glow_tts.yaml
@@ -127,7 +127,8 @@ trainer:
   gpus: -1 # number of gpus
   max_epochs: 350
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/hifigan/hifigan.yaml
+++ b/examples/tts/conf/hifigan/hifigan.yaml
@@ -49,7 +49,8 @@ trainer:
   gpus: -1 # number of gpus
   max_steps: ${model.max_steps}
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/hifigan/hifigan44100.yaml
+++ b/examples/tts/conf/hifigan/hifigan44100.yaml
@@ -49,7 +49,8 @@ trainer:
   gpus: -1 # number of gpus
   max_steps: ${model.max_steps}
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/melgan.yaml
+++ b/examples/tts/conf/melgan.yaml
@@ -94,7 +94,8 @@ trainer:
   gpus: 1 # number of gpus
   max_epochs: ???
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/squeezewave.yaml
+++ b/examples/tts/conf/squeezewave.yaml
@@ -87,7 +87,8 @@ trainer:
   max_epochs: 10000
   max_steps: 600000
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: false  # Provided by exp_manager
   logger: false  # Provided by exp_manager

--- a/examples/tts/conf/tacotron2.yaml
+++ b/examples/tts/conf/tacotron2.yaml
@@ -124,7 +124,8 @@ trainer:
   gpus: 1 # number of gpus
   max_epochs: ???
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/tacotron2_44100.yaml
+++ b/examples/tts/conf/tacotron2_44100.yaml
@@ -159,7 +159,8 @@ trainer:
   gpus: 1 # number of gpus
   max_epochs: ???
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/talknet-durs.yaml
+++ b/examples/tts/conf/talknet-durs.yaml
@@ -156,7 +156,8 @@ trainer:
   gpus: 1
   max_epochs: ???
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False
   logger: False

--- a/examples/tts/conf/talknet-pitch.yaml
+++ b/examples/tts/conf/talknet-pitch.yaml
@@ -160,7 +160,8 @@ trainer:
   gpus: 1
   max_epochs: ???
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False
   logger: False

--- a/examples/tts/conf/talknet-spect.yaml
+++ b/examples/tts/conf/talknet-spect.yaml
@@ -225,7 +225,8 @@ trainer:
   gpus: 1
   max_epochs: ???
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False
   logger: False

--- a/examples/tts/conf/uniglow.yaml
+++ b/examples/tts/conf/uniglow.yaml
@@ -80,7 +80,8 @@ trainer:
   gpus: 1 # number of gpus
   max_epochs: ???
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/examples/tts/conf/waveglow.yaml
+++ b/examples/tts/conf/waveglow.yaml
@@ -81,7 +81,8 @@ trainer:
   gpus: 1 # number of gpus
   max_epochs: ???
   num_nodes: 1
-  accelerator: ddp
+  accelerator: gpu
+  stratergy: ddp
   accumulate_grad_batches: 1
   checkpoint_callback: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -460,16 +460,16 @@ class ModelPT(LightningModule, Model):
                 optim_config['sched']['t_max_epochs'] = self._trainer.max_epochs
                 optim_config['sched']['t_accumulate_grad_batches'] = self._trainer.accumulate_grad_batches
                 optim_config['sched']['t_limit_train_batches'] = self._trainer.limit_train_batches
-                if self._trainer.distributed_backend is None:
+                if self._trainer.accelerator_connector.strategy None:
                     optim_config['sched']['t_num_workers'] = self._trainer.num_gpus or 1
-                elif self._trainer.distributed_backend == "ddp_cpu":
+                elif self._trainer.accelerator_connector.strategy == "ddp_cpu":
                     optim_config['sched']['t_num_workers'] = self._trainer.num_processes * self._trainer.num_nodes
-                elif self._trainer.distributed_backend == "ddp":
+                elif self._trainer.accelerator_connector.strategy == "ddp":
                     optim_config['sched']['t_num_workers'] = self._trainer.num_gpus * self._trainer.num_nodes
                 else:
                     logging.warning(
                         f"The lightning trainer received accelerator: {self._trainer.distributed_backend}. We "
-                        "recommend to use 'ddp' instead."
+                        "recommend to use strategy 'ddp' instead."
                     )
                     optim_config['sched']['t_num_workers'] = self._trainer.num_gpus * self._trainer.num_nodes
             else:

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -460,7 +460,7 @@ class ModelPT(LightningModule, Model):
                 optim_config['sched']['t_max_epochs'] = self._trainer.max_epochs
                 optim_config['sched']['t_accumulate_grad_batches'] = self._trainer.accumulate_grad_batches
                 optim_config['sched']['t_limit_train_batches'] = self._trainer.limit_train_batches
-                if self._trainer.accelerator_connector.strategy None:
+                if self._trainer.accelerator_connector.strategy is None:
                     optim_config['sched']['t_num_workers'] = self._trainer.num_gpus or 1
                 elif self._trainer.accelerator_connector.strategy == "ddp_cpu":
                     optim_config['sched']['t_num_workers'] = self._trainer.num_processes * self._trainer.num_nodes

--- a/tests/core/test_optimizers_schedulers.py
+++ b/tests/core/test_optimizers_schedulers.py
@@ -733,7 +733,8 @@ class TestOptimizersSchedulers:
         ):
             trainer = pl.Trainer(
                 max_epochs=max_epochs,
-                accelerator="ddp_cpu",
+                accelerator="cpu",
+                strategy="ddp",
                 num_processes=num_processes,
                 accumulate_grad_batches=accumulate_grad_batches,
                 limit_train_batches=limit_train_batches,

--- a/tests/core_ptl/check_for_ranks.py
+++ b/tests/core_ptl/check_for_ranks.py
@@ -78,7 +78,7 @@ class ExampleModel(ModelPT):
 
 def instantiate_multinode_ddp_if_possible():
     num_gpus = torch.cuda.device_count()
-    trainer = Trainer(gpus=num_gpus, accelerator='ddp', logger=None, checkpoint_callback=False)
+    trainer = Trainer(gpus=num_gpus, accelerator='gpu', logger=None, checkpoint_callback=False)
 
     exp_manager_cfg = ExpManagerConfig(exp_dir='./ddp_check/', use_datetime_version=False, version="")
     exp_manager(trainer, cfg=OmegaConf.structured(exp_manager_cfg))

--- a/tutorials/asr/ASR_with_NeMo.ipynb
+++ b/tutorials/asr/ASR_with_NeMo.ipynb
@@ -967,7 +967,7 @@
     "trainer = pl.Trainer(amp_level='O1', precision=16)\n",
     "\n",
     "# Trainer with a distributed backend:\n",
-    "trainer = pl.Trainer(gpus=2, num_nodes=2, accelerator='ddp')\n",
+    "trainer = pl.Trainer(gpus=2, num_nodes=2, accelerator='gpu', strategy='ddp')\n",
     "\n",
     "# Of course, you can combine these flags as well.\n",
     "```\n",

--- a/tutorials/asr/ASR_with_Subword_Tokenization.ipynb
+++ b/tutorials/asr/ASR_with_Subword_Tokenization.ipynb
@@ -1373,7 +1373,7 @@
         "trainer = pl.Trainer(amp_level='O1', precision=16)\r\n",
         "\r\n",
         "# Trainer with a distributed backend:\r\n",
-        "trainer = pl.Trainer(gpus=2, num_nodes=2, accelerator='ddp')\r\n",
+        "trainer = pl.Trainer(gpus=2, num_nodes=2, accelerator='gpu', strategy='ddp')\r\n",
         "\r\n",
         "# Of course, you can combine these flags as well.\r\n",
         "```\r\n",

--- a/tutorials/asr/Speech_Commands.ipynb
+++ b/tutorials/asr/Speech_Commands.ipynb
@@ -651,7 +651,7 @@
     "trainer = Trainer(amp_level='O1', precision=16)\n",
     "\n",
     "# Trainer with a distributed backend:\n",
-    "trainer = Trainer(gpus=2, num_nodes=2, accelerator='ddp')\n",
+    "trainer = Trainer(gpus=2, num_nodes=2, accelerator='gpu',strategy='ddp')\n",
     "\n",
     "# Of course, you can combine these flags as well.\n",
     "```"

--- a/tutorials/speaker_tasks/Speaker_Identification_Verification.ipynb
+++ b/tutorials/speaker_tasks/Speaker_Identification_Verification.ipynb
@@ -627,7 +627,7 @@
     "</code></pre>\n",
     "\n",
     "### Trainer with a distributed backend:\n",
-    "<pre><code>trainer = Trainer(gpus=2, num_nodes=2, accelerator='ddp')\n",
+    "<pre><code>trainer = Trainer(gpus=2, num_nodes=2, accelerator='gpu',strategy='ddp')\n",
     "</code></pre>\n",
     "\n",
     "Of course, you can combine these flags as well."

--- a/tutorials/tts/Tacotron2_Training.ipynb
+++ b/tutorials/tts/Tacotron2_Training.ipynb
@@ -239,7 +239,7 @@
     "  gpus: 1 # number of gpus\n",
     "  max_epochs: ???\n",
     "  num_nodes: 1\n",
-    "  accelerator: ddp\n",
+    "  accelerator: 'gpu'\n",
     "  accumulate_grad_batches: 1\n",
     "  checkpoint_callback: False  # Provided by exp_manager\n",
     "  logger: False  # Provided by exp_manager\n",


### PR DESCRIPTION
This PR updates deprecated variables in PTL
* distributed_backened is removed and replaced with strategy inside accelerator connector
* accelerator now only accepts the type of device input