### PR TITLE
Fix cfg issue for r1.5.0

### DIFF
--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -1143,7 +1143,6 @@ class ModelPT(LightningModule, Model):
         """
         self._cfg = cfg
         self._set_hparams({'cfg': self._cfg})
-        
 
     @staticmethod
     def _is_model_being_restored() -> bool:

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -1142,7 +1142,6 @@ class ModelPT(LightningModule, Model):
             Please create a new model using an updated config to properly update the model.
         """
         self._cfg = cfg
-        self._set_hparams(self._cfg)
         self._hparams_initial = copy.deepcopy(self._hparams)
 
     @staticmethod

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -1142,7 +1142,8 @@ class ModelPT(LightningModule, Model):
             Please create a new model using an updated config to properly update the model.
         """
         self._cfg = cfg
-        self._hparams_initial = copy.deepcopy(self._hparams)
+        self._set_hparams({'cfg': self._cfg})
+        
 
     @staticmethod
     def _is_model_being_restored() -> bool:


### PR DESCRIPTION
Fix issues with config saving TypeError: __init__() missing 1 required positional argument: 'cfg' when trying to do model.load_from_checkpoint(XYZ)

related to https://github.com/NVIDIA/NeMo/pull/3058 and https://github.com/PyTorchLightning/pytorch-lightning/discussions/7525