### PR TITLE
Add support to modify nemo cache directory

### DIFF
--- a/nemo/constants.py
+++ b/nemo/constants.py
@@ -16,3 +16,4 @@ NEMO_ENV_VARNAME_ENABLE_COLORING = "NEMO_ENABLE_COLORING"
 NEMO_ENV_VARNAME_REDIRECT_LOGS_TO_STDERR = "NEMO_REDIRECT_LOGS_TO_STDERR"
 NEMO_ENV_VARNAME_TESTING = "NEMO_TESTING"  # Set to True to enable nemo.util.logging's debug mode
 NEMO_ENV_VARNAME_VERSION = "NEMO_EXPM_VERSION"  # Used for nemo.utils.exp_manager versioning
+NEMO_ENV_CACHE_DIR = "NEMO_CACHE_DIR"  # Used to change default nemo cache directory

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -29,7 +29,7 @@ import wrapt
 
 import nemo
 from nemo.core.neural_types import NeuralType, NeuralTypeComparisonResult
-from nemo.utils import logging
+from nemo.utils import logging, model_utils
 from nemo.utils.cloud import maybe_download_from_cloud
 from nemo.utils.model_utils import import_class_by_path, maybe_update_config_version
 
@@ -719,7 +719,7 @@ class Model(Typing, Serialization, FileIO):
             )
         filename = location_in_the_cloud.split("/")[-1]
         url = location_in_the_cloud.replace(filename, "")
-        cache_dir = Path.joinpath(Path.home(), f'.cache/torch/NeMo/NeMo_{nemo.__version__}/{filename[:-5]}')
+        cache_dir = Path.joinpath(model_utils.resolve_cache_dir(), f'/{filename[:-5]}')
         # If either description and location in the cloud changes, this will force re-download
         cache_subfolder = hashlib.md5((location_in_the_cloud + description).encode('utf-8')).hexdigest()
         # if file exists on cache_folder/subfolder, it will be re-used, unless refresh_cache is True

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -719,7 +719,7 @@ class Model(Typing, Serialization, FileIO):
             )
         filename = location_in_the_cloud.split("/")[-1]
         url = location_in_the_cloud.replace(filename, "")
-        cache_dir = Path.joinpath(model_utils.resolve_cache_dir(), f'/{filename[:-5]}')
+        cache_dir = Path.joinpath(model_utils.resolve_cache_dir(), f'{filename[:-5]}')
         # If either description and location in the cloud changes, this will force re-download
         cache_subfolder = hashlib.md5((location_in_the_cloud + description).encode('utf-8')).hexdigest()
         # if file exists on cache_folder/subfolder, it will be re-used, unless refresh_cache is True

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Union
 
 import wrapt
 
+from nemo import constants
 from nemo.utils import logging
 
 # TODO @blisc: Perhaps refactor instead of import guarding
@@ -552,3 +553,23 @@ def check_lib_version(lib_name: str, checked_version: str, operator) -> (Optiona
 
     msg = f"Lib {lib_name} has not been installed. Please use pip or conda to install this package."
     return None, msg
+
+
+def resolve_cache_dir() -> Path:
+    """
+    Utility method to resolve a cache directory for NeMo that can be overriden by an environment variable.
+
+    Example:
+        NEMO_CACHE_DIR="~/nemo_cache_dir/" python nemo_example_script.py
+
+    Returns:
+        A Path object, resolved to the absolute path of the cache directory. If no override is provided,
+        uses an inbuilt default which adapts to nemo versions strings.
+    """
+    override_dir = os.environ.get(constants.NEMO_ENV_CACHE_DIR, "")
+    if override_dir == "":
+        path = Path.joinpath(Path.home(), f'.cache/torch/NeMo/NeMo_{nemo.__version__}')
+        return path
+    else:
+        path = Path(override_dir).resolve()
+        return path

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -21,6 +21,7 @@ from typing import List, Optional, Union
 
 import wrapt
 
+import nemo
 from nemo import constants
 from nemo.utils import logging
 
@@ -569,7 +570,6 @@ def resolve_cache_dir() -> Path:
     override_dir = os.environ.get(constants.NEMO_ENV_CACHE_DIR, "")
     if override_dir == "":
         path = Path.joinpath(Path.home(), f'.cache/torch/NeMo/NeMo_{nemo.__version__}')
-        return path
     else:
         path = Path(override_dir).resolve()
-        return path
+    return path


### PR DESCRIPTION
# Changelog
- Adds support to modify the nemo cache directory using an environment variable

# Usage

```sh
NEMO_CACHE_DIR="~/nemo_cache_dir/" python nemo_example_script.py
```

Closes https://github.com/NVIDIA/NeMo/issues/3185, https://github.com/NVIDIA/NeMo/issues/2025

Signed-off-by: smajumdar <titu1994@gmail.com> 