### PR TITLE
Fix the tutorial notebooks bug

### DIFF
--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -253,8 +253,9 @@ class NLPModel(ModelPT, Exportable):
             if 'cfg' in kwargs:
                 model = cls._load_model_state(checkpoint, strict=strict, **kwargs)
             else:
+                cfg = checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY].get('cfg', checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY])
                 model = cls._load_model_state(
-                    checkpoint, strict=strict, cfg=checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY], **kwargs
+                    checkpoint, strict=strict, cfg=cfg, **kwargs
                 )
             checkpoint = model
 

--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -253,10 +253,10 @@ class NLPModel(ModelPT, Exportable):
             if 'cfg' in kwargs:
                 model = cls._load_model_state(checkpoint, strict=strict, **kwargs)
             else:
-                cfg = checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY].get('cfg', checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY])
-                model = cls._load_model_state(
-                    checkpoint, strict=strict, cfg=cfg, **kwargs
+                cfg = checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY].get(
+                    'cfg', checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY]
                 )
+                model = cls._load_model_state(checkpoint, strict=strict, cfg=cfg, **kwargs)
             checkpoint = model
 
         finally:

--- a/tutorials/nlp/Relation_Extraction-BioMegatron.ipynb
+++ b/tutorials/nlp/Relation_Extraction-BioMegatron.ipynb
@@ -363,6 +363,7 @@
    "outputs": [],
    "source": [
     "# download the model's configuration file \n",
+    "MODEL_CONFIG = 'text_classification_config.yaml'\n",
     "config_dir = WORK_DIR + '/configs/'\n",
     "os.makedirs(config_dir, exist_ok=True)\n",
     "if not os.path.exists(config_dir + MODEL_CONFIG):\n",


### PR DESCRIPTION
`Joint_Intent_and_Slot_Classification.ipynb`
`Text_Classification_Sentiment_Analysis.ipynb`
problem are caused by extra `cfg` key in the checkpoint file 

`Relation_Extraction-BioMegatron.ipynb`
problem is caused by forgetting to set the correct `model_config` variable. 
