### PR TITLE
Fix UnivNet LibriTTS pretrained location

### DIFF
--- a/nemo/collections/tts/models/univnet.py
+++ b/nemo/collections/tts/models/univnet.py
@@ -310,7 +310,7 @@ class UnivNetModel(Vocoder, Exportable):
 
         model = PretrainedModelInfo(
             pretrained_model_name="tts_en_libritts_univnet",
-            location="https://api.ngc.nvidia.com/v2/models/nvidia/nemo/tts_en_lj_univnet/versions/1.7.0/files/tts_en_libritts_univnet.nemo",
+            location="https://api.ngc.nvidia.com/v2/models/nvidia/nemo/tts_en_libritts_univnet/versions/1.7.0/files/tts_en_libritts_multispeaker_univnet.nemo",
             description="This model is trained on all LibriTTS training data (train-clean-100, train-clean-360, and train-other-500) sampled at 22050Hz, and has been tested on generating English voices.",
             class_=cls,
         )


### PR DESCRIPTION
# What does this PR do ?

Mini-PR :) - Fixes the NGC location of the UnivNet LibriTTS pretrained model.

**Collection**: TTS

# Changelog 
- Fixes the NGC location of the UnivNet LibriTTS pretrained model.


# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [X] Did you add or update any necessary documentation?
- [X] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

