### PR TITLE
Fix spelling error in "num_workers" parameter to actually set number of dataset workers specified in yaml configs

### DIFF
--- a/nemo/collections/nlp/models/entity_linking/entity_linking_model.py
+++ b/nemo/collections/nlp/models/entity_linking/entity_linking_model.py
@@ -175,7 +175,7 @@ class EntityLinkingModel(NLPModel, Exportable):
             batch_size=cfg.batch_size,
             collate_fn=dataset.collate_fn,
             shuffle=cfg.get("shuffle", True),
-            num_workers=cfg.get("num_wokers", 2),
+            num_workers=cfg.get("num_workers", 2),
             pin_memory=cfg.get("pin_memory", False),
             drop_last=cfg.get("drop_last", False),
         )


### PR DESCRIPTION
Signed-off-by: Michael Menefee <mikem@mnetwork.org>

# What does this PR do ?

Corrects config file parsing to use number of workers specified instead of default "2", which generates warnings and slows training.

**Collection**: NLP

# Changelog 
- Fix spelling error in "num_workers" parameter to actually set number of dataset workers specified in yaml configs

# Usage
* Validating fix - 

```
cd examples/nlp/entity_linking 
vim ./conf/umls_medical_entity_linking_config.yaml
## Change num_workers ~= nproc
python data/umls_dataset_processing.py
python self_alignment_pretraining.py project_dir=. 
## should no longer see num_workers warnings
```

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [N/A] Did you write any new necessary tests?
- [N/A] Did you add or update any necessary documentation?
- [N/A] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
