### PR TITLE
patch librosa deprecation and fix

### DIFF
--- a/nemo/collections/asr/parts/utils/vad_utils.py
+++ b/nemo/collections/asr/parts/utils/vad_utils.py
@@ -115,7 +115,7 @@ def write_vad_infer_manifest(file, args_func):
     try:
         sr = 16000
         x, _sr = librosa.load(filepath, sr=sr, offset=in_offset, duration=in_duration)
-        duration = librosa.get_duration(x, sr=sr)
+        duration = librosa.get_duration(y=x, sr=sr)
         left = duration
         current_offset = in_offset
 
@@ -161,7 +161,7 @@ def write_vad_infer_manifest(file, args_func):
     except Exception as e:
         err_file = "error.log"
         with open(err_file, 'w', encoding='utf-8') as fout:
-            fout.write(file + ":" + str(e))
+            fout.write(filepath + ":" + str(e))
     return res
 
 
@@ -748,7 +748,7 @@ def plot(
     FRAME_LEN = 0.01
 
     audio, sample_rate = librosa.load(path=path2audio_file, sr=16000, mono=True, offset=offset, duration=duration)
-    dur = librosa.get_duration(audio, sr=sample_rate)
+    dur = librosa.get_duration(y=audio, sr=sample_rate)
 
     time = np.arange(offset, offset + dur, FRAME_LEN)
     frame = np.loadtxt(path2_vad_pred)


### PR DESCRIPTION
Signed-off-by: fayejf <fayejf07@gmail.com>

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.
Fix the deprecation of librosa get_duration in vad_utils.py and fix the error happened in http://10.110.40.131:8080/blue/organizations/jenkins/NeMo/detail/PR-3771/8/pipeline

**Collection**: [Note which collection this PR will affect]
ASR
# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
http://10.110.40.131:8080/blue/organizations/jenkins/NeMo/detail/PR-3771/8/pipeline