### PR TITLE
fix bug in intent/slot model reloading

### DIFF
--- a/nemo/collections/nlp/data/zero_shot_intent_recognition/zero_shot_intent_dataset.py
+++ b/nemo/collections/nlp/data/zero_shot_intent_recognition/zero_shot_intent_dataset.py
@@ -219,7 +219,7 @@ class ZeroShotIntentInferenceDataset(GLUEDataset):
         queries: List[str],
         candidate_labels: List[str],
         tokenizer: TokenizerSpec,
-        max_seq_length: str,
+        max_seq_length: int,
         hypothesis_template: str,
     ):
         """

--- a/nemo/collections/nlp/models/intent_slot_classification/intent_slot_classification_model.py
+++ b/nemo/collections/nlp/models/intent_slot_classification/intent_slot_classification_model.py
@@ -58,7 +58,8 @@ class IntentSlotClassificationModel(NLPModel):
         # Check the presence of data_dir.
         if not cfg.data_dir or not os.path.exists(cfg.data_dir):
             # Disable setup methods.
-            IntentSlotClassificationModel._set_model_restore_state(is_being_restored=True)
+            if not IntentSlotClassificationModel._is_model_being_restored():
+                IntentSlotClassificationModel._set_model_restore_state(is_being_restored=True)
             # Set default values of data_desc.
             self._set_defaults_data_desc(cfg)
         else:

--- a/nemo/collections/nlp/models/intent_slot_classification/multi_label_intent_slot_classification_model.py
+++ b/nemo/collections/nlp/models/intent_slot_classification/multi_label_intent_slot_classification_model.py
@@ -57,7 +57,8 @@ class MultiLabelIntentSlotClassificationModel(IntentSlotClassificationModel):
         # Check the presence of data_dir.
         if not cfg.data_dir or not os.path.exists(cfg.data_dir):
             # Disable setup methods.
-            MultiLabelIntentSlotClassificationModel._set_model_restore_state(is_being_restored=True)
+            if not MultiLabelIntentSlotClassificationModel._is_model_being_restored():
+                MultiLabelIntentSlotClassificationModel._set_model_restore_state(is_being_restored=True)
             # Set default values of data_desc.
             self._set_defaults_data_desc(cfg)
         else:

--- a/tutorials/nlp/Zero_Shot_Intent_Recognition.ipynb
+++ b/tutorials/nlp/Zero_Shot_Intent_Recognition.ipynb
@@ -647,7 +647,7 @@
   "accelerator": "GPU",
   "colab": {
    "collapsed_sections": [],
-   "name": "GLUE_Benchmark.ipynb",
+   "name": "Zero_Shot_Intent_Recognition.ipynb",
    "private_outputs": true,
    "provenance": []
   },


### PR DESCRIPTION
Signed-off-by: Carol Anderson <carola@nvidia.com>

# What does this PR do ?

Addresses the problem raised in #2769, where models cannot be reloaded if the data directory specified in the config is missing, such as when a model is reloaded on a different machine from the one on which it was trained.

**Collection**: NLP

# Changelog 
- Added a line to the IntentSlotClassificationModel and MultiLabelIntentSlotClassificationModel `__init__` methods to check whether `_is_model_being_restored()` is False before setting it to True. 
- Also fixed minor errors in the Zero Shot Intent Recognition model code: changed the display name of the tutorial notebook and corrected an incorrect type hint in the inference dataset class. 

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to  #2769 
