### PR TITLE
Add pipeline support to eval methods

### DIFF
--- a/examples/nlp/language_modeling/megatron_gpt_eval.py
+++ b/examples/nlp/language_modeling/megatron_gpt_eval.py
@@ -194,6 +194,8 @@ def main():
     print("***************************")
     print(response)
     print("***************************")
+    if args.prompt:
+        print(f'Prompt: {args.prompt}\n\n Response: {response[0][0][0]}')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# What does this PR do ?
Updates `.complete` and `.compute_logprobs` to work with pipeline parallelism.

**Collection**: [NLP]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
```
python megatron_gpt_eval.py \
--model_file /raid/nemo_files/gpt_126m_tf32_pp2_tp1/megatron_gpt.nemo \
--prompt "Four score and seven years ago our fathers brought forth on this continent, a new nation, conceived in Liberty, and dedicated to the proposition that all men" \
--tensor_model_parallel_size 1 \
--pipeline_model_parallel_size 2 \
--tokens_to_generate 64 \
--stop_after_sentence False --precision 32
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
