### PR TITLE
enable bias+dropout+add fusion with nvfuser at inference

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -325,7 +325,6 @@ class MegatronGPTModel(NLPModel):
 
         return loss_mean
 
-
     def on_train_batch_end(self, outputs, batch, batch_idx: int, unused: Optional[int] = 0) -> None:
         super().on_train_batch_end(outputs, batch, batch_idx)
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -106,7 +106,7 @@ class MegatronGPTModel(NLPModel):
         self._validate_trainer()
 
         # used in NVIDIA NGC PyTorch containers
-        # self._enable_nvidia_optimizations()
+        self._enable_nvidia_optimizations()
 
         if self.cfg.get('use_cpu_initialization', False) is False:
             torch.cuda.set_device(trainer.local_rank)
@@ -324,6 +324,7 @@ class MegatronGPTModel(NLPModel):
         )
 
         return loss_mean
+
 
     def on_train_batch_end(self, outputs, batch, batch_idx: int, unused: Optional[int] = 0) -> None:
         super().on_train_batch_end(outputs, batch, batch_idx)

--- a/nemo/collections/nlp/modules/common/megatron/fused_bias_dropout_add.py
+++ b/nemo/collections/nlp/modules/common/megatron/fused_bias_dropout_add.py
@@ -40,9 +40,11 @@ def bias_dropout_add_fused_train_(
 
 
 def bias_dropout_add_fused_train(x, bias, residual, prob):
-    args = _cast_if_autocast_enabled(x, bias, residual, prob)
-    with torch.cuda.amp.autocast(enabled=False):
-        return bias_dropout_add_fused_train_(*args)
+    # re-enable torch grad to enable fused optimization.
+    with torch.enable_grad():
+        args = _cast_if_autocast_enabled(x, bias, residual, prob)
+        with torch.cuda.amp.autocast(enabled=False):
+            return bias_dropout_add_fused_train_(*args)
 
 
 @torch.jit.script

--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -555,11 +555,9 @@ class ParallelTransformerLayer_(MegatronModule):
         else:
             bias_dropout_add_func = get_bias_dropout_add(self.training)
 
-        # re-enable torch grad to enable fused optimization.
-        with torch.enable_grad():
-            layernorm_input = bias_dropout_add_func(
-                attention_output, attention_bias.expand_as(residual), residual, self.hidden_dropout
-            )
+        layernorm_input = bias_dropout_add_func(
+            attention_output, attention_bias.expand_as(residual), residual, self.hidden_dropout
+        )
 
         # Layer norm post the self attention.
         layernorm_output = self.post_attention_layernorm(layernorm_input)
@@ -574,11 +572,9 @@ class ParallelTransformerLayer_(MegatronModule):
             else:
                 residual = layernorm_input
 
-            # re-enable torch grad to enable fused optimization.
-            with torch.enable_grad():
-                layernorm_input = bias_dropout_add_func(
-                    attention_output, attention_bias.expand_as(residual), residual, self.hidden_dropout
-                )
+            layernorm_input = bias_dropout_add_func(
+                attention_output, attention_bias.expand_as(residual), residual, self.hidden_dropout
+            )
 
             # Layer norm post the decoder attention
             layernorm_output = self.post_inter_attention_layernorm(layernorm_input)
@@ -592,9 +588,7 @@ class ParallelTransformerLayer_(MegatronModule):
         else:
             residual = layernorm_input
 
-        # re-enable torch grad to enable fused optimization.
-        with torch.enable_grad():
-            output = bias_dropout_add_func(mlp_output, mlp_bias.expand_as(residual), residual, self.hidden_dropout)
+        output = bias_dropout_add_func(mlp_output, mlp_bias.expand_as(residual), residual, self.hidden_dropout)
 
         if get_key_value:
             output = [output, presents]


### PR DESCRIPTION
# What does this PR do ?
Make nvfuser work at bias+dropout+add fusion at GPT inference

# Changelog 
Apply _torch.enable_grad_ to the fusion at training pass

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
