### PR TITLE
Pass float32 array to librosa.core.resample

### DIFF
--- a/nemo/collections/asr/parts/utils/decoder_timestamps_utils.py
+++ b/nemo/collections/asr/parts/utils/decoder_timestamps_utils.py
@@ -219,12 +219,11 @@ def get_samples(audio_file, target_sr=16000):
     Read the samples from the given audio_file path.
     """
     with sf.SoundFile(audio_file, 'r') as f:
-        dtype = 'int16'
+        dtype = 'float32'
         sample_rate = f.samplerate
         samples = f.read(dtype=dtype)
         if sample_rate != target_sr:
-            samples = librosa.core.resample(samples, sample_rate, target_sr)
-        samples = samples.astype('float32') / 32768
+            samples = librosa.core.resample(samples, sample_rate, target_sr)        
         samples = samples.transpose()
         del f
     return samples


### PR DESCRIPTION
Signed-off-by: rvygon <roman.vygon@gmail.com>

# What does this PR do ?

Fixes #3982, where get_samples passes int16 to librosa.core.resample instead of float32.

**Collection**: ASR

# Usage

```python
from pydub import AudioSegment
from nemo.collections.asr.parts.utils.decoder_timestamps_utils import get_samples
segment = AudioSegment.silent(duration=10000).set_frame_rate(22050).set_channels(1)
segment.export('test.wav', format='wav')

arr = get_samples('test.wav')
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #3982  (issue)
