### PR TITLE
ability to set log_prediction to false

### DIFF
--- a/nemo/collections/asr/modules/rnnt.py
+++ b/nemo/collections/asr/modules/rnnt.py
@@ -907,7 +907,7 @@ class RNNTJoint(rnnt_abstract.AbstractRNNTJoint, Exportable):
                     sub_transcripts = sub_transcripts.detach()
 
                     original_log_prediction = self.wer.log_prediction
-                    if batch_idx == 0:
+                    if original_log_prediction and batch_idx == 0:
                         self.wer.log_prediction = True
                     else:
                         self.wer.log_prediction = False


### PR DESCRIPTION
# What does this PR do ?

Fixes the bug preventing the user from being able to turn off log_prediction in RNNT models

**Collection**: ASR

# Changelog 
- Add specific line by line info of high level changes in this PR.
- one line change checking to see whether wer.log_predictions = True before turning them on

# Usage
model.wer.log_predictions = False


```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
