### PR TITLE
Enable param groups for ModelPT optimizer

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -215,6 +215,14 @@ class MegatronGPTModel(NLPModel):
     def setup_optimizer_param_groups(self):
         self._optimizer_param_groups = self._get_params_for_weight_decay_optimization()
 
+        assert len(list(self.parameters())) == len(self._optimizer_param_groups[0]['params']) + len(
+            self._optimizer_param_groups[1]['params']
+        )
+
+        assert sum([p.sum() for p in self.parameters()]) == sum(
+            [p.sum() for p in self._optimizer_param_groups[0]['params']]
+        ) + sum([p.sum() for p in self._optimizer_param_groups[1]['params']])
+
     def process_batch(self, batch):
 
         # Items and their type.

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -16,8 +16,8 @@ import re
 from typing import Any, Dict, List, Optional
 
 import torch
-from apex.transformer import parallel_state, tensor_parallel
 from apex.normalization.fused_layer_norm import MixedFusedLayerNorm as LayerNorm
+from apex.transformer import parallel_state, tensor_parallel
 from omegaconf.dictconfig import DictConfig
 from pytorch_lightning.trainer.trainer import Trainer
 

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -580,7 +580,7 @@ class ModelPT(LightningModule, Model):
         # This return allows multiple optimizers or schedulers to be created
         return self._optimizer, self._scheduler
 
-    def setup_optimization_param_groups(self):
+    def setup_optimizer_param_groups(self):
         """
             Used to create param groups for the optimizer.
             As an example, this can be used to specify per-layer learning rates:
@@ -599,7 +599,7 @@ class ModelPT(LightningModule, Model):
         self._optimizer_param_groups = param_groups
 
     def configure_optimizers(self):
-        self.setup_optimization_param_groups()
+        self.setup_optimizer_param_groups()
         self.setup_optimization()
 
         if self._scheduler is None:


### PR DESCRIPTION
Adds `.setup_optimizer_param_groups` method to `ModelPT`. The `.setup_optimization` method will give optimizers `self._optimizer_param_groups` instead of `self.parameters()`.

The `.setup_optimizer_param_groups` method will by default set `self._optimizer_param_groups=self.parameters()`.

This enables NeMo models to specify custom param groups so that, for example, per layer learning rates can be used.

In particular, this enables Megatron-LM style weight decay where LayerNorm and Bias weights are not decayed.