### PR TITLE
Bugfix, need to freeze the model

### DIFF
--- a/nemo/collections/nlp/models/text_classification/ptune_text_classification_model.py
+++ b/nemo/collections/nlp/models/text_classification/ptune_text_classification_model.py
@@ -87,8 +87,8 @@ class PTuneTextClassificationModel(NLPModel, Exportable):
             trainer=trainer,
         )
 
-        for param in self.model.parameters():
-            param.requires_grad = cfg.use_lm_finetune
+        if not cfg.use_lm_finetune:
+            self.model.freeze()
 
         hidden_size = self.model.cfg.hidden_size
 


### PR DESCRIPTION
The model needs to be in the eval mode by calling `freeze` so the dropout performs correctly. 