### PR TITLE
Fix RNNT ALSD Decoding Indexing bug

### DIFF
--- a/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
@@ -715,7 +715,7 @@ class BeamRNNTInfer(Typing):
 
             for bid, hyp in enumerate(B):
                 u = len(hyp.y_sequence) - 1
-                t = i - u + 1
+                t = i - u
 
                 if t > (h_length - 1):
                     batch_removal_ids.append(bid)


### PR DESCRIPTION
# Bugfix
- Fix an off-by-one indexing issue with ALSD decoding that causes it to skip the 0th timestep of the acoustic time dimension (T)

Closes https://github.com/NVIDIA/NeMo/issues/3199

Signed-off-by: smajumdar <titu1994@gmail.com>