### PR TITLE
Remove @experimental decorator in diarization related files.

### DIFF
--- a/nemo/collections/asr/parts/utils/diarization_utils.py
+++ b/nemo/collections/asr/parts/utils/diarization_utils.py
@@ -32,7 +32,6 @@ from nemo.collections.asr.parts.utils.speaker_utils import (
     write_rttm2manifest,
 )
 from nemo.utils import logging
-from nemo.utils.decorators.experimental import experimental
 
 try:
     import arpa
@@ -567,7 +566,6 @@ class ASR_DIAR_OFFLINE(object):
         word_pos = word_pos + self.word_ts_anchor_offset
         return word_pos
 
-    @experimental
     def realign_words_with_lm(self, word_dict_seq_list: List[Dict[str, float]]):
         """
         Realign the mapping between speaker labels and words using a language model.

--- a/nemo/collections/asr/parts/utils/nmesc_clustering.py
+++ b/nemo/collections/asr/parts/utils/nmesc_clustering.py
@@ -39,7 +39,6 @@ from sklearn.metrics.pairwise import cosine_similarity
 from sklearn.preprocessing import MinMaxScaler
 
 from nemo.utils import logging
-from nemo.utils.decorators.experimental import experimental
 
 scaler = MinMaxScaler(feature_range=(0, 1))
 
@@ -138,7 +137,6 @@ def getRepeatedList(mapping_argmat, score_mat_size):
     return repeat_list
 
 
-@experimental
 def get_argmin_mat(uniq_scale_dict):
     """
     Calculate the mapping between the base scale and other scales. A segment from a longer scale is
@@ -171,7 +169,6 @@ def get_argmin_mat(uniq_scale_dict):
     return session_scale_mapping_dict
 
 
-@experimental
 def getMultiScaleCosAffinityMatrix(uniq_embs_and_timestamps):
     """
     Calculate cosine similarity values among speaker embeddings for each scale then

--- a/nemo/collections/asr/parts/utils/speaker_utils.py
+++ b/nemo/collections/asr/parts/utils/speaker_utils.py
@@ -26,7 +26,6 @@ from tqdm import tqdm
 
 from nemo.collections.asr.parts.utils.nmesc_clustering import COSclustering
 from nemo.utils import logging
-from nemo.utils.decorators.experimental import experimental
 
 
 """
@@ -83,7 +82,6 @@ def audio_rttm_map(manifest):
     return AUDIO_RTTM_MAP
 
 
-@experimental
 def parse_scale_configs(window_lengths_in_sec, shift_lengths_in_sec, multiscale_weights):
     """
     Check whether multiscale parameters are provided correctly. window_lengths_in_sec, shift_lengfhs_in_sec and
@@ -157,7 +155,6 @@ def parse_scale_configs(window_lengths_in_sec, shift_lengths_in_sec, multiscale_
         return None
 
 
-@experimental
 def get_embs_and_timestamps(multiscale_embeddings_and_timestamps, multiscale_args_dict):
     """
     The embeddings and timestamps in multiscale_embeddings_and_timestamps dictionary are


### PR DESCRIPTION
Removes @experimental decorator in the diarization related files.

Signed-off-by: Taejin Park <tango4j@gmail.com>


