### PR TITLE
Fixing the defaults of conformer models in the config files

### DIFF
--- a/examples/asr/conf/conformer/conformer_ctc_bpe.yaml
+++ b/examples/asr/conf/conformer/conformer_ctc_bpe.yaml
@@ -72,7 +72,7 @@ model:
   # you may find more detail on how to train a tokenizer at: /scripts/tokenizers/process_asr_text_tokenizer.py
   tokenizer:
     dir: ???  # path to directory which contains either tokenizer.model (bpe) or vocab.txt (wpe)
-    type: wpe  # Can be either bpe (SentencePiece tokenizer) or wpe (WordPiece tokenizer)
+    type: bpe  # Can be either bpe (SentencePiece tokenizer) or wpe (WordPiece tokenizer)
 
   preprocessor:
     _target_: nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor

--- a/examples/asr/conf/conformer/conformer_transducer_bpe.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_bpe.yaml
@@ -39,7 +39,7 @@ model:
     shuffle: true
     num_workers: 8
     pin_memory: false
-    use_start_end_token: true
+    use_start_end_token: false
     trim_silence: false
     max_duration: 16.7 # it is set for LibriSpeech, you may need to update it for your dataset
     min_duration: 0.1
@@ -58,7 +58,7 @@ model:
     shuffle: false
     num_workers: 8
     pin_memory: false
-    use_start_end_token: true
+    use_start_end_token: false
 
   test_ds:
     manifest_filepath: null
@@ -67,12 +67,12 @@ model:
     shuffle: false
     num_workers: 8
     pin_memory: false
-    use_start_end_token: true
+    use_start_end_token: false
 
   # You may find more detail on how to train a tokenizer at: /scripts/tokenizers/process_asr_text_tokenizer.py
   tokenizer:
     dir: ???  # path to directory which contains either tokenizer.model (bpe) or vocab.txt (for wpe)
-    type: wpe  # Can be either bpe (SentencePiece tokenizer) or wpe (WordPiece tokenizer)
+    type: bpe  # Can be either bpe (SentencePiece tokenizer) or wpe (WordPiece tokenizer)
 
   preprocessor:
     _target_: nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor

--- a/examples/asr/conf/conformer/conformer_transducer_bpe_multilang.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_bpe_multilang.yaml
@@ -40,7 +40,7 @@ model:
     shuffle: true
     num_workers: 8
     pin_memory: false
-    use_start_end_token: true
+    use_start_end_token: false
     trim_silence: false
     max_duration: 16.7 # it is set for LibriSpeech, you may need to update it for your dataset
     min_duration: 0.1
@@ -59,7 +59,7 @@ model:
     shuffle: false
     num_workers: 8
     pin_memory: false
-    use_start_end_token: true
+    use_start_end_token: false
 
   test_ds:
     manifest_filepath: null
@@ -68,7 +68,7 @@ model:
     shuffle: false
     num_workers: 8
     pin_memory: false
-    use_start_end_token: true
+    use_start_end_token: false
 
   # You may find more detail on how to train a monolingual tokenizer at: /scripts/tokenizers/process_asr_text_tokenizer.py
   tokenizer:


### PR DESCRIPTION
# What does this PR do ?
Fixes the default values for the tokenizer type and add_start_end_token in the config files of Conformer models.
