### PR TITLE
bert_module: fix inputs of export model

### DIFF
--- a/nemo/collections/nlp/modules/common/bert_module.py
+++ b/nemo/collections/nlp/modules/common/bert_module.py
@@ -31,8 +31,8 @@ class BertModule(NeuralModule, Exportable):
     def input_types(self) -> Optional[Dict[str, NeuralType]]:
         return {
             "input_ids": NeuralType(('B', 'T'), ChannelType()),
-            "token_type_ids": NeuralType(('B', 'T'), ChannelType(), optional=True),
             "attention_mask": NeuralType(('B', 'T'), MaskType(), optional=True),
+            "token_type_ids": NeuralType(('B', 'T'), ChannelType(), optional=True),
         }
 
     @property
@@ -82,4 +82,5 @@ class BertModule(NeuralModule, Exportable):
         input_ids = torch.randint(low=0, high=2048, size=sz, device=sample.device)
         token_type_ids = torch.randint(low=0, high=1, size=sz, device=sample.device)
         attention_mask = torch.randint(low=0, high=1, size=sz, device=sample.device)
-        return tuple([input_ids, token_type_ids, attention_mask])
+        input_dict = {"input_ids": input_ids, "attention_mask": attention_mask, "token_type_ids": token_type_ids}
+        return tuple([input_dict])

--- a/tests/collections/nlp/test_nlp_exportables.py
+++ b/tests/collections/nlp/test_nlp_exportables.py
@@ -142,6 +142,8 @@ class TestExportableClassifiers:
             onnx_model = onnx.load(filename)
             onnx.checker.check_model(onnx_model, full_check=True)  # throws when failed
             assert onnx_model.graph.input[0].name == 'input_ids'
+            assert onnx_model.graph.input[1].name == 'attention_mask'
+            assert onnx_model.graph.input[2].name == 'token_type_ids'
             assert onnx_model.graph.output[0].name == 'logits'
 
     @pytest.mark.with_downloads()
@@ -155,7 +157,7 @@ class TestExportableClassifiers:
             onnx_model = onnx.load(filename)
             onnx.checker.check_model(onnx_model, full_check=True)  # throws when failed
             assert onnx_model.graph.input[0].name == 'input_ids'
-            # assert onnx_model.graph.input[2].name == 'token_type_ids'
+            assert onnx_model.graph.input[1].name == 'attention_mask'
             assert onnx_model.graph.output[0].name == 'punct_logits'
             assert onnx_model.graph.output[1].name == 'capit_logits'
 
@@ -170,7 +172,8 @@ class TestExportableClassifiers:
             onnx_model = onnx.load(filename)
             onnx.checker.check_model(onnx_model, full_check=True)  # throws when failed
             assert onnx_model.graph.input[0].name == 'input_ids'
-            assert onnx_model.graph.input[1].name == 'token_type_ids'
+            assert onnx_model.graph.input[1].name == 'attention_mask'
+            assert onnx_model.graph.input[2].name == 'token_type_ids'
             assert onnx_model.graph.output[0].name == 'logits'
 
 


### PR DESCRIPTION
Exported ONNX model had to be passed with "attention_mask" and
"token_type_ids" inputs swapped to get correct output.

Changing the input order fixes this issue.
Also return a dict instead of list for correctly passing inputs.

# What does this PR do ?

Fix swapped model inputs for exported ONNX/TRT model.

**Collection**: NLP

# Changelog 
- Fix order of inputs returned via input_types()

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? - Updated related tests.
- [x] Did you add or update any necessary documentation? - Not required
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc) - No
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] Bugfix

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?
@MaximumEntropy, @ericharper, @ekmb, @yzhang123

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
