### PR TITLE
Fix specaugment time start for numba kernel

### DIFF
--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -491,6 +491,7 @@ class SpectrogramAugmentation(NeuralModule):
 
         # Check if numba is supported, and use a Numba kernel if it is
         if use_numba_spec_augment and numba_utils.numba_cuda_is_supported(__NUMBA_MINIMUM_VERSION__):
+            logging.info('Numba CUDA SpecAugment kernel is being used')
             self.spec_augment_numba = SpecAugmentNumba(
                 freq_masks=freq_masks,
                 time_masks=time_masks,

--- a/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
+++ b/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
@@ -283,7 +283,7 @@ class SpecAugmentNumba(nn.Module, Typing):
                     torch.randint(0, time_width[idx] + 1, size=[1, self.time_masks], device=input_spec.device)
                 )
 
-            time_starts = torch.cat(time_lengths, 0)
+            time_starts = torch.cat(time_starts, 0)
             time_lengths = torch.cat(time_lengths, 0)
 
         else:


### PR DESCRIPTION
# Bugfix
- Correct the variable for time_starts when executing the numba kernel for adaptive spec augment

Closes #3298 

Signed-off-by: smajumdar <titu1994@gmail.com>
