### PR TITLE
[TTS] update waveglow export

### DIFF
--- a/nemo/collections/tts/models/waveglow.py
+++ b/nemo/collections/tts/models/waveglow.py
@@ -124,7 +124,7 @@ class WaveGlowModel(GlowVocoder, Exportable):
             "denoise": NeuralType(optional=True),
             "denoiser_strength": NeuralType(optional=True),
         },
-        output_types={"audio": NeuralType(('B', 'T'), AudioSignal())},
+        output_types={"audio_pred": NeuralType(('B', 'T'), AudioSignal())},
     )
     def convert_spectrogram_to_audio(
         self, spec: torch.Tensor, sigma: float = 1.0, denoise: bool = True, denoiser_strength: float = 0.01
@@ -247,6 +247,7 @@ class WaveGlowModel(GlowVocoder, Exportable):
     def _prepare_for_export(self, **kwargs):
         self.update_bias_spect()
         self.waveglow._prepare_for_export(**kwargs)
+        self.mode = OperationMode.infer
 
     def forward_for_export(self, spec, z=None):
         return self.waveglow(spec, z)

--- a/nemo/collections/tts/modules/waveglow.py
+++ b/nemo/collections/tts/modules/waveglow.py
@@ -134,11 +134,17 @@ class WaveGlowModule(NeuralModule, Exportable):
 
     @property
     def input_types(self):
+        if self.mode == OperationMode.training or self.mode == OperationMode.validation:
+            return {
+                "spec": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
+                "z": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
+                "audio": NeuralType(('B', 'T'), AudioSignal(), optional=True),
+                "run_inverse": NeuralType(elements_type=IntType(), optional=True),
+                "sigma": NeuralType(optional=True),
+            }
         return {
             "spec": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
             "z": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
-            "audio": NeuralType(('B', 'T'), AudioSignal(), optional=True),
-            "run_inverse": NeuralType(elements_type=IntType(), optional=True),
             "sigma": NeuralType(optional=True),
         }
 
@@ -153,7 +159,7 @@ class WaveGlowModule(NeuralModule, Exportable):
             }
         else:
             return {
-                "audio": NeuralType(('B', 'T'), AudioSignal()),
+                "audio_pred": NeuralType(('B', 'T'), AudioSignal()),
             }
 
     def input_example(self, max_batch=1, max_dim=256):
@@ -169,7 +175,7 @@ class WaveGlowModule(NeuralModule, Exportable):
             device=par.device,
             dtype=par.dtype,
         )
-        return {"spec": mel, "z": z}
+        return ({"spec": mel, "z": z},)
 
     def audio_to_normal_dist(self, *, spec: torch.Tensor, audio: torch.Tensor) -> (torch.Tensor, list, list):
         #  Upsample spectrogram to size of audio


### PR DESCRIPTION
# What does this PR do ?

Closes #3509 on the NeMo side. Requires a fix in Riva as well.

**Collection**: TTS

# Changelog 
- There was a name collusion with audio that resulted in a onnx dynamic axes error
- input_example was changed to be compliant with the new spec of (return dict,) as opposed to the older return dict
  
**PR Type**:
- [x] Bugfix