### PR TITLE
Fix minor problems in punctuation and capitalization model

### DIFF
--- a/examples/nlp/token_classification/data/create_punctuation_capitalization_tarred_dataset.py
+++ b/examples/nlp/token_classification/data/create_punctuation_capitalization_tarred_dataset.py
@@ -23,6 +23,7 @@ from nemo.collections.nlp.data.token_classification.punctuation_capitalization_t
     METADATA_PUNCT_LABEL_VOCAB_KEY,
     build_label_ids_from_list_of_labels,
     check_labels_for_being_unique_before_building_label_ids,
+    check_tar_file_prefix,
     create_tarred_dataset,
 )
 
@@ -230,7 +231,8 @@ def get_args() -> argparse.Namespace:
         "--tar_file_prefix",
         "-x",
         default="punctuation_capitalization",
-        help="A string from which tar file names start.",
+        help="A string from which tar file names start. It can contain only characters 'A-Z', 'a-z', '0-9', '_', '-', "
+        "'.'.",
     )
     parser.add_argument(
         "--n_jobs",
@@ -283,6 +285,7 @@ def get_args() -> argparse.Namespace:
         check_labels_for_being_unique_before_building_label_ids(
             args.pad_label, args.capit_labels, '--pad_label', '--capit_labels', parser.error
         )
+    check_tar_file_prefix(args.tar_file_prefix)
     return args
 
 

--- a/examples/nlp/token_classification/data/create_punctuation_capitalization_tarred_dataset.py
+++ b/examples/nlp/token_classification/data/create_punctuation_capitalization_tarred_dataset.py
@@ -285,7 +285,7 @@ def get_args() -> argparse.Namespace:
         check_labels_for_being_unique_before_building_label_ids(
             args.pad_label, args.capit_labels, '--pad_label', '--capit_labels', parser.error
         )
-    check_tar_file_prefix(args.tar_file_prefix)
+    check_tar_file_prefix(args.tar_file_prefix, parser.error, '--tar_file_prefix')
     return args
 
 

--- a/nemo/collections/nlp/data/token_classification/punctuation_capitalization_dataset.py
+++ b/nemo/collections/nlp/data/token_classification/punctuation_capitalization_dataset.py
@@ -63,9 +63,9 @@ class PunctuationCapitalizationDataConfigBase:
     """A base class for punctuation and capitalization data configs. This class does not define ``ds_item``
     attribute which works differently for train and evaluation data."""
 
-    #################################################
-    # COMMON DATASET PARAMETERS
-    #################################################
+    ###################################################
+    # PARAMETERS COMMON FOR REGULAR AND TARRED DATASETS
+    ###################################################
     use_tarred_dataset: bool = MISSING
     """Whether to use tarred dataset. If True, then you should provide ``tar_metadata_file``. Otherwise, you should
     provide ``text_file``, ``labels_file``, ``tokens_in_batch``."""
@@ -439,7 +439,7 @@ class TokenizeCreateMasksClipWorker:
         punct_label_lines: Optional[Union[List[str], Tuple[str, ...]]],
         capit_label_lines: Optional[Union[List[str], Tuple[str, ...]]],
         split_i: int,
-    ) -> Tuple[np.ndarray, List[np.ndarray], List[np.ndarray], List[np.ndarray]]:
+    ) -> Tuple[List[np.ndarray], List[np.ndarray], List[np.ndarray], List[np.ndarray]]:
         """
         Tokenize, clip, encode labels, and create masks of first tokens in words.
 

--- a/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py
+++ b/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import json
 import multiprocessing as mp
 import os
@@ -382,7 +383,7 @@ def check_label_ids(pad_label: str, punct_label_ids: Dict[str, int], capit_label
 
 
 def process_error(msg: str, error_class_or_function: Union[Type[Exception], Callable[[str], Any]]) -> None:
-    if issubclass(error_class_or_function, Exception):
+    if inspect.isclass(error_class_or_function) and issubclass(error_class_or_function, Exception):
         raise error_class_or_function(msg)
     if callable(error_class_or_function):
         error_class_or_function(msg)

--- a/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py
+++ b/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py
@@ -742,7 +742,7 @@ def create_tarred_dataset(
         prefix=tar_file_prefix,
         tokens_in_batch=tokens_in_batch,
         max_seq_length=max_seq_length,
-        tokenizer=tokenizer_name,
+        tokenizer=tokenizer_name.replace('/', '-'),
     )
     output_file_tmpl = ds_params_str + TAR_FINAL_TMPL
     metadata_file_name = output_dir / ('metadata.' + ds_params_str + '.json')

--- a/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py
+++ b/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py
@@ -642,7 +642,7 @@ def check_tar_file_prefix(
         msg = (
             f"Found {len(not_allowed_characters_in_prefix)} not allowed characters in `{var_name}`. Only 'A-Z', "
             f"'a-z', '0-9', '_', '-', '.' characters are allowed. Examples of not allowed characters: "
-            f"{list(not_allowed_characters_in_prefix)[:10]}. tar_file_prefix={repr(tar_file_prefix)}."
+            f"{list(not_allowed_characters_in_prefix)[:10]}. `{tar_file_prefix}`[:30]={repr(tar_file_prefix)[:30]}."
         )
         process_error(msg, error_class_or_function)
 

--- a/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py
+++ b/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py
@@ -632,16 +632,18 @@ def create_metadata_file(
         json.dump(metadata, f, indent=2)
 
 
-def check_tar_file_prefix(tar_file_prefix: str) -> None:
+def check_tar_file_prefix(
+    tar_file_prefix: str, error_class_or_function: Union[Type[Exception], Callable[[str], Any]], var_name: str
+) -> None:
     not_allowed_characters_in_prefix = NOT_ALLOWED_CHARACTERS_IN_FILE_NAME.findall(tar_file_prefix)
     if not_allowed_characters_in_prefix:
         not_allowed_characters_in_prefix = set(not_allowed_characters_in_prefix)
-        raise ValueError(
-            f"Found {len(not_allowed_characters_in_prefix)} not allowed characters in `tar_file_prefix`. Only 'A-Z', "
+        msg = (
+            f"Found {len(not_allowed_characters_in_prefix)} not allowed characters in `{var_name}`. Only 'A-Z', "
             f"'a-z', '0-9', '_', '-', '.' characters are allowed. Examples of not allowed characters: "
             f"{list(not_allowed_characters_in_prefix)[:10]}."
         )
-
+        process_error(msg, error_class_or_function)
 
 def create_tarred_dataset(
     text_file: Union[os.PathLike, str],
@@ -747,7 +749,7 @@ def create_tarred_dataset(
         n_jobs (:obj:`int`, `optional`): a number of workers for creating tarred dataset. If ``None``, then ``n_jobs``
             is equal to number of CPUs.
     """
-    check_tar_file_prefix(tar_file_prefix)
+    check_tar_file_prefix(tar_file_prefix, ValueError, 'tar_file_prefix')
     if n_jobs is None:
         n_jobs = mp.cpu_count()
     text_file, labels_file = Path(text_file).expanduser(), Path(labels_file).expanduser()

--- a/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py
+++ b/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py
@@ -642,7 +642,7 @@ def check_tar_file_prefix(
         msg = (
             f"Found {len(not_allowed_characters_in_prefix)} not allowed characters in `{var_name}`. Only 'A-Z', "
             f"'a-z', '0-9', '_', '-', '.' characters are allowed. Examples of not allowed characters: "
-            f"{list(not_allowed_characters_in_prefix)[:10]}. `{tar_file_prefix}`[:30]={repr(tar_file_prefix)[:30]}."
+            f"{list(not_allowed_characters_in_prefix)[:10]}. `{var_name}`[:30]={repr(tar_file_prefix)[:30]}."
         )
         process_error(msg, error_class_or_function)
 

--- a/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py
+++ b/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py
@@ -642,9 +642,10 @@ def check_tar_file_prefix(
         msg = (
             f"Found {len(not_allowed_characters_in_prefix)} not allowed characters in `{var_name}`. Only 'A-Z', "
             f"'a-z', '0-9', '_', '-', '.' characters are allowed. Examples of not allowed characters: "
-            f"{list(not_allowed_characters_in_prefix)[:10]}."
+            f"{list(not_allowed_characters_in_prefix)[:10]}. tar_file_prefix={repr(tar_file_prefix)}."
         )
         process_error(msg, error_class_or_function)
+
 
 def create_tarred_dataset(
     text_file: Union[os.PathLike, str],


### PR DESCRIPTION
1. Fix creating tarred dataset for cases when tokenizer name contains `/` character, e.g. `'facebook/mbart-large-50'`.
2. Fix subclass check [here](https://github.com/NVIDIA/NeMo/blob/f83b2c5524a787be21ffea170850c4b5486eac2b/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py#L383). It did not work if `error_class_or_function` is not a class
3. Fix return typing in a [method](https://github.com/NVIDIA/NeMo/blob/f83b2c5524a787be21ffea170850c4b5486eac2b/nemo/collections/nlp/data/token_classification/punctuation_capitalization_dataset.py#L436) `TokenizeCreateMasksClipWorker.__call__()`.
4. Make comment [here](https://github.com/NVIDIA/NeMo/blob/f83b2c5524a787be21ffea170850c4b5486eac2b/nemo/collections/nlp/data/token_classification/punctuation_capitalization_dataset.py#L67) more comprehensible. Before fix it was identical to a name of a model config section `common_dataset_parameters`, whereas it was not related to the section in any way.
5. In a spirit of fix 1 add checking of characters in `tar_file_prefix` parameter in functions [`create_tarred_dataset()`](https://github.com/NVIDIA/NeMo/blob/f83b2c5524a787be21ffea170850c4b5486eac2b/nemo/collections/nlp/data/token_classification/punctuation_capitalization_tarred_dataset.py#L633) and [`get_args()`](https://github.com/NVIDIA/NeMo/blob/f83b2c5524a787be21ffea170850c4b5486eac2b/examples/nlp/token_classification/data/create_punctuation_capitalization_tarred_dataset.py#L64).