### PR TITLE
Fix `punctuation_capitalization_train_evaluate.py` description

### DIFF
--- a/examples/nlp/token_classification/punctuation_capitalization_train_evaluate.py
+++ b/examples/nlp/token_classification/punctuation_capitalization_train_evaluate.py
@@ -50,13 +50,21 @@ For more details about the config files and different ways of model restoration,
 To run this script and train the model from scratch, use:
     python punctuation_capitalization_train_evaluate.py \
         model.train_ds.ds_item=<PATH_TO_TRAIN_DATA> \
-        model.validation_ds.ds_item=<PATH_TO_DEV_DATA>
+        model.train_ds.text_file=<NAME_OF_TRAIN_INPUT_TEXT_FILE> \
+        model.train_ds.labels_file=<NAME_OF_TRAIN_LABELS_FILE> \
+        model.validation_ds.ds_item=<PATH_TO_DEV_DATA> \
+        model.validation_ds.text_file=<NAME_OF_DEV_INPUT_TEXT_FILE> \
+        model.validation_ds.labels_file=<NAME_OF_DEV_LABELS_FILE>
 
 To use one of the pretrained versions of the model and finetune it, run:
     python punctuation_capitalization_train_evaluate.py \
         pretrained_model=punctuation_en_bert \
         model.train_ds.ds_item=<PATH_TO_TRAIN_DATA> \
-        model.validation_ds.ds_item=<PATH_TO_DEV_DATA>
+        model.train_ds.text_file=<NAME_OF_TRAIN_INPUT_TEXT_FILE> \
+        model.train_ds.labels_file=<NAME_OF_TRAIN_LABELS_FILE> \
+        model.validation_ds.ds_item=<PATH_TO_DEV_DATA> \
+        model.validation_ds.text_file=<NAME_OF_DEV_INPUT_TEXT_FILE> \
+        model.validation_ds.labels_file=<NAME_OF_DEV_LABELS_FILE>
     
     pretrained_model   - pretrained PunctuationCapitalization model from list_available_models() or 
         path to a .nemo file, for example: punctuation_en_bert or model.nemo
@@ -66,14 +74,23 @@ If you wish to perform testing after training set `do_testing` to `true:
         +do_testing=true \
         pretrained_model=punctuation_en_bert \
         model.train_ds.ds_item=<PATH_TO_TRAIN_DATA> \
-        model.validation_ds.ds_item=<PATH_TO_DEV_DATA>
+        model.train_ds.text_file=<NAME_OF_TRAIN_INPUT_TEXT_FILE> \
+        model.train_ds.labels_file=<NAME_OF_TRAIN_LABELS_FILE> \
+        model.validation_ds.ds_item=<PATH_TO_DEV_DATA> \
+        model.validation_ds.text_file=<NAME_OF_DEV_INPUT_TEXT_FILE> \
+        model.validation_ds.labels_file=<NAME_OF_DEV_LABELS_FILE> \
+        model.test_ds.ds_item=<PATH_TO_TEST_DATA> \
+        model.test_ds.text_file=<NAME_OF_TEST_INPUT_TEXT_FILE> \
+        model.test_ds.labels_file=<NAME_OF_TEST_LABELS_FILE>
 
 Set `do_training` to `false` and `do_testing` to `true` to perform evaluation without training:
     python punctuation_capitalization_train_evaluate.py \
         +do_testing=true \
         +do_training=false \
         pretrained_model=punctuation_en_bert \
-        model.validation_ds.ds_item=<PATH_TO_DEV_DATA>
+        model.test_ds.ds_item=<PATH_TO_TEST_DATA> \
+        model.test_ds.text_file=<NAME_OF_TEST_INPUT_TEXT_FILE> \
+        model.test_ds.labels_file=<NAME_OF_TEST_LABELS_FILE>
 
 """
 


### PR DESCRIPTION
Fix data parameters in examples of `punctuation_capitalization_train_evaluate.py` usage.