### PR TITLE
Moved shebangs to the first line

### DIFF
--- a/tools/text_processing_deployment/docker/build.sh
+++ b/tools/text_processing_deployment/docker/build.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,9 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-#!/bin/bash
 
 FORCE_REBUILD=${1:-""}
 docker build . --rm -t sparrowhawk $FORCE_REBUILD

--- a/tools/text_processing_deployment/docker/launch.sh
+++ b/tools/text_processing_deployment/docker/launch.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# !/bin/bash
 
 MODE=${1:-"export"}
 LANGUAGE=${2:-"en"}

--- a/tools/text_processing_deployment/export_grammars.sh
+++ b/tools/text_processing_deployment/export_grammars.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
 # Copyright 2015 and onwards Google, Inc.
 #
@@ -12,8 +14,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/bash
 
 # This script compiles and exports WFST-grammars from nemo_text_processing, builds C++ production backend Sparrowhawk (https://github.com/google/sparrowhawk) in docker, 
 # plugs grammars into Sparrowhawk and returns prompt inside docker.


### PR DESCRIPTION
The shebang must be the first line because it is interpreted by the kernel, which looks at the two bytes at the start of an executable file.
@okuchaiev , could you review please?