### PR TITLE
Text2sparql fix 1.5.0

### DIFF
--- a/examples/nlp/machine_translation/nmt_transformer_infer.py
+++ b/examples/nlp/machine_translation/nmt_transformer_infer.py
@@ -227,7 +227,7 @@ def main():
             src_text.append(line.strip())
             if len(src_text) == args.batch_size:
                 # warmup when measuring timing
-                if not all_timing:
+                if args.write_timing and (not all_timing):
                     print("running a warmup batch")
                     translate_text(
                         models=models,

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -107,6 +107,13 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
         )
         results.append(model)
 
+        model = PretrainedModelInfo(
+            pretrained_model_name="stt_de_contextnet_1024",
+            description="For details about this model, please visit https://ngc.nvidia.com/catalog/models/nvidia:nemo:stt_de_contextnet_1024",
+            location="https://api.ngc.nvidia.com/v2/models/nvidia/nemo/stt_de_contextnet_1024/versions/1.4.0/files/stt_de_contextnet_1024.nemo",
+        )
+        results.append(model)
+
         return results
 
     def __init__(self, cfg: DictConfig, trainer: Trainer = None):

--- a/nemo/collections/nlp/models/text2sparql/text2sparql_model.py
+++ b/nemo/collections/nlp/models/text2sparql/text2sparql_model.py
@@ -157,9 +157,6 @@ class Text2SparqlModel(ModelPT):
         Lightning calls this inside the validation loop with the data from the validation dataloader
         passed in as `batch`. Loss calculation from HuggingFace's BartForConditionalGeneration.
         """
-        import ipdb
-
-        ipdb.set_trace()
         input_ids, input_mask, decoder_input_ids, labels = batch
         loss, logits = self.forward(
             input_ids=input_ids, attention_mask=input_mask, decoder_input_ids=decoder_input_ids, labels=labels,

--- a/nemo/collections/nlp/models/text2sparql/text2sparql_model.py
+++ b/nemo/collections/nlp/models/text2sparql/text2sparql_model.py
@@ -44,12 +44,6 @@ class Text2SparqlModel(ModelPT):
             "labels": NeuralType(('B', 'T'), ChannelType(), optional=True),
         }
 
-    @property
-    def output_types(self) -> Optional[Dict[str, NeuralType]]:
-        return {
-            "loss": NeuralType((), LossType()),
-        }
-
     def __init__(self, cfg: DictConfig, trainer: Trainer = None):
 
         # must assign tokenizers before init
@@ -163,6 +157,7 @@ class Text2SparqlModel(ModelPT):
         Lightning calls this inside the validation loop with the data from the validation dataloader
         passed in as `batch`. Loss calculation from HuggingFace's BartForConditionalGeneration.
         """
+        import ipdb; ipdb.set_trace()
         input_ids, input_mask, decoder_input_ids, labels = batch
         loss, logits = self.forward(
             input_ids=input_ids, attention_mask=input_mask, decoder_input_ids=decoder_input_ids, labels=labels,

--- a/nemo/collections/nlp/models/text2sparql/text2sparql_model.py
+++ b/nemo/collections/nlp/models/text2sparql/text2sparql_model.py
@@ -48,8 +48,6 @@ class Text2SparqlModel(ModelPT):
     def output_types(self) -> Optional[Dict[str, NeuralType]]:
         return {
             "loss": NeuralType((), LossType()),
-            "decoder_hidden_states": NeuralType(("B", "T", "D"), ChannelType(), optional=True),
-            "encoder_hidden_states": NeuralType(("B", "T", "D"), ChannelType(), optional=True),
         }
 
     def __init__(self, cfg: DictConfig, trainer: Trainer = None):

--- a/nemo/collections/nlp/models/text2sparql/text2sparql_model.py
+++ b/nemo/collections/nlp/models/text2sparql/text2sparql_model.py
@@ -157,7 +157,9 @@ class Text2SparqlModel(ModelPT):
         Lightning calls this inside the validation loop with the data from the validation dataloader
         passed in as `batch`. Loss calculation from HuggingFace's BartForConditionalGeneration.
         """
-        import ipdb; ipdb.set_trace()
+        import ipdb
+
+        ipdb.set_trace()
         input_ids, input_mask, decoder_input_ids, labels = batch
         loss, logits = self.forward(
             input_ids=input_ids, attention_mask=input_mask, decoder_input_ids=decoder_input_ids, labels=labels,


### PR DESCRIPTION
Fixes

1. Accelerator = None
2. HF API change to outputs. Removed output neural types from the model since HF returns a tuple of tensors now.