### PR TITLE
Fixed duplicate cell bug

### DIFF
--- a/tutorials/nlp/Entity_Linking_Medical.ipynb
+++ b/tutorials/nlp/Entity_Linking_Medical.ipynb
@@ -38,17 +38,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "## Install dependencies\n",
-    "!pip install wget\n",
-    "!pip install faiss-gpu"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import faiss\n",
     "import torch\n",
     "import wget\n",


### PR DESCRIPTION
Fixes Duplicate cells in entity linking notebook bug

Bug 3509934 (https://nvbugswb.nvidia.com/NVBugs5/redir.aspx?url=/3509934 [ML-NeMo][Quadro GV100] Entity_Linking_Medical.ipynb tutorial notebook contains duplicate cells)

Signed-off-by: Virginia Adams <vadams@nvidia.com>