### PR TITLE
WIP: Persistent layer norm and module dependency check

### DIFF
--- a/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml
@@ -58,6 +58,7 @@ model:
   make_vocab_size_divisible_by: 128 # Pad the vocab size to be divisible by this value for computation efficiency.
   pre_process: True # add embedding
   post_process: True # add pooler
+  persist_layer_norm: True # Use of persistent fused layer norm kernel.
 
   tokenizer:
     library: 'megatron'

--- a/examples/nlp/language_modeling/megatron_gpt_pretraining.py
+++ b/examples/nlp/language_modeling/megatron_gpt_pretraining.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from pathlib import Path
 
 from omegaconf.omegaconf import OmegaConf, open_dict
@@ -27,6 +28,21 @@ from nemo.collections.nlp.parts.nlp_overrides import GradScaler, NLPDDPPlugin
 from nemo.core.config import hydra_runner
 from nemo.utils import logging
 from nemo.utils.exp_manager import StatelessTimer, exp_manager
+
+
+def check_config_dependency(cfg):
+    # version dependency check
+    nvidia_torch_version = os.getenv('NVIDIA_PYTORCH_VERSION', None)
+    if nvidia_torch_version is not None:
+        NVIDIA_TORCH_MAJOR = int(nvidia_torch_version.split('.')[0])
+        NVIDIA_TORCH_MINOR = int(nvidia_torch_version.split('.')[1])
+
+        # Persistent layer norm is supported from Nvidia PyTorch container v21.11
+        if NVIDIA_TORCH_MAJOR < 21 or (NVIDIA_TORCH_MAJOR == 21 and NVIDIA_TORCH_MINOR < 11):
+            cfg.model.persist_layer_norm = False
+    else:
+        # Not a Nvidia conatiner. Dependency check is on users
+        pass
 
 
 @hydra_runner(config_path="conf", config_name="megatron_gpt_config")
@@ -71,6 +87,8 @@ def main(cfg) -> None:
     # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
     with open_dict(cfg):
         cfg.model.precision = cfg.trainer.precision
+    check_config_dependency(cfg)
+
     model = MegatronGPTModel(cfg.model, trainer)
 
     trainer.fit(model)

--- a/nemo/collections/nlp/models/language_modeling/megatron/gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/gpt_model.py
@@ -81,6 +81,7 @@ class GPTModel(MegatronModule):
         activations_checkpoint_num_layers=1,
         layernorm_epsilon=1e-5,
         bias_gelu_fusion=True,
+        persist_layer_norm=False,
         openai_gelu=False,
         onnx_safe=False,
     ):
@@ -122,6 +123,7 @@ class GPTModel(MegatronModule):
             activations_checkpoint_num_layers=activations_checkpoint_num_layers,
             layernorm_epsilon=layernorm_epsilon,
             bias_gelu_fusion=bias_gelu_fusion,
+            persist_layer_norm=persist_layer_norm,
             openai_gelu=openai_gelu,
             onnx_safe=onnx_safe,
         )

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -104,6 +104,7 @@ class MegatronGPTModel(NLPModel):
             activations_checkpoint_method=cfg.get('activations_checkpoint_method', None),
             activations_checkpoint_num_layers=cfg.get('activations_checkpoint_num_layers', 1),
             layernorm_epsilon=cfg.get('layernorm_epsilon', 1e-5),
+            persist_layer_norm=cfg.get('persist_layer_norm', False),
             onnx_safe=cfg.get('onnx_safe', False),
         )
 

--- a/nemo/collections/nlp/modules/common/megatron/fused_layer_norm.py
+++ b/nemo/collections/nlp/modules/common/megatron/fused_layer_norm.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+
+from apex.normalization.fused_layer_norm import MixedFusedLayerNorm
+from apex.contrib.layer_norm.layer_norm import FastLayerNorm
+
+
+class FusedLayerNorm(torch.nn.Module):
+
+  def __init__(self, hidden_size, eps=1e-5, persist_layer_norm=False):
+        super().__init__()
+
+        # List of hiddens sizes supported in the persistent layer norm kernel
+        # If the hidden size is not supported, fall back to the non-persistent
+        # kernel.
+        persist_ln_hidden_sizes = [1024, 1536, 2048, 2304, 3072, 3840, 4096,
+            5120, 6144, 8192, 10240, 12288, 12800, 15360, 16384, 18432, 20480,
+            24576, 25600, 30720, 32768, 40960, 49152, 65536]
+        if hidden_size not in persist_ln_hidden_sizes:
+            persist_layer_norm = False
+
+        if persist_layer_norm:
+            self.layer_norm = FastLayerNorm(hidden_size, eps)
+        else:
+            self.layer_norm = MixedFusedLayerNorm(hidden_size, eps)
+
+  def forward(self, input):
+      return self.layer_norm(input)

--- a/nemo/collections/nlp/modules/common/megatron/language_model.py
+++ b/nemo/collections/nlp/modules/common/megatron/language_model.py
@@ -71,6 +71,7 @@ def get_language_model(
     activations_checkpoint_num_layers=1,
     layernorm_epsilon=1e-5,
     bias_gelu_fusion=True,
+    persist_layer_norm=False,
     openai_gelu=False,
     onnx_safe=False,
 ):
@@ -115,6 +116,7 @@ def get_language_model(
         activations_checkpoint_num_layers=activations_checkpoint_num_layers,
         layernorm_epsilon=layernorm_epsilon,
         bias_gelu_fusion=bias_gelu_fusion,
+        persist_layer_norm=persist_layer_norm,
         openai_gelu=openai_gelu,
         onnx_safe=onnx_safe,
     )
@@ -335,6 +337,7 @@ class TransformerLanguageModel(MegatronModule):
         activations_checkpoint_num_layers=1,
         layernorm_epsilon=1e-5,
         bias_gelu_fusion=True,
+        persist_layer_norm=False,
         openai_gelu=False,
         onnx_safe=False,
     ):
@@ -396,6 +399,7 @@ class TransformerLanguageModel(MegatronModule):
             hidden_dropout=hidden_dropout,
             use_cpu_initialization=use_cpu_initialization,
             bias_gelu_fusion=bias_gelu_fusion,
+            persist_layer_norm=persist_layer_norm,
             openai_gelu=openai_gelu,
             onnx_safe=onnx_safe,
         )
@@ -427,6 +431,7 @@ class TransformerLanguageModel(MegatronModule):
                 hidden_dropout=hidden_dropout,
                 use_cpu_initialization=use_cpu_initialization,
                 bias_gelu_fusion=bias_gelu_fusion,
+                persist_layer_norm=persist_layer_norm,
                 openai_gelu=openai_gelu,
                 onnx_safe=onnx_safe,
             )

--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -18,7 +18,6 @@ import math
 
 import torch
 import torch.nn.functional as F
-from apex.normalization.fused_layer_norm import MixedFusedLayerNorm as LayerNorm
 from apex.transformer import parallel_state, tensor_parallel
 from apex.transformer.enums import AttnMaskType, AttnType, LayerType
 from apex.transformer.functional.fused_softmax import FusedScaleMaskSoftmax
@@ -29,6 +28,7 @@ from nemo.collections.nlp.modules.common.megatron.fused_bias_dropout_add import 
     bias_dropout_add_fused_train,
 )
 from nemo.collections.nlp.modules.common.megatron.fused_bias_gelu import fused_bias_gelu
+from nemo.collections.nlp.modules.common.megatron.fused_layer_norm import FusedLayerNorm as LayerNorm
 from nemo.collections.nlp.modules.common.megatron.module import MegatronModule
 from nemo.collections.nlp.modules.common.megatron.utils import attention_mask_func, erf_gelu
 
@@ -395,6 +395,7 @@ class ParallelTransformerLayer_(MegatronModule):
         layernorm_epsilon=1e-5,
         hidden_dropout=0.1,
         bias_dropout_fusion=True,
+        persist_layer_norm=False,
         use_cpu_initialization=False,
         bias_gelu_fusion=True,
         openai_gelu=False,
@@ -418,7 +419,7 @@ class ParallelTransformerLayer_(MegatronModule):
         self.fp32_residual_connection = fp32_residual_connection  # if true move residual connections to fp32
 
         # Layernorm on the input data.
-        self.input_layernorm = LayerNorm(hidden_size, eps=layernorm_epsilon)
+        self.input_layernorm = LayerNorm(hidden_size, layernorm_epsilon, persist_layer_norm)
 
         # Self attention.
         self.self_attention = ParallelAttention(
@@ -440,7 +441,7 @@ class ParallelTransformerLayer_(MegatronModule):
         self.bias_dropout_fusion = bias_dropout_fusion  # if true, enable bias dropout fusion
 
         # Layernorm on the attention output
-        self.post_attention_layernorm = LayerNorm(hidden_size, eps=layernorm_epsilon)
+        self.post_attention_layernorm = LayerNorm(hidden_size, layernorm_epsilon, persist_layer_norm)
 
         if self.layer_type == LayerType.decoder:
             self.inter_attention = ParallelAttention(
@@ -459,7 +460,7 @@ class ParallelTransformerLayer_(MegatronModule):
                 attention_dropout=attention_dropout,
             )
             # Layernorm on the attention output.
-            self.post_inter_attention_layernorm = LayerNorm(hidden_size, eps=layernorm_epsilon)
+            self.post_inter_attention_layernorm = LayerNorm(hidden_size, layernorm_epsilon, persist_layer_norm)
 
         # MLP
         self.mlp = ParallelMLP(
@@ -617,6 +618,7 @@ class ParallelTransformer(MegatronModule):
         hidden_dropout=0.1,
         use_cpu_initialization=False,
         bias_gelu_fusion=True,
+        persist_layer_norm=False,
         openai_gelu=False,
         onnx_safe=False,
     ):
@@ -662,6 +664,7 @@ class ParallelTransformer(MegatronModule):
                 hidden_dropout=hidden_dropout,
                 use_cpu_initialization=use_cpu_initialization,
                 bias_gelu_fusion=bias_gelu_fusion,
+                persist_layer_norm=persist_layer_norm,
                 openai_gelu=openai_gelu,
                 onnx_safe=onnx_safe,
             )
@@ -694,7 +697,7 @@ class ParallelTransformer(MegatronModule):
 
         if self.post_process:
             # Final layer norm before output.
-            self.final_layernorm = LayerNorm(hidden_size, eps=layernorm_epsilon)
+            self.final_layernorm = LayerNorm(hidden_size, layernorm_epsilon, persist_layer_norm)
 
     def _get_layer(self, layer_number):
         return self.layers[layer_number]


### PR DESCRIPTION
This adds the option to use the persistent layer norm kernel from APEX.
The kernel is available from PyT container v21.11 so added a dependency check. Other pytorch- or container-dependency modules can have dependency checks in the same method. 

Signed-off-by: Sangkug Lym <slym@nvidia.com>