### PR TITLE
Fixing unneeded warmup batch when no timing is recored

### DIFF
--- a/examples/nlp/machine_translation/nmt_transformer_infer.py
+++ b/examples/nlp/machine_translation/nmt_transformer_infer.py
@@ -227,7 +227,7 @@ def main():
             src_text.append(line.strip())
             if len(src_text) == args.batch_size:
                 # warmup when measuring timing
-                if not all_timing:
+                if args.write_timing and (not all_timing):
                     print("running a warmup batch")
                     translate_text(
                         models=models,


### PR DESCRIPTION
Fixed continuous warmup with no write_timing is selected.