### PR TITLE
RADTTS-NeMo Porting

### DIFF
--- a/examples/tts/conf/rad-tts_dec.yaml
+++ b/examples/tts/conf/rad-tts_dec.yaml
@@ -1,0 +1,270 @@
+name: RadTTS_logs
+sample_rate: 22050
+
+train_dataset: "/ngc_workspace/ljspeech_train.json"
+validation_datasets: "/ngc_workspace/ljspeech_val.json"
+sup_data_path: "/raid/try/test_sup_data"
+sup_data_types: ["log_mel", "align_prior_matrix", "pitch", "voiced_mask", "p_voiced", "energy"] 
+
+whitelist_path: "/ngc_workspace/nemo_radtts/NeMo/nemo_text_processing/text_normalization/en/data/whitelist.tsv"
+
+# LJSpeech stats (per frame), train
+pitch_mean: 212.35873413085938
+pitch_std: 68.52806091308594
+
+# default values from librosa.pyin
+pitch_fmin: 65.40639132514966
+pitch_fmax: 2093.004522404789
+
+# default values for sample_rate=22050
+n_mels: 80
+n_window_size: 1024
+n_window_stride: 256
+n_fft: 1024
+lowfreq: 0
+highfreq: 8000
+window: "hann"
+
+pitch_loss_scale: 0.1
+durs_loss_scale: 0.1
+mel_loss_scale: 1.0
+
+phoneme_dict_path: "/ngc_workspace/nemo_radtts/NeMo/scripts/tts_dataset_files/cmudict-0.7b_nv22.01"
+heteronyms_path: "/ngc_workspace/nemo_radtts/NeMo/scripts/tts_dataset_files/heteronyms-030921" #"scripts/tts_dataset_files/heteronyms-030921"
+
+model:
+  # aligner
+  bin_loss_start_ratio: 0.2
+  bin_loss_warmup_epochs: 100
+
+  symbols_embedding_dim: 384
+  n_mel_channels: ${n_mels}
+
+  pitch_loss_scale: ${pitch_loss_scale}
+  durs_loss_scale: ${durs_loss_scale}
+  mel_loss_scale: ${mel_loss_scale}
+
+  pitch_mean: ${pitch_mean}
+  pitch_std: ${pitch_std}
+  
+  text_normalizer:
+      _target_: nemo_text_processing.text_normalization.normalize.Normalizer
+      lang: en
+      input_case: cased
+      whitelist: ${whitelist_path}
+
+  text_normalizer_call_kwargs:
+      verbose: false
+      punct_pre_process: true
+      punct_post_process: true
+      
+  train_ds:
+    dataset:
+      _target_: "nemo.collections.tts.torch.data.TTSDataset"
+      manifest_filepath: ${train_dataset}
+      sample_rate: ${sample_rate}
+      sup_data_path: ${sup_data_path}
+      sup_data_types: ${sup_data_types}
+      n_fft: ${n_fft} #hmmmmmmmm
+      win_length: ${n_window_size}
+      hop_length: ${n_window_stride}
+      window: ${window}
+      n_mels: ${n_mels}
+      lowfreq: ${lowfreq}
+      highfreq: ${highfreq}
+      max_duration: null
+      min_duration: 0.1
+      ignore_file: null
+      trim: False
+      pitch_fmin: ${pitch_fmin}
+      pitch_fmax: ${pitch_fmax} 
+      
+      
+      
+      text_tokenizer:
+        _target_: "nemo.collections.tts.torch.tts_tokenizers.EnglishPhonemesTokenizer"
+        punct: True
+        stresses: True
+        chars: True
+        space: ' '
+        silence: null
+        apostrophe: True
+        sep: '|'
+        add_blank_at: null
+        pad_with_space: True
+        g2p:
+          _target_: "nemo.collections.tts.torch.g2ps.EnglishG2p"
+          phoneme_dict: ${phoneme_dict_path}
+          heteronyms: ${heteronyms_path}
+    dataloader_params:
+      drop_last: false
+      shuffle: true
+      batch_size: 32
+      num_workers: 8
+      pin_memory: false
+
+  validation_ds:
+    dataset:
+      _target_: "nemo.collections.tts.torch.data.TTSDataset"
+      manifest_filepath: ${validation_datasets}
+      sample_rate: ${sample_rate}
+      sup_data_path: ${sup_data_path}
+      sup_data_types: ${sup_data_types}
+      n_fft: ${n_fft}
+      win_length: ${n_window_size}
+      hop_length: ${n_window_stride}
+      window: ${window}
+      n_mels: ${n_mels}
+      lowfreq: ${lowfreq}
+      highfreq: ${highfreq}
+      max_duration: null
+      min_duration: 0.1
+      ignore_file: null
+      trim: False
+      pitch_fmin: ${pitch_fmin}
+      pitch_fmax: ${pitch_fmax}
+      
+      
+        
+      text_tokenizer:
+        _target_: "nemo.collections.tts.torch.tts_tokenizers.EnglishPhonemesTokenizer"
+        punct: True
+        stresses: True
+        chars: True
+        space: ' '
+        silence: null
+        apostrophe: True
+        sep: '|'
+        add_blank_at: null
+        pad_with_space: True
+        g2p:
+          _target_: "nemo.collections.tts.torch.g2ps.EnglishG2p"
+          phoneme_dict: ${phoneme_dict_path}
+          heteronyms: ${heteronyms_path}
+
+    dataloader_params:
+      drop_last: false
+      shuffle: false
+      batch_size: 32
+      num_workers: 8
+      pin_memory: false
+
+  optim:
+    name: RAdam
+    lr: 0.0001
+    betas: [0.9, 0.98]
+    weight_decay: 0.000001
+
+    sched:
+      name: exp_decay
+      warmup_steps: 40000
+      last_epoch: -1 #dddddddddddddddddddddd
+      d_model: 1  # Disable scaling based on model dim #ddddddddddddd
+  trainerConfig:
+    sigma: 1
+    iters_per_checkpoint: 3000
+    seed: null
+    ignore_layers: []
+    finetune_layers: []
+    include_layers: []
+    with_tensorboard: true
+    dur_loss_weight: 1
+    ctc_loss_weight: 1
+    mask_unvoiced_f0: false
+    log_step: 1
+    binarization_start_iter: 6000
+    kl_loss_start_iter: 18000
+    loss_weights:
+        ctc_loss_weight: 0.1
+        dur_loss_weight: 1.0
+        f0_loss_weight: 1.0
+        energy_loss_weight: 1.0
+        vpred_loss_weight: 1.0
+    unfreeze_modules: "all"
+        
+
+    
+  load_from_checkpoint: False
+  init_from_ptl_ckpt: "/ngc_workspace/cleanup_radtts_nemo/1e5_bs32_decoder/model_checkpoint-last.ckpt"
+  modelConfig:
+        _target_: "nemo.collections.tts.modules.radtts.RadTTSModule"
+        n_speakers: 1
+        n_speaker_dim: 16
+        n_text: 384 #185
+        n_text_dim: 512
+        n_flows: 8
+        n_conv_layers_per_step: 4
+        n_mel_channels: 80
+        n_hidden: 1024
+        mel_encoder_n_hidden: 512
+        dummy_speaker_embedding: false
+        n_early_size: 2
+        n_early_every: 2
+        n_group_size: 2
+        affine_model: wavenet
+        include_modules: "decatnvpred"
+        scaling_fn: tanh
+        matrix_decomposition: LUS
+        learn_alignments: true
+        use_context_lstm: true
+        context_lstm_norm: spectral
+        context_lstm_w_f0_and_energy: true
+        text_encoder_lstm_norm: spectral
+        n_f0_dims: 1
+        n_energy_avg_dims: 1
+        use_first_order_features: false
+        unvoiced_bias_activation: "relu"
+        decoder_use_partial_padding: true
+        decoder_use_unvoiced_bias: true
+        ap_pred_log_f0: true
+        ap_use_unvoiced_bias: true
+        ap_use_voiced_embeddings: true
+        dur_model_config: null
+        f0_model_config: null
+        energy_model_config: null
+        v_model_config : 
+             name : dap
+             hparams : 
+                n_speaker_dim : 16 
+                take_log_of_input: false
+                bottleneck_hparams: 
+                    in_dim: 512
+                    reduction_factor: 16
+                    norm: weightnorm
+                    non_linearity: relu
+                arch_hparams: 
+                    out_dim: 1
+                    n_layers: 2
+                    n_channels: 256
+                    kernel_size: 3
+                    p_dropout: 0.5
+
+
+
+        
+
+trainer:
+  gpus: 8
+  precision: 16
+  max_epochs: 1000
+  num_nodes: 1
+  accelerator: ddp
+  accumulate_grad_batches: 1
+  checkpoint_callback: False
+  logger: False
+  gradient_clip_val: 1
+  flush_logs_every_n_steps: 1000
+  log_every_n_steps: 100
+  check_val_every_n_epoch: 5
+
+exp_manager:
+  exp_dir: /ngc_workspace/v_cleanup_radtts_nemo/1e6_bs32_decoder/output/
+  name: ${name}
+  create_tensorboard_logger: True
+  create_checkpoint_callback: True
+  checkpoint_callback_params:
+    monitor: val/loss_ctc
+    mode: min
+    filepath: /ngc_workspace/v_cleanup_radtts_nemo/1e6_bs32_decoder/output/
+    filename: model_checkpoint
+

--- a/examples/tts/conf/rad-tts_dec.yaml
+++ b/examples/tts/conf/rad-tts_dec.yaml
@@ -3,7 +3,7 @@ sample_rate: 22050
 
 train_dataset: "/ngc_workspace/ljspeech_train.json"
 validation_datasets: "/ngc_workspace/ljspeech_val.json"
-sup_data_path: "/raid/try/test_sup_data"
+sup_data_path: "./raid/try/test_sup_data"
 sup_data_types: ["log_mel", "align_prior_matrix", "pitch", "voiced_mask", "p_voiced", "energy"] 
 
 whitelist_path: "/ngc_workspace/nemo_radtts/NeMo/nemo_text_processing/text_normalization/en/data/whitelist.tsv"
@@ -258,13 +258,13 @@ trainer:
   check_val_every_n_epoch: 5
 
 exp_manager:
-  exp_dir: /ngc_workspace/v_cleanup_radtts_nemo/1e6_bs32_decoder/output/
+  exp_dir: /ngc_workspace/from_110_pc/1e6_bs32_decoder/output/
   name: ${name}
   create_tensorboard_logger: True
   create_checkpoint_callback: True
   checkpoint_callback_params:
     monitor: val/loss_ctc
     mode: min
-    filepath: /ngc_workspace/v_cleanup_radtts_nemo/1e6_bs32_decoder/output/
+    filepath: /ngc_workspace/from_110_pc/1e6_bs32_decoder/output/
     filename: model_checkpoint
 

--- a/examples/tts/conf/rad-tts_feature_pred.yaml
+++ b/examples/tts/conf/rad-tts_feature_pred.yaml
@@ -1,0 +1,333 @@
+name: RadTTS_logs
+sample_rate: 22050
+
+train_dataset: "/ngc_workspace/ljspeech_train.json"
+validation_datasets: "/ngc_workspace/ljspeech_val.json"
+sup_data_path: "/raid/test_sup_data"
+sup_data_types: ["log_mel", "duration_prior", "pitch", "voiced_mask", "p_voiced", "energy"] 
+
+whitelist_path: "/ngc_workspace/nemo_radtts/NeMo/nemo_text_processing/text_normalization/en/data/whitelist.tsv"
+
+# LJSpeech stats (per frame), train
+pitch_mean: 212.35873413085938
+pitch_std: 68.52806091308594
+
+# default values from librosa.pyin
+pitch_fmin: 65.40639132514966
+pitch_fmax: 2093.004522404789
+
+# default values for sample_rate=22050
+n_mels: 80
+n_window_size: 1024
+n_window_stride: 256
+n_fft: 1024
+lowfreq: 0
+highfreq: 8000
+window: "hann"
+
+pitch_loss_scale: 0.1
+durs_loss_scale: 0.1
+mel_loss_scale: 1.0
+
+phoneme_dict_path: "/ngc_workspace/nemo_radtts/NeMo/scripts/tts_dataset_files/cmudict-0.7b_nv22.01"
+heteronyms_path: "/ngc_workspace/nemo_radtts/NeMo/scripts/tts_dataset_files/heteronyms-030921" #"scripts/tts_dataset_files/heteronyms-030921"
+
+model:
+  # aligner
+  bin_loss_start_ratio: 0.2
+  bin_loss_warmup_epochs: 100
+
+  symbols_embedding_dim: 384
+  n_mel_channels: ${n_mels}
+
+  pitch_loss_scale: ${pitch_loss_scale}
+  durs_loss_scale: ${durs_loss_scale}
+  mel_loss_scale: ${mel_loss_scale}
+
+  pitch_mean: ${pitch_mean}
+  pitch_std: ${pitch_std}
+  
+  text_normalizer:
+      _target_: nemo_text_processing.text_normalization.normalize.Normalizer
+      lang: en
+      input_case: cased
+      whitelist: ${whitelist_path}
+
+  text_normalizer_call_kwargs:
+      verbose: false
+      punct_pre_process: true
+      punct_post_process: true
+      
+  train_ds:
+    dataset:
+      _target_: "nemo.collections.tts.torch.data.TTSDataset"
+      manifest_filepath: ${train_dataset}
+      sample_rate: ${sample_rate}
+      sup_data_path: ${sup_data_path}
+      sup_data_types: ${sup_data_types}
+      n_fft: ${n_fft} #hmmmmmmmm
+      win_length: ${n_window_size}
+      hop_length: ${n_window_stride}
+      window: ${window}
+      n_mels: ${n_mels}
+      lowfreq: ${lowfreq}
+      highfreq: ${highfreq}
+      max_duration: null
+      min_duration: 0.1
+      ignore_file: null
+      trim: False
+      pitch_fmin: ${pitch_fmin}
+      pitch_fmax: ${pitch_fmax} 
+      
+      
+      
+      text_tokenizer:
+        _target_: "nemo.collections.tts.torch.tts_tokenizers.EnglishPhonemesTokenizer"
+        punct: True
+        stresses: True
+        chars: True
+        space: ' '
+        silence: null
+        apostrophe: True
+        sep: '|'
+        add_blank_at: null
+        pad_with_space: True
+        g2p:
+          _target_: "nemo.collections.tts.torch.g2ps.EnglishG2p"
+          phoneme_dict: ${phoneme_dict_path}
+          heteronyms: ${heteronyms_path}
+    dataloader_params:
+      drop_last: false
+      shuffle: true
+      batch_size: 32
+      num_workers: 8
+      pin_memory: false
+
+  validation_ds:
+    dataset:
+      _target_: "nemo.collections.tts.torch.data.TTSDataset"
+      manifest_filepath: ${validation_datasets}
+      sample_rate: ${sample_rate}
+      sup_data_path: ${sup_data_path}
+      sup_data_types: ${sup_data_types}
+      n_fft: ${n_fft}
+      win_length: ${n_window_size}
+      hop_length: ${n_window_stride}
+      window: ${window}
+      n_mels: ${n_mels}
+      lowfreq: ${lowfreq}
+      highfreq: ${highfreq}
+      max_duration: null
+      min_duration: 0.1
+      ignore_file: null
+      trim: False
+      pitch_fmin: ${pitch_fmin}
+      pitch_fmax: ${pitch_fmax}
+      
+      
+        
+      text_tokenizer:
+        _target_: "nemo.collections.tts.torch.tts_tokenizers.EnglishPhonemesTokenizer"
+        punct: True
+        stresses: True
+        chars: True
+        space: ' '
+        silence: null
+        apostrophe: True
+        sep: '|'
+        add_blank_at: null
+        pad_with_space: True
+        g2p:
+          _target_: "nemo.collections.tts.torch.g2ps.EnglishG2p"
+          phoneme_dict: ${phoneme_dict_path}
+          heteronyms: ${heteronyms_path}
+
+    dataloader_params:
+      drop_last: false
+      shuffle: false
+      batch_size: 32
+      num_workers: 8
+      pin_memory: false
+
+  optim:
+    name: RAdam
+    lr: 0.001
+    betas: [0.9, 0.98]
+    weight_decay: 0.000001
+
+    sched:
+      name: exp_decay
+      warmup_steps: 40000
+      last_epoch: -1 #dddddddddddddddddddddd
+      d_model: 1  # Disable scaling based on model dim #ddddddddddddd
+  trainerConfig:
+    sigma: 1
+    iters_per_checkpoint: 3000
+    seed: null
+    ignore_layers: []
+    finetune_layers: []
+    include_layers: []
+    with_tensorboard: true
+    dur_loss_weight: 1
+    ctc_loss_weight: 1
+    mask_unvoiced_f0: false
+    log_step: 1
+    binarization_start_iter: 1000000
+    kl_loss_start_iter: 1000000
+    loss_weights:
+        ctc_loss_weight: 0.1
+        dur_loss_weight: 1.0
+        f0_loss_weight: 1.0
+        energy_loss_weight: 1.0
+        vpred_loss_weight: 1.0
+    unfreeze_modules: "durf0energyvpred"
+        
+
+    
+  load_from_checkpoint: True
+  init_from_ptl_ckpt: "/ngc_workspace/try_folder_clean_2/1e3_bs32_decoder/model_checkpoint-v1.ckpt"
+  modelConfig:
+        _target_: "nemo.collections.tts.modules.radtts.RadTTSModule"
+        n_speakers: 1
+        n_speaker_dim: 16
+        text_encoder_name: tacotron2
+        n_text: 384 #185
+        n_text_dim: 512
+        n_flows: 8
+        n_conv_layers_per_step: 4
+        n_mel_channels: 80
+        n_hidden: 1024
+        mel_encoder_n_hidden: 512
+        n_components: 0
+        mean_scale: 0
+        fixed_gaussian: true
+        dummy_speaker_embedding: false
+        use_positional_embedding: false
+        n_early_size: 2
+        n_early_every: 2
+        n_group_size: 2
+        use_feature_gating: false
+        affine_model: wavenet
+        include_modules: "decatnunvbiasdpmvpredapm"
+        what_to_train: decatnunvbias
+        scaling_fn: tanh
+        reduction_norm: ""
+        matrix_decomposition: LUS
+        learn_alignments: true
+        use_query_proj: true
+        align_query_enc_type: 3xconv
+        lstm_applicable_steps: []
+        use_context_lstm: true
+        context_lstm_norm: spectral
+        context_lstm_w_f0_and_energy: true
+        text_encoder_lstm_norm: spectral
+        use_text_conditional_priors: false
+        zero_out_context: false
+        n_aug_dims: 6
+        n_f0_dims: 1
+        n_energy_avg_dims: 1
+        use_first_order_features: false
+        unvoiced_bias_activation: "relu"
+        decoder_use_partial_padding: false
+        decoder_use_unvoiced_bias: true
+        ap_pred_log_f0: true
+        ap_use_unvoiced_bias: true
+        ap_use_voiced_embeddings: true
+        p_dropout: 0.1
+        noise_to_unvoiced_in_f0: 0
+        noise_to_pvoiced: 0
+        dur_model_config: 
+            name: dap 
+            hparams: 
+                #_target_: "nemo.collections.tts.modules.feature_prediction_model.FP"
+                n_speaker_dim: 16 
+                bottleneck_hparams: 
+                    in_dim: 512
+                    reduction_factor: 16
+                    norm: weightnorm
+                    non_linearity: relu
+                take_log_of_input: true
+                arch_hparams: 
+                    out_dim: 1
+                    n_layers: 2
+                    n_channels: 256
+                    kernel_size: 3
+                    p_dropout: 0.1
+        f0_model_config: 
+            name: dap
+            hparams:
+                n_speaker_dim: 16
+                bottleneck_hparams: 
+                    in_dim: 512
+                    reduction_factor: 16
+                    norm: weightnorm
+                    non_linearity: relu
+                take_log_of_input: false
+                arch_hparams: 
+                    out_dim: 1
+                    n_layers: 2
+                    n_channels: 256
+                    kernel_size: 11
+                    p_dropout: 0.5
+
+        energy_model_config: 
+            name: dap
+            hparams:
+                n_speaker_dim: 16
+                bottleneck_hparams: 
+                    in_dim: 512
+                    reduction_factor: 16
+                    norm: weightnorm
+                    non_linearity: relu
+                take_log_of_input: false
+                arch_hparams: 
+                    out_dim: 1
+                    n_layers: 2
+                    n_channels: 256
+                    kernel_size: 3
+                    p_dropout: 0.5
+        v_model_config : 
+            name: dap
+            hparams:
+                n_speaker_dim: 16
+                take_log_of_input: false
+                bottleneck_hparams: 
+                    in_dim: 512
+                    reduction_factor: 16
+                    norm: weightnorm
+                    non_linearity: relu
+                arch_hparams: 
+                    out_dim: 1
+                    n_layers: 2
+                    n_channels: 256
+                    kernel_size: 3
+                    p_dropout: 0.5
+
+
+
+        
+
+trainer:
+  gpus: 8
+  precision: 16
+  max_epochs: 1000
+  num_nodes: 1
+  accelerator: ddp
+  accumulate_grad_batches: 1
+  checkpoint_callback: False
+  logger: False
+  gradient_clip_val: 1
+  flush_logs_every_n_steps: 1000
+  log_every_n_steps: 100
+  check_val_every_n_epoch: 2
+
+exp_manager:
+  exp_dir: /ngc_workspace/try_folder_clean_3/try_feature/output/ 
+  name: ${name}
+  create_tensorboard_logger: True
+  create_checkpoint_callback: True
+  checkpoint_callback_params:
+    monitor: val/loss_energy
+    mode: min
+    filepath: /ngc_workspace/try_folder_clean_3/try_feature/output/ 
+    filename: model_checkpoint

--- a/examples/tts/radtts_train.py
+++ b/examples/tts/radtts_train.py
@@ -1,4 +1,3 @@
-  
 # Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,10 +15,11 @@
 import pytorch_lightning as pl
 
 from nemo.collections.common.callbacks import LogEpochTimeCallback
-from nemo.collections.tts.models.radtts import RadTTSModel 
+from nemo.collections.tts.models.radtts import RadTTSModel
 from nemo.core.config import hydra_runner
-from nemo.utils.exp_manager import exp_manager
 from nemo.utils import logging
+from nemo.utils.exp_manager import exp_manager
+
 
 def freeze(model):
     for p in model.parameters():
@@ -29,10 +29,11 @@ def freeze(model):
 def unfreeze(model):
     for p in model.parameters():
         p.requires_grad = True
-        
+
+
 def prepare_model_weights(model, unfreeze_modules):
     if unfreeze_modules != 'all':
-        model.freeze() # freeze everything
+        model.freeze()  # freeze everything
         logging.info("module freezed, about to unfreeze modules to be trained")
         if 'dur' in unfreeze_modules and hasattr(model.model, 'dur_pred_layer'):
             logging.info("Training duration prediction")
@@ -56,12 +57,10 @@ def prepare_model_weights(model, unfreeze_modules):
         logging.info("Training everything")
 
 
-
 @hydra_runner(config_path="/home/add_radtts_to_nemo/NeMo/examples/tts/conf", config_name="rad-tts_dec")
-
 def main(cfg):
     trainer = pl.Trainer(**cfg.trainer)
-    exp_manager(trainer, cfg.exp_manager)    
+    exp_manager(trainer, cfg.exp_manager)
     model = RadTTSModel(cfg=cfg.model, trainer=trainer)
     if cfg.model.load_from_checkpoint:
         model.maybe_init_from_pretrained_checkpoint(cfg=cfg.model)
@@ -73,4 +72,4 @@ def main(cfg):
 
 
 if __name__ == '__main__':
-    main()   
+    main()

--- a/examples/tts/radtts_train.py
+++ b/examples/tts/radtts_train.py
@@ -57,7 +57,7 @@ def prepare_model_weights(model, unfreeze_modules):
 
 
 
-@hydra_runner(config_path="/ngc_workspace/very_clean_up_radtts_nemo/NeMo/examples/tts/conf", config_name="rad-tts_dec")
+@hydra_runner(config_path="/home/add_radtts_to_nemo/NeMo/examples/tts/conf", config_name="rad-tts_dec")
 
 def main(cfg):
     trainer = pl.Trainer(**cfg.trainer)

--- a/examples/tts/radtts_train.py
+++ b/examples/tts/radtts_train.py
@@ -1,0 +1,76 @@
+  
+# Copyright (c) 2021, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytorch_lightning as pl
+
+from nemo.collections.common.callbacks import LogEpochTimeCallback
+from nemo.collections.tts.models.radtts import RadTTSModel 
+from nemo.core.config import hydra_runner
+from nemo.utils.exp_manager import exp_manager
+from nemo.utils import logging
+
+def freeze(model):
+    for p in model.parameters():
+        p.requires_grad = False
+
+
+def unfreeze(model):
+    for p in model.parameters():
+        p.requires_grad = True
+        
+def prepare_model_weights(model, unfreeze_modules):
+    if unfreeze_modules != 'all':
+        model.freeze() # freeze everything
+        logging.info("module freezed, about to unfreeze modules to be trained")
+        if 'dur' in unfreeze_modules and hasattr(model.model, 'dur_pred_layer'):
+            logging.info("Training duration prediction")
+            unfreeze(model.model.dur_pred_layer)
+        if 'f0' in unfreeze_modules and hasattr(model.model, 'f0_pred_module'):
+            logging.info("Training F0 prediction")
+            unfreeze(model.model.f0_pred_module)
+        if 'energy' in unfreeze_modules and hasattr(model.model, 'energy_pred_module'):
+            logging.info("Training energy prediction")
+            unfreeze(model.model.energy_pred_module)
+        if 'vpred' in unfreeze_modules and hasattr(model.model, 'v_pred_module'):
+            logging.info("Training voiced prediction")
+            unfreeze(model.model.v_pred_module)
+            if hasattr(model, 'v_embeddings'):
+                logging.info("Training voiced embeddings")
+                unfreeze(model.model.v_embeddings)
+        if 'unvbias' in unfreeze_modules and hasattr(model.model, 'unvoiced_bias_module'):
+            logging.info("Training unvoiced bias")
+            unfreeze(model.model.unvoiced_bias_module)
+    else:
+        logging.info("Training everything")
+
+
+
+@hydra_runner(config_path="/ngc_workspace/very_clean_up_radtts_nemo/NeMo/examples/tts/conf", config_name="rad-tts_dec")
+
+def main(cfg):
+    trainer = pl.Trainer(**cfg.trainer)
+    exp_manager(trainer, cfg.exp_manager)    
+    model = RadTTSModel(cfg=cfg.model, trainer=trainer)
+    if cfg.model.load_from_checkpoint:
+        model.maybe_init_from_pretrained_checkpoint(cfg=cfg.model)
+        prepare_model_weights(model, cfg.model.trainerConfig.unfreeze_modules)
+    lr_logger = pl.callbacks.LearningRateMonitor()
+    epoch_time_logger = LogEpochTimeCallback()
+    trainer.callbacks.extend([lr_logger, epoch_time_logger])
+    trainer.fit(model)
+
+
+if __name__ == '__main__':
+    main()   

--- a/nemo/collections/tts/helpers/common.py
+++ b/nemo/collections/tts/helpers/common.py
@@ -1,0 +1,857 @@
+###############################################################################
+#
+#  Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###############################################################################
+import torch
+from torch import nn
+from torch.nn import functional as F
+from torch.cuda import amp
+from torch.cuda.amp import autocast as autocast
+import numpy as np
+import ast
+from nemo.collections.tts.helpers.splines import (piecewise_linear_transform,
+                     piecewise_linear_inverse_transform,
+                     unbounded_piecewise_quadratic_transform)
+from nemo.collections.tts.helpers.partialconv1d import PartialConv1d as pconv1d
+from typing import Tuple
+
+def update_params(config, params):
+    for param in params:
+        print(param)
+        k, v = param.split("=")
+        try:
+            v = ast.literal_eval(v)
+        except:
+            pass
+
+        k_split = k.split('.')
+        if len(k_split) > 1:
+            parent_k = k_split[0]
+            cur_param = ['.'.join(k_split[1:])+"="+str(v)]
+            update_params(config[parent_k], cur_param)
+        elif k in config and len(k_split) == 1:
+            print(f"overriding {k} with {v}")
+            config[k] = v
+        else:
+            print("{}, {} params not updated".format(k, v))
+
+
+def get_mask_from_lengths(lengths):
+    """Constructs binary mask from a 1D torch tensor of input lengths
+
+    Args:
+        lengths (torch.tensor): 1D tensor
+    Returns:
+        mask (torch.tensor): num_sequences x max_length x 1 binary tensor
+    """
+    max_len = torch.max(lengths).item()
+    ids = torch.arange(0, max_len, out=torch.cuda.LongTensor(max_len))
+    mask = (ids < lengths.unsqueeze(1)).bool()
+    return mask
+
+
+@torch.jit.script
+def fused_add_tanh_sigmoid_multiply(input_a, input_b):
+    t_act = torch.tanh(input_a)
+    s_act = torch.sigmoid(input_b)
+    acts = t_act * s_act
+    return acts
+
+
+class ExponentialClass(torch.nn.Module):
+    def __init__(self):
+        super(ExponentialClass, self).__init__()
+
+    def forward(self, x):
+        return torch.exp(x)
+
+
+class LinearNorm(torch.nn.Module):
+    def __init__(self, in_dim, out_dim, bias=True, w_init_gain='linear'):
+        super(LinearNorm, self).__init__()
+        self.linear_layer = torch.nn.Linear(in_dim, out_dim, bias=bias)
+
+        torch.nn.init.xavier_uniform_(
+            self.linear_layer.weight,
+            gain=torch.nn.init.calculate_gain(w_init_gain))
+
+    def forward(self, x):
+        return self.linear_layer(x)
+
+
+class ConvNorm(torch.nn.Module):
+    def __init__(self, in_channels, out_channels, kernel_size=1, stride=1,
+                 padding=None, dilation=1, bias=True, w_init_gain='linear',
+                 use_partial_padding=False, use_weight_norm=False):
+        super(ConvNorm, self).__init__()
+        if padding is None:
+            assert(kernel_size % 2 == 1)
+            padding = int(dilation * (kernel_size - 1) / 2)
+        self.kernel_size = kernel_size
+        self.dilation = dilation
+        self.use_partial_padding = use_partial_padding
+        self.use_weight_norm = use_weight_norm
+        conv_fn = torch.nn.Conv1d
+        if self.use_partial_padding:
+            conv_fn = pconv1d
+        self.conv = conv_fn(in_channels, out_channels,
+                            kernel_size=kernel_size, stride=stride,
+                            padding=padding, dilation=dilation,
+                            bias=bias)
+        torch.nn.init.xavier_uniform_(
+            self.conv.weight, gain=torch.nn.init.calculate_gain(w_init_gain))
+        if self.use_weight_norm:
+            self.conv = nn.utils.weight_norm(self.conv)
+
+    def forward(self, signal, mask=None):
+        if self.use_partial_padding:
+            conv_signal = self.conv(signal, mask)
+        else:
+            conv_signal = self.conv(signal)
+        return conv_signal
+
+
+class DenseLayer(nn.Module):
+    def __init__(self, in_dim=1024, sizes=[1024, 1024]):
+        super(DenseLayer, self).__init__()
+        in_sizes = [in_dim] + sizes[:-1]
+        self.layers = nn.ModuleList(
+            [LinearNorm(in_size, out_size, bias=True)
+             for (in_size, out_size) in zip(in_sizes, sizes)])
+
+    def forward(self, x):
+        for linear in self.layers:
+            x = torch.tanh(linear(x))
+        return x
+
+
+class LengthRegulator(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, dur):
+        output = []
+        for x_i, dur_i in zip(x, dur):
+            expanded = self.expand(x_i, dur_i)
+            output.append(expanded)
+        output = self.pad(output)
+        return output
+
+    def expand(self, x, dur):
+        output = []
+        for i, frame in enumerate(x):
+            expanded_len = int(dur[i] + 0.5)
+            expanded = frame.expand(expanded_len, -1)
+            output.append(expanded)
+        output = torch.cat(output, 0)
+        return output
+
+    def pad(self, x):
+        output = []
+        max_len = max([x[i].size(0) for i in range(len(x))])
+        for i, seq in enumerate(x):
+            padded = F.pad(
+                seq, [0, 0, 0, max_len - seq.size(0)], 'constant', 0.0)
+            output.append(padded)
+        output = torch.stack(output)
+        return output
+
+
+class ConvLSTMLinear(nn.Module):
+    def __init__(self, in_dim, out_dim, n_layers=2, n_channels=256,
+                 kernel_size=3, p_dropout=0.1):
+        super(ConvLSTMLinear, self).__init__()
+        self.out_dim = out_dim
+        self.dropout = nn.Dropout(p=p_dropout)
+
+        convolutions = []
+        for i in range(n_layers):
+            conv_layer = ConvNorm(
+                in_dim if i == 0 else n_channels, n_channels,
+                kernel_size=kernel_size, stride=1,
+                padding=int((kernel_size - 1) / 2), dilation=1,
+                w_init_gain='relu')
+            conv_layer = torch.nn.utils.weight_norm(
+                conv_layer.conv, name='weight')
+            convolutions.append(conv_layer)
+
+        self.convolutions = nn.ModuleList(convolutions)
+
+        self.bilstm = nn.LSTM(n_channels, int(n_channels // 2), 1,
+                              batch_first=True, bidirectional=True)
+        lstm_norm_fn_pntr = nn.utils.spectral_norm
+        self.bilstm = lstm_norm_fn_pntr(self.bilstm, 'weight_hh_l0')
+        self.bilstm = lstm_norm_fn_pntr(self.bilstm, 'weight_hh_l0_reverse')
+        self.dense = nn.Linear(n_channels, out_dim)
+
+    def run_padded_sequence(self, context, lens):
+        context_embedded = []
+        for b_ind in range(context.size()[0]):  # TODO: speed up
+            curr_context = context[b_ind:b_ind+1, :, :lens[b_ind]].clone()
+            for conv in self.convolutions:
+                curr_context = self.dropout(F.relu(conv(curr_context)))
+            context_embedded.append(curr_context[0].transpose(0, 1))
+        context = torch.nn.utils.rnn.pad_sequence(
+            context_embedded, batch_first=True)
+        return context
+
+    def run_unsorted_inputs(self, fn, context, lens):
+        lens_sorted, ids_sorted = torch.sort(lens, descending=True)
+        unsort_ids = [0] * lens.size(0)
+        for i in range(len(ids_sorted)):
+            unsort_ids[ids_sorted[i]] = i
+        lens_sorted = lens_sorted.long().cpu()
+
+        context = context[ids_sorted]
+        context = nn.utils.rnn.pack_padded_sequence(
+            context, lens_sorted, batch_first=True)
+        context = fn(context)[0]
+        context = nn.utils.rnn.pad_packed_sequence(
+            context, batch_first=True)[0]
+
+        # map back to original indices
+        context = context[unsort_ids]
+        return context
+
+    def forward(self, context, lens):
+        if context.size()[0] > 1:
+            context = self.run_padded_sequence(context, lens)
+        else:
+            for conv in self.convolutions:
+                context = self.dropout(F.relu(conv(context)))
+            context = context.transpose(1, 2)
+
+        self.bilstm.flatten_parameters()
+        if lens is not None:
+            context = self.run_unsorted_inputs(self.bilstm, context, lens)
+        else:
+            context = self.bilstm(context)[0]
+
+        x_hat = self.dense(context).permute(0, 2, 1)
+
+        return x_hat
+
+    def infer(self, z, txt_enc, spk_emb):
+        x_hat = self.forward(txt_enc, spk_emb)['x_hat']
+        x_hat = self.feature_processing.denormalize(x_hat)
+        return x_hat
+
+
+class Encoder(nn.Module):
+    """Encoder module:
+        - Three 1-d convolution banks
+        - Bidirectional LSTM
+    """
+    def __init__(self, encoder_n_convolutions=3, encoder_embedding_dim=512,
+                 encoder_kernel_size=5, norm_fn=nn.BatchNorm1d,
+                 lstm_norm_fn=None):
+        super(Encoder, self).__init__()
+
+        convolutions = []
+        for _ in range(encoder_n_convolutions):
+            conv_layer = nn.Sequential(
+                ConvNorm(encoder_embedding_dim,
+                         encoder_embedding_dim,
+                         kernel_size=encoder_kernel_size, stride=1,
+                         padding=int((encoder_kernel_size - 1) / 2),
+                         dilation=1, w_init_gain='relu', use_partial_padding=True),
+                norm_fn(encoder_embedding_dim, affine=True))
+            convolutions.append(conv_layer)
+        self.convolutions = nn.ModuleList(convolutions)
+
+        self.lstm = nn.LSTM(encoder_embedding_dim,
+                            int(encoder_embedding_dim / 2), 1,
+                            batch_first=True, bidirectional=True)
+        if lstm_norm_fn is not None:
+            if 'spectral' in lstm_norm_fn:
+                print("Applying spectral norm to text encoder LSTM")
+                lstm_norm_fn_pntr = torch.nn.utils.spectral_norm
+            elif 'weight' in lstm_norm_fn:
+                print("Applying weight norm to text encoder LSTM")
+                lstm_norm_fn_pntr = torch.nn.utils.weight_norm
+            self.lstm = lstm_norm_fn_pntr(self.lstm, 'weight_hh_l0')
+            self.lstm = lstm_norm_fn_pntr(self.lstm, 'weight_hh_l0_reverse')
+
+    @amp.autocast(False)
+    def forward(self, x, in_lens):
+        """
+        Args:
+            x (torch.tensor): N x C x L padded input of text embeddings
+            in_lens (torch.tensor): 1D tensor of sequence lengths
+        """
+        if x.size()[0] > 1:
+            x_embedded = []
+            for b_ind in range(x.size()[0]):  # TODO: improve speed
+                curr_x = x[b_ind:b_ind+1, :, :in_lens[b_ind]].clone()
+                for conv in self.convolutions:
+                    curr_x = F.dropout(F.relu(conv(curr_x)), 0.5, self.training)
+                x_embedded.append(curr_x[0].transpose(0, 1))
+            x = torch.nn.utils.rnn.pad_sequence(x_embedded, batch_first=True)
+        else:
+            for conv in self.convolutions:
+                x = F.dropout(F.relu(conv(x)), 0.5, self.training)
+            x = x.transpose(1, 2)
+
+        # recent amp change -- change in_lens to int
+        in_lens = in_lens.int().cpu()
+        # mikyas added this for RuntimeError: `lengths` array must be sorted in decreasing order when `enforce_sorted` is True. You can pass `enforce_sorted=False` to pack_padded_sequence and/or pack_sequence to sidestep this requirement if you do not need ONNX exportability.
+        in_lens = sorted(in_lens, reverse=True)
+        x = nn.utils.rnn.pack_padded_sequence(x, in_lens, batch_first=True)
+
+        self.lstm.flatten_parameters()
+        outputs, _ = self.lstm(x)
+
+        outputs, _ = nn.utils.rnn.pad_packed_sequence(
+            outputs, batch_first=True)
+
+        return outputs
+
+    @amp.autocast(False)
+    def infer(self, x):
+        for conv in self.convolutions:
+            x = F.dropout(F.relu(conv(x)), 0.5, self.training)
+
+        x = x.transpose(1, 2)
+        self.lstm.flatten_parameters()
+        outputs, _ = self.lstm(x)
+
+        return outputs
+
+
+class Invertible1x1ConvLUS(torch.nn.Module):
+    def __init__(self, c):
+        super(Invertible1x1ConvLUS, self).__init__()
+        # Sample a random orthonormal matrix to initialize weights
+        W = torch.qr(torch.FloatTensor(c, c).normal_())[0]
+        # Ensure determinant is 1.0 not -1.0
+        if torch.det(W) < 0:
+            W[:, 0] = -1*W[:, 0]
+        p, lower, upper = torch.lu_unpack(*torch.lu(W))
+
+        self.register_buffer('p', p)
+        # diagonals of lower will always be 1s anyway
+        lower = torch.tril(lower, -1)
+        lower_diag = torch.diag(torch.eye(c, c))
+        self.register_buffer('lower_diag', lower_diag)
+        self.lower = nn.Parameter(lower)
+        self.upper_diag = nn.Parameter(torch.diag(upper))
+        self.upper = nn.Parameter(torch.triu(upper, 1))
+
+    @amp.autocast(False)
+    def forward(self, z, inverse=False):
+        U = torch.triu(self.upper, 1) + torch.diag(self.upper_diag)
+        L = torch.tril(self.lower, -1) + torch.diag(self.lower_diag)
+        W = torch.mm(self.p, torch.mm(L, U))
+        if inverse:
+            if not hasattr(self, 'W_inverse'):
+                # inverse computation
+                W_inverse = W.float().inverse()
+                if z.type() == 'torch.cuda.HalfTensor':
+                    W_inverse = W_inverse.half()
+
+                self.W_inverse = W_inverse[..., None]
+            z = F.conv1d(z, self.W_inverse, bias=None, stride=1, padding=0)
+            return z
+        else:
+            W = W[..., None]
+            z = F.conv1d(z, W, bias=None, stride=1, padding=0)
+            log_det_W = torch.sum(torch.log(torch.abs(self.upper_diag)))
+            return z, log_det_W
+
+
+class Invertible1x1Conv(torch.nn.Module):
+    """
+    The layer outputs both the convolution, and the log determinant
+    of its weight matrix.  If inverse=True it does convolution with
+    inverse
+    """
+    def __init__(self, c):
+        super(Invertible1x1Conv, self).__init__()
+        self.conv = torch.nn.Conv1d(c, c, kernel_size=1, stride=1, padding=0,
+                                    bias=False)
+
+        # Sample a random orthonormal matrix to initialize weights
+        W = torch.qr(torch.FloatTensor(c, c).normal_())[0]
+
+        # Ensure determinant is 1.0 not -1.0
+        if torch.det(W) < 0:
+            W[:, 0] = -1*W[:, 0]
+        W = W.view(c, c, 1)
+        self.conv.weight.data = W
+
+    def forward(self, z, inverse=False):
+        # DO NOT apply n_of_groups, as it doesn't account for padded sequences
+        W = self.conv.weight.squeeze()
+
+        if inverse:
+            if not hasattr(self, 'W_inverse'):
+                # Inverse computation
+                W_inverse = W.float().inverse()
+                if z.type() == 'torch.cuda.HalfTensor':
+                    W_inverse = W_inverse.half()
+
+                self.W_inverse = W_inverse[..., None]
+            z = F.conv1d(z, self.W_inverse, bias=None, stride=1, padding=0)
+            return z
+        else:
+            # Forward computation
+            log_det_W = torch.logdet(W).clone()
+            z = self.conv(z)
+            return z, log_det_W
+
+
+class SimpleConvNet(torch.nn.Module):
+    def __init__(self, n_mel_channels, n_context_dim, final_out_channels,
+                 n_layers=2, kernel_size=5, with_dilation=True,
+                 max_channels=1024, zero_init=True, use_partial_padding=True):
+        super(SimpleConvNet, self).__init__()
+        self.layers = torch.nn.ModuleList()
+        self.n_layers = n_layers
+        in_channels = n_mel_channels + n_context_dim
+        out_channels = -1
+        self.use_partial_padding = use_partial_padding
+        for i in range(n_layers):
+            dilation = 2 ** i if with_dilation else 1
+            padding = int((kernel_size*dilation - dilation)/2)
+            out_channels = min(max_channels, in_channels * 2)
+            self.layers.append(ConvNorm(in_channels, out_channels,
+                                        kernel_size=kernel_size, stride=1,
+                                        padding=padding, dilation=dilation,
+                                        bias=True, w_init_gain='relu', use_partial_padding=use_partial_padding))
+            in_channels = out_channels
+
+        self.last_layer = torch.nn.Conv1d(
+            out_channels, final_out_channels, kernel_size=1)
+
+        if zero_init:
+            self.last_layer.weight.data *= 0
+            self.last_layer.bias.data *= 0
+
+    def forward(self, z_w_context, seq_lens: torch.Tensor=None):
+        # seq_lens: tensor array of sequence sequence lengths
+        # output should be b x n_mel_channels x z_w_context.shape(2)
+        mask = None
+        if self.use_partial_padding:
+            mask = get_mask_from_lengths(seq_lens).unsqueeze(1).float()
+
+        for i in range(self.n_layers):
+            z_w_context = self.layers[i](z_w_context, mask)
+            z_w_context = torch.relu(z_w_context)
+
+        z_w_context = self.last_layer(z_w_context)
+        return z_w_context
+
+
+class WN(torch.nn.Module):
+    """
+    Adapted from WN() module in WaveGlow with modififcations to variable names
+    """
+    def __init__(self, n_in_channels, n_context_dim, n_layers, n_channels,
+                 kernel_size=5, affine_activation='softplus', use_partial_padding=True):
+        super(WN, self).__init__()
+        assert(kernel_size % 2 == 1)
+        assert(n_channels % 2 == 0)
+        self.n_layers = n_layers
+        self.n_channels = n_channels
+        self.in_layers = torch.nn.ModuleList()
+        self.res_skip_layers = torch.nn.ModuleList()
+        start = torch.nn.Conv1d(n_in_channels+n_context_dim, n_channels, 1)
+        start = torch.nn.utils.weight_norm(start, name='weight')
+        self.start = start
+        self.softplus = torch.nn.Softplus()
+        self.affine_activation = affine_activation
+        self.use_partial_padding = use_partial_padding
+        # Initializing last layer to 0 makes the affine coupling layers
+        # do nothing at first.  This helps with training stability
+        end = torch.nn.Conv1d(n_channels, 2*n_in_channels, 1)
+        end.weight.data.zero_()
+        end.bias.data.zero_()
+        self.end = end
+
+        for i in range(n_layers):
+            dilation = 2 ** i
+            padding = int((kernel_size*dilation - dilation)/2)
+            in_layer = ConvNorm(n_channels, n_channels, kernel_size=kernel_size,
+                                dilation=dilation, padding=padding, use_partial_padding=use_partial_padding,
+                                use_weight_norm=True)
+            # in_layer = nn.Conv1d(n_channels, n_channels, kernel_size,
+            #                      dilation=dilation, padding=padding)
+            # in_layer = nn.utils.weight_norm(in_layer)
+            self.in_layers.append(in_layer)
+            res_skip_layer = nn.Conv1d(n_channels, n_channels, 1)
+            res_skip_layer = nn.utils.weight_norm(res_skip_layer)
+            self.res_skip_layers.append(res_skip_layer)
+
+    def forward(self, forward_input : Tuple[torch.Tensor, torch.Tensor], seq_lens : torch.Tensor=None):
+        z, context = forward_input
+        z = torch.cat((z, context), 1)  # append context to z as well
+        z = self.start(z)
+        output = torch.zeros_like(z)
+        mask = None
+        if self.use_partial_padding:
+            mask = get_mask_from_lengths(seq_lens).unsqueeze(1).float()
+        non_linearity = torch.relu
+        if self.affine_activation == 'softplus':
+            non_linearity = self.softplus
+
+        for i in range(self.n_layers):
+            z = non_linearity(self.in_layers[i](z, mask))
+            res_skip_acts = non_linearity(self.res_skip_layers[i](z))
+            output = output + res_skip_acts
+
+        output = self.end(output)  # [B, dim, seq_len]
+        return output
+
+
+# Affine Coupling Layers
+class SplineTransformationLayerAR(torch.nn.Module):
+    def __init__(self, n_in_channels, n_context_dim, n_layers,
+                 affine_model='simple_conv', kernel_size=1, scaling_fn='exp',
+                 affine_activation='softplus', n_channels=1024, n_bins=8,
+                 left=-6, right=6, bottom=-6, top=6, use_quadratic=False):
+        super(SplineTransformationLayerAR, self).__init__()
+        self.n_in_channels = n_in_channels  # input dimensions
+        self.left = left
+        self.right = right
+        self.bottom = bottom
+        self.top = top
+        self.n_bins = n_bins
+        self.spline_fn = piecewise_linear_transform
+        self.inv_spline_fn = piecewise_linear_inverse_transform
+        self.use_quadratic = use_quadratic
+
+        if self.use_quadratic:
+            self.spline_fn = unbounded_piecewise_quadratic_transform
+            self.inv_spline_fn = unbounded_piecewise_quadratic_transform
+            self.n_bins = 2 * self.n_bins + 1
+        final_out_channels = self.n_in_channels * self.n_bins
+
+        # autoregressive flow, kernel size 1 and no dilation
+        self.param_predictor = SimpleConvNet(
+            n_context_dim, 0, final_out_channels, n_layers,
+            with_dilation=False, kernel_size=1, zero_init=True, use_partial_padding=False)
+
+        # output is unnormalized bin weights
+
+    def normalize(self, z, inverse):
+        # normalize to [0, 1]
+        if inverse:
+            z = (z - self.bottom) / (self.top - self.bottom)
+        else:
+            z = (z - self.left) / (self.right - self.left)
+
+        return z
+
+    def denormalize(self, z, inverse):
+        if inverse:
+            z = z * (self.right - self.left) + self.left
+        else:
+            z = z * (self.top - self.bottom) + self.bottom
+
+        return z
+
+    def forward(self, z, context, inverse=False):
+        b_s, c_s, t_s = z.size(0), z.size(1), z.size(2)
+
+        z = self.normalize(z, inverse)
+
+        if z.min() < 0.0 or z.max() > 1.0:
+            print('spline z scaled beyond [0, 1]', z.min(), z.max())
+
+
+        z_reshaped = z.permute(0, 2, 1).reshape(b_s * t_s, -1)
+        affine_params = self.param_predictor(context)
+        q_tilde = affine_params.permute(0, 2, 1).reshape(b_s * t_s, c_s, -1)
+        with amp.autocast(enabled=False):
+            if self.use_quadratic:
+                w = q_tilde[:, :, :self.n_bins // 2]
+                v = q_tilde[:, :, self.n_bins // 2:]
+                z_tformed, log_s = self.spline_fn(
+                    z_reshaped.float(), w.float(), v.float(), inverse=inverse)
+            else:
+                z_tformed, log_s = self.spline_fn(
+                    z_reshaped.float(), q_tilde.float())
+
+        z = z_tformed.reshape(b_s, t_s, -1).permute(0, 2, 1)
+        z = self.denormalize(z, inverse)
+        if inverse:
+            return z
+
+        log_s = log_s.reshape(b_s, t_s, -1)
+        log_s = log_s.permute(0, 2, 1)
+        log_s = log_s + c_s * (np.log(self.top - self.bottom) -
+                               np.log(self.right - self.left))
+        return z, log_s
+
+
+class SplineTransformationLayer(torch.nn.Module):
+    def __init__(self, n_mel_channels, n_context_dim, n_layers,
+                 with_dilation=True, kernel_size=5,
+                 scaling_fn='exp', affine_activation='softplus',
+                 n_channels=1024, n_bins=8, left=-4, right=4, bottom=-4, top=4,
+                 use_quadratic=False):
+        super(SplineTransformationLayer, self).__init__()
+        self.n_mel_channels = n_mel_channels  # input dimensions
+        self.half_mel_channels = int(n_mel_channels/2)  # half, because we split
+        self.left = left
+        self.right = right
+        self.bottom = bottom
+        self.top = top
+        self.n_bins = n_bins
+        self.spline_fn = piecewise_linear_transform
+        self.inv_spline_fn = piecewise_linear_inverse_transform
+        self.use_quadratic = use_quadratic
+
+        if self.use_quadratic:
+            self.spline_fn = unbounded_piecewise_quadratic_transform
+            self.inv_spline_fn = unbounded_piecewise_quadratic_transform
+            self.n_bins = 2*self.n_bins+1
+        final_out_channels = self.half_mel_channels*self.n_bins
+
+        self.param_predictor = SimpleConvNet(
+            self.half_mel_channels, n_context_dim, final_out_channels,
+            n_layers, with_dilation=with_dilation, kernel_size=kernel_size,
+            zero_init=False)
+
+        # output is unnormalized bin weights
+
+    def forward(self, z, context, inverse=False, seq_lens=None):
+        b_s, c_s, t_s = z.size(0), z.size(1), z.size(2)
+
+        # condition on z_0, transform z_1
+        n_half = self.half_mel_channels
+        z_0, z_1 = z[:, :n_half], z[:, n_half:]
+
+        # normalize to [0,1]
+        if inverse:
+            z_1 = (z_1 - self.bottom)/(self.top - self.bottom)
+        else:
+            z_1 = (z_1 - self.left)/(self.right - self.left)
+
+        z_w_context = torch.cat((z_0, context), 1)
+        affine_params = self.param_predictor(z_w_context, seq_lens)
+        z_1_reshaped = z_1.permute(0, 2, 1).reshape(b_s*t_s, -1)
+        q_tilde = affine_params.permute(0, 2, 1).reshape(
+            b_s*t_s, n_half, self.n_bins)
+
+        with autocast(enabled=False):
+            if self.use_quadratic:
+                w = q_tilde[:, :, :self.n_bins//2]
+                v = q_tilde[:, :, self.n_bins//2:]
+                z_1_tformed, log_s = self.spline_fn(
+                    z_1_reshaped.float(), w.float(), v.float(),
+                    inverse=inverse)
+                if not inverse:
+                    log_s = torch.sum(log_s, 1)
+            else:
+                if inverse:
+                    z_1_tformed, _dc = self.inv_spline_fn(
+                        z_1_reshaped.float(), q_tilde.float(), False)
+                else:
+                    z_1_tformed, log_s = self.spline_fn(
+                        z_1_reshaped.float(), q_tilde.float())
+
+        z_1 = z_1_tformed.reshape(b_s, t_s, -1).permute(0, 2, 1)
+
+        # undo [0, 1] normalization
+        if inverse:
+            z_1 = z_1 * (self.right - self.left) + self.left
+            z = torch.cat((z_0, z_1), dim=1)
+            return z
+        else:  # training
+            z_1 = z_1 * (self.top - self.bottom) + self.bottom
+            z = torch.cat((z_0, z_1), dim=1)
+            log_s = log_s.reshape(b_s, t_s).unsqueeze(1) + n_half*(np.log(self.top - self.bottom) - np.log(self.right-self.left))
+            return z, log_s
+
+
+class AffineTransformationLayer(torch.nn.Module):
+    def __init__(self, n_mel_channels, n_context_dim, n_layers,
+                 affine_model='simple_conv', with_dilation=True, kernel_size=5,
+                 scaling_fn='exp', affine_activation='softplus',
+                 n_channels=1024, use_partial_padding=False):
+        super(AffineTransformationLayer, self).__init__()
+        if affine_model not in ("wavenet", "simple_conv"):
+            raise Exception("{} affine model not supported".format(affine_model))
+        if isinstance(scaling_fn, list):
+            if not all([x in ("translate", "exp", "tanh", "sigmoid") for x in scaling_fn]):
+                raise Exception("{} scaling fn not supported".format(scaling_fn))
+        else:
+            if scaling_fn not in ("translate", "exp", "tanh", "sigmoid"):
+                raise Exception("{} scaling fn not supported".format(scaling_fn))
+
+        self.affine_model = affine_model
+        self.scaling_fn = scaling_fn
+        if affine_model == 'wavenet':
+            self.affine_param_predictor = WN(
+                int(n_mel_channels/2), n_context_dim, n_layers=n_layers,
+                n_channels=n_channels, affine_activation=affine_activation, use_partial_padding=use_partial_padding)
+        elif affine_model == 'simple_conv':
+            self.affine_param_predictor = SimpleConvNet(
+                int(n_mel_channels / 2), n_context_dim, n_mel_channels,
+                n_layers, with_dilation=with_dilation, kernel_size=kernel_size,
+                use_partial_padding=use_partial_padding)
+        self.n_mel_channels = n_mel_channels
+
+    def get_scaling_and_logs(self, scale_unconstrained):
+        # (rvalle) re-write this
+        if self.scaling_fn == 'translate':
+            s = torch.exp(scale_unconstrained*0)
+            log_s = scale_unconstrained*0
+        elif self.scaling_fn == 'exp':
+            s = torch.exp(scale_unconstrained)
+            log_s = scale_unconstrained  # log(exp
+        elif self.scaling_fn == 'tanh':
+            s = torch.tanh(scale_unconstrained) + 1 + 1e-6
+            log_s = torch.log(s)
+        elif self.scaling_fn == 'sigmoid':
+            s = torch.sigmoid(scale_unconstrained + 10) + 1e-6
+            log_s = torch.log(s)
+        elif isinstance(self.scaling_fn, list):
+            s_list, log_s_list = [], []
+            for i in range(scale_unconstrained.shape[1]):
+                scaling_i = self.scaling_fn[i]
+                if scaling_i == 'translate':
+                    s_i = torch.exp(scale_unconstrained[:i]*0)
+                    log_s_i = scale_unconstrained[:, i]*0
+                elif scaling_i == 'exp':
+                    s_i = torch.exp(scale_unconstrained[:, i])
+                    log_s_i = scale_unconstrained[:, i]
+                elif scaling_i == 'tanh':
+                    s_i = torch.tanh(scale_unconstrained[:, i]) + 1 + 1e-6
+                    log_s_i = torch.log(s_i)
+                elif scaling_i == 'sigmoid':
+                    s_i = torch.sigmoid(scale_unconstrained[:, i]) + 1e-6
+                    log_s_i = torch.log(s_i)
+                s_list.append(s_i[:, None])
+                log_s_list.append(log_s_i[:, None])
+            s = torch.cat(s_list, dim=1)
+            log_s = torch.cat(log_s_list, dim=1)
+        return s, log_s
+
+    def forward(self, z, context, inverse=False, seq_lens=None):
+        n_half = int(self.n_mel_channels / 2)
+        z_0, z_1 = z[:, :n_half], z[:, n_half:]
+        if self.affine_model == 'wavenet':
+            affine_params = self.affine_param_predictor((z_0, context), seq_lens=seq_lens)
+        elif self.affine_model == 'simple_conv':
+            z_w_context = torch.cat((z_0, context), 1)
+            affine_params = self.affine_param_predictor(z_w_context, seq_lens=seq_lens)
+
+        scale_unconstrained = affine_params[:, :n_half, :]
+        b = affine_params[:, n_half:, :]
+        s, log_s = self.get_scaling_and_logs(scale_unconstrained)
+
+        if inverse:
+            z_1 = (z_1 - b) / s
+            z = torch.cat((z_0, z_1), dim=1)
+            return z
+        else:
+            z_1 = s * z_1 + b
+            z = torch.cat((z_0, z_1), dim=1)
+            return z, log_s
+
+
+class ConvAttention(torch.nn.Module):
+    def __init__(self, n_mel_channels=80, n_speaker_dim=128,
+                 n_text_channels=512, n_att_channels=80, temperature=1.0):
+        super(ConvAttention, self).__init__()
+        self.temperature = temperature
+        self.softmax = torch.nn.Softmax(dim=3)
+        self.log_softmax = torch.nn.LogSoftmax(dim=3)
+        self.query_proj = Invertible1x1ConvLUS(n_mel_channels)
+
+        self.key_proj = nn.Sequential(
+            ConvNorm(n_text_channels, n_text_channels*2, kernel_size=3,
+                        bias=True, w_init_gain='relu'),
+            torch.nn.ReLU(),
+            ConvNorm(n_text_channels*2, n_att_channels, kernel_size=1,
+                        bias=True))
+
+        self.query_proj = nn.Sequential(
+            ConvNorm(n_mel_channels, n_mel_channels*2, kernel_size=3,
+                     bias=True, w_init_gain='relu'),
+            torch.nn.ReLU(),
+            ConvNorm(n_mel_channels*2, n_mel_channels, kernel_size=1,
+                     bias=True),
+            torch.nn.ReLU(),
+            ConvNorm(n_mel_channels, n_att_channels, kernel_size=1, bias=True)
+        )
+
+    def run_padded_sequence(self, sorted_idx, unsort_idx, lens, padded_data,
+                            recurrent_model):
+        """Sorts input data by previded ordering (and un-ordering) and runs the
+        packed data through the recurrent model
+
+        Args:
+            sorted_idx (torch.tensor): 1D sorting index
+            unsort_idx (torch.tensor): 1D unsorting index (inverse of sorted_idx)
+            lens: lengths of input data (sorted in descending order)
+            padded_data (torch.tensor): input sequences (padded)
+            recurrent_model (nn.Module): recurrent model to run data through
+        Returns:
+            hidden_vectors (torch.tensor): outputs of the RNN, in the original,
+            unsorted, ordering
+        """
+
+        # sort the data by decreasing length using provided index
+        # we assume batch index is in dim=1
+        padded_data = padded_data[:, sorted_idx]
+        padded_data = nn.utils.rnn.pack_padded_sequence(padded_data, lens)
+        hidden_vectors = recurrent_model(padded_data)[0]
+        hidden_vectors, _ = nn.utils.rnn.pad_packed_sequence(hidden_vectors)
+        # unsort the results at dim=1 and return
+        hidden_vectors = hidden_vectors[:, unsort_idx]
+        return hidden_vectors
+
+    def forward(self, queries, keys, query_lens, mask=None, key_lens=None,
+                attn_prior=None):
+        """Attention mechanism for radtts. Unlike in Flowtron, we have no
+        restrictions such as causality etc, since we only need this during
+        training.
+
+        Args:
+            queries (torch.tensor): B x C x T1 tensor (likely mel data)
+            keys (torch.tensor): B x C2 x T2 tensor (text data)
+            query_lens: lengths for sorting the queries in descending order
+            mask (torch.tensor): uint8 binary mask for variable length entries
+                                 (should be in the T2 domain)
+        Output:
+            attn (torch.tensor): B x 1 x T1 x T2 attention mask.
+                                 Final dim T2 should sum to 1
+        """
+        temp = 0.0005
+        keys_enc = self.key_proj(keys)  # B x n_attn_dims x T2
+        # Beware can only do this since query_dim = attn_dim = n_mel_channels
+        queries_enc = self.query_proj(queries)
+
+        # Gaussian Isotopic Attention
+        # B x n_attn_dims x T1 x T2
+        attn = (queries_enc[:, :, :, None] - keys_enc[:, :, None])**2
+
+        # compute log-likelihood from gaussian
+        eps = 1e-8
+        attn = -temp * attn.sum(1, keepdim=True)
+        if attn_prior is not None:
+            attn = self.log_softmax(attn) + torch.log(attn_prior[:, None] + eps)
+
+        attn_logprob = attn.clone()
+
+        if mask is not None:
+            attn.data.masked_fill_(
+                mask.permute(0, 2, 1).unsqueeze(2), -float("inf"))
+
+        attn = self.softmax(attn)  # softmax along T2
+        return attn, attn_logprob

--- a/nemo/collections/tts/helpers/partialconv1d.py
+++ b/nemo/collections/tts/helpers/partialconv1d.py
@@ -1,0 +1,62 @@
+###############################################################################
+# BSD 3-Clause License
+#
+# Copyright (c) 2012, NVIDIA CORPORATION. All rights reserved.
+#
+# Author & Contact: Guilin Liu (guilinl@nvidia.com)
+###############################################################################
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+from typing import Tuple
+
+
+class PartialConv1d(nn.Conv1d):
+    def __init__(self, *args, **kwargs):
+
+        self.multi_channel = False
+        self.return_mask = False
+        super(PartialConv1d, self).__init__(*args, **kwargs)
+
+        self.weight_maskUpdater = torch.ones(1, 1, self.kernel_size[0])
+        self.slide_winsize = self.weight_maskUpdater.shape[1] * self.weight_maskUpdater.shape[2]
+
+        self.last_size = (None, None, None)
+        self.update_mask = None
+        self.mask_ratio = None
+
+    @torch.jit.ignore
+    def forward(self, input: torch.Tensor, mask_in : Tuple[int, int, int] = None):
+        assert len(input.shape) == 3
+        # if a mask is input, or tensor shape changed, update mask ratio
+        if mask_in is not None or self.last_size != tuple(input.shape):
+            self.last_size = tuple(input.shape)
+            with torch.no_grad():
+                if self.weight_maskUpdater.type() != input.type():
+                    self.weight_maskUpdater = self.weight_maskUpdater.to(input)
+                if mask_in is None:
+                    mask = torch.ones(1, 1, input.data.shape[2]).to(input)
+                else:
+                    mask = mask_in
+                self.update_mask = F.conv1d(mask, self.weight_maskUpdater,
+                                            bias=None, stride=self.stride,
+                                            padding=self.padding,
+                                            dilation=self.dilation, groups=1)
+                # for mixed precision training, change 1e-8 to 1e-6
+                self.mask_ratio = self.slide_winsize/(self.update_mask + 1e-6)
+                self.update_mask = torch.clamp(self.update_mask, 0, 1)
+                self.mask_ratio = torch.mul(self.mask_ratio, self.update_mask)
+        raw_out = super(PartialConv1d, self).forward(
+            torch.mul(input, mask) if mask_in is not None else input)
+        if self.bias is not None:
+            bias_view = self.bias.view(1, self.out_channels, 1)
+            output = torch.mul(raw_out - bias_view, self.mask_ratio) + bias_view
+            output = torch.mul(output, self.update_mask)
+        else:
+            output = torch.mul(raw_out, self.mask_ratio)
+
+        if self.return_mask:
+            return output, self.update_mask
+        else:
+            return output

--- a/nemo/collections/tts/helpers/partialconv1d.py
+++ b/nemo/collections/tts/helpers/partialconv1d.py
@@ -6,10 +6,11 @@
 # Author & Contact: Guilin Liu (guilinl@nvidia.com)
 ###############################################################################
 
+from typing import Tuple
+
 import torch
 import torch.nn.functional as F
 from torch import nn
-from typing import Tuple
 
 
 class PartialConv1d(nn.Conv1d):
@@ -27,7 +28,7 @@ class PartialConv1d(nn.Conv1d):
         self.mask_ratio = None
 
     @torch.jit.ignore
-    def forward(self, input: torch.Tensor, mask_in : Tuple[int, int, int] = None):
+    def forward(self, input: torch.Tensor, mask_in: Tuple[int, int, int] = None):
         assert len(input.shape) == 3
         # if a mask is input, or tensor shape changed, update mask ratio
         if mask_in is not None or self.last_size != tuple(input.shape):
@@ -39,16 +40,20 @@ class PartialConv1d(nn.Conv1d):
                     mask = torch.ones(1, 1, input.data.shape[2]).to(input)
                 else:
                     mask = mask_in
-                self.update_mask = F.conv1d(mask, self.weight_maskUpdater,
-                                            bias=None, stride=self.stride,
-                                            padding=self.padding,
-                                            dilation=self.dilation, groups=1)
+                self.update_mask = F.conv1d(
+                    mask,
+                    self.weight_maskUpdater,
+                    bias=None,
+                    stride=self.stride,
+                    padding=self.padding,
+                    dilation=self.dilation,
+                    groups=1,
+                )
                 # for mixed precision training, change 1e-8 to 1e-6
-                self.mask_ratio = self.slide_winsize/(self.update_mask + 1e-6)
+                self.mask_ratio = self.slide_winsize / (self.update_mask + 1e-6)
                 self.update_mask = torch.clamp(self.update_mask, 0, 1)
                 self.mask_ratio = torch.mul(self.mask_ratio, self.update_mask)
-        raw_out = super(PartialConv1d, self).forward(
-            torch.mul(input, mask) if mask_in is not None else input)
+        raw_out = super(PartialConv1d, self).forward(torch.mul(input, mask) if mask_in is not None else input)
         if self.bias is not None:
             bias_view = self.bias.view(1, self.out_channels, 1)
             output = torch.mul(raw_out - bias_view, self.mask_ratio) + bias_view

--- a/nemo/collections/tts/helpers/radam.py
+++ b/nemo/collections/tts/helpers/radam.py
@@ -1,0 +1,122 @@
+"""RAdam
+Original source taken from https://github.com/LiyuanLucasLiu/RAdam
+
+Copyright 2019 Liyuan Liu
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+"""
+import math
+
+import torch
+
+# pylint: disable=no-name-in-module
+from torch.optim.optimizer import Optimizer
+
+
+class RAdam(Optimizer):
+    """RAdam optimizer"""
+
+    def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8,
+                 weight_decay=0):
+        """
+        Init
+
+        :param params: parameters to optimize
+        :param lr: learning rate
+        :param betas: beta
+        :param eps: numerical precision
+        :param weight_decay: weight decay weight
+        """
+        defaults = dict(lr=lr, betas=betas, eps=eps, weight_decay=weight_decay)
+        self.buffer = [[None, None, None] for _ in range(10)]
+        super().__init__(params, defaults)
+
+    def step(self, closure=None):
+
+        loss = None
+        if closure is not None:
+            loss = closure()
+
+        for group in self.param_groups:
+
+            for p in group['params']:
+                if p.grad is None:
+                    continue
+                grad = p.grad.data.float()
+                if grad.is_sparse:
+                    raise RuntimeError(
+                        'RAdam does not support sparse gradients'
+                    )
+
+                p_data_fp32 = p.data.float()
+
+                state = self.state[p]
+
+                if len(state) == 0:
+                    state['step'] = 0
+                    state['exp_avg'] = torch.zeros_like(p_data_fp32)
+                    state['exp_avg_sq'] = torch.zeros_like(p_data_fp32)
+                else:
+                    state['exp_avg'] = state['exp_avg'].type_as(p_data_fp32)
+                    state['exp_avg_sq'] = (
+                        state['exp_avg_sq'].type_as(p_data_fp32)
+                    )
+
+                exp_avg, exp_avg_sq = state['exp_avg'], state['exp_avg_sq']
+                beta1, beta2 = group['betas']
+
+                exp_avg_sq.mul_(beta2).addcmul_(1 - beta2, grad, grad)
+                exp_avg.mul_(beta1).add_(1 - beta1, grad)
+
+                state['step'] += 1
+                buffered = self.buffer[int(state['step'] % 10)]
+                if state['step'] == buffered[0]:
+                    N_sma, step_size = buffered[1], buffered[2]
+                else:
+                    buffered[0] = state['step']
+                    beta2_t = beta2 ** state['step']
+                    N_sma_max = 2 / (1 - beta2) - 1
+                    N_sma = (
+                        N_sma_max - 2 * state['step'] * beta2_t / (1 - beta2_t)
+                    )
+                    buffered[1] = N_sma
+
+                    # more conservative since it's an approximated value
+                    if N_sma >= 5:
+                        step_size = (
+                            group['lr'] *
+                            math.sqrt(
+                                (1 - beta2_t) * (N_sma - 4) /
+                                (N_sma_max - 4) * (N_sma - 2) /
+                                N_sma * N_sma_max / (N_sma_max - 2)
+                            ) / (1 - beta1 ** state['step'])
+                        )
+                    else:
+                        step_size = group['lr'] / (1 - beta1 ** state['step'])
+                    buffered[2] = step_size
+
+                if group['weight_decay'] != 0:
+                    p_data_fp32.add_(
+                        -group['weight_decay'] * group['lr'], p_data_fp32
+                    )
+
+                # more conservative since it's an approximated value
+                if N_sma >= 5:
+                    denom = exp_avg_sq.sqrt().add_(group['eps'])
+                    p_data_fp32.addcdiv_(-step_size, exp_avg, denom)
+                else:
+                    p_data_fp32.add_(-step_size, exp_avg)
+
+                p.data.copy_(p_data_fp32)
+
+        return loss

--- a/nemo/collections/tts/helpers/radam.py
+++ b/nemo/collections/tts/helpers/radam.py
@@ -26,8 +26,7 @@ from torch.optim.optimizer import Optimizer
 class RAdam(Optimizer):
     """RAdam optimizer"""
 
-    def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8,
-                 weight_decay=0):
+    def __init__(self, params, lr=1e-3, betas=(0.9, 0.999), eps=1e-8, weight_decay=0):
         """
         Init
 
@@ -54,9 +53,7 @@ class RAdam(Optimizer):
                     continue
                 grad = p.grad.data.float()
                 if grad.is_sparse:
-                    raise RuntimeError(
-                        'RAdam does not support sparse gradients'
-                    )
+                    raise RuntimeError('RAdam does not support sparse gradients')
 
                 p_data_fp32 = p.data.float()
 
@@ -68,9 +65,7 @@ class RAdam(Optimizer):
                     state['exp_avg_sq'] = torch.zeros_like(p_data_fp32)
                 else:
                     state['exp_avg'] = state['exp_avg'].type_as(p_data_fp32)
-                    state['exp_avg_sq'] = (
-                        state['exp_avg_sq'].type_as(p_data_fp32)
-                    )
+                    state['exp_avg_sq'] = state['exp_avg_sq'].type_as(p_data_fp32)
 
                 exp_avg, exp_avg_sq = state['exp_avg'], state['exp_avg_sq']
                 beta1, beta2 = group['betas']
@@ -86,29 +81,30 @@ class RAdam(Optimizer):
                     buffered[0] = state['step']
                     beta2_t = beta2 ** state['step']
                     N_sma_max = 2 / (1 - beta2) - 1
-                    N_sma = (
-                        N_sma_max - 2 * state['step'] * beta2_t / (1 - beta2_t)
-                    )
+                    N_sma = N_sma_max - 2 * state['step'] * beta2_t / (1 - beta2_t)
                     buffered[1] = N_sma
 
                     # more conservative since it's an approximated value
                     if N_sma >= 5:
                         step_size = (
-                            group['lr'] *
-                            math.sqrt(
-                                (1 - beta2_t) * (N_sma - 4) /
-                                (N_sma_max - 4) * (N_sma - 2) /
-                                N_sma * N_sma_max / (N_sma_max - 2)
-                            ) / (1 - beta1 ** state['step'])
+                            group['lr']
+                            * math.sqrt(
+                                (1 - beta2_t)
+                                * (N_sma - 4)
+                                / (N_sma_max - 4)
+                                * (N_sma - 2)
+                                / N_sma
+                                * N_sma_max
+                                / (N_sma_max - 2)
+                            )
+                            / (1 - beta1 ** state['step'])
                         )
                     else:
                         step_size = group['lr'] / (1 - beta1 ** state['step'])
                     buffered[2] = step_size
 
                 if group['weight_decay'] != 0:
-                    p_data_fp32.add_(
-                        -group['weight_decay'] * group['lr'], p_data_fp32
-                    )
+                    p_data_fp32.add_(-group['weight_decay'] * group['lr'], p_data_fp32)
 
                 # more conservative since it's an approximated value
                 if N_sma >= 5:

--- a/nemo/collections/tts/helpers/splines.py
+++ b/nemo/collections/tts/helpers/splines.py
@@ -1,0 +1,297 @@
+"""
+Original Source:
+https://github.com/ndeutschmann/zunis/blob/master/zunis_lib/zunis/models/flows/coupling_cells/piecewise_coupling/piecewise_linear.py
+https://github.com/ndeutschmann/zunis/blob/master/zunis_lib/zunis/models/flows/coupling_cells/piecewise_coupling/piecewise_quadratic.py
+Modifications made to jacobian computation
+License: MIT License
+Copyright 2020 Nicolas Deutschmann
+"""
+
+import torch
+import torch.nn.functional as F
+third_dimension_softmax = torch.nn.Softmax(dim=2)
+
+
+def piecewise_linear_transform(x, q_tilde, compute_jacobian=True,
+                               outlier_passthru=True):
+    """Apply an element-wise piecewise-linear transformation to some variables
+
+    Parameters
+    ----------
+    x : torch.Tensor
+        a tensor with shape (N,k) where N is the batch dimension while k is the
+        dimension of the variable space. This variable span the k-dimensional unit
+        hypercube
+
+    q_tilde: torch.Tensor
+        is a tensor with shape (N,k,b) where b is the number of bins.
+        This contains the un-normalized heights of the bins of the piecewise-constant PDF for dimension k,
+        i.e. q_tilde lives in all of R and we don't impose a constraint on their sum yet.
+        Normalization is imposed in this function using softmax.
+
+    compute_jacobian : bool, optional
+        determines whether the jacobian should be compute or None is returned
+
+    Returns
+    -------
+    tuple of torch.Tensor
+        pair `(y,h)`.
+        - `y` is a tensor with shape (N,k) living in the k-dimensional unit hypercube
+        - `j` is the jacobian of the transformation with shape (N,) if compute_jacobian==True, else None.
+    """
+    logj = None
+
+    # TODO bottom-up assesment of handling the differentiability of variables
+    # Compute the bin width w
+    N, k, b = q_tilde.shape
+    Nx, kx = x.shape
+    assert N == Nx and k == kx, "Shape mismatch"
+
+    w = 1. / b
+
+    # Compute normalized bin heights with softmax function on bin dimension
+    q = 1. / w * third_dimension_softmax(q_tilde)
+    # x is in the mx-th bin: x \in [0,1],
+    # mx \in [[0,b-1]], so we clamp away the case x == 1
+    mx = torch.clamp(torch.floor(b * x), 0, b - 1).to(torch.long)
+    # Need special error handling because trying to index with mx
+    # if it contains nans will lock the GPU. (device-side assert triggered)
+    if torch.any(torch.isnan(mx)).item() or torch.any(mx < 0) or torch.any(mx >= b):
+        raise AvertedCUDARuntimeError("NaN detected in PWLinear bin indexing")
+
+    # We compute the output variable in-place
+    out = x - mx * w  # alpha (element of [0.,w], the position of x in its bin
+
+    # Multiply by the slope
+    # q has shape (N,k,b), mxu = mx.unsqueeze(-1) has shape (N,k) with entries that are a b-index
+    # gather defines slope[i, j, k] = q[i, j, mxu[i, j, k]] with k taking only 0 as a value
+    # i.e. we say slope[i, j] = q[i, j, mx [i, j]]
+    slopes = torch.gather(q, 2, mx.unsqueeze(-1)).squeeze(-1)
+    out = out * slopes
+    # The jacobian is the product of the slopes in all dimensions
+
+    # Compute the integral over the left-bins.
+    # 1. Compute all integrals: cumulative sum of bin height * bin weight.
+    # We want that index i contains the cumsum *strictly to the left* so we shift by 1
+    # leaving the first entry null, which is achieved with a roll and assignment
+    q_left_integrals = torch.roll(torch.cumsum(q, 2) * w, 1, 2)
+    q_left_integrals[:, :, 0] = 0
+
+    # 2. Access the correct index to get the left integral of each point and add it to our transformation
+    out = out + torch.gather(q_left_integrals, 2, mx.unsqueeze(-1)).squeeze(-1)
+
+    # Regularization: points must be strictly within the unit hypercube
+    # Use the dtype information from pytorch
+    eps = torch.finfo(out.dtype).eps
+    out = out.clamp(
+        min=eps,
+        max=1. - eps
+    )
+    oob_mask = torch.logical_or(x < 0.0, x >1.0).detach().float()
+    if outlier_passthru:
+        out = out * (1-oob_mask) + x * oob_mask
+        slopes = slopes * (1-oob_mask) + oob_mask
+
+    if compute_jacobian:
+        #logj = torch.log(torch.prod(slopes.float(), 1))
+        logj = torch.sum(torch.log(slopes), 1)
+    del slopes
+
+    return out, logj
+
+
+def piecewise_linear_inverse_transform(y, q_tilde, compute_jacobian=True,
+                                       outlier_passthru=True):
+    """
+    Apply inverse of an element-wise piecewise-linear transformation to some
+    variables
+
+    Parameters
+    ----------
+    y : torch.Tensor
+        a tensor with shape (N,k) where N is the batch dimension while k is the
+        dimension of the variable space. This variable span the k-dimensional unit
+        hypercube
+
+    q_tilde: torch.Tensor
+        is a tensor with shape (N,k,b) where b is the number of bins.
+        This contains the un-normalized heights of the bins of the piecewise-constant PDF for dimension k,
+        i.e. q_tilde lives in all of R and we don't impose a constraint on their sum yet.
+        Normalization is imposed in this function using softmax.
+
+    compute_jacobian : bool, optional
+        determines whether the jacobian should be compute or None is returned
+
+    Returns
+    -------
+    tuple of torch.Tensor
+        pair `(x,h)`.
+        - `x` is a tensor with shape (N,k) living in the k-dimensional unit hypercube
+        - `j` is the jacobian of the transformation with shape (N,) if compute_jacobian==True, else None.
+    """
+
+    # TODO bottom-up assesment of handling the differentiability of variables
+
+    # Compute the bin width w
+    N, k, b = q_tilde.shape
+    Ny, ky = y.shape
+    assert N == Ny and k == ky, "Shape mismatch"
+
+    w = 1. / b
+
+    # Compute normalized bin heights with softmax function on the bin dimension
+    q = 1. / w * third_dimension_softmax(q_tilde)
+
+    # Compute the integral over the left-bins in the forward transform.
+    # 1. Compute all integrals: cumulative sum of bin height * bin weight.
+    # We want that index i contains the cumsum *strictly to the left*,
+    # so we shift by 1 leaving the first entry null,
+    # which is achieved with a roll and assignment
+    q_left_integrals = torch.roll(torch.cumsum(q.float(), 2) * w, 1, 2)
+    q_left_integrals[:, :, 0] = 0
+
+    # Find which bin each y belongs to by finding the smallest bin such that
+    # y - q_left_integral is positive
+
+    edges = (y.unsqueeze(-1) - q_left_integrals).detach()
+    # y and q_left_integrals are between 0 and 1,
+    # so that their difference is at most 1.
+    # By setting the negative values to 2., we know that the
+    # smallest value left is the smallest positive
+    edges[edges < 0] = 2.
+    edges = torch.clamp(torch.argmin(edges, dim=2), 0, b - 1).to(torch.long)
+
+    # Need special error handling because trying to index with mx
+    # if it contains nans will lock the GPU. (device-side assert triggered)
+    if torch.any(torch.isnan(edges)).item() or torch.any(edges < 0) or torch.any(edges >= b):
+        raise AvertedCUDARuntimeError("NaN detected in PWLinear bin indexing")
+
+    # Gather the left integrals at each edge. See comment about gathering in q_left_integrals
+    # for the unsqueeze
+    q_left_integrals = q_left_integrals.gather(2, edges.unsqueeze(-1)).squeeze(-1)
+
+    # Gather the slope at each edge.
+    q = q.gather(2, edges.unsqueeze(-1)).squeeze(-1)
+
+    # Build the output
+    x = (y - q_left_integrals) / q + edges * w
+
+    # Regularization: points must be strictly within the unit hypercube
+    # Use the dtype information from pytorch
+    eps = torch.finfo(x.dtype).eps
+    x = x.clamp(
+        min=eps,
+        max=1. - eps
+    )
+    oob_mask = torch.logical_or(y < 0.0, y >1.0).detach().float()
+    if outlier_passthru:
+        x = x * (1-oob_mask) + y * oob_mask
+        q = q * (1-oob_mask) + oob_mask
+
+    # Prepare the jacobian
+    logj = None
+    if compute_jacobian:
+        #logj = - torch.log(torch.prod(q, 1))
+        logj = -torch.sum(torch.log(q.float()), 1)
+    return x.detach(), logj
+
+
+def unbounded_piecewise_quadratic_transform(x, w_tilde, v_tilde, upper=1,
+                                            lower=0, inverse=False):
+    assert upper > lower
+    _range = upper - lower
+    inside_interval_mask = (x >= lower) & (x < upper)
+    outside_interval_mask = ~inside_interval_mask
+
+    outputs = torch.zeros_like(x)
+    log_j = torch.zeros_like(x)
+
+    outputs[outside_interval_mask] = x[outside_interval_mask]
+    log_j[outside_interval_mask] = 0
+
+    output, _log_j = piecewise_quadratic_transform(
+        (x[inside_interval_mask] - lower) / _range,
+        w_tilde[inside_interval_mask, :],
+        v_tilde[inside_interval_mask, :],
+        inverse=inverse)
+    outputs[inside_interval_mask] = output * _range + lower
+    if not inverse:
+        # the before and after transformation cancel out, so the log_j would be just as it is.
+        log_j[inside_interval_mask] = _log_j
+    else:
+        log_j = None
+    return outputs, log_j
+
+def weighted_softmax(v, w):
+    # to avoid NaN...
+    v = v - torch.max(v, dim=-1, keepdim=True)[0]
+    v = torch.exp(v) + 1e-8 # to avoid NaN...
+    v_sum = torch.sum((v[..., :-1] + v[..., 1:]) / 2 * w, dim=-1, keepdim=True)
+    return v / v_sum
+
+def piecewise_quadratic_transform(x, w_tilde, v_tilde, inverse=False):
+    """Element-wise piecewise-quadratic transformation
+    Parameters
+    ----------
+    x : torch.Tensor
+        *, The variable spans the D-dim unit hypercube ([0,1))
+    w_tilde : torch.Tensor
+        * x K defined in the paper
+    v_tilde : torch.Tensor
+        * x (K+1) defined in the paper
+    inverse : bool
+        forward or inverse
+    Returns
+    -------
+    c : torch.Tensor
+        *, transformed value
+    log_j : torch.Tensor
+        *, log determinant of the Jacobian matrix
+    """
+    w = torch.softmax(w_tilde, dim=-1)
+    v = weighted_softmax(v_tilde, w)
+    w_cumsum = torch.cumsum(w, dim=-1)
+    # force sum = 1
+    w_cumsum[..., -1] = 1.
+    w_cumsum_shift = F.pad(w_cumsum, (1,0), 'constant', 0)
+    cdf = torch.cumsum((v[..., 1:] + v[..., :-1]) / 2 * w, dim=-1)
+    # force sum = 1
+    cdf[..., -1] = 1.
+    cdf_shift = F.pad(cdf, (1,0), 'constant', 0)
+
+    if not inverse:
+        # * x D x 1, (w_cumsum[idx-1] < x <= w_cumsum[idx])
+        bin_index = torch.searchsorted(w_cumsum, x.unsqueeze(-1))
+    else:
+        # * x D x 1, (cdf[idx-1] < x <= cdf[idx])
+        bin_index = torch.searchsorted(cdf, x.unsqueeze(-1))
+
+    w_b = torch.gather(w, -1, bin_index).squeeze(-1)
+    w_bn1 = torch.gather(w_cumsum_shift, -1, bin_index).squeeze(-1)
+    v_b = torch.gather(v, -1, bin_index).squeeze(-1)
+    v_bp1 = torch.gather(v, -1, bin_index + 1).squeeze(-1)
+    cdf_bn1 = torch.gather(cdf_shift, -1, bin_index).squeeze(-1)
+
+    if not inverse:
+        alpha = (x - w_bn1) / w_b.clamp(min=torch.finfo(w_b.dtype).eps)
+        c = (alpha ** 2) / 2 * (v_bp1 - v_b) * w_b + alpha * v_b * w_b + cdf_bn1
+
+        # just sum of log pdfs
+        log_j = torch.lerp(v_b, v_bp1, alpha).clamp(min=torch.finfo(c.dtype).eps).log()
+
+        # make sure it falls into [0,1)
+        c = c.clamp(min=torch.finfo(c.dtype).eps, max=1. - torch.finfo(c.dtype).eps)
+        return c, log_j
+    else:
+        # quadratic equation for alpha
+        # alpha should fall into (0, 1]. Since a, b > 0, the symmetry axis -b/2a < 0 and we should pick the larger root
+        # skip calculating the log_j in inverse since we don't need it
+        a = (v_bp1 - v_b) * w_b / 2
+        b = v_b * w_b
+        c = cdf_bn1 - x
+        alpha = (-b + torch.sqrt((b**2) - 4 * a * c)) / (2 * a)
+        inv = alpha * w_b + w_bn1
+
+        # make sure it falls into [0,1)
+        inv = inv.clamp(min=torch.finfo(c.dtype).eps, max=1. - torch.finfo(inv.dtype).eps)
+        return inv, None

--- a/nemo/collections/tts/helpers/splines.py
+++ b/nemo/collections/tts/helpers/splines.py
@@ -9,11 +9,11 @@ Copyright 2020 Nicolas Deutschmann
 
 import torch
 import torch.nn.functional as F
+
 third_dimension_softmax = torch.nn.Softmax(dim=2)
 
 
-def piecewise_linear_transform(x, q_tilde, compute_jacobian=True,
-                               outlier_passthru=True):
+def piecewise_linear_transform(x, q_tilde, compute_jacobian=True, outlier_passthru=True):
     """Apply an element-wise piecewise-linear transformation to some variables
 
     Parameters
@@ -47,10 +47,10 @@ def piecewise_linear_transform(x, q_tilde, compute_jacobian=True,
     Nx, kx = x.shape
     assert N == Nx and k == kx, "Shape mismatch"
 
-    w = 1. / b
+    w = 1.0 / b
 
     # Compute normalized bin heights with softmax function on bin dimension
-    q = 1. / w * third_dimension_softmax(q_tilde)
+    q = 1.0 / w * third_dimension_softmax(q_tilde)
     # x is in the mx-th bin: x \in [0,1],
     # mx \in [[0,b-1]], so we clamp away the case x == 1
     mx = torch.clamp(torch.floor(b * x), 0, b - 1).to(torch.long)
@@ -83,25 +83,21 @@ def piecewise_linear_transform(x, q_tilde, compute_jacobian=True,
     # Regularization: points must be strictly within the unit hypercube
     # Use the dtype information from pytorch
     eps = torch.finfo(out.dtype).eps
-    out = out.clamp(
-        min=eps,
-        max=1. - eps
-    )
-    oob_mask = torch.logical_or(x < 0.0, x >1.0).detach().float()
+    out = out.clamp(min=eps, max=1.0 - eps)
+    oob_mask = torch.logical_or(x < 0.0, x > 1.0).detach().float()
     if outlier_passthru:
-        out = out * (1-oob_mask) + x * oob_mask
-        slopes = slopes * (1-oob_mask) + oob_mask
+        out = out * (1 - oob_mask) + x * oob_mask
+        slopes = slopes * (1 - oob_mask) + oob_mask
 
     if compute_jacobian:
-        #logj = torch.log(torch.prod(slopes.float(), 1))
+        # logj = torch.log(torch.prod(slopes.float(), 1))
         logj = torch.sum(torch.log(slopes), 1)
     del slopes
 
     return out, logj
 
 
-def piecewise_linear_inverse_transform(y, q_tilde, compute_jacobian=True,
-                                       outlier_passthru=True):
+def piecewise_linear_inverse_transform(y, q_tilde, compute_jacobian=True, outlier_passthru=True):
     """
     Apply inverse of an element-wise piecewise-linear transformation to some
     variables
@@ -137,10 +133,10 @@ def piecewise_linear_inverse_transform(y, q_tilde, compute_jacobian=True,
     Ny, ky = y.shape
     assert N == Ny and k == ky, "Shape mismatch"
 
-    w = 1. / b
+    w = 1.0 / b
 
     # Compute normalized bin heights with softmax function on the bin dimension
-    q = 1. / w * third_dimension_softmax(q_tilde)
+    q = 1.0 / w * third_dimension_softmax(q_tilde)
 
     # Compute the integral over the left-bins in the forward transform.
     # 1. Compute all integrals: cumulative sum of bin height * bin weight.
@@ -158,7 +154,7 @@ def piecewise_linear_inverse_transform(y, q_tilde, compute_jacobian=True,
     # so that their difference is at most 1.
     # By setting the negative values to 2., we know that the
     # smallest value left is the smallest positive
-    edges[edges < 0] = 2.
+    edges[edges < 0] = 2.0
     edges = torch.clamp(torch.argmin(edges, dim=2), 0, b - 1).to(torch.long)
 
     # Need special error handling because trying to index with mx
@@ -179,25 +175,21 @@ def piecewise_linear_inverse_transform(y, q_tilde, compute_jacobian=True,
     # Regularization: points must be strictly within the unit hypercube
     # Use the dtype information from pytorch
     eps = torch.finfo(x.dtype).eps
-    x = x.clamp(
-        min=eps,
-        max=1. - eps
-    )
-    oob_mask = torch.logical_or(y < 0.0, y >1.0).detach().float()
+    x = x.clamp(min=eps, max=1.0 - eps)
+    oob_mask = torch.logical_or(y < 0.0, y > 1.0).detach().float()
     if outlier_passthru:
-        x = x * (1-oob_mask) + y * oob_mask
-        q = q * (1-oob_mask) + oob_mask
+        x = x * (1 - oob_mask) + y * oob_mask
+        q = q * (1 - oob_mask) + oob_mask
 
     # Prepare the jacobian
     logj = None
     if compute_jacobian:
-        #logj = - torch.log(torch.prod(q, 1))
+        # logj = - torch.log(torch.prod(q, 1))
         logj = -torch.sum(torch.log(q.float()), 1)
     return x.detach(), logj
 
 
-def unbounded_piecewise_quadratic_transform(x, w_tilde, v_tilde, upper=1,
-                                            lower=0, inverse=False):
+def unbounded_piecewise_quadratic_transform(x, w_tilde, v_tilde, upper=1, lower=0, inverse=False):
     assert upper > lower
     _range = upper - lower
     inside_interval_mask = (x >= lower) & (x < upper)
@@ -213,7 +205,8 @@ def unbounded_piecewise_quadratic_transform(x, w_tilde, v_tilde, upper=1,
         (x[inside_interval_mask] - lower) / _range,
         w_tilde[inside_interval_mask, :],
         v_tilde[inside_interval_mask, :],
-        inverse=inverse)
+        inverse=inverse,
+    )
     outputs[inside_interval_mask] = output * _range + lower
     if not inverse:
         # the before and after transformation cancel out, so the log_j would be just as it is.
@@ -222,12 +215,14 @@ def unbounded_piecewise_quadratic_transform(x, w_tilde, v_tilde, upper=1,
         log_j = None
     return outputs, log_j
 
+
 def weighted_softmax(v, w):
     # to avoid NaN...
     v = v - torch.max(v, dim=-1, keepdim=True)[0]
-    v = torch.exp(v) + 1e-8 # to avoid NaN...
+    v = torch.exp(v) + 1e-8  # to avoid NaN...
     v_sum = torch.sum((v[..., :-1] + v[..., 1:]) / 2 * w, dim=-1, keepdim=True)
     return v / v_sum
+
 
 def piecewise_quadratic_transform(x, w_tilde, v_tilde, inverse=False):
     """Element-wise piecewise-quadratic transformation
@@ -252,12 +247,12 @@ def piecewise_quadratic_transform(x, w_tilde, v_tilde, inverse=False):
     v = weighted_softmax(v_tilde, w)
     w_cumsum = torch.cumsum(w, dim=-1)
     # force sum = 1
-    w_cumsum[..., -1] = 1.
-    w_cumsum_shift = F.pad(w_cumsum, (1,0), 'constant', 0)
+    w_cumsum[..., -1] = 1.0
+    w_cumsum_shift = F.pad(w_cumsum, (1, 0), 'constant', 0)
     cdf = torch.cumsum((v[..., 1:] + v[..., :-1]) / 2 * w, dim=-1)
     # force sum = 1
-    cdf[..., -1] = 1.
-    cdf_shift = F.pad(cdf, (1,0), 'constant', 0)
+    cdf[..., -1] = 1.0
+    cdf_shift = F.pad(cdf, (1, 0), 'constant', 0)
 
     if not inverse:
         # * x D x 1, (w_cumsum[idx-1] < x <= w_cumsum[idx])
@@ -280,7 +275,7 @@ def piecewise_quadratic_transform(x, w_tilde, v_tilde, inverse=False):
         log_j = torch.lerp(v_b, v_bp1, alpha).clamp(min=torch.finfo(c.dtype).eps).log()
 
         # make sure it falls into [0,1)
-        c = c.clamp(min=torch.finfo(c.dtype).eps, max=1. - torch.finfo(c.dtype).eps)
+        c = c.clamp(min=torch.finfo(c.dtype).eps, max=1.0 - torch.finfo(c.dtype).eps)
         return c, log_j
     else:
         # quadratic equation for alpha
@@ -289,9 +284,9 @@ def piecewise_quadratic_transform(x, w_tilde, v_tilde, inverse=False):
         a = (v_bp1 - v_b) * w_b / 2
         b = v_b * w_b
         c = cdf_bn1 - x
-        alpha = (-b + torch.sqrt((b**2) - 4 * a * c)) / (2 * a)
+        alpha = (-b + torch.sqrt((b ** 2) - 4 * a * c)) / (2 * a)
         inv = alpha * w_b + w_bn1
 
         # make sure it falls into [0,1)
-        inv = inv.clamp(min=torch.finfo(c.dtype).eps, max=1. - torch.finfo(inv.dtype).eps)
+        inv = inv.clamp(min=torch.finfo(c.dtype).eps, max=1.0 - torch.finfo(inv.dtype).eps)
         return inv, None

--- a/nemo/collections/tts/losses/radttsloss.py
+++ b/nemo/collections/tts/losses/radttsloss.py
@@ -17,11 +17,11 @@
 import torch
 import torch.nn as nn
 from torch.nn import functional as F
+
 from nemo.collections.tts.helpers.common import get_mask_from_lengths
 
 
-def compute_flow_loss(z, log_det_W_list, log_s_list, n_elements, n_dims, mask,
-                     sigma=1.0):
+def compute_flow_loss(z, log_det_W_list, log_s_list, n_elements, n_dims, mask, sigma=1.0):
 
     log_det_W_total = 0.0
     for i, log_s in enumerate(log_s_list):
@@ -38,7 +38,7 @@ def compute_flow_loss(z, log_det_W_list, log_s_list, n_elements, n_dims, mask,
         log_det_W_total *= n_elements
 
     z = z * mask
-    prior_NLL = torch.sum(z*z)/(2*sigma*sigma)
+    prior_NLL = torch.sum(z * z) / (2 * sigma * sigma)
 
     loss = prior_NLL - log_s_total - log_det_W_total
 
@@ -87,14 +87,20 @@ class AttributePredictionLoss(torch.nn.Module):
             n_dims = model_output['z'].size(1)
 
             loss, loss_prior = compute_flow_loss(
-                model_output['z'], model_output['log_det_W_list'],
-                model_output['log_s_list'], n_elements, n_dims, mask,
-                self.sigma)
-            loss_dict = {"loss_{}".format(self.name): (loss, self.loss_weight),
-                         "loss_prior_{}".format(self.name): (loss_prior, 0.0)}
+                model_output['z'],
+                model_output['log_det_W_list'],
+                model_output['log_s_list'],
+                n_elements,
+                n_dims,
+                mask,
+                self.sigma,
+            )
+            loss_dict = {
+                "loss_{}".format(self.name): (loss, self.loss_weight),
+                "loss_prior_{}".format(self.name): (loss_prior, 0.0),
+            }
         elif 'x_hat' in model_output:
-            loss_dict = compute_regression_loss(
-                    model_output['x_hat'], model_output['x'], mask, self.name)
+            loss_dict = compute_regression_loss(model_output['x_hat'], model_output['x'], mask, self.name)
             for k, v in loss_dict.items():
                 loss_dict[k] = (v, self.loss_weight)
 
@@ -114,20 +120,20 @@ class AttentionCTCLoss(torch.nn.Module):
     def forward(self, attn_logprob, in_lens, out_lens):
         key_lens = in_lens
         query_lens = out_lens
-        attn_logprob_padded = F.pad(
-            input=attn_logprob, pad=(1, 0, 0, 0, 0, 0, 0, 0),
-            value=self.blank_logprob)
+        attn_logprob_padded = F.pad(input=attn_logprob, pad=(1, 0, 0, 0, 0, 0, 0, 0), value=self.blank_logprob)
         cost_total = 0.0
         for bid in range(attn_logprob.shape[0]):
-            target_seq = torch.arange(1, key_lens[bid]+1).unsqueeze(0)
-            curr_logprob = attn_logprob_padded[bid].permute(1, 0, 2)[
-                :query_lens[bid], :, :key_lens[bid]+1]
+            target_seq = torch.arange(1, key_lens[bid] + 1).unsqueeze(0)
+            curr_logprob = attn_logprob_padded[bid].permute(1, 0, 2)[: query_lens[bid], :, : key_lens[bid] + 1]
             curr_logprob = self.log_softmax(curr_logprob[None])[0]
-            ctc_cost = self.CTCLoss(curr_logprob, target_seq,
-                                    input_lengths=query_lens[bid:bid+1],
-                                    target_lengths=key_lens[bid:bid+1])
+            ctc_cost = self.CTCLoss(
+                curr_logprob,
+                target_seq,
+                input_lengths=query_lens[bid : bid + 1],
+                target_lengths=key_lens[bid : bid + 1],
+            )
             cost_total += ctc_cost
-        cost = cost_total/attn_logprob.shape[0]
+        cost = cost_total / attn_logprob.shape[0]
         return cost
 
 
@@ -141,9 +147,16 @@ class AttentionBinarizationLoss(torch.nn.Module):
 
 
 class RADTTSLoss(torch.nn.Module):
-    def __init__(self, sigma=1.0, n_group_size=1, dur_model_config=None,
-                 f0_model_config=None, energy_model_config=None,
-                 vpred_model_config=None, loss_weights=None):
+    def __init__(
+        self,
+        sigma=1.0,
+        n_group_size=1,
+        dur_model_config=None,
+        f0_model_config=None,
+        energy_model_config=None,
+        vpred_model_config=None,
+        loss_weights=None,
+    ):
         super(RADTTSLoss, self).__init__()
         self.sigma = sigma
         self.n_group_size = n_group_size
@@ -153,21 +166,23 @@ class RADTTSLoss(torch.nn.Module):
         self.loss_fns = {}
         if dur_model_config is not None:
             self.loss_fns['duration_model_outputs'] = AttributePredictionLoss(
-                'duration', dur_model_config, loss_weights['dur_loss_weight'])
+                'duration', dur_model_config, loss_weights['dur_loss_weight']
+            )
 
         if f0_model_config is not None:
             self.loss_fns['f0_model_outputs'] = AttributePredictionLoss(
-                'f0', f0_model_config, loss_weights['f0_loss_weight'],
-                sigma=1.0)
+                'f0', f0_model_config, loss_weights['f0_loss_weight'], sigma=1.0
+            )
 
         if energy_model_config is not None:
             self.loss_fns['energy_model_outputs'] = AttributePredictionLoss(
-                'energy',
-                energy_model_config, loss_weights['energy_loss_weight'])
+                'energy', energy_model_config, loss_weights['energy_loss_weight']
+            )
 
         if vpred_model_config is not None:
             self.loss_fns['vpred_model_outputs'] = AttributePredictionLoss(
-                'vpred', vpred_model_config, loss_weights['vpred_loss_weight'])
+                'vpred', vpred_model_config, loss_weights['vpred_loss_weight']
+            )
 
     def forward(self, model_output, in_lens, out_lens):
         loss_dict = {}
@@ -177,16 +192,19 @@ class RADTTSLoss(torch.nn.Module):
             mask = mask[:, None].float()
             n_dims = model_output['z_mel'].size(1)
             loss_mel, loss_prior_mel = compute_flow_loss(
-                model_output['z_mel'], model_output['log_det_W_list'],
-                model_output['log_s_list'], n_elements, n_dims, mask,
-                self.sigma)
+                model_output['z_mel'],
+                model_output['log_det_W_list'],
+                model_output['log_s_list'],
+                n_elements,
+                n_dims,
+                mask,
+                self.sigma,
+            )
             loss_dict['loss_mel'] = (loss_mel, 1.0)  # loss, weight
             loss_dict['loss_prior_mel'] = (loss_prior_mel, 0.0)
 
-        ctc_cost = self.attn_ctc_loss(
-            model_output['attn_logprob'], in_lens, out_lens)
-        loss_dict['loss_ctc'] = (
-            ctc_cost, self.loss_weights['ctc_loss_weight'])
+        ctc_cost = self.attn_ctc_loss(model_output['attn_logprob'], in_lens, out_lens)
+        loss_dict['loss_ctc'] = (ctc_cost, self.loss_weights['ctc_loss_weight'])
 
         for k in model_output:
             if k in self.loss_fns:

--- a/nemo/collections/tts/losses/radttsloss.py
+++ b/nemo/collections/tts/losses/radttsloss.py
@@ -1,0 +1,199 @@
+###############################################################################
+#
+#  Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###############################################################################
+import torch
+import torch.nn as nn
+from torch.nn import functional as F
+from nemo.collections.tts.helpers.common import get_mask_from_lengths
+
+
+def compute_flow_loss(z, log_det_W_list, log_s_list, n_elements, n_dims, mask,
+                     sigma=1.0):
+
+    log_det_W_total = 0.0
+    for i, log_s in enumerate(log_s_list):
+        if i == 0:
+            log_s_total = torch.sum(log_s * mask)
+            if len(log_det_W_list):
+                log_det_W_total = log_det_W_list[i]
+        else:
+            log_s_total = log_s_total + torch.sum(log_s * mask)
+            if len(log_det_W_list):
+                log_det_W_total += log_det_W_list[i]
+
+    if len(log_det_W_list):
+        log_det_W_total *= n_elements
+
+    z = z * mask
+    prior_NLL = torch.sum(z*z)/(2*sigma*sigma)
+
+    loss = prior_NLL - log_s_total - log_det_W_total
+
+    denom = n_elements * n_dims
+    loss = loss / denom
+    loss_prior = prior_NLL / denom
+    return loss, loss_prior
+
+
+def compute_regression_loss(x_hat, x, mask, name=False):
+    x = x[:, None] if len(x.shape) == 2 else x  # add channel dim
+    mask = mask[:, None] if len(mask.shape) == 2 else mask  # add channel dim
+    assert len(x.shape) == len(mask.shape)
+
+    x = x * mask
+    x_hat = x_hat * mask
+
+    if name == 'vpred':
+        loss = F.binary_cross_entropy_with_logits(x_hat, x, reduction='sum')
+    else:
+        loss = F.mse_loss(x_hat, x, reduction='sum')
+    loss = loss / mask.sum()
+
+    loss_dict = {"loss_{}".format(name): loss}
+
+    return loss_dict
+
+
+class AttributePredictionLoss(torch.nn.Module):
+    def __init__(self, name, model_config, loss_weight, sigma=1.0):
+        super(AttributePredictionLoss, self).__init__()
+        self.name = name
+        self.sigma = sigma
+        self.model_name = model_config['name']
+        self.loss_weight = loss_weight
+        self.n_group_size = 1
+        if 'n_group_size' in model_config['hparams']:
+            self.n_group_size = model_config['hparams']['n_group_size']
+
+    def forward(self, model_output, lens):
+        mask = get_mask_from_lengths(lens // self.n_group_size)
+        mask = mask[:, None].float()
+        loss_dict = {}
+        if 'z' in model_output:
+            n_elements = lens.sum() // self.n_group_size
+            n_dims = model_output['z'].size(1)
+
+            loss, loss_prior = compute_flow_loss(
+                model_output['z'], model_output['log_det_W_list'],
+                model_output['log_s_list'], n_elements, n_dims, mask,
+                self.sigma)
+            loss_dict = {"loss_{}".format(self.name): (loss, self.loss_weight),
+                         "loss_prior_{}".format(self.name): (loss_prior, 0.0)}
+        elif 'x_hat' in model_output:
+            loss_dict = compute_regression_loss(
+                    model_output['x_hat'], model_output['x'], mask, self.name)
+            for k, v in loss_dict.items():
+                loss_dict[k] = (v, self.loss_weight)
+
+        if len(loss_dict) == 0:
+            raise Exception("loss not supported")
+
+        return loss_dict
+
+
+class AttentionCTCLoss(torch.nn.Module):
+    def __init__(self, blank_logprob=-1):
+        super(AttentionCTCLoss, self).__init__()
+        self.log_softmax = torch.nn.LogSoftmax(dim=3)
+        self.blank_logprob = blank_logprob
+        self.CTCLoss = nn.CTCLoss(zero_infinity=True)
+
+    def forward(self, attn_logprob, in_lens, out_lens):
+        key_lens = in_lens
+        query_lens = out_lens
+        attn_logprob_padded = F.pad(
+            input=attn_logprob, pad=(1, 0, 0, 0, 0, 0, 0, 0),
+            value=self.blank_logprob)
+        cost_total = 0.0
+        for bid in range(attn_logprob.shape[0]):
+            target_seq = torch.arange(1, key_lens[bid]+1).unsqueeze(0)
+            curr_logprob = attn_logprob_padded[bid].permute(1, 0, 2)[
+                :query_lens[bid], :, :key_lens[bid]+1]
+            curr_logprob = self.log_softmax(curr_logprob[None])[0]
+            ctc_cost = self.CTCLoss(curr_logprob, target_seq,
+                                    input_lengths=query_lens[bid:bid+1],
+                                    target_lengths=key_lens[bid:bid+1])
+            cost_total += ctc_cost
+        cost = cost_total/attn_logprob.shape[0]
+        return cost
+
+
+class AttentionBinarizationLoss(torch.nn.Module):
+    def __init__(self):
+        super(AttentionBinarizationLoss, self).__init__()
+
+    def forward(self, hard_attention, soft_attention):
+        log_sum = torch.log(soft_attention[hard_attention == 1]).sum()
+        return -log_sum / hard_attention.sum()
+
+
+class RADTTSLoss(torch.nn.Module):
+    def __init__(self, sigma=1.0, n_group_size=1, dur_model_config=None,
+                 f0_model_config=None, energy_model_config=None,
+                 vpred_model_config=None, loss_weights=None):
+        super(RADTTSLoss, self).__init__()
+        self.sigma = sigma
+        self.n_group_size = n_group_size
+        self.loss_weights = loss_weights
+        self.attn_ctc_loss = AttentionCTCLoss()
+        self.loss_weights = loss_weights
+        self.loss_fns = {}
+        if dur_model_config is not None:
+            self.loss_fns['duration_model_outputs'] = AttributePredictionLoss(
+                'duration', dur_model_config, loss_weights['dur_loss_weight'])
+
+        if f0_model_config is not None:
+            self.loss_fns['f0_model_outputs'] = AttributePredictionLoss(
+                'f0', f0_model_config, loss_weights['f0_loss_weight'],
+                sigma=1.0)
+
+        if energy_model_config is not None:
+            self.loss_fns['energy_model_outputs'] = AttributePredictionLoss(
+                'energy',
+                energy_model_config, loss_weights['energy_loss_weight'])
+
+        if vpred_model_config is not None:
+            self.loss_fns['vpred_model_outputs'] = AttributePredictionLoss(
+                'vpred', vpred_model_config, loss_weights['vpred_loss_weight'])
+
+    def forward(self, model_output, in_lens, out_lens):
+        loss_dict = {}
+        if len(model_output['z_mel']):
+            n_elements = out_lens.sum() // self.n_group_size
+            mask = get_mask_from_lengths(out_lens // self.n_group_size)
+            mask = mask[:, None].float()
+            n_dims = model_output['z_mel'].size(1)
+            loss_mel, loss_prior_mel = compute_flow_loss(
+                model_output['z_mel'], model_output['log_det_W_list'],
+                model_output['log_s_list'], n_elements, n_dims, mask,
+                self.sigma)
+            loss_dict['loss_mel'] = (loss_mel, 1.0)  # loss, weight
+            loss_dict['loss_prior_mel'] = (loss_prior_mel, 0.0)
+
+        ctc_cost = self.attn_ctc_loss(
+            model_output['attn_logprob'], in_lens, out_lens)
+        loss_dict['loss_ctc'] = (
+            ctc_cost, self.loss_weights['ctc_loss_weight'])
+
+        for k in model_output:
+            if k in self.loss_fns:
+                if model_output[k] is not None and len(model_output[k]) > 0:
+                    t_lens = in_lens if 'dur' in k else out_lens
+                    mout = model_output[k]
+                    for loss_name, v in self.loss_fns[k](mout, t_lens).items():
+                        loss_dict[loss_name] = v
+
+        return loss_dict

--- a/nemo/collections/tts/models/radtts.py
+++ b/nemo/collections/tts/models/radtts.py
@@ -1,0 +1,385 @@
+###########################################################################
+#
+#  Copyright (c) 2020, NVIDIA CORPORATION. All rights reserved.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+# ##########################################################################
+# import argparse
+import os
+import torch
+from torch.utils.data import DataLoader
+from torch.cuda import amp
+from nemo.collections.tts.losses.radttsloss import RADTTSLoss
+from nemo.collections.tts.losses.radttsloss import AttentionBinarizationLoss
+from nemo.collections.tts.modules.radtts import RadTTSModule
+from nemo.collections.tts.modules.alignment import plot_alignment_to_numpy
+from nemo.collections.tts.helpers.helpers import plot_spectrogram_to_numpy
+
+from nemo.collections.tts.helpers.radam import RAdam
+from timeit import default_timer as timer
+import hashlib
+from nemo.collections.tts.torch.tts_tokenizers import BaseTokenizer, EnglishCharsTokenizer, EnglishPhonemesTokenizer
+
+from torch.optim.lr_scheduler import ExponentialLR, CosineAnnealingWarmRestarts
+from torch.optim.lr_scheduler import ReduceLROnPlateau, StepLR
+import pytorch_lightning as pl
+from nemo.collections.tts.models.base import SpectrogramGenerator
+from hydra.utils import instantiate
+from omegaconf import MISSING, DictConfig, OmegaConf, open_dict
+from pytorch_lightning import Trainer
+from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
+from nemo.collections.asr.data.audio_to_text import AudioToCharWithDursF0Dataset
+from nemo.core.classes import Exportable
+from nemo.utils import logging
+torch.cuda.empty_cache()
+
+
+class RadTTSModel(SpectrogramGenerator, Exportable):
+    def __init__(self, cfg: DictConfig, trainer: Trainer = None):
+        if isinstance(cfg, dict):
+            cfg = OmegaConf.create(cfg)
+        
+        self._setup_tokenizer(cfg.validation_ds.dataset)
+        
+        assert self.tokenizer is not None
+
+        num_tokens = len(self.tokenizer.tokens)
+        self.tokenizer_pad = self.tokenizer.pad
+        self.tokenizer_unk = self.tokenizer.oov
+        
+        self.text_tokenizer_pad_id = None
+        self.tokens = None
+        
+        super().__init__(cfg=cfg, trainer=trainer)
+        self.feat_loss_weight = 1.0
+        self.model_config = cfg.modelConfig
+        self.train_config = cfg.trainerConfig
+        self.optim = cfg.optim
+        self.criterion = RADTTSLoss(self.train_config.sigma,self.model_config.n_group_size,
+                                      self.model_config.dur_model_config, self.model_config.f0_model_config,
+                                      self.model_config.energy_model_config,
+                                      vpred_model_config=self.model_config.v_model_config,
+                                      loss_weights=self.train_config.loss_weights)
+        
+        self.attention_kl_loss = AttentionBinarizationLoss()
+        self.model = instantiate(cfg.modelConfig)
+        self._parser = None
+        self._tb_logger = None
+        self.cfg = cfg
+        self.log_train_images = False
+    def batch_dict(self, batch_data):
+        batch_data_dict = {
+            "audio": batch_data[0],
+            "audio_lens": batch_data[1],
+            "text": batch_data[2],
+            "text_lens": batch_data[3],
+            "log_mel": batch_data[4],
+            "log_mel_lens": batch_data[5],
+            "align_prior_matrix": batch_data[6],
+            "pitch": batch_data[7],
+            "pitch_lens":batch_data[8],
+            "voiced_mask": batch_data[9],
+            "p_voiced": batch_data[10],
+            "energy": batch_data[11],
+            "energy_lens":batch_data[12],}
+            #"speaker_id": batch_data[13],}
+        return batch_data_dict
+    
+    def forward(self, batch):
+        batch = self.batch_dict(batch)
+        mel = batch['log_mel']
+        speaker_ids = batch['speaker_id']
+        text = batch['text']
+        in_lens = batch['text_lens']
+        out_lens = batch['log_mel_lens']
+        attn_prior = batch['align_prior_matrix']
+        aug_idxs = None
+        f0 = batch['pitch']
+        voiced_mask = batch['voiced_mask']
+        p_voiced = batch['p_voiced']
+        energy_avg = batch['energy']
+        if self.train_config.binarization_start_iter >= 0 and self.global_step >= self.train_config.binarization_start_iter:
+            # binarization training phase
+            binarize = True
+        else:
+            # no binarization, soft-only
+            binarize = False
+        
+        return self.model(mel=mel, speaker_ids=speaker_ids , text=text, in_lens =in_lens, out_lens=out_lens,
+            binarize_attention=binarize, attn_prior=attn_prior,
+            aug_idxs=aug_idxs, f0=f0, energy_avg=energy_avg,
+            voiced_mask=voiced_mask, p_voiced=p_voiced)
+    
+    def training_step(self, batch, batch_idx):
+        batch = self.batch_dict(batch)
+        mel = batch['log_mel']
+        speaker_ids = speaker_ids = torch.tensor([0]*(batch['text']).size(0)).cuda().to(self.device)#batch['speaker_id'] single speaker for now
+        text = batch['text']#batch['lm_token']
+        in_lens = batch['text_lens']
+        out_lens = batch['log_mel_lens']
+        attn_prior = batch['align_prior_matrix']
+        aug_idxs = None
+        f0 = batch['pitch']
+        voiced_mask = batch['voiced_mask']
+        p_voiced = batch['p_voiced']
+        energy_avg = batch['energy']
+                       
+        if self.train_config.binarization_start_iter >= 0 and self.global_step >= self.train_config.binarization_start_iter:
+            # binarization training phase
+            binarize = True
+        else:
+            # no binarization, soft-only
+            binarize = False
+    
+        outputs = self.model(
+            mel, speaker_ids, text, in_lens, out_lens,
+            binarize_attention=binarize, attn_prior=attn_prior,
+           f0=f0, energy_avg=energy_avg,
+            voiced_mask=voiced_mask, p_voiced=p_voiced)
+        loss_outputs = self.criterion(outputs, in_lens, out_lens)
+        
+        loss = None
+        for k, (v, w) in loss_outputs.items():
+            if w > 0:
+                loss = v * w if loss is None else loss + v * w
+
+        
+        if binarize  and self.global_step >= self.train_config.kl_loss_start_iter:
+            binarization_loss = self.attention_kl_loss(
+                outputs['attn'], outputs['attn_soft'])
+            loss += binarization_loss
+        else:
+            binarization_loss = torch.zeros_like(loss)
+        loss_outputs['binarization_loss'] = (binarization_loss, 1.0)
+        
+        for k, (v, w) in loss_outputs.items():
+            self.log("train/"+k, loss_outputs[k][0])
+        
+        return {'loss': loss}
+    
+    def validation_step(self, batch, batch_idx):
+        batch = self.batch_dict(batch)
+        speaker_ids = torch.tensor([0]*(batch['text']).size(0)).cuda().to(self.device)#batch['speaker_id'] single speaker for now
+        text = batch['text']#batch['text']
+        in_lens = batch['text_lens']
+        out_lens = batch['log_mel_lens']
+        attn_prior = batch['align_prior_matrix']
+        aug_idxs = None
+        f0 = batch['pitch']
+        voiced_mask = batch['voiced_mask']
+        p_voiced = batch['p_voiced']
+        energy_avg = batch['energy']
+        mel = batch['log_mel']
+        if self.train_config.binarization_start_iter >= 0 and self.global_step >= self.train_config.binarization_start_iter:
+            # binarization training phase
+            binarize = True
+        else:
+            # no binarization, soft-only
+            binarize = False
+        outputs = self.model(
+            mel, speaker_ids, text, in_lens, out_lens,
+            binarize_attention=True, attn_prior=attn_prior,
+            f0=f0, energy_avg=energy_avg,
+            voiced_mask=voiced_mask, p_voiced=p_voiced)
+        loss_outputs = self.criterion(outputs, in_lens, out_lens)
+        
+        loss = None
+        for k, (v, w) in loss_outputs.items():
+            if w > 0:
+                loss = v * w if loss is None else loss + v * w
+
+       
+    
+        if binarize and self.train_config.kl_loss_start_iter >= 0 and self.global_step >= self.train_config.kl_loss_start_iter:
+            binarization_loss = self.attention_kl_loss(
+                outputs['attn'], outputs['attn_soft'])
+            loss += binarization_loss
+        else:
+            binarization_loss = torch.zeros_like(loss)
+        loss_outputs['binarization_loss'] = binarization_loss
+        
+        return {"loss_outputs":loss_outputs,
+                "attn": outputs["attn"] if batch_idx == 0 else None,
+                "attn_soft": outputs["attn_soft"] if batch_idx == 0 else None,
+                "audiopaths": "audio_1" if batch_idx == 0 else None,}
+        
+    def validation_epoch_end(self, outputs):
+
+        loss_outputs = outputs[0]["loss_outputs"]
+
+        for k, v in loss_outputs.items():
+            if k!="binarization_loss":
+                self.log("val/"+k, loss_outputs[k][0])
+                
+        attn = outputs[0]["attn"]
+        attn_soft = outputs[0]["attn_soft"]
+        
+        
+        self.tb_logger.add_image(
+            'attention_weights_mas',plot_alignment_to_numpy(attn[0, 0].data.cpu().numpy().T, title="audio"), self.global_step, dataformats='HWC')
+        
+
+        
+        self.tb_logger.add_image(
+            'attention_weights',plot_alignment_to_numpy(attn_soft[0, 0].data.cpu().numpy().T, title="audio"), self.global_step, dataformats='HWC')
+        
+        self.log_train_images = True
+        
+    
+    def configure_optimizers(self):
+        logging.info("Initializing %s optimizer" % (self.optim.name))
+        if len(self.train_config.finetune_layers):
+            for name, param in model.named_parameters():
+                if any([l in name for l in self.train_config.finetune_layers]):  # short list hack
+                    logging.info("Fine-tuning parameter", name)
+                    param.requires_grad = True
+                else:
+                    param.requires_grad = False
+        if self.optim.name == 'Adam':
+            optimizer = torch.optim.Adam(self.model.parameters(), lr=self.optim.lr,
+                                         weight_decay=self.optim.weight_decay)
+        elif self.optim.name == 'RAdam':
+            optimizer = RAdam(self.model.parameters(), lr=self.optim.lr,
+                              weight_decay=self.optim.weight_decay)
+        else:
+            logging.info("Unrecognized optimizer %s!" % (self.optim.name))
+            exit(1)
+    
+        if self.optim.sched.name == 'cosine':
+            # keeping init restart at epoch = 2
+            # operate at iteration level instead of epoch level.
+            restart_iteration = 1500
+            lr_scheduler = CosineAnnealingWarmRestarts(
+                optimizer, T_0=restart_iteration, T_mult=2, eta_min=1e-5)
+    
+        elif self.optim.sched.name == 'exp_decay':
+            # Decays at epoch level, 10k steps / epoch
+            # gamma = Multiplicative factor of learning rate decay.
+            # Set gamma st starting at 0.0035 lr, ending at 1e-5 in 50k steps
+            # Setting gamma using equation: 0.0035 * gamma ^ 50000 = 1e-5
+            lr_scheduler = ExponentialLR(optimizer, gamma=0.99)
+        elif self.optim.sched.name == 'red_on_plateau':
+            lr_scheduler = ReduceLROnPlateau(optimizer)
+        elif self.optim.sched.name == 'step_decay':
+            # have to explicitly set the init lr.
+            for param_group in optimizer.param_groups:
+                param_group['lr'] = self.optim.sched.name
+                param_group['initial_lr'] = self.optim.sched.name
+            if self.train_config.scheduler_start_iteration > 1:
+                max_decay_steps = self.train_config.scheduler_start_iteration
+            else:
+                max_decay_steps = 100000
+            # decay every 500 steps, calculated gamma using eq: 0.0035 * gamma ^ 50k = 1e-5
+            lr_scheduler = StepLR(
+                optimizer, step_size=500, gamma=0.99, last_epoch=max_decay_steps)
+        else:
+            lr_scheduler = None
+            # force set the learning rate to what is specified
+            for param_group in optimizer.param_groups:
+                param_group['lr'] = self.optim.lr
+    
+        return optimizer
+
+    @staticmethod
+    def _loader(cfg):
+        try:
+            _ = cfg.dataset.manifest_filepath
+        except omegaconf.errors.MissingMandatoryValue:
+            logging.warning("manifest_filepath was skipped. No dataset for this model.")
+            return None
+
+        dataset = instantiate(cfg.dataset)
+        return torch.utils.data.DataLoader(  # noqa
+            dataset=dataset, collate_fn=dataset.collate_fn, **cfg.dataloader_params,
+        )
+
+    def setup_training_data(self, cfg):
+        self._train_dl = self._loader(cfg)
+
+    def setup_validation_data(self, cfg):
+        self._validation_dl = self._loader(cfg)
+
+    def setup_test_data(self, cfg):
+        """Omitted."""
+        pass
+   
+   def generate_spectrogram(self, tokens: 'torch.tensor', speaker: int = 0, sigma: float = 1.0) -> torch.tensor:
+        self.eval()
+        #s = [0]
+        if self.training:
+            logging.warning("generate_spectrogram() is meant to be called in eval mode.")
+        speaker = torch.tensor([speaker]).long().cuda().to(self.device)
+        outputs = self.model.infer(
+                speaker, tokens, sigma=sigma)
+
+        spect = outputs['mel']
+        return spect
+
+    
+    @property
+    def parser(self):
+        if self._parser is not None:
+            return self._parser
+        return self._parser
+    
+    def _setup_tokenizer(self, cfg):
+        text_tokenizer_kwargs = {}
+        if "g2p" in cfg.text_tokenizer:
+            g2p_kwargs = {}
+
+            if "phoneme_dict" in cfg.text_tokenizer.g2p:
+                g2p_kwargs["phoneme_dict"] = self.register_artifact(
+                    'text_tokenizer.g2p.phoneme_dict', cfg.text_tokenizer.g2p.phoneme_dict,
+                )
+
+            if "heteronyms" in cfg.text_tokenizer.g2p:
+                g2p_kwargs["heteronyms"] = self.register_artifact(
+                    'text_tokenizer.g2p.heteronyms', cfg.text_tokenizer.g2p.heteronyms,
+                )
+
+            text_tokenizer_kwargs["g2p"] = instantiate(cfg.text_tokenizer.g2p, **g2p_kwargs)
+
+        self.tokenizer = instantiate(cfg.text_tokenizer, **text_tokenizer_kwargs)
+        if isinstance(self.tokenizer, BaseTokenizer):
+            self.text_tokenizer_pad_id = self.tokenizer.pad
+            self.tokens = self.tokenizer.tokens
+        else:
+            if text_tokenizer_pad_id is None:
+                raise ValueError(f"text_tokenizer_pad_id must be specified if text_tokenizer is not BaseTokenizer")
+
+            if tokens is None:
+                raise ValueError(f"tokens must be specified if text_tokenizer is not BaseTokenizer")
+
+            self.text_tokenizer_pad_id = text_tokenizer_pad_id
+            self.tokens = tokens
+        
+    def parse(self, text: str, normalize=False) -> torch.Tensor:
+        if self.training:
+            logging.warning("parse() is meant to be called in eval mode.")
+        if normalize and self.text_normalizer_call is not None:
+            text = self.text_normalizer_call(text, **self.text_normalizer_call_kwargs)
+        return torch.tensor(self.tokenizer(text)).long().unsqueeze(0).cuda().to(self.device)
+    
+    @property
+    def tb_logger(self):
+        if self._tb_logger is None:
+            if self.logger is None and self.logger.experiment is None:
+                return None
+            tb_logger = self.logger.experiment
+            if isinstance(self.logger, LoggerCollection):
+                for logger in self.logger:
+                    if isinstance(logger, TensorBoardLogger):
+                        tb_logger = logger.experiment
+                        break
+            self._tb_logger = tb_logger
+        return self._tb_logger

--- a/nemo/collections/tts/models/radtts.py
+++ b/nemo/collections/tts/models/radtts.py
@@ -313,7 +313,7 @@ class RadTTSModel(SpectrogramGenerator, Exportable):
         """Omitted."""
         pass
    
-   def generate_spectrogram(self, tokens: 'torch.tensor', speaker: int = 0, sigma: float = 1.0) -> torch.tensor:
+    def generate_spectrogram(self, tokens: 'torch.tensor', speaker: int = 0, sigma: float = 1.0) -> torch.tensor:
         self.eval()
         #s = [0]
         if self.training:

--- a/nemo/collections/tts/modules/alignment.py
+++ b/nemo/collections/tts/modules/alignment.py
@@ -1,0 +1,83 @@
+import sys
+import numpy as np
+from matplotlib import pylab as plt
+from numba import jit
+
+def save_figure_to_numpy(fig):
+    # save it to a numpy array.
+    data = np.fromstring(fig.canvas.tostring_rgb(), dtype=np.uint8, sep='')
+    data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    return data
+
+
+def plot_alignment_to_numpy(alignment, title='', info=None, phoneme_seq=None,
+                            vmin=None, vmax=None):
+    if phoneme_seq:
+        fig, ax = plt.subplots(figsize=(15, 10))
+    else:
+        fig, ax = plt.subplots(figsize=(6, 4))
+    im = ax.imshow(alignment, aspect='auto', origin='lower',
+                   interpolation='none', vmin=vmin, vmax=vmax)
+    ax.set_title(title)
+    fig.colorbar(im, ax=ax)
+    xlabel = 'Decoder timestep'
+    if info is not None:
+        xlabel += '\n\n' + info
+    plt.xlabel(xlabel)
+    plt.ylabel('Encoder timestep')
+    plt.tight_layout()
+
+    if phoneme_seq != None:
+        # for debugging of phonemes and durs in maps. Not used by def in training code
+        ax.set_yticks(np.arange(len(phoneme_seq)))
+        ax.set_yticklabels(phoneme_seq)
+        ax.hlines(np.arange(len(phoneme_seq)), xmin=0.0, xmax=max(ax.get_xticks()))
+
+    fig.canvas.draw()
+    data = save_figure_to_numpy(fig)
+    plt.close()
+    return data
+
+
+
+
+def save_plot(fname, attn_map):
+    plt.imshow(attn_map)
+    plt.savefig(fname)
+
+@jit(nopython=True)
+def mas_width1(attn_map):
+    """mas with hardcoded width=1"""
+    # assumes mel x text
+    opt = np.zeros_like(attn_map)
+    attn_map = np.log(attn_map)
+    attn_map[0, 1:] = -np.inf
+    log_p = np.zeros_like(attn_map)
+    log_p[0, :] = attn_map[0, :]
+    prev_ind = np.zeros_like(attn_map, dtype=np.int64)
+    for i in range(1, attn_map.shape[0]):
+        for j in range(attn_map.shape[1]):  # for each text dim
+            prev_log = log_p[i-1, j]
+            prev_j = j
+
+            if j-1 >= 0 and log_p[i-1, j-1] >= log_p[i-1, j]:
+                prev_log = log_p[i-1, j-1]
+                prev_j = j-1
+
+            log_p[i, j] = attn_map[i, j] + prev_log
+            prev_ind[i, j] = prev_j
+
+    # now backtrack
+    curr_text_idx = attn_map.shape[1]-1
+    for i in range(attn_map.shape[0]-1, -1, -1):
+        opt[i, curr_text_idx] = 1
+        curr_text_idx = prev_ind[i, curr_text_idx]
+    opt[0, curr_text_idx] = 1
+    return opt
+
+if __name__ == '__main__':
+    attn_ = np.load(sys.argv[1])
+    attn = attn_.squeeze()
+    save_plot('orig.png', attn)
+    binarized = mas(attn)
+    save_plot('binarized.png', binarized)

--- a/nemo/collections/tts/modules/alignment.py
+++ b/nemo/collections/tts/modules/alignment.py
@@ -1,7 +1,9 @@
 import sys
+
 import numpy as np
 from matplotlib import pylab as plt
 from numba import jit
+
 
 def save_figure_to_numpy(fig):
     # save it to a numpy array.
@@ -10,14 +12,12 @@ def save_figure_to_numpy(fig):
     return data
 
 
-def plot_alignment_to_numpy(alignment, title='', info=None, phoneme_seq=None,
-                            vmin=None, vmax=None):
+def plot_alignment_to_numpy(alignment, title='', info=None, phoneme_seq=None, vmin=None, vmax=None):
     if phoneme_seq:
         fig, ax = plt.subplots(figsize=(15, 10))
     else:
         fig, ax = plt.subplots(figsize=(6, 4))
-    im = ax.imshow(alignment, aspect='auto', origin='lower',
-                   interpolation='none', vmin=vmin, vmax=vmax)
+    im = ax.imshow(alignment, aspect='auto', origin='lower', interpolation='none', vmin=vmin, vmax=vmax)
     ax.set_title(title)
     fig.colorbar(im, ax=ax)
     xlabel = 'Decoder timestep'
@@ -39,11 +39,10 @@ def plot_alignment_to_numpy(alignment, title='', info=None, phoneme_seq=None,
     return data
 
 
-
-
 def save_plot(fname, attn_map):
     plt.imshow(attn_map)
     plt.savefig(fname)
+
 
 @jit(nopython=True)
 def mas_width1(attn_map):
@@ -57,23 +56,24 @@ def mas_width1(attn_map):
     prev_ind = np.zeros_like(attn_map, dtype=np.int64)
     for i in range(1, attn_map.shape[0]):
         for j in range(attn_map.shape[1]):  # for each text dim
-            prev_log = log_p[i-1, j]
+            prev_log = log_p[i - 1, j]
             prev_j = j
 
-            if j-1 >= 0 and log_p[i-1, j-1] >= log_p[i-1, j]:
-                prev_log = log_p[i-1, j-1]
-                prev_j = j-1
+            if j - 1 >= 0 and log_p[i - 1, j - 1] >= log_p[i - 1, j]:
+                prev_log = log_p[i - 1, j - 1]
+                prev_j = j - 1
 
             log_p[i, j] = attn_map[i, j] + prev_log
             prev_ind[i, j] = prev_j
 
     # now backtrack
-    curr_text_idx = attn_map.shape[1]-1
-    for i in range(attn_map.shape[0]-1, -1, -1):
+    curr_text_idx = attn_map.shape[1] - 1
+    for i in range(attn_map.shape[0] - 1, -1, -1):
         opt[i, curr_text_idx] = 1
         curr_text_idx = prev_ind[i, curr_text_idx]
     opt[0, curr_text_idx] = 1
     return opt
+
 
 if __name__ == '__main__':
     attn_ = np.load(sys.argv[1])

--- a/nemo/collections/tts/modules/attribute_prediction_model.py
+++ b/nemo/collections/tts/modules/attribute_prediction_model.py
@@ -1,0 +1,95 @@
+import torch
+from torch import nn
+from torch.nn import functional as F
+
+from nemo.collections.tts.helpers.common import get_mask_from_lengths
+from nemo.collections.tts.helpers.common import ConvNorm, Invertible1x1Conv
+from nemo.collections.tts.helpers.common import AffineTransformationLayer, SplineTransformationLayer
+from nemo.collections.tts.helpers.common import ConvLSTMLinear
+from nemo.collections.tts.modules.autoregressive_flow import AR_Step, AR_Back_Step
+
+
+def get_attribute_prediction_model(config):
+    name = config['name']
+    hparams = config['hparams']
+    if name == 'dap':
+        model = DAP(**hparams)
+    else:
+        raise Exception("{} model is not supported".format(name))
+
+    return model
+
+
+class AttributeProcessing():
+    def __init__(self, take_log_of_input=False):
+        super(AttributeProcessing).__init__()
+        self.take_log_of_input = take_log_of_input
+
+    def normalize(self, x):
+        if self.take_log_of_input:
+            x = torch.log(x + 1)
+        return x
+
+    def denormalize(self, x):
+        if self.take_log_of_input:
+            x = torch.exp(x) - 1
+        return x
+
+
+class BottleneckLayerLayer(nn.Module):
+    def __init__(self, in_dim, reduction_factor, norm='weightnorm',
+                 non_linearity='relu', use_pconv=False):
+        super(BottleneckLayerLayer, self).__init__()
+
+        self.reduction_factor = reduction_factor
+        reduced_dim = int(in_dim / reduction_factor)
+        self.out_dim = reduced_dim
+        if self.reduction_factor > 1:
+            fn = ConvNorm(in_dim, reduced_dim, kernel_size=3)
+            if norm == 'weightnorm':
+                fn = torch.nn.utils.weight_norm(fn.conv, name='weight')
+            elif norm == 'instancenorm':
+                fn = nn.Sequential(
+                    fn, nn.InstanceNorm1d(reduced_dim, affine=True))
+
+            self.projection_fn = fn
+            self.non_linearity = non_linearity
+
+    def forward(self, x):
+        if self.reduction_factor > 1:
+            x = self.projection_fn(x)
+            if self.non_linearity == 'relu':
+                x = F.relu(x)
+            elif self.non_linearity == 'leakyrelu':
+                x = F.leaky_relu(x)
+        return x
+
+
+class DAP(nn.Module):
+    def __init__(self, n_speaker_dim, bottleneck_hparams, take_log_of_input,
+                 arch_hparams):
+        super(DAP, self).__init__()
+        self.attribute_processing = AttributeProcessing(take_log_of_input)
+        self.bottleneck_layer = BottleneckLayerLayer(**bottleneck_hparams)
+
+        arch_hparams['in_dim'] = self.bottleneck_layer.out_dim + n_speaker_dim
+        self.feat_pred_fn = ConvLSTMLinear(**arch_hparams)
+
+    def forward(self, txt_enc, spk_emb, x, lens):
+        if x is not None:
+            x = self.attribute_processing.normalize(x)
+
+        txt_enc = self.bottleneck_layer(txt_enc)
+        spk_emb_expanded = spk_emb[..., None].expand(-1, -1, txt_enc.shape[2])
+        context = torch.cat((txt_enc, spk_emb_expanded), 1)
+
+        x_hat = self.feat_pred_fn(context, lens)
+
+        outputs = {'x_hat': x_hat, 'x': x}
+        return outputs
+
+    def infer(self, z, txt_enc, spk_emb, lens=None):
+        x_hat = self.forward(txt_enc, spk_emb, x=None, lens=lens)['x_hat']
+        x_hat = self.attribute_processing.denormalize(x_hat)
+        return x_hat
+

--- a/nemo/collections/tts/modules/attribute_prediction_model.py
+++ b/nemo/collections/tts/modules/attribute_prediction_model.py
@@ -2,11 +2,15 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 
-from nemo.collections.tts.helpers.common import get_mask_from_lengths
-from nemo.collections.tts.helpers.common import ConvNorm, Invertible1x1Conv
-from nemo.collections.tts.helpers.common import AffineTransformationLayer, SplineTransformationLayer
-from nemo.collections.tts.helpers.common import ConvLSTMLinear
-from nemo.collections.tts.modules.autoregressive_flow import AR_Step, AR_Back_Step
+from nemo.collections.tts.helpers.common import (
+    AffineTransformationLayer,
+    ConvLSTMLinear,
+    ConvNorm,
+    Invertible1x1Conv,
+    SplineTransformationLayer,
+    get_mask_from_lengths,
+)
+from nemo.collections.tts.modules.autoregressive_flow import AR_Back_Step, AR_Step
 
 
 def get_attribute_prediction_model(config):
@@ -20,7 +24,7 @@ def get_attribute_prediction_model(config):
     return model
 
 
-class AttributeProcessing():
+class AttributeProcessing:
     def __init__(self, take_log_of_input=False):
         super(AttributeProcessing).__init__()
         self.take_log_of_input = take_log_of_input
@@ -37,8 +41,7 @@ class AttributeProcessing():
 
 
 class BottleneckLayerLayer(nn.Module):
-    def __init__(self, in_dim, reduction_factor, norm='weightnorm',
-                 non_linearity='relu', use_pconv=False):
+    def __init__(self, in_dim, reduction_factor, norm='weightnorm', non_linearity='relu', use_pconv=False):
         super(BottleneckLayerLayer, self).__init__()
 
         self.reduction_factor = reduction_factor
@@ -49,8 +52,7 @@ class BottleneckLayerLayer(nn.Module):
             if norm == 'weightnorm':
                 fn = torch.nn.utils.weight_norm(fn.conv, name='weight')
             elif norm == 'instancenorm':
-                fn = nn.Sequential(
-                    fn, nn.InstanceNorm1d(reduced_dim, affine=True))
+                fn = nn.Sequential(fn, nn.InstanceNorm1d(reduced_dim, affine=True))
 
             self.projection_fn = fn
             self.non_linearity = non_linearity
@@ -66,8 +68,7 @@ class BottleneckLayerLayer(nn.Module):
 
 
 class DAP(nn.Module):
-    def __init__(self, n_speaker_dim, bottleneck_hparams, take_log_of_input,
-                 arch_hparams):
+    def __init__(self, n_speaker_dim, bottleneck_hparams, take_log_of_input, arch_hparams):
         super(DAP, self).__init__()
         self.attribute_processing = AttributeProcessing(take_log_of_input)
         self.bottleneck_layer = BottleneckLayerLayer(**bottleneck_hparams)
@@ -92,4 +93,3 @@ class DAP(nn.Module):
         x_hat = self.forward(txt_enc, spk_emb, x=None, lens=lens)['x_hat']
         x_hat = self.attribute_processing.denormalize(x_hat)
         return x_hat
-

--- a/nemo/collections/tts/modules/autoregressive_flow.py
+++ b/nemo/collections/tts/modules/autoregressive_flow.py
@@ -1,0 +1,207 @@
+###############################################################################
+#
+#  Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###############################################################################
+import torch
+from torch import nn
+from nemo.collections.tts.helpers.common import DenseLayer, SplineTransformationLayerAR
+
+
+class AR_Back_Step(torch.nn.Module):
+    def __init__(self, n_attr_channels, n_speaker_dim, n_text_dim,
+                 n_hidden, n_lstm_layers, scaling_fn, spline_flow_params=None):
+        super(AR_Back_Step, self).__init__()
+        self.ar_step = AR_Step(n_attr_channels, n_speaker_dim, n_text_dim,
+                               n_hidden, n_lstm_layers, scaling_fn,
+                               spline_flow_params)
+
+    def forward(self, mel, context, lens):
+        mel = torch.flip(mel, (0, ))
+        context = torch.flip(context, (0, ))
+        # backwards flow, send padded zeros back to end
+        for k in range(mel.size(1)):
+            mel[:, k] = mel[:, k].roll(lens[k].item(), dims=0)
+            context[:, k] = context[:, k].roll(lens[k].item(), dims=0)
+
+        mel, log_s = self.ar_step(mel, context, lens)
+
+        # move padded zeros back to beginning
+        for k in range(mel.size(1)):
+            mel[:, k] = mel[:, k].roll(-lens[k].item(), dims=0)
+
+        return torch.flip(mel, (0, )), log_s
+
+    def infer(self, residual, context):
+        residual = self.ar_step.infer(
+            torch.flip(residual, (0, )), torch.flip(context, (0, )))
+        residual = torch.flip(residual, (0, ))
+        return residual
+
+
+class AR_Step(torch.nn.Module):
+    def __init__(self, n_attr_channels, n_speaker_dim, n_text_channels,
+                 n_hidden, n_lstm_layers, scaling_fn, spline_flow_params=None):
+        super(AR_Step, self).__init__()
+        if spline_flow_params is not None:
+            self.spline_flow = SplineTransformationLayerAR(
+                **spline_flow_params)
+        else:
+            self.n_out_dims = n_attr_channels
+            self.conv = torch.nn.Conv1d(n_hidden, 2*n_attr_channels, 1)
+            self.conv.weight.data = 0.0 * self.conv.weight.data
+            self.conv.bias.data = 0.0 * self.conv.bias.data
+
+        self.attr_lstm = torch.nn.LSTM(n_attr_channels, n_hidden)
+        self.lstm = torch.nn.LSTM(n_hidden + n_text_channels + n_speaker_dim,
+                                  n_hidden, n_lstm_layers)
+
+        if spline_flow_params is None:
+            self.dense_layer = DenseLayer(in_dim=n_hidden,
+                                          sizes=[n_hidden, n_hidden])
+            self.scaling_fn = scaling_fn
+
+    def run_padded_sequence(self, sorted_idx, unsort_idx, lens, padded_data,
+                            recurrent_model):
+        """Sorts input data by previded ordering (and un-ordering) and runs the
+        packed data through the recurrent model
+
+        Args:
+            sorted_idx (torch.tensor): 1D sorting index
+            unsort_idx (torch.tensor): 1D unsorting index (inverse sorted_idx)
+            lens: lengths of input data (sorted in descending order)
+            padded_data (torch.tensor): input sequences (padded)
+            recurrent_model (nn.Module): recurrent model to run data through
+        Returns:
+            hidden_vectors (torch.tensor): outputs of the RNN, in the original,
+            unsorted, ordering
+        """
+
+        # sort the data by decreasing length using provided index
+        # we assume batch index is in dim=1
+        padded_data = padded_data[:, sorted_idx]
+        padded_data = nn.utils.rnn.pack_padded_sequence(
+            padded_data, lens.cpu())
+        hidden_vectors = recurrent_model(padded_data)[0]
+        hidden_vectors, _ = nn.utils.rnn.pad_packed_sequence(hidden_vectors)
+        # unsort the results at dim=1 and return
+        hidden_vectors = hidden_vectors[:, unsort_idx]
+        return hidden_vectors
+
+    def get_scaling_and_logs(self, scale_unconstrained):
+        if self.scaling_fn == 'translate':
+            s = torch.exp(scale_unconstrained*0)
+            log_s = scale_unconstrained*0
+        elif self.scaling_fn == 'exp':
+            s = torch.exp(scale_unconstrained)
+            log_s = scale_unconstrained  # log(exp
+        elif self.scaling_fn == 'tanh':
+            s = torch.tanh(scale_unconstrained) + 1 + 1e-6
+            log_s = torch.log(s)
+        elif self.scaling_fn == 'sigmoid':
+            s = torch.sigmoid(scale_unconstrained + 10) + 1e-6
+            log_s = torch.log(s)
+        else:
+            raise Exception("Scaling fn {} not supp.".format(self.scaling_fn))
+
+        return s, log_s
+
+    def forward(self, mel, context, lens):
+        dummy = torch.FloatTensor(1, mel.size(1), mel.size(2)).zero_()
+        dummy = dummy.type(mel.type())
+        # seq_len x batch x dim
+        mel0 = torch.cat([dummy, mel[:-1]], 0)
+
+        self.lstm.flatten_parameters()
+        self.attr_lstm.flatten_parameters()
+        if lens is not None:
+            # collect decreasing length indices
+            lens, ids = torch.sort(lens, descending=True)
+            original_ids = [0] * lens.size(0)
+            for i, ids_i in enumerate(ids):
+                original_ids[ids_i] = i
+            # mel_seq_len x batch x hidden_dim
+            mel_hidden = self.run_padded_sequence(
+                ids, original_ids, lens, mel0, self.attr_lstm)
+        else:
+            mel_hidden = self.attr_lstm(mel0)[0]
+
+        decoder_input = torch.cat((mel_hidden, context), -1)
+
+        if lens is not None:
+            # reorder, run padded sequence and undo reordering
+            lstm_hidden = self.run_padded_sequence(
+                ids, original_ids, lens, decoder_input, self.lstm)
+        else:
+            lstm_hidden = self.lstm(decoder_input)[0]
+
+        if hasattr(self, 'spline_flow'):
+            # spline flow fn expects inputs to be batch, channel, time
+            lstm_hidden = lstm_hidden.permute(1, 2, 0)
+            mel = mel.permute(1, 2, 0)
+            mel, log_s = self.spline_flow(mel, lstm_hidden, inverse=False)
+            mel = mel.permute(2, 0, 1)
+            log_s = log_s.permute(2, 0, 1)
+        else:
+            lstm_hidden = self.dense_layer(lstm_hidden).permute(1, 2, 0)
+            decoder_output = self.conv(lstm_hidden).permute(2, 0, 1)
+
+            scale, log_s = self.get_scaling_and_logs(
+                decoder_output[:, :, :self.n_out_dims])
+            bias = decoder_output[:, :, self.n_out_dims:]
+
+            mel = scale * mel + bias
+
+        return mel, log_s
+
+    def infer(self, residual, context):
+        total_output = []  # seems 10FPS faster than pre-allocation
+
+        output = None
+        dummy = torch.cuda.FloatTensor(
+            1, residual.size(1), residual.size(2)).zero_()
+        self.attr_lstm.flatten_parameters()
+
+        for i in range(0, residual.size(0)):
+            if i == 0:
+                output = dummy
+                mel_hidden, (h, c) = self.attr_lstm(output)
+            else:
+                mel_hidden, (h, c) = self.attr_lstm(output, (h, c))
+
+            decoder_input = torch.cat((mel_hidden, context[i][None]), -1)
+
+            if i == 0:
+                lstm_hidden, (h1, c1) = self.lstm(decoder_input)
+            else:
+                lstm_hidden, (h1, c1) = self.lstm(decoder_input, (h1, c1))
+
+            if hasattr(self, 'spline_flow'):
+                # expects inputs to be batch, channel, time
+                lstm_hidden = lstm_hidden.permute(1, 2, 0)
+                output = residual[i:i+1].permute(1, 2, 0)
+                output = self.spline_flow(output, lstm_hidden, inverse=True)
+                output = output.permute(2, 0, 1)
+            else:
+                lstm_hidden = self.dense_layer(lstm_hidden).permute(1, 2, 0)
+                decoder_output = self.conv(lstm_hidden).permute(2, 0, 1)
+
+                s, log_s = self.get_scaling_and_logs(
+                    decoder_output[:, :, :decoder_output.size(2)//2])
+                b = decoder_output[:, :, decoder_output.size(2)//2:]
+                output = (residual[i:i+1] - b)/s
+            total_output.append(output)
+
+        total_output = torch.cat(total_output, 0)
+        return total_output

--- a/nemo/collections/tts/modules/radtts.py
+++ b/nemo/collections/tts/modules/radtts.py
@@ -1,0 +1,670 @@
+###############################################################################
+#
+#  Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+###############################################################################
+import torch
+from torch import nn
+from nemo.collections.tts.helpers.common import Encoder, LengthRegulator, ConvAttention
+from nemo.collections.tts.helpers.common import Invertible1x1ConvLUS, Invertible1x1Conv
+from nemo.collections.tts.helpers.common import AffineTransformationLayer, LinearNorm, ExponentialClass
+from nemo.collections.tts.helpers.common import get_mask_from_lengths
+from nemo.collections.tts.modules.attribute_prediction_model import get_attribute_prediction_model
+from nemo.collections.tts.modules.alignment import mas_width1 as mas
+
+
+class FlowStep(nn.Module):
+    def __init__(self,  n_mel_channels, n_context_dim, n_layers,
+                 affine_model='simple_conv', scaling_fn='exp',
+                 matrix_decomposition='', affine_activation='softplus',
+                 use_partial_padding=False):
+        super(FlowStep, self).__init__()
+        if matrix_decomposition == 'LUS':
+            self.invtbl_conv = Invertible1x1ConvLUS(n_mel_channels)
+        else:
+            self.invtbl_conv = Invertible1x1Conv(n_mel_channels)
+
+        self.affine_tfn = AffineTransformationLayer(
+            n_mel_channels, n_context_dim, n_layers, affine_model=affine_model,
+            scaling_fn=scaling_fn, affine_activation=affine_activation,
+            use_partial_padding=use_partial_padding)
+
+    def forward(self, z, context, inverse=False, seq_lens=None):
+        if inverse:  # for inference z-> mel
+            z = self.affine_tfn(z, context, inverse, seq_lens=seq_lens)
+            z = self.invtbl_conv(z, inverse)
+            return z
+        else:  # training mel->z
+            z, log_det_W = self.invtbl_conv(z)
+            z, log_s = self.affine_tfn(z, context, seq_lens=seq_lens)
+            return z, log_det_W, log_s
+
+
+class RadTTSModule(torch.nn.Module):
+    def __init__(self, n_speakers, n_speaker_dim, n_text, n_text_dim, n_flows,
+                 n_conv_layers_per_step, n_mel_channels, n_hidden,
+                 mel_encoder_n_hidden, dummy_speaker_embedding, n_early_size,
+                 n_early_every, n_group_size, affine_model, dur_model_config,
+                 f0_model_config, energy_model_config, v_model_config=None,
+                 include_modules='dec', scaling_fn='exp',
+                 matrix_decomposition='', learn_alignments=False,
+                 affine_activation='softplus', attn_use_CTC=True,
+                 use_context_lstm=False, context_lstm_norm=None,
+                 text_encoder_lstm_norm=None, n_f0_dims=0,
+                 n_energy_avg_dims=0, context_lstm_w_f0_and_energy=True,
+                 use_first_order_features=False, unvoiced_bias_activation='',
+                 ap_pred_log_f0=False, **kwargs):
+        super(RadTTSModule, self).__init__()
+        assert(n_early_size % 2 == 0)
+        self.n_mel_channels = n_mel_channels
+        self.n_f0_dims = n_f0_dims  # >= 1 to trains with f0
+        self.n_energy_avg_dims = n_energy_avg_dims  # >= 1 trains with energy
+        self.decoder_use_partial_padding = kwargs['decoder_use_partial_padding']
+        self.n_speaker_dim = n_speaker_dim
+        assert(self.n_speaker_dim % 2 == 0)
+        self.speaker_embedding = torch.nn.Embedding(
+            n_speakers, self.n_speaker_dim)
+        self.embedding = torch.nn.Embedding(n_text, n_text_dim)
+        self.flows = torch.nn.ModuleList()
+        self.encoder = Encoder(encoder_embedding_dim=n_text_dim,
+                               norm_fn=nn.InstanceNorm1d,
+                               lstm_norm_fn=text_encoder_lstm_norm)
+        self.dummy_speaker_embedding = dummy_speaker_embedding
+        self.learn_alignments = learn_alignments
+        self.affine_activation = affine_activation
+        self.include_modules = include_modules
+        self.attn_use_CTC = bool(attn_use_CTC)
+        self.use_context_lstm = bool(use_context_lstm)
+        self.context_lstm_norm = context_lstm_norm
+        self.context_lstm_w_f0_and_energy = context_lstm_w_f0_and_energy
+        self.length_regulator = LengthRegulator()
+        self.use_first_order_features = bool(use_first_order_features)
+        self.decoder_use_unvoiced_bias = kwargs['decoder_use_unvoiced_bias']
+        self.ap_pred_log_f0 = ap_pred_log_f0
+        self.ap_use_unvoiced_bias = kwargs['ap_use_unvoiced_bias']
+        if 'atn' in include_modules or 'dec' in include_modules:
+            if self.learn_alignments:
+                self.attention = ConvAttention(
+                    n_mel_channels, self.n_speaker_dim, n_text_dim)
+
+            self.n_flows = n_flows
+            self.n_group_size = n_group_size
+
+            n_flowstep_cond_dims = (
+                self.n_speaker_dim +
+                (n_text_dim + n_f0_dims + n_energy_avg_dims) * n_group_size)
+
+            if self.use_context_lstm:
+                n_in_context_lstm = (
+                    self.n_speaker_dim + n_text_dim * n_group_size)
+                n_context_lstm_hidden = int(
+                    (self.n_speaker_dim + n_text_dim * n_group_size) / 2)
+
+                if self.context_lstm_w_f0_and_energy:
+                    n_in_context_lstm = (
+                        n_f0_dims + n_energy_avg_dims + n_text_dim)
+                    n_in_context_lstm *= n_group_size
+                    n_in_context_lstm += self.n_speaker_dim
+
+                    n_context_hidden = (
+                        n_f0_dims + n_energy_avg_dims + n_text_dim)
+                    n_context_hidden = n_context_hidden * n_group_size / 2
+                    n_context_hidden = self.n_speaker_dim + n_context_hidden
+                    n_context_hidden = int(n_context_hidden)
+
+                    n_flowstep_cond_dims = (
+                        self.n_speaker_dim + n_text_dim * n_group_size)
+
+                self.context_lstm = torch.nn.LSTM(
+                    input_size=n_in_context_lstm,
+                    hidden_size=n_context_lstm_hidden, num_layers=1,
+                    batch_first=True, bidirectional=True)
+
+                if context_lstm_norm is not None:
+                    if 'spectral' in context_lstm_norm:
+                        print("Applying spectral norm to context encoder LSTM")
+                        lstm_norm_fn_pntr = torch.nn.utils.spectral_norm
+                    elif 'weight' in context_lstm_norm:
+                        print("Applying weight norm to context encoder LSTM")
+                        lstm_norm_fn_pntr = torch.nn.utils.weight_norm
+
+                    self.context_lstm = lstm_norm_fn_pntr(
+                        self.context_lstm, 'weight_hh_l0')
+                    self.context_lstm = lstm_norm_fn_pntr(
+                        self.context_lstm, 'weight_hh_l0_reverse')
+
+            if self.n_group_size > 1:
+                self.unfold_params = {'kernel_size': (n_group_size, 1),
+                                      'stride': n_group_size,
+                                      'padding': 0, 'dilation': 1}
+                self.unfold = nn.Unfold(**self.unfold_params)
+
+            self.exit_steps = []
+            self.n_early_size = n_early_size
+            n_mel_channels = n_mel_channels*n_group_size
+
+            for i in range(self.n_flows):
+                if i > 0 and i % n_early_every == 0:  # early exitting
+                    n_mel_channels -= self.n_early_size
+                    self.exit_steps.append(i)
+
+                self.flows.append(FlowStep(
+                    n_mel_channels, n_flowstep_cond_dims,
+                    n_conv_layers_per_step, affine_model, scaling_fn,
+                    matrix_decomposition, affine_activation=affine_activation,
+                    use_partial_padding=self.decoder_use_partial_padding))
+
+        if 'dpm' in include_modules:
+            dur_model_config['hparams']['n_speaker_dim'] = n_speaker_dim
+            self.dur_pred_layer = get_attribute_prediction_model(
+                dur_model_config)
+
+        self.use_unvoiced_bias = False
+        self.use_vpred_module = False
+        self.ap_use_voiced_embeddings = kwargs['ap_use_voiced_embeddings']
+
+        if self.decoder_use_unvoiced_bias or self.ap_use_unvoiced_bias:
+            assert (unvoiced_bias_activation in {'relu', 'exp'})
+            self.use_unvoiced_bias = True
+            if unvoiced_bias_activation == 'relu':
+                unvbias_nonlin = nn.ReLU()
+            elif unvoiced_bias_activation == 'exp':
+                unvbias_nonlin = ExponentialClass()
+            else:
+                exit(1)  # we won't reach here anyway due to the assertion
+            self.unvoiced_bias_module = nn.Sequential(
+                LinearNorm(n_text_dim, 1), unvbias_nonlin)
+
+        # all situations in which the vpred module is necessary
+        if self.ap_use_voiced_embeddings or self.use_unvoiced_bias or 'vpred' in include_modules:
+            self.use_vpred_module = True
+
+        if self.use_vpred_module:
+            v_model_config['hparams']['n_speaker_dim'] = n_speaker_dim
+            self.v_pred_module = get_attribute_prediction_model(v_model_config)
+            # 4 embeddings, first two are scales, second two are biases
+            if self.ap_use_voiced_embeddings:
+                self.v_embeddings = torch.nn.Embedding(4, n_text_dim)
+
+        if 'apm' in include_modules:
+            f0_model_config['hparams']['n_speaker_dim'] = n_speaker_dim
+            energy_model_config['hparams']['n_speaker_dim'] = n_speaker_dim
+            if self.use_first_order_features:
+                f0_model_config['hparams']['n_in_dim'] = 2
+                energy_model_config['hparams']['n_in_dim'] = 2
+                if 'spline_flow_params' in f0_model_config['hparams'] and f0_model_config['hparams']['spline_flow_params'] is not None:
+                    f0_model_config['hparams']['spline_flow_params']['n_in_channels'] = 2
+                if 'spline_flow_params' in energy_model_config['hparams'] and energy_model_config['hparams']['spline_flow_params'] is not None:
+                    energy_model_config['hparams']['spline_flow_params']['n_in_channels'] = 2
+            else:
+                if 'spline_flow_params' in f0_model_config['hparams'] and f0_model_config['hparams']['spline_flow_params'] is not None:
+                    f0_model_config['hparams']['spline_flow_params']['n_in_channels'] = f0_model_config['hparams']['n_in_dim']
+                if 'spline_flow_params' in energy_model_config['hparams'] and energy_model_config['hparams']['spline_flow_params'] is not None:
+                    energy_model_config['hparams']['spline_flow_params']['n_in_channels'] = energy_model_config['hparams']['n_in_dim']
+
+            self.f0_pred_module = get_attribute_prediction_model(
+                f0_model_config)
+            self.energy_pred_module = get_attribute_prediction_model(
+                energy_model_config)
+
+    def encode_speaker(self, spk_ids):
+        spk_ids = spk_ids * 0 if self.dummy_speaker_embedding else spk_ids
+        spk_vecs = self.speaker_embedding(spk_ids)
+        return spk_vecs
+
+    def encode_text(self, text, in_lens):
+        # text_embeddings: b x len_text x n_text_dim
+        text_embeddings = self.embedding(text).transpose(1, 2)
+        # text_enc: b x n_text_dim x encoder_dim (512)
+        if in_lens is None:
+            text_enc = self.encoder.infer(text_embeddings).transpose(1, 2)
+        else:
+            text_enc = self.encoder(text_embeddings, in_lens).transpose(1, 2)
+
+        return text_enc, text_embeddings
+
+    def preprocess_context(self, context, speaker_vecs, out_lens=None, f0=None,
+                           energy_avg=None):
+
+        if self.n_group_size > 1:
+            context = self.unfold(context.unsqueeze(-1))
+            # (todo): fix unfolding zero-padded values
+            if f0 is not None:
+                f0 = self.unfold(f0[:, None, :, None])
+            if energy_avg is not None:
+                energy_avg = self.unfold(energy_avg[:, None, :, None])
+        speaker_vecs = speaker_vecs[..., None].expand(-1, -1, context.shape[2])
+        context_w_spkvec = torch.cat((context, speaker_vecs), 1)
+
+        if self.use_context_lstm:
+            if self.context_lstm_w_f0_and_energy:
+                if f0 is not None:
+                    context_w_spkvec = torch.cat((context_w_spkvec, f0), 1)
+
+                if energy_avg is not None:
+                    context_w_spkvec = torch.cat(
+                        (context_w_spkvec, energy_avg), 1)
+
+            unfolded_out_lens = (out_lens // self.n_group_size).long().cpu()
+            unfolded_out_lens_packed = nn.utils.rnn.pack_padded_sequence(
+                context_w_spkvec.transpose(1, 2), unfolded_out_lens,
+                batch_first=True, enforce_sorted=False)
+            self.context_lstm.flatten_parameters()
+            context_lstm_packed_output, _ = self.context_lstm(
+                unfolded_out_lens_packed)
+            context_lstm_padded_output, _ = nn.utils.rnn.pad_packed_sequence(
+                context_lstm_packed_output, batch_first=True)
+            context_w_spkvec = context_lstm_padded_output.transpose(1, 2)
+
+        if not self.context_lstm_w_f0_and_energy:
+            if f0 is not None:
+                context_w_spkvec = torch.cat((context_w_spkvec, f0), 1)
+
+            if energy_avg is not None:
+                context_w_spkvec = torch.cat((context_w_spkvec, energy_avg), 1)
+
+        return context_w_spkvec
+
+    def fold(self, mel):
+        """Inverse of the self.unfold(mel.unsqueeze(-1)) operation used for the
+        grouping or "squeeze" operation on input
+
+        Args:
+            mel: B x C x T tensor of temporal data
+        """
+        mel = nn.functional.fold(
+            mel, output_size=(mel.shape[2]*self.n_group_size, 1),
+            **self.unfold_params).squeeze(-1)
+        return mel
+
+    def binarize_attention(self, attn, in_lens, out_lens):
+        """For training purposes only. Binarizes attention with MAS. These will
+        no longer recieve a gradient
+        Args:
+            attn: B x 1 x max_mel_len x max_text_len
+        """
+        b_size = attn.shape[0]
+        with torch.no_grad():
+            attn_cpu = attn.data.cpu().numpy()
+            attn_out = torch.zeros_like(attn)
+            for ind in range(b_size):
+                hard_attn = mas(attn_cpu[ind, 0, :out_lens[ind], :in_lens[ind]])
+                attn_out[ind, 0, :out_lens[ind], :in_lens[ind]] = torch.tensor(
+                    hard_attn, device=attn.get_device())
+        return attn_out
+
+    def get_first_order_features(self, feats, out_lens, dilation=1):
+        """
+        feats: b x max_length
+        out_lens: b-dim
+        """
+        # add an extra column
+        feats_extended_R = torch.cat(
+            (feats, torch.zeros_like(feats[:, 0:dilation])), dim=1)
+        feats_extended_L = torch.cat(
+            (torch.zeros_like(feats[:, 0:dilation]), feats), dim=1)
+        dfeats_R = feats_extended_R[:, dilation:] - feats
+        dfeats_L = feats - feats_extended_L[:, 0:-dilation]
+
+        return (dfeats_R + dfeats_L) * 0.5
+
+    def apply_voice_mask_to_text(self, text_enc, voiced_mask):
+        """
+        text_enc: b x C x N
+        voiced_mask: b x N
+        """
+        voiced_mask = voiced_mask.unsqueeze(1)
+        voiced_embedding_s = self.v_embeddings.weight[0:1, :, None]
+        unvoiced_embedding_s = self.v_embeddings.weight[1:2, :, None]
+        voiced_embedding_b = self.v_embeddings.weight[2:3, :, None]
+        unvoiced_embedding_b = self.v_embeddings.weight[3:4, :, None]
+        scale = torch.sigmoid(voiced_embedding_s*voiced_mask + unvoiced_embedding_s*(1-voiced_mask))
+        bias = 0.1*torch.tanh(voiced_embedding_b*voiced_mask + unvoiced_embedding_b*(1-voiced_mask))
+        return text_enc*scale+bias
+
+    def forward(self, mel, speaker_ids, text, in_lens, out_lens,
+                binarize_attention=False, attn_prior=None,
+                f0=None, energy_avg=None, voiced_mask=None, p_voiced=None):
+        speaker_vecs = self.encode_speaker(speaker_ids)
+        text_enc, text_embeddings = self.encode_text(text, in_lens)
+
+        log_s_list, log_det_W_list, z_mel = [], [], []
+        attn = None
+        attn_soft = None
+        attn_hard = None
+        if 'atn' in self.include_modules or 'dec' in self.include_modules:
+            # make sure to do the alignments before folding
+            attn_mask = get_mask_from_lengths(in_lens)[..., None] == 0
+            # attn_mask shld be 1 for unsd t-steps in text_enc_w_spkvec tensor
+            attn_soft, attn_logprob = self.attention(
+                mel, text_embeddings, out_lens, attn_mask,
+                key_lens=in_lens, attn_prior=attn_prior)
+
+            if binarize_attention:
+                attn = self.binarize_attention(attn_soft, in_lens, out_lens)
+                attn_hard = attn
+            else:
+                attn = attn_soft
+
+            context = torch.bmm(text_enc, attn.squeeze(1).transpose(1, 2))
+
+        f0_bias = 0
+        # unvoiced bias forward pass
+        if self.use_unvoiced_bias:
+            f0_bias = self.unvoiced_bias_module(context.permute(0, 2, 1))
+            f0_bias = -f0_bias[..., 0]
+            f0_bias = f0_bias * (~voiced_mask.bool()).float()
+
+        # mel decoder forward pass
+        if 'dec' in self.include_modules:
+            if self.n_group_size > 1:
+                # might truncate some frames at the end, but that's ok
+                # sometimes referred to as the "squeeeze" operation
+                # invert this by calling self.fold(mel_or_z)
+                mel = self.unfold(mel.unsqueeze(-1))
+            z_out = []
+            # where context is folded
+            # mask f0 in case values are interpolated
+            if self.decoder_use_unvoiced_bias:
+                context_w_spkvec = self.preprocess_context(
+                    context, speaker_vecs, out_lens, f0 * voiced_mask + f0_bias,
+                    energy_avg)
+            else:
+                context_w_spkvec = self.preprocess_context(
+                    context, speaker_vecs, out_lens, f0 * voiced_mask,
+                    energy_avg)
+
+            log_s_list, log_det_W_list, z_out = [], [], []
+            unfolded_seq_lens = out_lens//self.n_group_size
+            for i, flow_step in enumerate(self.flows):
+                if i in self.exit_steps:
+                    z = mel[:, :self.n_early_size]
+                    z_out.append(z)
+                    mel = mel[:, self.n_early_size:]
+                mel, log_det_W, log_s = flow_step(mel, context_w_spkvec, seq_lens=unfolded_seq_lens)
+                log_s_list.append(log_s)
+                log_det_W_list.append(log_det_W)
+
+            z_out.append(mel)
+            z_mel = torch.cat(z_out, 1)
+
+        # duration predictor forward pass
+        duration_model_outputs = None
+        if 'dpm' in self.include_modules:
+            if attn_hard is None:
+                attn_hard = self.binarize_attention(
+                    attn_soft, in_lens, out_lens)
+
+            # convert hard attention to durations
+            attn_hard_reduced = attn_hard.sum(2)[:, 0, :]
+            duration_model_outputs = self.dur_pred_layer(
+                torch.detach(text_enc),
+                torch.detach(speaker_vecs),
+                torch.detach(attn_hard_reduced.float()), in_lens)
+
+        # f0, energy, vpred predictors forward pass
+        f0_model_outputs = None
+        energy_model_outputs = None
+        vpred_model_outputs = None
+        if 'apm' in self.include_modules:
+            if attn_hard is None:
+                attn_hard = self.binarize_attention(
+                    attn_soft, in_lens, out_lens)
+
+            # convert hard attention to durations
+            if binarize_attention:
+                text_enc_time_expanded = context.clone()
+            else:
+                text_enc_time_expanded = torch.bmm(text_enc, attn_hard.squeeze(1).transpose(1, 2))
+
+            if self.use_vpred_module:
+                # unvoiced bias requires  voiced mask prediction
+                vpred_model_outputs = self.v_pred_module(
+                    torch.detach(text_enc_time_expanded),
+                    torch.detach(speaker_vecs),
+                    torch.detach(voiced_mask), out_lens)
+
+                # affine transform context using voiced mask
+                if self.ap_use_voiced_embeddings:
+                    text_enc_time_expanded = self.apply_voice_mask_to_text(
+                        text_enc_time_expanded, voiced_mask)
+            if self.ap_use_unvoiced_bias: # whether to use the unvoiced bias in the attribute predictor
+                f0_target = torch.detach(f0 * voiced_mask + f0_bias)
+            else:
+                f0_target = torch.detach(f0)
+            # fit to log f0 in f0 predictor
+            f0_target[voiced_mask.bool()] = torch.log(
+                f0_target[voiced_mask.bool()])
+            f0_target = f0_target / 6  # scale to ~ [0, 1] in log space
+            energy_avg = energy_avg * 2 - 1  # scale to ~ [-1, 1]
+
+            if self.use_first_order_features:
+                df0 = self.get_first_order_features(f0_target, out_lens)
+                denergy_avg = self.get_first_order_features(
+                    energy_avg, out_lens)
+
+                f0_voiced = torch.cat(
+                    (f0_target[:, None],  df0[:, None]), dim=1)
+                energy_avg = torch.cat(
+                        (energy_avg[:, None], denergy_avg[:, None]), dim=1)
+
+                f0_voiced = f0_voiced * 3  # scale to ~ 1 std
+                energy_avg = energy_avg * 3  # scale to ~ 1 std
+            else:
+                f0_voiced = f0_target * 2  # scale to ~ 1 std
+                energy_avg = energy_avg * 1.4  # scale to ~ 1 std
+            f0_model_outputs = self.f0_pred_module(
+                    text_enc_time_expanded, torch.detach(speaker_vecs),
+                    f0_voiced, out_lens)
+
+            energy_model_outputs = self.energy_pred_module(
+                    text_enc_time_expanded, torch.detach(speaker_vecs),
+                    energy_avg, out_lens)
+
+        outputs = {'z_mel': z_mel,
+                   'log_det_W_list': log_det_W_list,
+                   'log_s_list': log_s_list,
+                   'duration_model_outputs': duration_model_outputs,
+                   'f0_model_outputs': f0_model_outputs,
+                   'energy_model_outputs': energy_model_outputs,
+                   'vpred_model_outputs': vpred_model_outputs,
+                   'attn_soft': attn_soft,
+                   'attn': attn,
+                   'text_embeddings': text_embeddings,
+                   'attn_logprob': attn_logprob
+                   }
+
+        return outputs
+
+    def infer(self, speaker_id, text, sigma, sigma_txt=0.8, sigma_f0=0.8,
+              sigma_energy=0.8, token_dur_scaling=1.0, token_duration_max=100,
+              dur=None, f0=None, energy_avg=None, voiced_mask=None):
+
+        n_tokens = text.shape[1]
+        spk_vec = self.encode_speaker(speaker_id)
+        txt_enc, txt_emb = self.encode_text(text, None)
+
+        if dur is None:
+            # get token durations
+            z_dur = torch.cuda.FloatTensor(1, 1, n_tokens)
+            z_dur = z_dur.normal_() * sigma_txt
+
+            dur = self.dur_pred_layer.infer(z_dur, txt_enc, spk_vec)
+            if dur.shape[-1] < txt_enc.shape[-1]:
+                to_pad = txt_enc.shape[-1] - dur.shape[2]
+                pad_fn = nn.ReplicationPad1d((0, to_pad))
+                dur = pad_fn(dur)
+            dur = dur[:, 0]
+            dur = dur.clamp(0, token_duration_max)
+            dur = dur * token_dur_scaling if token_dur_scaling > 0 else dur
+            dur = (dur + 0.5).floor().int()
+
+        n_frames = dur.sum().item()
+        out_lens = torch.LongTensor([n_frames]).to(txt_enc.device)
+
+        # get attributes f0, energy, vpred, etc)
+        txt_enc_time_expanded = self.length_regulator(
+            txt_enc.transpose(1, 2), dur).transpose(1, 2)
+
+        if voiced_mask is None:
+            if self.use_vpred_module:
+                # get logits
+                voiced_mask = self.v_pred_module.infer(
+                    None, txt_enc_time_expanded, spk_vec)
+                voiced_mask = (torch.sigmoid(voiced_mask[:, 0]) > 0.5)
+                voiced_mask = voiced_mask.float()
+
+        ap_txt_enc_time_expanded = txt_enc_time_expanded
+        # voice mask augmentation only used for attribute prediction
+        if self.ap_use_voiced_embeddings:
+            ap_txt_enc_time_expanded = self.apply_voice_mask_to_text(
+                txt_enc_time_expanded, voiced_mask)
+
+        f0_bias = 0
+        # unvoiced bias forward pass
+        if self.use_unvoiced_bias:
+            f0_bias = self.unvoiced_bias_module(
+                txt_enc_time_expanded.permute(0, 2, 1))
+            f0_bias = -f0_bias[..., 0]
+            f0_bias = f0_bias * (~voiced_mask.bool()).float()
+
+        if f0 is None:
+            n_f0_feature_channels = 2 if self.use_first_order_features else 1
+            z_f0 = torch.cuda.FloatTensor(
+                1, n_f0_feature_channels, n_frames).normal_() * sigma_f0
+            f0 = self.infer_f0(
+                z_f0, ap_txt_enc_time_expanded, spk_vec, voiced_mask, out_lens)[:, 0]
+
+        if energy_avg is None:
+            n_energy_feature_channels = 2 if self.use_first_order_features else 1
+            z_energy_avg = torch.cuda.FloatTensor(
+                1, n_energy_feature_channels, n_frames).normal_() * sigma_energy
+            energy_avg = self.infer_energy(
+                z_energy_avg, ap_txt_enc_time_expanded, spk_vec, out_lens)[:, 0]
+
+        # replication pad, because ungrouping with different group sizes
+        # may lead to mismatched lengths
+        if energy_avg.shape[1] < out_lens[0]:
+            to_pad = out_lens[0] - energy_avg.shape[1]
+            pad_fn = nn.ReplicationPad1d((0, to_pad))
+            #f0 = pad_fn(f0[None])[0]
+            energy_avg = pad_fn(energy_avg[None])[0]
+        if f0.shape[1] < out_lens[0]:
+            to_pad = out_lens[0] - f0.shape[1]
+            pad_fn = nn.ReplicationPad1d((0, to_pad))
+            f0 = pad_fn(f0[None])[0]
+
+        if self.decoder_use_unvoiced_bias:
+            context_w_spkvec = self.preprocess_context(
+                txt_enc_time_expanded, spk_vec, out_lens, f0 * voiced_mask + f0_bias,
+                energy_avg)
+
+        else:
+            context_w_spkvec = self.preprocess_context(
+                txt_enc_time_expanded, spk_vec, out_lens, f0*voiced_mask, energy_avg)
+
+        residual = torch.cuda.FloatTensor(
+            1, 80 * self.n_group_size, n_frames // self.n_group_size)
+        residual = residual.normal_() * sigma
+
+        # map from z sample to data
+        exit_steps_stack = self.exit_steps.copy()
+        mel = residual[:, len(exit_steps_stack) * self.n_early_size:]
+        remaining_residual = residual[:, :len(exit_steps_stack)*self.n_early_size]
+        unfolded_seq_lens = out_lens//self.n_group_size
+        for i, flow_step in enumerate(reversed(self.flows)):
+            curr_step = len(self.flows) - i - 1
+            mel = flow_step(mel, context_w_spkvec, inverse=True, seq_lens=unfolded_seq_lens)
+            if len(exit_steps_stack) > 0 and curr_step == exit_steps_stack[-1]:
+                # concatenate the next chunk of z
+                exit_steps_stack.pop()
+                residual_to_add = remaining_residual[
+                    :, len(exit_steps_stack)*self.n_early_size:]
+                remaining_residual = remaining_residual[
+                    :, :len(exit_steps_stack)*self.n_early_size]
+                mel = torch.cat((residual_to_add, mel), 1)
+
+        if self.n_group_size > 1:
+            mel = self.fold(mel)
+
+        return {'mel': mel,
+                'dur': dur,
+                'f0': f0,
+                'energy_avg': energy_avg
+                }
+
+    def infer_f0(self, residual, txt_enc_time_expanded, spk_vec,
+                 voiced_mask=None, lens=None):
+        print("txt_enc_time_expanded", txt_enc_time_expanded.size())
+        print("spk_vec", spk_vec.size())
+        f0 = self.f0_pred_module.infer(
+                residual, txt_enc_time_expanded, spk_vec, lens)
+
+        if voiced_mask is not None and len(voiced_mask.shape) == 2:
+            voiced_mask = voiced_mask[:, None]
+        # constants
+        if self.ap_pred_log_f0:
+            if self.use_first_order_features:
+                f0 = f0[:,0:1,:] / 3
+            else:
+                f0 = f0 / 2
+            f0 = f0 * 6
+        else:
+            f0 = f0 / 6
+            f0 = f0 / 640
+
+        if voiced_mask is None:
+            voiced_mask = f0 > 0.0
+        else:
+            voiced_mask = voiced_mask.bool()
+        # due to grouping, f0 might be 1 frame short
+        voiced_mask = voiced_mask[:,:,:f0.shape[-1]]
+        if self.ap_pred_log_f0:
+            # if variable is set, decoder sees linear f0
+            # mask = f0 > 0.0 if voiced_mask is None else voiced_mask.bool()
+            f0[voiced_mask] = torch.exp(f0[voiced_mask])
+        f0[~voiced_mask] = 0.0
+        return f0
+
+    def infer_energy(self, residual, txt_enc_time_expanded, spk_vec, lens):
+        energy = self.energy_pred_module.infer(
+                residual, txt_enc_time_expanded, spk_vec, lens)
+
+        # magic constants
+        if self.use_first_order_features:
+            energy = energy / 3
+        else:
+            energy = energy / 1.4
+        energy = (energy + 1) / 2
+        return energy
+
+    def remove_norms(self):
+        """Removes spectral and weightnorms from model. Call before inference
+        """
+        for name, module in self.named_modules():
+            try:
+                nn.utils.remove_spectral_norm(module, name='weight_hh_l0')
+                print("Removed spectral norm from {}".format(name))
+            except:
+                pass
+            try:
+                nn.utils.remove_spectral_norm(module, name='weight_hh_l0_reverse')
+                print("Removed spectral norm from {}".format(name))
+            except:
+                pass
+            try:
+                nn.utils.remove_weight_norm(module)
+                print("Removed wnorm from {}".format(name))
+            except:
+                pass

--- a/nemo/collections/tts/modules/radtts.py
+++ b/nemo/collections/tts/modules/radtts.py
@@ -16,19 +16,34 @@
 ###############################################################################
 import torch
 from torch import nn
-from nemo.collections.tts.helpers.common import Encoder, LengthRegulator, ConvAttention
-from nemo.collections.tts.helpers.common import Invertible1x1ConvLUS, Invertible1x1Conv
-from nemo.collections.tts.helpers.common import AffineTransformationLayer, LinearNorm, ExponentialClass
-from nemo.collections.tts.helpers.common import get_mask_from_lengths
-from nemo.collections.tts.modules.attribute_prediction_model import get_attribute_prediction_model
+
+from nemo.collections.tts.helpers.common import (
+    AffineTransformationLayer,
+    ConvAttention,
+    Encoder,
+    ExponentialClass,
+    Invertible1x1Conv,
+    Invertible1x1ConvLUS,
+    LengthRegulator,
+    LinearNorm,
+    get_mask_from_lengths,
+)
 from nemo.collections.tts.modules.alignment import mas_width1 as mas
+from nemo.collections.tts.modules.attribute_prediction_model import get_attribute_prediction_model
 
 
 class FlowStep(nn.Module):
-    def __init__(self,  n_mel_channels, n_context_dim, n_layers,
-                 affine_model='simple_conv', scaling_fn='exp',
-                 matrix_decomposition='', affine_activation='softplus',
-                 use_partial_padding=False):
+    def __init__(
+        self,
+        n_mel_channels,
+        n_context_dim,
+        n_layers,
+        affine_model='simple_conv',
+        scaling_fn='exp',
+        matrix_decomposition='',
+        affine_activation='softplus',
+        use_partial_padding=False,
+    ):
         super(FlowStep, self).__init__()
         if matrix_decomposition == 'LUS':
             self.invtbl_conv = Invertible1x1ConvLUS(n_mel_channels)
@@ -36,9 +51,14 @@ class FlowStep(nn.Module):
             self.invtbl_conv = Invertible1x1Conv(n_mel_channels)
 
         self.affine_tfn = AffineTransformationLayer(
-            n_mel_channels, n_context_dim, n_layers, affine_model=affine_model,
-            scaling_fn=scaling_fn, affine_activation=affine_activation,
-            use_partial_padding=use_partial_padding)
+            n_mel_channels,
+            n_context_dim,
+            n_layers,
+            affine_model=affine_model,
+            scaling_fn=scaling_fn,
+            affine_activation=affine_activation,
+            use_partial_padding=use_partial_padding,
+        )
 
     def forward(self, z, context, inverse=False, seq_lens=None):
         if inverse:  # for inference z-> mel
@@ -52,34 +72,57 @@ class FlowStep(nn.Module):
 
 
 class RadTTSModule(torch.nn.Module):
-    def __init__(self, n_speakers, n_speaker_dim, n_text, n_text_dim, n_flows,
-                 n_conv_layers_per_step, n_mel_channels, n_hidden,
-                 mel_encoder_n_hidden, dummy_speaker_embedding, n_early_size,
-                 n_early_every, n_group_size, affine_model, dur_model_config,
-                 f0_model_config, energy_model_config, v_model_config=None,
-                 include_modules='dec', scaling_fn='exp',
-                 matrix_decomposition='', learn_alignments=False,
-                 affine_activation='softplus', attn_use_CTC=True,
-                 use_context_lstm=False, context_lstm_norm=None,
-                 text_encoder_lstm_norm=None, n_f0_dims=0,
-                 n_energy_avg_dims=0, context_lstm_w_f0_and_energy=True,
-                 use_first_order_features=False, unvoiced_bias_activation='',
-                 ap_pred_log_f0=False, **kwargs):
+    def __init__(
+        self,
+        n_speakers,
+        n_speaker_dim,
+        n_text,
+        n_text_dim,
+        n_flows,
+        n_conv_layers_per_step,
+        n_mel_channels,
+        n_hidden,
+        mel_encoder_n_hidden,
+        dummy_speaker_embedding,
+        n_early_size,
+        n_early_every,
+        n_group_size,
+        affine_model,
+        dur_model_config,
+        f0_model_config,
+        energy_model_config,
+        v_model_config=None,
+        include_modules='dec',
+        scaling_fn='exp',
+        matrix_decomposition='',
+        learn_alignments=False,
+        affine_activation='softplus',
+        attn_use_CTC=True,
+        use_context_lstm=False,
+        context_lstm_norm=None,
+        text_encoder_lstm_norm=None,
+        n_f0_dims=0,
+        n_energy_avg_dims=0,
+        context_lstm_w_f0_and_energy=True,
+        use_first_order_features=False,
+        unvoiced_bias_activation='',
+        ap_pred_log_f0=False,
+        **kwargs
+    ):
         super(RadTTSModule, self).__init__()
-        assert(n_early_size % 2 == 0)
+        assert n_early_size % 2 == 0
         self.n_mel_channels = n_mel_channels
         self.n_f0_dims = n_f0_dims  # >= 1 to trains with f0
         self.n_energy_avg_dims = n_energy_avg_dims  # >= 1 trains with energy
         self.decoder_use_partial_padding = kwargs['decoder_use_partial_padding']
         self.n_speaker_dim = n_speaker_dim
-        assert(self.n_speaker_dim % 2 == 0)
-        self.speaker_embedding = torch.nn.Embedding(
-            n_speakers, self.n_speaker_dim)
+        assert self.n_speaker_dim % 2 == 0
+        self.speaker_embedding = torch.nn.Embedding(n_speakers, self.n_speaker_dim)
         self.embedding = torch.nn.Embedding(n_text, n_text_dim)
         self.flows = torch.nn.ModuleList()
-        self.encoder = Encoder(encoder_embedding_dim=n_text_dim,
-                               norm_fn=nn.InstanceNorm1d,
-                               lstm_norm_fn=text_encoder_lstm_norm)
+        self.encoder = Encoder(
+            encoder_embedding_dim=n_text_dim, norm_fn=nn.InstanceNorm1d, lstm_norm_fn=text_encoder_lstm_norm
+        )
         self.dummy_speaker_embedding = dummy_speaker_embedding
         self.learn_alignments = learn_alignments
         self.affine_activation = affine_activation
@@ -95,41 +138,36 @@ class RadTTSModule(torch.nn.Module):
         self.ap_use_unvoiced_bias = kwargs['ap_use_unvoiced_bias']
         if 'atn' in include_modules or 'dec' in include_modules:
             if self.learn_alignments:
-                self.attention = ConvAttention(
-                    n_mel_channels, self.n_speaker_dim, n_text_dim)
+                self.attention = ConvAttention(n_mel_channels, self.n_speaker_dim, n_text_dim)
 
             self.n_flows = n_flows
             self.n_group_size = n_group_size
 
-            n_flowstep_cond_dims = (
-                self.n_speaker_dim +
-                (n_text_dim + n_f0_dims + n_energy_avg_dims) * n_group_size)
+            n_flowstep_cond_dims = self.n_speaker_dim + (n_text_dim + n_f0_dims + n_energy_avg_dims) * n_group_size
 
             if self.use_context_lstm:
-                n_in_context_lstm = (
-                    self.n_speaker_dim + n_text_dim * n_group_size)
-                n_context_lstm_hidden = int(
-                    (self.n_speaker_dim + n_text_dim * n_group_size) / 2)
+                n_in_context_lstm = self.n_speaker_dim + n_text_dim * n_group_size
+                n_context_lstm_hidden = int((self.n_speaker_dim + n_text_dim * n_group_size) / 2)
 
                 if self.context_lstm_w_f0_and_energy:
-                    n_in_context_lstm = (
-                        n_f0_dims + n_energy_avg_dims + n_text_dim)
+                    n_in_context_lstm = n_f0_dims + n_energy_avg_dims + n_text_dim
                     n_in_context_lstm *= n_group_size
                     n_in_context_lstm += self.n_speaker_dim
 
-                    n_context_hidden = (
-                        n_f0_dims + n_energy_avg_dims + n_text_dim)
+                    n_context_hidden = n_f0_dims + n_energy_avg_dims + n_text_dim
                     n_context_hidden = n_context_hidden * n_group_size / 2
                     n_context_hidden = self.n_speaker_dim + n_context_hidden
                     n_context_hidden = int(n_context_hidden)
 
-                    n_flowstep_cond_dims = (
-                        self.n_speaker_dim + n_text_dim * n_group_size)
+                    n_flowstep_cond_dims = self.n_speaker_dim + n_text_dim * n_group_size
 
                 self.context_lstm = torch.nn.LSTM(
                     input_size=n_in_context_lstm,
-                    hidden_size=n_context_lstm_hidden, num_layers=1,
-                    batch_first=True, bidirectional=True)
+                    hidden_size=n_context_lstm_hidden,
+                    num_layers=1,
+                    batch_first=True,
+                    bidirectional=True,
+                )
 
                 if context_lstm_norm is not None:
                     if 'spectral' in context_lstm_norm:
@@ -139,43 +177,50 @@ class RadTTSModule(torch.nn.Module):
                         print("Applying weight norm to context encoder LSTM")
                         lstm_norm_fn_pntr = torch.nn.utils.weight_norm
 
-                    self.context_lstm = lstm_norm_fn_pntr(
-                        self.context_lstm, 'weight_hh_l0')
-                    self.context_lstm = lstm_norm_fn_pntr(
-                        self.context_lstm, 'weight_hh_l0_reverse')
+                    self.context_lstm = lstm_norm_fn_pntr(self.context_lstm, 'weight_hh_l0')
+                    self.context_lstm = lstm_norm_fn_pntr(self.context_lstm, 'weight_hh_l0_reverse')
 
             if self.n_group_size > 1:
-                self.unfold_params = {'kernel_size': (n_group_size, 1),
-                                      'stride': n_group_size,
-                                      'padding': 0, 'dilation': 1}
+                self.unfold_params = {
+                    'kernel_size': (n_group_size, 1),
+                    'stride': n_group_size,
+                    'padding': 0,
+                    'dilation': 1,
+                }
                 self.unfold = nn.Unfold(**self.unfold_params)
 
             self.exit_steps = []
             self.n_early_size = n_early_size
-            n_mel_channels = n_mel_channels*n_group_size
+            n_mel_channels = n_mel_channels * n_group_size
 
             for i in range(self.n_flows):
                 if i > 0 and i % n_early_every == 0:  # early exitting
                     n_mel_channels -= self.n_early_size
                     self.exit_steps.append(i)
 
-                self.flows.append(FlowStep(
-                    n_mel_channels, n_flowstep_cond_dims,
-                    n_conv_layers_per_step, affine_model, scaling_fn,
-                    matrix_decomposition, affine_activation=affine_activation,
-                    use_partial_padding=self.decoder_use_partial_padding))
+                self.flows.append(
+                    FlowStep(
+                        n_mel_channels,
+                        n_flowstep_cond_dims,
+                        n_conv_layers_per_step,
+                        affine_model,
+                        scaling_fn,
+                        matrix_decomposition,
+                        affine_activation=affine_activation,
+                        use_partial_padding=self.decoder_use_partial_padding,
+                    )
+                )
 
         if 'dpm' in include_modules:
             dur_model_config['hparams']['n_speaker_dim'] = n_speaker_dim
-            self.dur_pred_layer = get_attribute_prediction_model(
-                dur_model_config)
+            self.dur_pred_layer = get_attribute_prediction_model(dur_model_config)
 
         self.use_unvoiced_bias = False
         self.use_vpred_module = False
         self.ap_use_voiced_embeddings = kwargs['ap_use_voiced_embeddings']
 
         if self.decoder_use_unvoiced_bias or self.ap_use_unvoiced_bias:
-            assert (unvoiced_bias_activation in {'relu', 'exp'})
+            assert unvoiced_bias_activation in {'relu', 'exp'}
             self.use_unvoiced_bias = True
             if unvoiced_bias_activation == 'relu':
                 unvbias_nonlin = nn.ReLU()
@@ -183,8 +228,7 @@ class RadTTSModule(torch.nn.Module):
                 unvbias_nonlin = ExponentialClass()
             else:
                 exit(1)  # we won't reach here anyway due to the assertion
-            self.unvoiced_bias_module = nn.Sequential(
-                LinearNorm(n_text_dim, 1), unvbias_nonlin)
+            self.unvoiced_bias_module = nn.Sequential(LinearNorm(n_text_dim, 1), unvbias_nonlin)
 
         # all situations in which the vpred module is necessary
         if self.ap_use_voiced_embeddings or self.use_unvoiced_bias or 'vpred' in include_modules:
@@ -203,20 +247,34 @@ class RadTTSModule(torch.nn.Module):
             if self.use_first_order_features:
                 f0_model_config['hparams']['n_in_dim'] = 2
                 energy_model_config['hparams']['n_in_dim'] = 2
-                if 'spline_flow_params' in f0_model_config['hparams'] and f0_model_config['hparams']['spline_flow_params'] is not None:
+                if (
+                    'spline_flow_params' in f0_model_config['hparams']
+                    and f0_model_config['hparams']['spline_flow_params'] is not None
+                ):
                     f0_model_config['hparams']['spline_flow_params']['n_in_channels'] = 2
-                if 'spline_flow_params' in energy_model_config['hparams'] and energy_model_config['hparams']['spline_flow_params'] is not None:
+                if (
+                    'spline_flow_params' in energy_model_config['hparams']
+                    and energy_model_config['hparams']['spline_flow_params'] is not None
+                ):
                     energy_model_config['hparams']['spline_flow_params']['n_in_channels'] = 2
             else:
-                if 'spline_flow_params' in f0_model_config['hparams'] and f0_model_config['hparams']['spline_flow_params'] is not None:
-                    f0_model_config['hparams']['spline_flow_params']['n_in_channels'] = f0_model_config['hparams']['n_in_dim']
-                if 'spline_flow_params' in energy_model_config['hparams'] and energy_model_config['hparams']['spline_flow_params'] is not None:
-                    energy_model_config['hparams']['spline_flow_params']['n_in_channels'] = energy_model_config['hparams']['n_in_dim']
+                if (
+                    'spline_flow_params' in f0_model_config['hparams']
+                    and f0_model_config['hparams']['spline_flow_params'] is not None
+                ):
+                    f0_model_config['hparams']['spline_flow_params']['n_in_channels'] = f0_model_config['hparams'][
+                        'n_in_dim'
+                    ]
+                if (
+                    'spline_flow_params' in energy_model_config['hparams']
+                    and energy_model_config['hparams']['spline_flow_params'] is not None
+                ):
+                    energy_model_config['hparams']['spline_flow_params']['n_in_channels'] = energy_model_config[
+                        'hparams'
+                    ]['n_in_dim']
 
-            self.f0_pred_module = get_attribute_prediction_model(
-                f0_model_config)
-            self.energy_pred_module = get_attribute_prediction_model(
-                energy_model_config)
+            self.f0_pred_module = get_attribute_prediction_model(f0_model_config)
+            self.energy_pred_module = get_attribute_prediction_model(energy_model_config)
 
     def encode_speaker(self, spk_ids):
         spk_ids = spk_ids * 0 if self.dummy_speaker_embedding else spk_ids
@@ -234,8 +292,7 @@ class RadTTSModule(torch.nn.Module):
 
         return text_enc, text_embeddings
 
-    def preprocess_context(self, context, speaker_vecs, out_lens=None, f0=None,
-                           energy_avg=None):
+    def preprocess_context(self, context, speaker_vecs, out_lens=None, f0=None, energy_avg=None):
 
         if self.n_group_size > 1:
             context = self.unfold(context.unsqueeze(-1))
@@ -253,18 +310,17 @@ class RadTTSModule(torch.nn.Module):
                     context_w_spkvec = torch.cat((context_w_spkvec, f0), 1)
 
                 if energy_avg is not None:
-                    context_w_spkvec = torch.cat(
-                        (context_w_spkvec, energy_avg), 1)
+                    context_w_spkvec = torch.cat((context_w_spkvec, energy_avg), 1)
 
             unfolded_out_lens = (out_lens // self.n_group_size).long().cpu()
             unfolded_out_lens_packed = nn.utils.rnn.pack_padded_sequence(
-                context_w_spkvec.transpose(1, 2), unfolded_out_lens,
-                batch_first=True, enforce_sorted=False)
+                context_w_spkvec.transpose(1, 2), unfolded_out_lens, batch_first=True, enforce_sorted=False
+            )
             self.context_lstm.flatten_parameters()
-            context_lstm_packed_output, _ = self.context_lstm(
-                unfolded_out_lens_packed)
+            context_lstm_packed_output, _ = self.context_lstm(unfolded_out_lens_packed)
             context_lstm_padded_output, _ = nn.utils.rnn.pad_packed_sequence(
-                context_lstm_packed_output, batch_first=True)
+                context_lstm_packed_output, batch_first=True
+            )
             context_w_spkvec = context_lstm_padded_output.transpose(1, 2)
 
         if not self.context_lstm_w_f0_and_energy:
@@ -283,9 +339,9 @@ class RadTTSModule(torch.nn.Module):
         Args:
             mel: B x C x T tensor of temporal data
         """
-        mel = nn.functional.fold(
-            mel, output_size=(mel.shape[2]*self.n_group_size, 1),
-            **self.unfold_params).squeeze(-1)
+        mel = nn.functional.fold(mel, output_size=(mel.shape[2] * self.n_group_size, 1), **self.unfold_params).squeeze(
+            -1
+        )
         return mel
 
     def binarize_attention(self, attn, in_lens, out_lens):
@@ -299,9 +355,8 @@ class RadTTSModule(torch.nn.Module):
             attn_cpu = attn.data.cpu().numpy()
             attn_out = torch.zeros_like(attn)
             for ind in range(b_size):
-                hard_attn = mas(attn_cpu[ind, 0, :out_lens[ind], :in_lens[ind]])
-                attn_out[ind, 0, :out_lens[ind], :in_lens[ind]] = torch.tensor(
-                    hard_attn, device=attn.get_device())
+                hard_attn = mas(attn_cpu[ind, 0, : out_lens[ind], : in_lens[ind]])
+                attn_out[ind, 0, : out_lens[ind], : in_lens[ind]] = torch.tensor(hard_attn, device=attn.get_device())
         return attn_out
 
     def get_first_order_features(self, feats, out_lens, dilation=1):
@@ -310,10 +365,8 @@ class RadTTSModule(torch.nn.Module):
         out_lens: b-dim
         """
         # add an extra column
-        feats_extended_R = torch.cat(
-            (feats, torch.zeros_like(feats[:, 0:dilation])), dim=1)
-        feats_extended_L = torch.cat(
-            (torch.zeros_like(feats[:, 0:dilation]), feats), dim=1)
+        feats_extended_R = torch.cat((feats, torch.zeros_like(feats[:, 0:dilation])), dim=1)
+        feats_extended_L = torch.cat((torch.zeros_like(feats[:, 0:dilation]), feats), dim=1)
         dfeats_R = feats_extended_R[:, dilation:] - feats
         dfeats_L = feats - feats_extended_L[:, 0:-dilation]
 
@@ -329,13 +382,24 @@ class RadTTSModule(torch.nn.Module):
         unvoiced_embedding_s = self.v_embeddings.weight[1:2, :, None]
         voiced_embedding_b = self.v_embeddings.weight[2:3, :, None]
         unvoiced_embedding_b = self.v_embeddings.weight[3:4, :, None]
-        scale = torch.sigmoid(voiced_embedding_s*voiced_mask + unvoiced_embedding_s*(1-voiced_mask))
-        bias = 0.1*torch.tanh(voiced_embedding_b*voiced_mask + unvoiced_embedding_b*(1-voiced_mask))
-        return text_enc*scale+bias
+        scale = torch.sigmoid(voiced_embedding_s * voiced_mask + unvoiced_embedding_s * (1 - voiced_mask))
+        bias = 0.1 * torch.tanh(voiced_embedding_b * voiced_mask + unvoiced_embedding_b * (1 - voiced_mask))
+        return text_enc * scale + bias
 
-    def forward(self, mel, speaker_ids, text, in_lens, out_lens,
-                binarize_attention=False, attn_prior=None,
-                f0=None, energy_avg=None, voiced_mask=None, p_voiced=None):
+    def forward(
+        self,
+        mel,
+        speaker_ids,
+        text,
+        in_lens,
+        out_lens,
+        binarize_attention=False,
+        attn_prior=None,
+        f0=None,
+        energy_avg=None,
+        voiced_mask=None,
+        p_voiced=None,
+    ):
         speaker_vecs = self.encode_speaker(speaker_ids)
         text_enc, text_embeddings = self.encode_text(text, in_lens)
 
@@ -348,8 +412,8 @@ class RadTTSModule(torch.nn.Module):
             attn_mask = get_mask_from_lengths(in_lens)[..., None] == 0
             # attn_mask shld be 1 for unsd t-steps in text_enc_w_spkvec tensor
             attn_soft, attn_logprob = self.attention(
-                mel, text_embeddings, out_lens, attn_mask,
-                key_lens=in_lens, attn_prior=attn_prior)
+                mel, text_embeddings, out_lens, attn_mask, key_lens=in_lens, attn_prior=attn_prior
+            )
 
             if binarize_attention:
                 attn = self.binarize_attention(attn_soft, in_lens, out_lens)
@@ -378,20 +442,20 @@ class RadTTSModule(torch.nn.Module):
             # mask f0 in case values are interpolated
             if self.decoder_use_unvoiced_bias:
                 context_w_spkvec = self.preprocess_context(
-                    context, speaker_vecs, out_lens, f0 * voiced_mask + f0_bias,
-                    energy_avg)
+                    context, speaker_vecs, out_lens, f0 * voiced_mask + f0_bias, energy_avg
+                )
             else:
                 context_w_spkvec = self.preprocess_context(
-                    context, speaker_vecs, out_lens, f0 * voiced_mask,
-                    energy_avg)
+                    context, speaker_vecs, out_lens, f0 * voiced_mask, energy_avg
+                )
 
             log_s_list, log_det_W_list, z_out = [], [], []
-            unfolded_seq_lens = out_lens//self.n_group_size
+            unfolded_seq_lens = out_lens // self.n_group_size
             for i, flow_step in enumerate(self.flows):
                 if i in self.exit_steps:
-                    z = mel[:, :self.n_early_size]
+                    z = mel[:, : self.n_early_size]
                     z_out.append(z)
-                    mel = mel[:, self.n_early_size:]
+                    mel = mel[:, self.n_early_size :]
                 mel, log_det_W, log_s = flow_step(mel, context_w_spkvec, seq_lens=unfolded_seq_lens)
                 log_s_list.append(log_s)
                 log_det_W_list.append(log_det_W)
@@ -403,15 +467,13 @@ class RadTTSModule(torch.nn.Module):
         duration_model_outputs = None
         if 'dpm' in self.include_modules:
             if attn_hard is None:
-                attn_hard = self.binarize_attention(
-                    attn_soft, in_lens, out_lens)
+                attn_hard = self.binarize_attention(attn_soft, in_lens, out_lens)
 
             # convert hard attention to durations
             attn_hard_reduced = attn_hard.sum(2)[:, 0, :]
             duration_model_outputs = self.dur_pred_layer(
-                torch.detach(text_enc),
-                torch.detach(speaker_vecs),
-                torch.detach(attn_hard_reduced.float()), in_lens)
+                torch.detach(text_enc), torch.detach(speaker_vecs), torch.detach(attn_hard_reduced.float()), in_lens
+            )
 
         # f0, energy, vpred predictors forward pass
         f0_model_outputs = None
@@ -419,8 +481,7 @@ class RadTTSModule(torch.nn.Module):
         vpred_model_outputs = None
         if 'apm' in self.include_modules:
             if attn_hard is None:
-                attn_hard = self.binarize_attention(
-                    attn_soft, in_lens, out_lens)
+                attn_hard = self.binarize_attention(attn_soft, in_lens, out_lens)
 
             # convert hard attention to durations
             if binarize_attention:
@@ -433,31 +494,28 @@ class RadTTSModule(torch.nn.Module):
                 vpred_model_outputs = self.v_pred_module(
                     torch.detach(text_enc_time_expanded),
                     torch.detach(speaker_vecs),
-                    torch.detach(voiced_mask), out_lens)
+                    torch.detach(voiced_mask),
+                    out_lens,
+                )
 
                 # affine transform context using voiced mask
                 if self.ap_use_voiced_embeddings:
-                    text_enc_time_expanded = self.apply_voice_mask_to_text(
-                        text_enc_time_expanded, voiced_mask)
-            if self.ap_use_unvoiced_bias: # whether to use the unvoiced bias in the attribute predictor
+                    text_enc_time_expanded = self.apply_voice_mask_to_text(text_enc_time_expanded, voiced_mask)
+            if self.ap_use_unvoiced_bias:  # whether to use the unvoiced bias in the attribute predictor
                 f0_target = torch.detach(f0 * voiced_mask + f0_bias)
             else:
                 f0_target = torch.detach(f0)
             # fit to log f0 in f0 predictor
-            f0_target[voiced_mask.bool()] = torch.log(
-                f0_target[voiced_mask.bool()])
+            f0_target[voiced_mask.bool()] = torch.log(f0_target[voiced_mask.bool()])
             f0_target = f0_target / 6  # scale to ~ [0, 1] in log space
             energy_avg = energy_avg * 2 - 1  # scale to ~ [-1, 1]
 
             if self.use_first_order_features:
                 df0 = self.get_first_order_features(f0_target, out_lens)
-                denergy_avg = self.get_first_order_features(
-                    energy_avg, out_lens)
+                denergy_avg = self.get_first_order_features(energy_avg, out_lens)
 
-                f0_voiced = torch.cat(
-                    (f0_target[:, None],  df0[:, None]), dim=1)
-                energy_avg = torch.cat(
-                        (energy_avg[:, None], denergy_avg[:, None]), dim=1)
+                f0_voiced = torch.cat((f0_target[:, None], df0[:, None]), dim=1)
+                energy_avg = torch.cat((energy_avg[:, None], denergy_avg[:, None]), dim=1)
 
                 f0_voiced = f0_voiced * 3  # scale to ~ 1 std
                 energy_avg = energy_avg * 3  # scale to ~ 1 std
@@ -465,31 +523,44 @@ class RadTTSModule(torch.nn.Module):
                 f0_voiced = f0_target * 2  # scale to ~ 1 std
                 energy_avg = energy_avg * 1.4  # scale to ~ 1 std
             f0_model_outputs = self.f0_pred_module(
-                    text_enc_time_expanded, torch.detach(speaker_vecs),
-                    f0_voiced, out_lens)
+                text_enc_time_expanded, torch.detach(speaker_vecs), f0_voiced, out_lens
+            )
 
             energy_model_outputs = self.energy_pred_module(
-                    text_enc_time_expanded, torch.detach(speaker_vecs),
-                    energy_avg, out_lens)
+                text_enc_time_expanded, torch.detach(speaker_vecs), energy_avg, out_lens
+            )
 
-        outputs = {'z_mel': z_mel,
-                   'log_det_W_list': log_det_W_list,
-                   'log_s_list': log_s_list,
-                   'duration_model_outputs': duration_model_outputs,
-                   'f0_model_outputs': f0_model_outputs,
-                   'energy_model_outputs': energy_model_outputs,
-                   'vpred_model_outputs': vpred_model_outputs,
-                   'attn_soft': attn_soft,
-                   'attn': attn,
-                   'text_embeddings': text_embeddings,
-                   'attn_logprob': attn_logprob
-                   }
+        outputs = {
+            'z_mel': z_mel,
+            'log_det_W_list': log_det_W_list,
+            'log_s_list': log_s_list,
+            'duration_model_outputs': duration_model_outputs,
+            'f0_model_outputs': f0_model_outputs,
+            'energy_model_outputs': energy_model_outputs,
+            'vpred_model_outputs': vpred_model_outputs,
+            'attn_soft': attn_soft,
+            'attn': attn,
+            'text_embeddings': text_embeddings,
+            'attn_logprob': attn_logprob,
+        }
 
         return outputs
 
-    def infer(self, speaker_id, text, sigma, sigma_txt=0.8, sigma_f0=0.8,
-              sigma_energy=0.8, token_dur_scaling=1.0, token_duration_max=100,
-              dur=None, f0=None, energy_avg=None, voiced_mask=None):
+    def infer(
+        self,
+        speaker_id,
+        text,
+        sigma,
+        sigma_txt=0.8,
+        sigma_f0=0.8,
+        sigma_energy=0.8,
+        token_dur_scaling=1.0,
+        token_duration_max=100,
+        dur=None,
+        f0=None,
+        energy_avg=None,
+        voiced_mask=None,
+    ):
 
         n_tokens = text.shape[1]
         spk_vec = self.encode_speaker(speaker_id)
@@ -514,51 +585,43 @@ class RadTTSModule(torch.nn.Module):
         out_lens = torch.LongTensor([n_frames]).to(txt_enc.device)
 
         # get attributes f0, energy, vpred, etc)
-        txt_enc_time_expanded = self.length_regulator(
-            txt_enc.transpose(1, 2), dur).transpose(1, 2)
+        txt_enc_time_expanded = self.length_regulator(txt_enc.transpose(1, 2), dur).transpose(1, 2)
 
         if voiced_mask is None:
             if self.use_vpred_module:
                 # get logits
-                voiced_mask = self.v_pred_module.infer(
-                    None, txt_enc_time_expanded, spk_vec)
-                voiced_mask = (torch.sigmoid(voiced_mask[:, 0]) > 0.5)
+                voiced_mask = self.v_pred_module.infer(None, txt_enc_time_expanded, spk_vec)
+                voiced_mask = torch.sigmoid(voiced_mask[:, 0]) > 0.5
                 voiced_mask = voiced_mask.float()
 
         ap_txt_enc_time_expanded = txt_enc_time_expanded
         # voice mask augmentation only used for attribute prediction
         if self.ap_use_voiced_embeddings:
-            ap_txt_enc_time_expanded = self.apply_voice_mask_to_text(
-                txt_enc_time_expanded, voiced_mask)
+            ap_txt_enc_time_expanded = self.apply_voice_mask_to_text(txt_enc_time_expanded, voiced_mask)
 
         f0_bias = 0
         # unvoiced bias forward pass
         if self.use_unvoiced_bias:
-            f0_bias = self.unvoiced_bias_module(
-                txt_enc_time_expanded.permute(0, 2, 1))
+            f0_bias = self.unvoiced_bias_module(txt_enc_time_expanded.permute(0, 2, 1))
             f0_bias = -f0_bias[..., 0]
             f0_bias = f0_bias * (~voiced_mask.bool()).float()
 
         if f0 is None:
             n_f0_feature_channels = 2 if self.use_first_order_features else 1
-            z_f0 = torch.cuda.FloatTensor(
-                1, n_f0_feature_channels, n_frames).normal_() * sigma_f0
-            f0 = self.infer_f0(
-                z_f0, ap_txt_enc_time_expanded, spk_vec, voiced_mask, out_lens)[:, 0]
+            z_f0 = torch.cuda.FloatTensor(1, n_f0_feature_channels, n_frames).normal_() * sigma_f0
+            f0 = self.infer_f0(z_f0, ap_txt_enc_time_expanded, spk_vec, voiced_mask, out_lens)[:, 0]
 
         if energy_avg is None:
             n_energy_feature_channels = 2 if self.use_first_order_features else 1
-            z_energy_avg = torch.cuda.FloatTensor(
-                1, n_energy_feature_channels, n_frames).normal_() * sigma_energy
-            energy_avg = self.infer_energy(
-                z_energy_avg, ap_txt_enc_time_expanded, spk_vec, out_lens)[:, 0]
+            z_energy_avg = torch.cuda.FloatTensor(1, n_energy_feature_channels, n_frames).normal_() * sigma_energy
+            energy_avg = self.infer_energy(z_energy_avg, ap_txt_enc_time_expanded, spk_vec, out_lens)[:, 0]
 
         # replication pad, because ungrouping with different group sizes
         # may lead to mismatched lengths
         if energy_avg.shape[1] < out_lens[0]:
             to_pad = out_lens[0] - energy_avg.shape[1]
             pad_fn = nn.ReplicationPad1d((0, to_pad))
-            #f0 = pad_fn(f0[None])[0]
+            # f0 = pad_fn(f0[None])[0]
             energy_avg = pad_fn(energy_avg[None])[0]
         if f0.shape[1] < out_lens[0]:
             to_pad = out_lens[0] - f0.shape[1]
@@ -567,56 +630,48 @@ class RadTTSModule(torch.nn.Module):
 
         if self.decoder_use_unvoiced_bias:
             context_w_spkvec = self.preprocess_context(
-                txt_enc_time_expanded, spk_vec, out_lens, f0 * voiced_mask + f0_bias,
-                energy_avg)
+                txt_enc_time_expanded, spk_vec, out_lens, f0 * voiced_mask + f0_bias, energy_avg
+            )
 
         else:
             context_w_spkvec = self.preprocess_context(
-                txt_enc_time_expanded, spk_vec, out_lens, f0*voiced_mask, energy_avg)
+                txt_enc_time_expanded, spk_vec, out_lens, f0 * voiced_mask, energy_avg
+            )
 
-        residual = torch.cuda.FloatTensor(
-            1, 80 * self.n_group_size, n_frames // self.n_group_size)
+        residual = torch.cuda.FloatTensor(1, 80 * self.n_group_size, n_frames // self.n_group_size)
         residual = residual.normal_() * sigma
 
         # map from z sample to data
         exit_steps_stack = self.exit_steps.copy()
-        mel = residual[:, len(exit_steps_stack) * self.n_early_size:]
-        remaining_residual = residual[:, :len(exit_steps_stack)*self.n_early_size]
-        unfolded_seq_lens = out_lens//self.n_group_size
+        mel = residual[:, len(exit_steps_stack) * self.n_early_size :]
+        remaining_residual = residual[:, : len(exit_steps_stack) * self.n_early_size]
+        unfolded_seq_lens = out_lens // self.n_group_size
         for i, flow_step in enumerate(reversed(self.flows)):
             curr_step = len(self.flows) - i - 1
             mel = flow_step(mel, context_w_spkvec, inverse=True, seq_lens=unfolded_seq_lens)
             if len(exit_steps_stack) > 0 and curr_step == exit_steps_stack[-1]:
                 # concatenate the next chunk of z
                 exit_steps_stack.pop()
-                residual_to_add = remaining_residual[
-                    :, len(exit_steps_stack)*self.n_early_size:]
-                remaining_residual = remaining_residual[
-                    :, :len(exit_steps_stack)*self.n_early_size]
+                residual_to_add = remaining_residual[:, len(exit_steps_stack) * self.n_early_size :]
+                remaining_residual = remaining_residual[:, : len(exit_steps_stack) * self.n_early_size]
                 mel = torch.cat((residual_to_add, mel), 1)
 
         if self.n_group_size > 1:
             mel = self.fold(mel)
 
-        return {'mel': mel,
-                'dur': dur,
-                'f0': f0,
-                'energy_avg': energy_avg
-                }
+        return {'mel': mel, 'dur': dur, 'f0': f0, 'energy_avg': energy_avg}
 
-    def infer_f0(self, residual, txt_enc_time_expanded, spk_vec,
-                 voiced_mask=None, lens=None):
+    def infer_f0(self, residual, txt_enc_time_expanded, spk_vec, voiced_mask=None, lens=None):
         print("txt_enc_time_expanded", txt_enc_time_expanded.size())
         print("spk_vec", spk_vec.size())
-        f0 = self.f0_pred_module.infer(
-                residual, txt_enc_time_expanded, spk_vec, lens)
+        f0 = self.f0_pred_module.infer(residual, txt_enc_time_expanded, spk_vec, lens)
 
         if voiced_mask is not None and len(voiced_mask.shape) == 2:
             voiced_mask = voiced_mask[:, None]
         # constants
         if self.ap_pred_log_f0:
             if self.use_first_order_features:
-                f0 = f0[:,0:1,:] / 3
+                f0 = f0[:, 0:1, :] / 3
             else:
                 f0 = f0 / 2
             f0 = f0 * 6
@@ -629,7 +684,7 @@ class RadTTSModule(torch.nn.Module):
         else:
             voiced_mask = voiced_mask.bool()
         # due to grouping, f0 might be 1 frame short
-        voiced_mask = voiced_mask[:,:,:f0.shape[-1]]
+        voiced_mask = voiced_mask[:, :, : f0.shape[-1]]
         if self.ap_pred_log_f0:
             # if variable is set, decoder sees linear f0
             # mask = f0 > 0.0 if voiced_mask is None else voiced_mask.bool()
@@ -638,8 +693,7 @@ class RadTTSModule(torch.nn.Module):
         return f0
 
     def infer_energy(self, residual, txt_enc_time_expanded, spk_vec, lens):
-        energy = self.energy_pred_module.infer(
-                residual, txt_enc_time_expanded, spk_vec, lens)
+        energy = self.energy_pred_module.infer(residual, txt_enc_time_expanded, spk_vec, lens)
 
         # magic constants
         if self.use_first_order_features:

--- a/nemo/collections/tts/torch/data.py
+++ b/nemo/collections/tts/torch/data.py
@@ -43,11 +43,11 @@ from nemo.collections.tts.torch.tts_data_types import (
     Energy,
     LMTokens,
     LogMel,
-    Pitch,
-    Voiced_mask,
     P_voiced,
+    Pitch,
     SpeakerID,
     TTSDataType,
+    Voiced_mask,
     WithLens,
 )
 from nemo.collections.tts.torch.tts_tokenizers import BaseTokenizer, EnglishCharsTokenizer, EnglishPhonemesTokenizer
@@ -362,14 +362,13 @@ class TTSDataset(Dataset):
         self.pitch_mean = kwargs.pop("pitch_mean", None)
         self.pitch_std = kwargs.pop("pitch_std", None)
         self.pitch_norm = kwargs.pop("pitch_norm", False)
-        
-    #saving voiced_mask and p_voiced with pitch
+
+    # saving voiced_mask and p_voiced with pitch
     def add_voiced_mask(self, **kwargs):
         pass
-    
+
     def add_p_voiced(self, **kwargs):
         pass
-
 
     def add_energy(self, **kwargs):
         self.energy_folder = kwargs.pop('energy_folder', None)
@@ -479,10 +478,7 @@ class TTSDataset(Dataset):
                 pitch = torch.from_numpy(pitch).float()
                 voiced_mask = torch.from_numpy(voiced_mask).float()
                 p_voiced = torch.from_numpy(p_voiced).float()
-                torch.save({'pitch': pitch,
-                            'voiced_mask': voiced_mask,
-                            'p_voiced': p_voiced}, pitch_path)
-
+                torch.save({'pitch': pitch, 'voiced_mask': voiced_mask, 'p_voiced': p_voiced}, pitch_path)
 
             if self.pitch_mean is not None and self.pitch_std is not None and self.pitch_norm:
                 pitch -= self.pitch_mean
@@ -521,7 +517,7 @@ class TTSDataset(Dataset):
             align_prior_matrix,
             pitch,
             pitch_length,
-            voiced_mask, 
+            voiced_mask,
             p_voiced,
             energy,
             energy_length,
@@ -553,7 +549,7 @@ class TTSDataset(Dataset):
             align_prior_matrices_list,
             pitches,
             pitches_lengths,
-            voiced_masks, 
+            voiced_masks,
             p_voiceds,
             energies,
             energies_lengths,
@@ -579,7 +575,17 @@ class TTSDataset(Dataset):
             if AlignPriorMatrix in self.sup_data_types_set
             else []
         )
-        audios, tokens, log_mels, durations_list, pitches, voiced_masks, p_voiceds, energies, speaker_ids = [], [], [], [], [], [], [], [], []
+        audios, tokens, log_mels, durations_list, pitches, voiced_masks, p_voiceds, energies, speaker_ids = (
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+        )
 
         for i, sample_tuple in enumerate(batch):
             (
@@ -593,7 +599,7 @@ class TTSDataset(Dataset):
                 align_prior_matrix,
                 pitch,
                 pitch_length,
-                voiced_mask, 
+                voiced_mask,
                 p_voiced,
                 energy,
                 energy_length,
@@ -616,12 +622,12 @@ class TTSDataset(Dataset):
                 ] = align_prior_matrix
             if Pitch in self.sup_data_types_set:
                 pitches.append(general_padding(pitch, pitch_length.item(), max_pitches_len))
-                
+
             if Pitch in self.sup_data_types_set:
                 voiced_masks.append(general_padding(voiced_mask, pitch_length.item(), max_pitches_len))
             if Pitch in self.sup_data_types_set:
                 p_voiceds.append(general_padding(voiced_mask, pitch_length.item(), max_pitches_len))
-                
+
             if Energy in self.sup_data_types_set:
                 energies.append(general_padding(energy, energy_length.item(), max_energies_len))
             if SpeakerID in self.sup_data_types_set:

--- a/nemo/collections/tts/torch/tts_data_types.py
+++ b/nemo/collections/tts/torch/tts_data_types.py
@@ -53,11 +53,12 @@ class Energy(TTSDataType, WithLens):
 
 class SpeakerID(TTSDataType):
     name = "speaker_id"
-    
-    
+
+
 class Voiced_mask(TTSDataType):
     name = "voiced_mask"
-    
+
+
 class P_voiced(TTSDataType):
     name = "p_voiced"
 
@@ -67,5 +68,15 @@ class LMTokens(TTSDataType):
 
 
 MAIN_DATA_TYPES = [Audio, Text]
-VALID_SUPPLEMENTARY_DATA_TYPES = [LogMel, Durations, AlignPriorMatrix, Pitch, Voiced_mask, P_voiced, Energy, SpeakerID, LMTokens]
+VALID_SUPPLEMENTARY_DATA_TYPES = [
+    LogMel,
+    Durations,
+    AlignPriorMatrix,
+    Pitch,
+    Voiced_mask,
+    P_voiced,
+    Energy,
+    SpeakerID,
+    LMTokens,
+]
 DATA_STR2DATA_CLASS = {d.name: d for d in MAIN_DATA_TYPES + VALID_SUPPLEMENTARY_DATA_TYPES}

--- a/nemo/collections/tts/torch/tts_data_types.py
+++ b/nemo/collections/tts/torch/tts_data_types.py
@@ -53,6 +53,13 @@ class Energy(TTSDataType, WithLens):
 
 class SpeakerID(TTSDataType):
     name = "speaker_id"
+    
+    
+class Voiced_mask(TTSDataType):
+    name = "voiced_mask"
+    
+class P_voiced(TTSDataType):
+    name = "p_voiced"
 
 
 class LMTokens(TTSDataType):
@@ -60,5 +67,5 @@ class LMTokens(TTSDataType):
 
 
 MAIN_DATA_TYPES = [Audio, Text]
-VALID_SUPPLEMENTARY_DATA_TYPES = [LogMel, Durations, AlignPriorMatrix, Pitch, Energy, SpeakerID, LMTokens]
+VALID_SUPPLEMENTARY_DATA_TYPES = [LogMel, Durations, AlignPriorMatrix, Pitch, Voiced_mask, P_voiced, Energy, SpeakerID, LMTokens]
 DATA_STR2DATA_CLASS = {d.name: d for d in MAIN_DATA_TYPES + VALID_SUPPLEMENTARY_DATA_TYPES}


### PR DESCRIPTION
# What does this PR do ?

It's ports ADLR implementation of RADTTS to NeMo.

It affects TTS collection.  Specifically, TTS/Torch.

# Changelog 
- Added modules, model, loss functions, and helper functions for RADTTS

# Usage
Their is two stage training which requires two config files that are found under /examples/tts/conf/
- for each stage of the training different learning rates are used 
      - first stage learning rate (le4, 1e4, 5e5, 1e6(with fp= 32)) , config file: rad-tts_dec
      - second stage learning rate (1e3, 1e4, 1e5), config file: rad-tts_feature_pred


```python
# Add a code snippet demonstrating how to use this 
Once the config files are filled out. Run examples/tts/radtts_train.py

# Before your PR is "Ready for review"
**Pre checks**:
- [ x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ x] Did you write any new necessary tests?
- [ x] Did you add or update any necessary documentation?
- [ x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ x] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

- onnx exportability is still not added
- not tested with multi-speaker TTS training  
## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
Adding P_voiced and Voiced_mask might create conflicts with the other TTS repos so let's discuss about it. 