### PR TITLE
LJSpeech alignment scripts fixed for latest MFA

### DIFF
--- a/scripts/dataset_processing/ljspeech/extract_ljspeech_phonemes_and_durs.sh
+++ b/scripts/dataset_processing/ljspeech/extract_ljspeech_phonemes_and_durs.sh
@@ -98,8 +98,8 @@ else
   echo "Setting up conda environment for MFA (env name \"aligner\")..."
   conda create -n $ENV_NAME -c conda-forge openblas python=3.8 openfst pynini ngram baumwelch
   conda activate $ENV_NAME
-  pip install montreal-forced-aligner tgt torch
-  mfa thirdparty download
+  pip install tgt torch
+  conda install -c conda-forge montreal-forced-aligner
   echo "Conda environment \"$ENV_NAME\" set up."
 fi
 
@@ -129,7 +129,7 @@ Could not run MFA. If it could not find OpenBlas, you may need to install it man
 (e.g. sudo apt-get install libopenblas-dev)
 EOM
 
-if ! mfa download acoustic english; then
+if ! mfa model download acoustic english; then
   echo $MFA_ERROR_MSG
 fi
 mfa align --clean $LJSPEECH_BASE $G2P_DICT english $LJSPEECH_BASE/alignments


### PR DESCRIPTION
The latest releases of MFA breaks extract_ljspeech_phonemes_and_durs.sh

Example:
```
~/NeMo/scripts/dataset_processing/ljspeech$ mfa thirdparty
usage: mfa [-h]
           {version,align,adapt,train,validate,g2p,train_g2p,model,train_lm,train_dictionary,train_ivector,classify_speakers,create_segments,transcribe,configure,history,annotator,anchor}
           ...
mfa: error: argument subcommand: invalid choice: 'thirdparty' (choose from 'version', 'align', 'adapt', 'train', 'validate', 'g2p', 'train_g2p', 'model', 'train_lm', 'train_dictionary', 'train_ivector', 'classify_speakers', 'create_segments', 'transcribe', 'configure', 'history', 'annotator', 'anchor')

~/NeMo/scripts/dataset_processing/ljspeech$ mfa download acoustic english
usage: mfa [-h]
           {version,align,adapt,train,validate,g2p,train_g2p,model,train_lm,train_dictionary,train_ivector,classify_speakers,create_segments,transcribe,configure,history,annotator,anchor}
           ...
mfa: error: argument subcommand: invalid choice: 'download' (choose from 'version', 'align', 'adapt', 'train', 'validate', 'g2p', 'train_g2p', 'model', 'train_lm', 'train_dictionary', 'train_ivector', 'classify_speakers', 'create_segments', 'transcribe', 'configure', 'history', 'annotator', 'anchor')
``` 

Latest version uses conda-forge and also changed "mfa download" to "mfa model download".
Described in 
https://github.com/MontrealCorpusTools/Montreal-Forced-Aligner/issues/349#issuecomment-966610658

This is related to TTS (@blisc?)