### PR TITLE
Multiple ASR Fixes to SPE tokenization

### DIFF
--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -270,12 +270,13 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
         Returns:
             A pytorch DataLoader for the given audio file(s).
         """
+        batch_size = min(config['batch_size'], len(config['paths2audio_files']))
         dl_config = {
             'manifest_filepath': os.path.join(config['temp_dir'], 'manifest.json'),
             'sample_rate': self.preprocessor._sample_rate,
-            'batch_size': min(config['batch_size'], len(config['paths2audio_files'])),
+            'batch_size': batch_size,
             'shuffle': False,
-            'num_workers': os.cpu_count() - 1,
+            'num_workers': min(batch_size, os.cpu_count() - 1),
             'pin_memory': True,
             'use_start_end_token': self.cfg.validation_ds.get('use_start_end_token', False),
         }

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -650,14 +650,15 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
         Returns:
             A pytorch DataLoader for the given audio file(s).
         """
+        batch_size = min(config['batch_size'], len(config['paths2audio_files']))
         dl_config = {
             'manifest_filepath': os.path.join(config['temp_dir'], 'manifest.json'),
             'sample_rate': self.preprocessor._sample_rate,
             'labels': self.decoder.vocabulary,
-            'batch_size': min(config['batch_size'], len(config['paths2audio_files'])),
+            'batch_size': batch_size,
             'trim_silence': False,
             'shuffle': False,
-            'num_workers': os.cpu_count() - 1,
+            'num_workers': min(batch_size, os.cpu_count() - 1),
             'pin_memory': True,
         }
 

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -349,12 +349,13 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
         Returns:
             A pytorch DataLoader for the given audio file(s).
         """
+        batch_size = min(config['batch_size'], len(config['paths2audio_files']))
         dl_config = {
             'manifest_filepath': os.path.join(config['temp_dir'], 'manifest.json'),
             'sample_rate': self.preprocessor._sample_rate,
-            'batch_size': min(config['batch_size'], len(config['paths2audio_files'])),
+            'batch_size': batch_size,
             'shuffle': False,
-            'num_workers': os.cpu_count() - 1,
+            'num_workers': min(batch_size, os.cpu_count() - 1),
             'pin_memory': True,
             'use_start_end_token': self.cfg.validation_ds.get('use_start_end_token', False),
         }

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -802,14 +802,15 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecJointModel):
         Returns:
             A pytorch DataLoader for the given audio file(s).
         """
+        batch_size = min(config['batch_size'], len(config['paths2audio_files']))
         dl_config = {
             'manifest_filepath': os.path.join(config['temp_dir'], 'manifest.json'),
             'sample_rate': self.preprocessor._sample_rate,
             'labels': self.joint.vocabulary,
-            'batch_size': min(config['batch_size'], len(config['paths2audio_files'])),
+            'batch_size': batch_size,
             'trim_silence': False,
             'shuffle': False,
-            'num_workers': os.cpu_count() - 1,
+            'num_workers': min(batch_size, os.cpu_count() - 1),
             'pin_memory': True,
         }
 

--- a/scripts/tokenizers/process_asr_text_tokenizer.py
+++ b/scripts/tokenizers/process_asr_text_tokenizer.py
@@ -73,8 +73,27 @@
 #   --spe_max_sentencepiece_length: Limits the maximum length that any any SentencePiece subword can be.
 #       Using this will change the subword tokens generated.
 #
+#   --spe_pad: Adds <pad> as special token.
+#
+#   --spe_bos: Adds <s> as Begining-of-Sentence special token.
+#
+#   --spe_eos: Adds </s> as End-of-Sentence special token.
+#
 #   --log: Whether the script should display log messages
 
+"""
+
+python process_asr_text_tokenizer.py \
+    --manifest=/media/smajumdar/data/Datasets/ASR_SET_LM/ASR_SET_2.0/tarred_audio_manifest.json \
+    --data_root="/home/smajumdar/PycharmProjects/nemo-eval/nemo_beta_eval/asrset/manifests/nemo/asrset_2.0/tokenizers/temp/" \
+    --tokenizer=spe \
+    --no_lower_case \
+    --spe_eos \
+    --spe_bos \
+    --log \
+    --spe_type=bpe \
+    --vocab_size=1024
+"""
 
 import argparse
 import json
@@ -205,14 +224,23 @@ def __process_data(
     Returns:
     """
     if tokenizer_type == 'spe':
+
+        # Prepare directory of tokenizer
         if spe_max_sentencepiece_length > 0:
-            tokenizer_dir = os.path.join(dst_folder, 'tokenizer_{}_{}_v{}_max{}').format(
+            tokenizer_dir = os.path.join(dst_folder, 'tokenizer_{}_{}_v{}_max_{}').format(
                 tokenizer_type, spe_type, vocab_size, spe_max_sentencepiece_length
             )
         else:
             tokenizer_dir = os.path.join(dst_folder, 'tokenizer_{}_{}_v{}').format(
                 tokenizer_type, spe_type, vocab_size
             )
+
+        if spe_pad:
+            tokenizer_dir = f'{tokenizer_dir}_pad'
+        if spe_bos:
+            tokenizer_dir = f'{tokenizer_dir}_bos'
+        if spe_eos:
+            tokenizer_dir = f'{tokenizer_dir}_eos'
 
         if not os.path.exists(tokenizer_dir):
             os.makedirs(tokenizer_dir)
@@ -221,6 +249,7 @@ def __process_data(
             logging.warning("Model file already exists, overriding old model file !")
             os.remove(os.path.join(tokenizer_dir, 'tokenizer.model'))
 
+        # Build tokenizer
         tokenizer_path, vocab_path = create_spt_model(
             data_file=text_path,
             vocab_size=vocab_size,

--- a/scripts/tokenizers/process_asr_text_tokenizer.py
+++ b/scripts/tokenizers/process_asr_text_tokenizer.py
@@ -81,20 +81,6 @@
 #
 #   --log: Whether the script should display log messages
 
-"""
-
-python process_asr_text_tokenizer.py \
-    --manifest=/media/smajumdar/data/Datasets/ASR_SET_LM/ASR_SET_2.0/tarred_audio_manifest.json \
-    --data_root="/home/smajumdar/PycharmProjects/nemo-eval/nemo_beta_eval/asrset/manifests/nemo/asrset_2.0/tokenizers/temp/" \
-    --tokenizer=spe \
-    --no_lower_case \
-    --spe_eos \
-    --spe_bos \
-    --log \
-    --spe_type=bpe \
-    --vocab_size=1024
-"""
-
 import argparse
 import json
 import logging

--- a/tests/collections/asr/test_asr_ctc_encoder_model_bpe.py
+++ b/tests/collections/asr/test_asr_ctc_encoder_model_bpe.py
@@ -144,6 +144,7 @@ class TestEncDecCTCModel:
             assert new_model.vocab_path.endswith('_vocab.txt')
             assert new_model.spe_vocab_path.endswith('_tokenizer.vocab')
 
+            assert new_model.tokenizer.tokenizer.vocab_size == 128
             assert len(new_model.tokenizer.tokenizer.get_vocab()) == 128
 
     @pytest.mark.unit


### PR DESCRIPTION
# Changelog
- Fix issue with transcribe building more workers than samples
- Fix SPE tokenizer vocab being built incorrectly for tokenizers with BOS EOS and PAD
- Update tokenizer script to designate tokenizer dir with BOS EOS and PAD token.

# Breaking change
- SPE tokenizer based models, when requested for their vocab via model.tokenizer.tokenizer.get_vocab() will return special tokens + order of tokens will be different than previous result. 