### PR TITLE
remove cfg in _load_model_state in nlp_models

### DIFF
--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -249,9 +249,7 @@ class NLPModel(ModelPT, Exportable):
                 config_kwargs.pop('trainer')
             checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY].update(config_kwargs)
 
-            model = cls._load_model_state(
-                checkpoint, strict=strict, **kwargs
-            )
+            model = cls._load_model_state(checkpoint, strict=strict, **kwargs)
             checkpoint = model
 
         finally:

--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -250,7 +250,7 @@ class NLPModel(ModelPT, Exportable):
             checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY].update(config_kwargs)
 
             model = cls._load_model_state(
-                checkpoint, strict=strict, cfg=checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY], **kwargs
+                checkpoint, strict=strict, **kwargs
             )
             checkpoint = model
 


### PR DESCRIPTION
We patched cfg issue in modelPT level in https://github.com/NVIDIA/NeMo/pull/3170.
Revert the cfg arg in `_load_model_state` in nlp_models in https://github.com/NVIDIA/NeMo/pull/3149 since it will break the fix and is deprecated in PTL. 

Signed-off-by: fayejf <fayejf07@gmail.com>