### PR TITLE
Test only if the model was trained on single GPU for accurate results.

### DIFF
--- a/examples/asr/asr_ctc/speech_to_text_ctc.py
+++ b/examples/asr/asr_ctc/speech_to_text_ctc.py
@@ -90,15 +90,8 @@ def main(cfg):
     trainer.fit(asr_model)
 
     if hasattr(cfg.model, 'test_ds') and cfg.model.test_ds.manifest_filepath is not None:
-        gpu = 1 if cfg.trainer.gpus != 0 else 0
-        test_trainer = pl.Trainer(
-            gpus=gpu,
-            precision=trainer.precision,
-            amp_level=trainer.accelerator_connector.amp_level,
-            amp_backend=cfg.trainer.get("amp_backend", "native"),
-        )
-        if asr_model.prepare_test(test_trainer):
-            test_trainer.test(asr_model)
+        if asr_model.prepare_test(trainer):
+            trainer.test(asr_model)
 
 
 if __name__ == '__main__':

--- a/examples/asr/asr_ctc/speech_to_text_ctc_bpe.py
+++ b/examples/asr/asr_ctc/speech_to_text_ctc_bpe.py
@@ -86,15 +86,8 @@ def main(cfg):
     trainer.fit(asr_model)
 
     if hasattr(cfg.model, 'test_ds') and cfg.model.test_ds.manifest_filepath is not None:
-        gpu = 1 if cfg.trainer.gpus != 0 else 0
-        test_trainer = pl.Trainer(
-            gpus=gpu,
-            precision=trainer.precision,
-            amp_level=trainer.accelerator_connector.amp_level,
-            amp_backend=cfg.trainer.get("amp_backend", "native"),
-        )
-        if asr_model.prepare_test(test_trainer):
-            test_trainer.test(asr_model)
+        if asr_model.prepare_test(trainer):
+            trainer.test(asr_model)
 
 
 if __name__ == '__main__':

--- a/examples/asr/asr_transducer/speech_to_text_rnnt.py
+++ b/examples/asr/asr_transducer/speech_to_text_rnnt.py
@@ -89,15 +89,8 @@ def main(cfg):
     trainer.fit(asr_model)
 
     if hasattr(cfg.model, 'test_ds') and cfg.model.test_ds.manifest_filepath is not None:
-        gpu = 1 if cfg.trainer.gpus != 0 else 0
-        test_trainer = pl.Trainer(
-            gpus=gpu,
-            precision=trainer.precision,
-            amp_level=trainer.accelerator_connector.amp_level,
-            amp_backend=cfg.trainer.get("amp_backend", "native"),
-        )
-        if asr_model.prepare_test(test_trainer):
-            test_trainer.test(asr_model)
+        if asr_model.prepare_test(trainer):
+            trainer.test(asr_model)
 
 
 if __name__ == '__main__':

--- a/examples/asr/asr_transducer/speech_to_text_rnnt_bpe.py
+++ b/examples/asr/asr_transducer/speech_to_text_rnnt_bpe.py
@@ -81,15 +81,8 @@ def main(cfg):
     trainer.fit(asr_model)
 
     if hasattr(cfg.model, 'test_ds') and cfg.model.test_ds.manifest_filepath is not None:
-        gpu = 1 if cfg.trainer.gpus != 0 else 0
-        test_trainer = pl.Trainer(
-            gpus=gpu,
-            precision=trainer.precision,
-            amp_level=trainer.accelerator_connector.amp_level,
-            amp_backend=cfg.trainer.get("amp_backend", "native"),
-        )
-        if asr_model.prepare_test(test_trainer):
-            test_trainer.test(asr_model)
+        if asr_model.prepare_test(trainer):
+            trainer.test(asr_model)
 
 
 if __name__ == '__main__':

--- a/examples/asr/speech_classification/speech_to_label.py
+++ b/examples/asr/speech_classification/speech_to_label.py
@@ -121,6 +121,17 @@ from nemo.core.config import hydra_runner
 from nemo.utils import logging
 from nemo.utils.exp_manager import exp_manager
 
+"""
+python speech_to_label.py \
+    --config-path="/home/smajumdar/PycharmProjects/nemo-eval/nemo_beta_eval/speech_commands/configs" \
+    --config-name="matchboxnet_3x1x64_v1.yaml" \
+    model.train_ds.manifest_filepath="/home/smajumdar/PycharmProjects/nemo-eval/nemo_beta_eval/speech_commands/manifests/v1_validation_manifest.json" \
+    model.validation_ds.manifest_filepath=/home/smajumdar/PycharmProjects/nemo-eval/nemo_beta_eval/speech_commands/manifests/v1_validation_manifest.json \
+    model.test_ds.manifest_filepath=/home/smajumdar/PycharmProjects/nemo-eval/nemo_beta_eval/speech_commands/manifests/v1_validation_manifest.json \
+    trainer.gpus=2 \
+    trainer.accelerator="ddp" \
+    trainer.max_steps=5 
+"""
 
 @hydra_runner(config_path="../conf/matchboxnet", config_name="matchboxnet_3x1x64_v1")
 def main(cfg):
@@ -136,8 +147,6 @@ def main(cfg):
     trainer.fit(asr_model)
 
     if hasattr(cfg.model, 'test_ds') and cfg.model.test_ds.manifest_filepath is not None:
-        gpu = 1 if cfg.trainer.gpus != 0 else 0
-        trainer = pl.Trainer(gpus=gpu)
         if asr_model.prepare_test(trainer):
             trainer.test(asr_model)
 

--- a/examples/asr/speech_classification/speech_to_label.py
+++ b/examples/asr/speech_classification/speech_to_label.py
@@ -121,17 +121,6 @@ from nemo.core.config import hydra_runner
 from nemo.utils import logging
 from nemo.utils.exp_manager import exp_manager
 
-"""
-python speech_to_label.py \
-    --config-path="/home/smajumdar/PycharmProjects/nemo-eval/nemo_beta_eval/speech_commands/configs" \
-    --config-name="matchboxnet_3x1x64_v1.yaml" \
-    model.train_ds.manifest_filepath="/home/smajumdar/PycharmProjects/nemo-eval/nemo_beta_eval/speech_commands/manifests/v1_validation_manifest.json" \
-    model.validation_ds.manifest_filepath=/home/smajumdar/PycharmProjects/nemo-eval/nemo_beta_eval/speech_commands/manifests/v1_validation_manifest.json \
-    model.test_ds.manifest_filepath=/home/smajumdar/PycharmProjects/nemo-eval/nemo_beta_eval/speech_commands/manifests/v1_validation_manifest.json \
-    trainer.gpus=2 \
-    trainer.accelerator="ddp" \
-    trainer.max_steps=5 
-"""
 
 @hydra_runner(config_path="../conf/matchboxnet", config_name="matchboxnet_3x1x64_v1")
 def main(cfg):


### PR DESCRIPTION
# Changelog
- Revert previous code that constructs a trainer on one GPU to evaluate results. The code is misleading because the torch environment is still distributed, and all processes run the code
- From now on, test only if the model was trained on a single GPU with no ddp.

Signed-off-by: smajumdar <titu1994@gmail.com>