### PR TITLE
Process correctly label ids dataset parameter + standardize type of label ids model attribute + minor changes (error messages, typing)

### DIFF
--- a/nemo/collections/nlp/data/token_classification/punctuation_capitalization_dataset.py
+++ b/nemo/collections/nlp/data/token_classification/punctuation_capitalization_dataset.py
@@ -875,8 +875,8 @@ class BertPunctuationCapitalizationDataset(Dataset):
         num_samples: int = -1,
         tokens_in_batch: int = 5000,
         pad_label: str = 'O',
-        punct_label_ids: Optional[Dict[str, int]] = None,
-        capit_label_ids: Optional[Dict[str, int]] = None,
+        punct_label_ids: Optional[Union[Dict[str, int], DictConfig]] = None,
+        capit_label_ids: Optional[Union[Dict[str, int], DictConfig]] = None,
         ignore_extra_tokens: bool = False,
         ignore_start_end: bool = True,
         use_cache: bool = True,
@@ -893,6 +893,10 @@ class BertPunctuationCapitalizationDataset(Dataset):
         batch_building_progress_queue: Optional[mp.Queue] = None,
     ) -> None:
         """ Initializes BertPunctuationCapitalizationDataset. """
+        if isinstance(punct_label_ids, DictConfig):
+            punct_label_ids = OmegaConf.to_container(punct_label_ids)
+        if isinstance(capit_label_ids, DictConfig):
+            capit_label_ids = OmegaConf.to_container(capit_label_ids)
         self._check_constructor_parameters(
             text_file,
             labels_file,
@@ -1028,9 +1032,9 @@ class BertPunctuationCapitalizationDataset(Dataset):
             )
         if not (os.path.exists(text_file) and os.path.exists(labels_file)):
             raise FileNotFoundError(
-                f'{text_file} or {labels_file} not found. The data should be split into 2 files: text.txt and'
-                f'labels.txt. Each line of the text.txt file contains text sequences, where words are separated with'
-                f'spaces. The labels.txt file contains corresponding labels for each word in text.txt, the labels are'
+                f'{text_file} or {labels_file} not found. The data should be split into 2 files: text.txt and '
+                f'labels.txt. Each line of the text.txt file contains text sequences, where words are separated with '
+                f'spaces. The labels.txt file contains corresponding labels for each word in text.txt, the labels are '
                 f'separated with spaces. Each line of the files should follow the format:\n'
                 f'   [WORD] [SPACE] [WORD] [SPACE] [WORD] (for text.txt) and '
                 f'   [LABEL] [SPACE] [LABEL] [SPACE] [LABEL] (for labels.txt).'

--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
@@ -682,13 +682,13 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
                     f"The artifact `class_labels.punct_labels_file` was not found in checkpoint. Will rely on "
                     f"`punct_label_ids` parameter"
                 )
-                self.punct_label_ids = self._cfg.common_dataset_parameters.punct_label_ids.to_container()
+                self.punct_label_ids = OmegaConf.to_container(self._cfg.common_dataset_parameters.punct_label_ids)
             else:
                 self.punct_label_ids = load_label_ids(
                     self.register_artifact('class_labels.punct_labels_file', str(punct_label_vocab_file))
                 )
         elif self._cfg.common_dataset_parameters.punct_label_ids is not None:
-            self.punct_label_ids = self._cfg.common_dataset_parameters.punct_label_ids.to_container()
+            self.punct_label_ids = OmegaConf.to_container(self._cfg.common_dataset_parameters.punct_label_ids)
         else:
             raise ValueError(
                 f"Could not set attribute `punct_label_ids`. Config parameters "
@@ -704,13 +704,13 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
                     f"The artifact `class_labels.capit_labels_file` was not found in checkpoint. Will rely on "
                     f"`capit_label_ids` parameter"
                 )
-                self.capit_label_ids = self._cfg.common_dataset_parameters.capit_label_ids.to_container()
+                self.capit_label_ids = OmegaConf.to_container(self._cfg.common_dataset_parameters.capit_label_ids)
             else:
                 self.capit_label_ids = load_label_ids(
                     self.register_artifact('class_labels.capit_labels_file', str(capit_label_vocab_file))
                 )
         elif self._cfg.common_dataset_parameters.capit_label_ids is not None:
-            self.capit_label_ids = self._cfg.common_dataset_parameters.capit_label_ids.to_container()
+            self.capit_label_ids = OmegaConf.to_container(self._cfg.common_dataset_parameters.capit_label_ids)
         else:
             raise ValueError(
                 f"Could not set attribute `capit_label_ids`. Config parameters "

--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
@@ -102,10 +102,11 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
         self.world_size = 1
         if trainer is not None:
             self.world_size = trainer.num_nodes * trainer.num_gpus
-        self.metrics = None
-        self.label_ids_are_set = False
-        self.punct_label_ids = None
-        self.capit_label_ids = None
+        # For structure of `self.metrics` attribute see `self._setup_metrics_dictionary` method.
+        self.metrics: Optional[torch.nn.ModuleDict] = None
+        self.label_ids_are_set: bool = False
+        self.punct_label_ids: Optional[Dict[str, int]] = None
+        self.capit_label_ids: Optional[Dict[str, int]] = None
         super().__init__(cfg=cfg, trainer=trainer)
         if not self.label_ids_are_set:
             self._set_label_ids()
@@ -681,13 +682,13 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
                     f"The artifact `class_labels.punct_labels_file` was not found in checkpoint. Will rely on "
                     f"`punct_label_ids` parameter"
                 )
-                self.punct_label_ids = self._cfg.common_dataset_parameters.punct_label_ids
+                self.punct_label_ids = self._cfg.common_dataset_parameters.punct_label_ids.to_container()
             else:
                 self.punct_label_ids = load_label_ids(
                     self.register_artifact('class_labels.punct_labels_file', str(punct_label_vocab_file))
                 )
         elif self._cfg.common_dataset_parameters.punct_label_ids is not None:
-            self.punct_label_ids = self._cfg.common_dataset_parameters.punct_label_ids
+            self.punct_label_ids = self._cfg.common_dataset_parameters.punct_label_ids.to_container()
         else:
             raise ValueError(
                 f"Could not set attribute `punct_label_ids`. Config parameters "
@@ -703,13 +704,13 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
                     f"The artifact `class_labels.capit_labels_file` was not found in checkpoint. Will rely on "
                     f"`capit_label_ids` parameter"
                 )
-                self.capit_label_ids = self._cfg.common_dataset_parameters.capit_label_ids
+                self.capit_label_ids = self._cfg.common_dataset_parameters.capit_label_ids.to_container()
             else:
                 self.capit_label_ids = load_label_ids(
                     self.register_artifact('class_labels.capit_labels_file', str(capit_label_vocab_file))
                 )
         elif self._cfg.common_dataset_parameters.capit_label_ids is not None:
-            self.capit_label_ids = self._cfg.common_dataset_parameters.capit_label_ids
+            self.capit_label_ids = self._cfg.common_dataset_parameters.capit_label_ids.to_container()
         else:
             raise ValueError(
                 f"Could not set attribute `capit_label_ids`. Config parameters "


### PR DESCRIPTION
1. If  `BertPunctuationCapitalizationDataset.__init__` arguments `punct_label_ids` and `capit_label_ids` are  `DictConfig`s, then transform them to dictionaries.
2. Make sure that `PunctuationCapitalizationModel` attributes `punct_label_ids` and `capit_label_ids` are always dictionaries and not `DictConfig`s. Previously, type of these attributes varied depending on where the attributes are set.
3. Add more typing and improve error messages.