### PR TITLE
update speaker collate functions

### DIFF
--- a/examples/speaker_tasks/recognition/README.md
+++ b/examples/speaker_tasks/recognition/README.md
@@ -9,7 +9,7 @@ Documentation section for speaker related tasks can be found at:
 |:------------------------------:|:---------------------:|:--------------------------------------:|
 | [speakerverification_speakernet](https://ngc.nvidia.com/catalog/models/nvidia:nemo:speakerverification_speakernet) |        xvector        |                  1.96                  |
 |           [ecapa_tdnn](https://ngc.nvidia.com/catalog/models/nvidia:nemo:ecapa_tdnn)           | channel-<br>attention |                  0.92                  |
-|           [titanet_large](https://ngc.nvidia.com/catalog/models/nvidia:nemo:ecapa_tdnn)           | channel-<br>attention |                  0.69                  |
+|           [titanet_large](https://ngc.nvidia.com/catalog/models/nvidia:nemo:ecapa_tdnn)           | channel-<br>attention |                  0.66                  |
 
 ## Training
 Speaker Recognition models can be trained in a similar way as other models in NeMo using train and dev manifest files. Steps on how to create manifest files for voxceleb are provided below.

--- a/examples/speaker_tasks/recognition/conf/SpeakerNet_recognition_3x2x512.yaml
+++ b/examples/speaker_tasks/recognition/conf/SpeakerNet_recognition_3x2x512.yaml
@@ -12,7 +12,6 @@ model:
     labels: null
     batch_size: 64
     shuffle: True
-    time_length: 8
     is_tarred: False
     tarred_audio_filepaths: null
     tarred_shard_strategy: "scatter"
@@ -23,7 +22,6 @@ model:
     labels: null
     batch_size: 128
     shuffle: False
-    time_length: 8
 
   test_ds:
     manifest_filepath: ???
@@ -31,7 +29,6 @@ model:
     labels: null
     batch_size: 1
     shuffle: False
-    time_length: 8
     embedding_dir: '.'
 
   preprocessor:

--- a/examples/speaker_tasks/recognition/conf/SpeakerNet_verification_3x2x256.yaml
+++ b/examples/speaker_tasks/recognition/conf/SpeakerNet_verification_3x2x256.yaml
@@ -12,7 +12,6 @@ model:
     labels: null
     batch_size: 64
     shuffle: True
-    time_length: 8
     is_tarred: False
     tarred_audio_filepaths: null
     tarred_shard_strategy: "scatter"
@@ -23,7 +22,6 @@ model:
     labels: null
     batch_size: 128
     shuffle: False
-    time_length: 8
 
   preprocessor:
     _target_: nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor

--- a/examples/speaker_tasks/recognition/conf/ecapa_tdnn.yaml
+++ b/examples/speaker_tasks/recognition/conf/ecapa_tdnn.yaml
@@ -10,7 +10,6 @@ model:
     labels: null
     batch_size: 64
     shuffle: True
-    time_length: 3
     augmentor:
       noise:
         manifest_path: null
@@ -31,7 +30,6 @@ model:
     labels: null
     batch_size: 128
     shuffle: False
-    time_length: 3
 
   preprocessor:
     _target_: nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor

--- a/examples/speaker_tasks/recognition/conf/titanet-large.yaml
+++ b/examples/speaker_tasks/recognition/conf/titanet-large.yaml
@@ -8,7 +8,6 @@ model:
     labels: null
     batch_size: 64
     shuffle: True
-    time_length: 8
     is_tarred: False
     tarred_audio_filepaths: null
     tarred_shard_strategy: "scatter"
@@ -40,7 +39,6 @@ model:
     labels: null
     batch_size: 128
     shuffle: False
-    time_length: 8
 
   model_defaults:
     filters: 1024

--- a/examples/speaker_tasks/recognition/extract_speaker_embeddings.py
+++ b/examples/speaker_tasks/recognition/extract_speaker_embeddings.py
@@ -54,14 +54,7 @@ except ImportError:
 
 def get_embeddings(speaker_model, manifest_file, batch_size=1, embedding_dir='./', device='cuda'):
     test_config = OmegaConf.create(
-        dict(
-            manifest_filepath=manifest_file,
-            sample_rate=16000,
-            labels=None,
-            batch_size=batch_size,
-            shuffle=False,
-            time_length=20,
-        )
+        dict(manifest_filepath=manifest_file, sample_rate=16000, labels=None, batch_size=batch_size, shuffle=False,)
     )
 
     speaker_model.setup_test_data(test_config)
@@ -138,7 +131,7 @@ def main():
         device = 'cpu'
         logging.warning("Running model on CPU, for faster performance it is adviced to use atleast one NVIDIA GPUs")
 
-    get_embeddings(speaker_model, args.manifest, batch_size=64, embedding_dir=args.embedding_dir, device=device)
+    get_embeddings(speaker_model, args.manifest, batch_size=1, embedding_dir=args.embedding_dir, device=device)
 
 
 if __name__ == '__main__':

--- a/nemo/collections/asr/models/__init__.py
+++ b/nemo/collections/asr/models/__init__.py
@@ -19,7 +19,7 @@ try:
     from nemo.collections.asr.models.clustering_diarizer import ClusteringDiarizer
     from nemo.collections.asr.models.ctc_bpe_models import EncDecCTCModelBPE
     from nemo.collections.asr.models.ctc_models import EncDecCTCModel
-    from nemo.collections.asr.models.label_models import EncDecSpeakerLabelModel, ExtractSpeakerEmbeddingsModel
+    from nemo.collections.asr.models.label_models import EncDecSpeakerLabelModel
     from nemo.collections.asr.models.rnnt_bpe_models import EncDecRNNTBPEModel
     from nemo.collections.asr.models.rnnt_models import EncDecRNNTModel
 except ModuleNotFoundError:
@@ -32,7 +32,6 @@ except ModuleNotFoundError:
     class EncDecCTCModelBPE(CheckInstall): pass
     class EncDecCTCModel(CheckInstall): pass
     class EncDecSpeakerLabelModel(CheckInstall): pass
-    class ExtractSpeakerEmbeddingsModel(CheckInstall): pass
     class EncDecRNNTBPEModel(CheckInstall): pass
     class EncDecRNNTModel(CheckInstall): pass
     # fmt: on


### PR DESCRIPTION
Signed-off-by: nithinraok <nithinrao.koluguri@gmail.com>

This PR 
* removes time-length and shift-length concept for training speaker label models. 
> This assumes all the samples present in training manifest must adhere to max of 8 secs. (3 sec is ideal) 

* removes sliced_seq_collate_fn : Since we introduced segmentation for creating manifest files hence this collate func is no longer required now, and existing seq_collate_fn can be used for getting speaker embeddings for diarization as well. 

