### PR TITLE
Compatability override to load_state_dict for old TTS checkpoints

### DIFF
--- a/nemo/collections/tts/models/glow_tts.py
+++ b/nemo/collections/tts/models/glow_tts.py
@@ -288,6 +288,7 @@ class GlowTTSModel(SpectrogramGenerator):
         switch from torch_stft. It will be removed when this model is deprecated.
         """
         if 'preprocessor.featurizer.stft.forward_basis' in state_dict:
+            logging.warning("Loading old checkpoint, defaulting to hann window.")
             window_dim = state_dict['preprocessor.featurizer.stft.forward_basis'].shape[-1]
             state_dict['preprocessor.featurizer.window'] = torch.hann_window(window_dim)
             del state_dict['preprocessor.featurizer.stft.forward_basis']

--- a/nemo/collections/tts/models/glow_tts.py
+++ b/nemo/collections/tts/models/glow_tts.py
@@ -280,3 +280,16 @@ class GlowTTSModel(SpectrogramGenerator):
         )
         list_of_models.append(model)
         return list_of_models
+
+    def load_state_dict(self, state_dict, strict=True):
+        """Stopgap measure to keep old checkpoints working before full model deprecation.
+
+        This override fiddles with the state_dict in order to keep functionality from old checkpoints after the
+        switch from torch_stft. It will be removed when this model is deprecated.
+        """
+        if 'preprocessor.featurizer.stft.forward_basis' in state_dict:
+            window_dim = state_dict['preprocessor.featurizer.stft.forward_basis'].shape[-1]
+            state_dict['preprocessor.featurizer.window'] = torch.hann_window(window_dim)
+            del state_dict['preprocessor.featurizer.stft.forward_basis']
+            del state_dict['preprocessor.featurizer.stft.inverse_basis']
+        super().load_state_dict(state_dict, strict=strict)

--- a/nemo/collections/tts/models/squeezewave.py
+++ b/nemo/collections/tts/models/squeezewave.py
@@ -227,3 +227,16 @@ class SqueezeWaveModel(GlowVocoder):
         )
         list_of_models.append(model)
         return list_of_models
+
+    def load_state_dict(self, state_dict, strict=True):
+        """Stopgap measure to keep old checkpoints working before full model deprecation.
+
+        This override fiddles with the state_dict in order to keep functionality from old checkpoints after the
+        switch from torch_stft. It will be removed when this model is deprecated.
+        """
+        if 'audio_to_melspec_precessor.stft.forward_basis' in state_dict:
+            window_dim = state_dict['audio_to_melspec_precessor.stft.forward_basis'].shape[-1]
+            state_dict['audio_to_melspec_precessor.window'] = torch.hann_window(window_dim)
+            del state_dict['audio_to_melspec_precessor.stft.forward_basis']
+            del state_dict['audio_to_melspec_precessor.stft.inverse_basis']
+        super().load_state_dict(state_dict, strict=strict)

--- a/nemo/collections/tts/models/squeezewave.py
+++ b/nemo/collections/tts/models/squeezewave.py
@@ -235,6 +235,7 @@ class SqueezeWaveModel(GlowVocoder):
         switch from torch_stft. It will be removed when this model is deprecated.
         """
         if 'audio_to_melspec_precessor.stft.forward_basis' in state_dict:
+            logging.warning("Loading old checkpoint, defaulting to hann window.")
             window_dim = state_dict['audio_to_melspec_precessor.stft.forward_basis'].shape[-1]
             state_dict['audio_to_melspec_precessor.window'] = torch.hann_window(window_dim)
             del state_dict['audio_to_melspec_precessor.stft.forward_basis']

--- a/nemo/collections/tts/models/talknet.py
+++ b/nemo/collections/tts/models/talknet.py
@@ -30,6 +30,7 @@ from nemo.core import Exportable
 from nemo.core.classes import ModelPT, PretrainedModelInfo, typecheck
 from nemo.core.neural_types import MelSpectrogramType, NeuralType
 from nemo.core.neural_types.elements import LengthsType, MelSpectrogramType, RegressionValuesType, TokenIndex
+from nemo.utils import logging
 from nemo.utils.decorators import deprecated
 
 
@@ -422,6 +423,7 @@ class TalkNetSpectModel(SpectrogramGenerator, Exportable):
         switch from torch_stft. It will be removed when this model is deprecated.
         """
         if 'preprocessor.featurizer.stft.forward_basis' in state_dict:
+            logging.warning("Loading old checkpoint, defaulting to hann window.")
             window_dim = state_dict['preprocessor.featurizer.stft.forward_basis'].shape[-1]
             state_dict['preprocessor.featurizer.window'] = torch.hann_window(window_dim)
             del state_dict['preprocessor.featurizer.stft.forward_basis']

--- a/nemo/collections/tts/models/uniglow.py
+++ b/nemo/collections/tts/models/uniglow.py
@@ -272,6 +272,7 @@ class UniGlowModel(GlowVocoder):
         switch from torch_stft. It will be removed when this model is deprecated.
         """
         if 'audio_to_melspec_precessor.stft.forward_basis' in state_dict:
+            logging.warning("Loading old checkpoint, defaulting to hann window.")
             window_dim = state_dict['audio_to_melspec_precessor.stft.forward_basis'].shape[-1]
             state_dict['audio_to_melspec_precessor.window'] = torch.hann_window(window_dim)
             del state_dict['audio_to_melspec_precessor.stft.forward_basis']

--- a/tutorials/tts/Tacotron2_Training.ipynb
+++ b/tutorials/tts/Tacotron2_Training.ipynb
@@ -263,14 +263,22 @@
    },
    "outputs": [],
    "source": [
-    "!wget https://github.com/NVIDIA/NeMo/releases/download/v0.11.0/test_data.tar.gz && mkdir -p tests/data && tar xzf test_data.tar.gz -C tests/data\n",
+    "!wget https://github.com/NVIDIA/NeMo/releases/download/v0.11.0/test_data.tar.gz \\\n",
+    "    && mkdir -p tests/data \\\n",
+    "    && tar xzf test_data.tar.gz -C tests/data\n",
     "\n",
     "# Just like ASR, the Tacotron2 require .json files to define the training and validation data.\n",
     "!cat tests/data/asr/an4_val.json\n",
     "\n",
     "# Now that we have some sample data, we can try training Tacotron 2\n",
     "# NOTE: The sample data is not enough data to properly train a Tacotron 2. This will not result in a trained Tacotron 2 and is used to illustrate how to train Tacotron 2 model\n",
-    "!python tacotron2.py sample_rate=16000 train_dataset=tests/data/asr/an4_train.json validation_datasets=tests/data/asr/an4_val.json trainer.max_epochs=3 trainer.accelerator=null trainer.check_val_every_n_epoch=1"
+    "!python tacotron2.py \\\n",
+    "sample_rate=16000 \\\n",
+    "train_dataset=tests/data/asr/an4_train.json \\\n",
+    "validation_datasets=tests/data/asr/an4_val.json \\\n",
+    "trainer.max_epochs=3 \\\n",
+    "trainer.accelerator=null trainer.check_val_every_n_epoch=1 \\\n",
+    "+trainer.gpus=1"
    ]
   },
   {
@@ -317,7 +325,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -331,7 +339,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/tutorials/tts/TalkNet_Training.ipynb
+++ b/tutorials/tts/TalkNet_Training.ipynb
@@ -115,7 +115,7 @@
     "# We can load the pre-trained model as follows\n",
     "pretrained_model = \"tts_en_talknet\"\n",
     "model = TalkNetSpectModel.from_pretrained(pretrained_model)\n",
-    "model.eval()"
+    "model.eval();"
    ]
   },
   {
@@ -496,7 +496,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -510,7 +510,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Signed-off-by: Jocelyn Huang <jocelynh@nvidia.com>

# What does this PR do ?

Overrides `load_state_dict` for four TTS models (to be deprecated in 1.9.0) such that they work with old NGC checkpoints, plus minor tutorial fixes/updates.

**Collection**: TTS

# Changelog 
- Removes `forward_basis` and `inverse_basis` from the `state_dict` of existing checkpoints, which were trained before NeMo moved away from using torch_stft
- Adds `window` to `state_dict` for the preprocessor
- Semicolon added to one line in the TalkNet training tutorial to avoid printing the whole model
- Added `trainer.gpu` command line argument to Tacotron2 notebook
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation