### PR TITLE
[TTS] Fix typo in FastPitch config (pitch_avg -> pitch_mean)

### DIFF
--- a/examples/tts/conf/fastpitch_align_v1.05.yaml
+++ b/examples/tts/conf/fastpitch_align_v1.05.yaml
@@ -99,7 +99,7 @@ model:
       pitch_fmin: ${model.pitch_fmin}
       pitch_fmax: ${model.pitch_fmax}
       pitch_norm: true
-      pitch_avg: ${model.pitch_mean}
+      pitch_mean: ${model.pitch_mean}
       pitch_std: ${model.pitch_std}
 
     dataloader_params:


### PR DESCRIPTION
# What does this PR do ?
Fixes a typo in fastpitch_align_v1.05 config that leads to high pitch loss values on validation.

**Collection**: TTS

**PR Type**:
- [x] Bugfix
