### PR TITLE
fix: multilingual transcribe does not require lang id param

### DIFF
--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -261,7 +261,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
             with tempfile.TemporaryDirectory() as tmpdir:
                 with open(os.path.join(tmpdir, 'manifest.json'), 'w', encoding='utf-8') as fp:
                     for audio_file in paths2audio_files:
-                        entry = {'audio_filepath': audio_file, 'duration': 100000, 'text': 'nothing'}
+                        entry = {'audio_filepath': audio_file, 'duration': 100000, 'text': ''}
                         fp.write(json.dumps(entry) + '\n')
 
                 config = {

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -264,7 +264,7 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, Exportable):
             with tempfile.TemporaryDirectory() as tmpdir:
                 with open(os.path.join(tmpdir, 'manifest.json'), 'w', encoding='utf-8') as fp:
                     for audio_file in paths2audio_files:
-                        entry = {'audio_filepath': audio_file, 'duration': 100000, 'text': 'nothing'}
+                        entry = {'audio_filepath': audio_file, 'duration': 100000, 'text': ''}
                         fp.write(json.dumps(entry) + '\n')
 
                 config = {

--- a/nemo/collections/common/parts/preprocessing/collections.py
+++ b/nemo/collections/common/parts/preprocessing/collections.py
@@ -150,13 +150,17 @@ class AudioText(_Collection):
                 num_filtered += 1
                 continue
 
-            if hasattr(parser, "is_aggregate") and parser.is_aggregate:
-                if lang is not None:
-                    text_tokens = parser(text, lang)
+            # 'nothing' is a special word emitted by the transcribe method
+            if text != 'nothing':
+                if hasattr(parser, "is_aggregate") and parser.is_aggregate:
+                    if lang is not None:
+                        text_tokens = parser(text, lang)
+                    else:
+                        raise ValueError("lang required in manifest when using aggregate tokenizers")
                 else:
-                    raise ValueError("lang required in manifest when using aggregate tokenizers")
+                    text_tokens = parser(text)
             else:
-                text_tokens = parser(text)
+                text_tokens = []
 
             if text_tokens is None:
                 duration_filtered += duration

--- a/nemo/collections/common/parts/preprocessing/collections.py
+++ b/nemo/collections/common/parts/preprocessing/collections.py
@@ -150,8 +150,7 @@ class AudioText(_Collection):
                 num_filtered += 1
                 continue
 
-            # 'nothing' is a special word emitted by the transcribe method
-            if text != 'nothing':
+            if text != '':
                 if hasattr(parser, "is_aggregate") and parser.is_aggregate:
                     if lang is not None:
                         text_tokens = parser(text, lang)


### PR DESCRIPTION
# What does this PR do ?

Fixes model.transcribe() for multilingual models.

**Collection**: ASR

# Changelog 
- multilingual models require language id for manifests during training. The transcribe method used to generate a transient
manifest that had 'nothing' as placeholder text. Replacing this placeholder text with ''. If this empty string is detected , the manifest language id requirement gets lifted in this PR.

# Usage
* No changes to interface

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
