### PR TITLE
Add Beta-binomial Interpolator to TTSDataset

### DIFF
--- a/nemo/collections/tts/torch/helpers.py
+++ b/nemo/collections/tts/torch/helpers.py
@@ -11,10 +11,35 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import functools
 
 import numpy as np
 import torch
+from scipy import ndimage
 from scipy.stats import betabinom
+
+
+class BetaBinomialInterpolator:
+    """
+        This module calculates alignment prior matrices (based on beta-binomial distribution) using cached popular sizes and image interpolation.
+        The implementation is taken from https://github.com/NVIDIA/DeepLearningExamples.
+    """
+
+    def __init__(self, round_mel_len_to=100, round_text_len_to=20):
+        self.round_mel_len_to = round_mel_len_to
+        self.round_text_len_to = round_text_len_to
+        self.bank = functools.lru_cache(beta_binomial_prior_distribution)
+
+    def round(self, val, to):
+        return max(1, int(np.round((val + 1) / to))) * to
+
+    def __call__(self, w, h):
+        bw = self.round(w, to=self.round_mel_len_to)
+        bh = self.round(h, to=self.round_text_len_to)
+        ret = ndimage.zoom(self.bank(bw, bh).T, zoom=(w / bw, h / bh), order=1)
+        assert ret.shape[0] == w, ret.shape
+        assert ret.shape[1] == h, ret.shape
+        return ret
 
 
 def general_padding(item, item_len, max_len, pad_value=0):


### PR DESCRIPTION
Beta-Binomial Interpolator is taken from [DeepLearningExamples](https://github.com/NVIDIA/DeepLearningExamples/blob/master/PyTorch/SpeechSynthesis/FastPitch/fastpitch/data_function.py#L45) repository.

Signed-off-by: Oktai Tatanov <oktai.tatanov@gmail.com>