### PR TITLE
[TTS] Add speakerID to libritts/get_data.py

### DIFF
--- a/scripts/dataset_processing/tts/libritts/get_data.py
+++ b/scripts/dataset_processing/tts/libritts/get_data.py
@@ -74,9 +74,9 @@ def __process_transcript(file_path: str):
         assert os.path.exists(wav_file), f"{wav_file} not found!"
         duration = subprocess.check_output(f"soxi -D {wav_file}", shell=True)
         entry = {
-            'audio_filepath': os.path.abspath(wav_file), 
-            'duration': float(duration), 
-            'text': text, 
+            'audio_filepath': os.path.abspath(wav_file),
+            'duration': float(duration),
+            'text': text,
             'speaker': int(speaker_id),
         }
 

--- a/scripts/dataset_processing/tts/libritts/get_data.py
+++ b/scripts/dataset_processing/tts/libritts/get_data.py
@@ -73,7 +73,12 @@ def __process_transcript(file_path: str):
         speaker_id = file_path.split('/')[-3]
         assert os.path.exists(wav_file), f"{wav_file} not found!"
         duration = subprocess.check_output(f"soxi -D {wav_file}", shell=True)
-        entry = {'audio_filepath': os.path.abspath(wav_file), 'duration': float(duration), 'text': text, 'speaker': int(speaker_id)}
+        entry = {
+            'audio_filepath': os.path.abspath(wav_file), 
+            'duration': float(duration), 
+            'text': text, 
+            'speaker': int(speaker_id),
+        }
 
         entries.append(entry)
 

--- a/scripts/dataset_processing/tts/libritts/get_data.py
+++ b/scripts/dataset_processing/tts/libritts/get_data.py
@@ -70,9 +70,10 @@ def __process_transcript(file_path: str):
 
         # TODO(oktai15): add normalized text via Normalizer/NormalizerWithAudio
         wav_file = file_path.replace(".normalized.txt", ".wav")
+        speaker_id = file_path.split('/')[-3]
         assert os.path.exists(wav_file), f"{wav_file} not found!"
         duration = subprocess.check_output(f"soxi -D {wav_file}", shell=True)
-        entry = {'audio_filepath': os.path.abspath(wav_file), 'duration': float(duration), 'text': text}
+        entry = {'audio_filepath': os.path.abspath(wav_file), 'duration': float(duration), 'text': text, 'speaker': int(speaker_id)}
 
         entries.append(entry)
 


### PR DESCRIPTION
Signed-off-by: Subhankar Ghosh <subhankar2321@gmail.com>

# What does this PR do ?

Adds SpeakerID to `process_transcript` method of libritts/get_data.py

# Changelog 
Gets speakerID from the path because the path to every manifest has the speakerID.
Adds the speakerID to the entry as another (key,value) pair. 

# Usage
Doesn't change how libritts/get_data.py will be called. The manifests will contain speaker field.


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
