### PR TITLE
Patch LR max_step computation check

### DIFF
--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -455,7 +455,7 @@ class ModelPT(LightningModule, Model):
         if 'sched' in optim_config and self._trainer is not None:
             if not isinstance(self._trainer.accumulate_grad_batches, int):
                 raise ValueError("We do not currently support gradient acculumation that is not an integer.")
-            if self._trainer.max_steps is None:
+            if self._trainer.max_steps is None or self.trainer.max_steps <= 0:
                 # Store information needed to calculate max_steps
                 optim_config['sched']['t_max_epochs'] = self._trainer.max_epochs
                 optim_config['sched']['t_accumulate_grad_batches'] = self._trainer.accumulate_grad_batches

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -455,7 +455,7 @@ class ModelPT(LightningModule, Model):
         if 'sched' in optim_config and self._trainer is not None:
             if not isinstance(self._trainer.accumulate_grad_batches, int):
                 raise ValueError("We do not currently support gradient acculumation that is not an integer.")
-            if self._trainer.max_steps is None or self.trainer.max_steps <= 0:
+            if self._trainer.max_steps is None or self.trainer.max_steps < 0:
                 # Store information needed to calculate max_steps
                 optim_config['sched']['t_max_epochs'] = self._trainer.max_epochs
                 optim_config['sched']['t_accumulate_grad_batches'] = self._trainer.accumulate_grad_batches

--- a/nemo/core/config/schedulers.py
+++ b/nemo/core/config/schedulers.py
@@ -110,7 +110,7 @@ class WarmupAnnealingParams(WarmupSchedulerParams):
     It is not derived from Config as it is not a NeMo object (and in particular it doesn't need a name).
     """
 
-    warmup_ratio: float = 0.0
+    warmup_ratio: Optional[float] = None
 
 
 @dataclass

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -188,6 +188,9 @@ class WarmupAnnealHoldPolicy(_LRScheduler):
         assert not (
             warmup_steps is not None and warmup_ratio is not None
         ), "Either use particular number of step or ratio"
+        assert not (
+            constant_steps is not None and constant_ratio is not None
+        ), "Either use constant_steps or constant_ratio"
         assert warmup_ratio is None or max_steps is not None, "If there is a ratio, there should be a total steps"
 
         # It is necessary to assign all attributes *before* __init__,
@@ -705,7 +708,7 @@ def prepare_lr_scheduler(
         # we may need to override ModelPT setup_optimization
         if train_dataloader.batch_size is not None:
             batch_size = train_dataloader.batch_size
-        elif train_dataloader.batch_sampler is not None:
+        elif hasattr(train_dataloader, 'batch_sampler') and train_dataloader.batch_sampler is not None:
             if train_dataloader.batch_sampler.micro_batch_size is not None:
                 batch_size = train_dataloader.batch_sampler.micro_batch_size
             else:


### PR DESCRIPTION
# Bugfix
- Compute explicit max steps if max_steps = None or negative numbers (new default in PTL 1.5.0+)

Signed-off-by: smajumdar <titu1994@gmail.com>