### PR TITLE
Better default for RNNT greedy decoding

### DIFF
--- a/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
@@ -1072,11 +1072,11 @@ class ONNXGreedyBatchedRNNTInfer:
 
 @dataclass
 class GreedyRNNTInferConfig:
-    max_symbols_per_step: Optional[int] = None
+    max_symbols_per_step: Optional[int] = 10
     preserve_alignments: bool = False
 
 
 @dataclass
 class GreedyBatchedRNNTInferConfig:
-    max_symbols_per_step: Optional[int] = None
+    max_symbols_per_step: Optional[int] = 10
     preserve_alignments: bool = False


### PR DESCRIPTION
# Changelog
- Better rnnt greedy decoding default of 10 max decoding time steps

Signed-off-by: smajumdar <titu1994@gmail.com>