### PR TITLE
Add missing tag in ALL_TAGS list

### DIFF
--- a/nemo/collections/nlp/data/text_normalization/constants.py
+++ b/nemo/collections/nlp/data/text_normalization/constants.py
@@ -58,7 +58,7 @@ SAME_TAG = 'SAME'  # Tag indicates that a token can be kept the same without any
 TASK_TAG = 'TASK'  # Tag indicates that a token belongs to a task prefix (the prefix indicates whether the current task is TN or ITN)
 PUNCT_TAG = 'PUNCT'  # Tag indicates that a token is a punctuation
 TRANSFORM_TAG = 'TRANSFORM'  # Tag indicates that a token needs to be transformed by the decoder
-ALL_TAGS = [TASK_TAG, SAME_TAG, TRANSFORM_TAG]
+ALL_TAGS = [TASK_TAG, SAME_TAG, PUNCT_TAG, TRANSFORM_TAG]
 
 # ALL_TAG_LABELS
 ALL_TAG_LABELS = []


### PR DESCRIPTION
There is a missing tag which prevents the `DuplexTagger` Model from loading correctly