### PR TITLE
pytorch-lightning version requirement fix

### DIFF
--- a/requirements/requirements_lightning.txt
+++ b/requirements/requirements_lightning.txt
@@ -1,4 +1,4 @@
-pytorch-lightning>1.4.9
+pytorch-lightning>=1.4.9
 torchmetrics>=0.4.1rc0
 transformers>=4.0.1
 webdataset>=0.1.48,<=0.1.62


### PR DESCRIPTION
The latest version of pytorch-lightning is 1.4.9 though currently the version higher that is required. The commit fixes this by allowing the 1.4.9 version to use