### PR TITLE
Add configurable LogSoftmax support to Punctuator Model

### DIFF
--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
@@ -111,8 +111,7 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
             self.log_softmax = cfg.get("log_softmax")
         else:
             self.log_softmax = False
-            
-        self.log_softmax: bool = cfg.get("use_logsoftmax")
+        
         super().__init__(cfg=cfg, trainer=trainer)
         if not self.label_ids_are_set:
             self._set_label_ids()

--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
@@ -1119,7 +1119,7 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
                             acc_probs[q_i] = b_probs_i
                         else:
                             all_preds[q_i], acc_probs[q_i] = self._move_acc_probs_to_token_preds(
-                                self.log_softmax, all_preds[q_i], acc_probs[q_i], start_word_id - len(all_preds[q_i])
+                                all_preds[q_i], acc_probs[q_i], start_word_id - len(all_preds[q_i])
                             )
                             acc_probs[q_i] = self._update_accumulated_probabilities(
                                 self.log_softmax, acc_probs[q_i], b_probs_i

--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
@@ -1119,7 +1119,7 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
                             acc_probs[q_i] = b_probs_i
                         else:
                             all_preds[q_i], acc_probs[q_i] = self._move_acc_probs_to_token_preds(
-                                all_preds[q_i], acc_probs[q_i], start_word_id - len(all_preds[q_i])
+                                self.log_softmax, all_preds[q_i], acc_probs[q_i], start_word_id - len(all_preds[q_i])
                             )
                             acc_probs[q_i] = self._update_accumulated_probabilities(
                                 self.log_softmax, acc_probs[q_i], b_probs_i

--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
@@ -916,8 +916,7 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
                     p = self._remove_margins(logits, margin, keep_left=first, keep_right=last)[stm]
                 else:
                     p = torch.nn.functional.softmax(
-                        self._remove_margins(logits, margin, keep_left=first, keep_right=last)[stm],
-                        dim=-1,
+                        self._remove_margins(logits, margin, keep_left=first, keep_right=last)[stm], dim=-1
                     )
                 b_probs.append(p.detach().cpu().numpy())
 
@@ -1103,9 +1102,7 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
             ):
                 inp_ids, inp_type_ids, inp_mask, subtokens_mask, start_word_ids, query_ids, is_first, is_last = batch
                 punct_logits, capit_logits = self.forward(
-                    input_ids=inp_ids.to(d),
-                    token_type_ids=inp_type_ids.to(d),
-                    attention_mask=inp_mask.to(d),
+                    input_ids=inp_ids.to(d), token_type_ids=inp_type_ids.to(d), attention_mask=inp_mask.to(d),
                 )
                 _res = self._transform_logit_to_prob_and_remove_margins_and_extract_word_probs(
                     punct_logits, capit_logits, subtokens_mask, start_word_ids, margin, is_first, is_last
@@ -1122,9 +1119,7 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
                             acc_probs[q_i] = b_probs_i
                         else:
                             all_preds[q_i], acc_probs[q_i] = self._move_acc_probs_to_token_preds(
-                                all_preds[q_i],
-                                acc_probs[q_i],
-                                start_word_id - len(all_preds[q_i]),
+                                all_preds[q_i], acc_probs[q_i], start_word_id - len(all_preds[q_i])
                             )
                             acc_probs[q_i] = self._update_accumulated_probabilities(
                                 self.log_softmax, acc_probs[q_i], b_probs_i

--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
@@ -16,8 +16,6 @@ import copy
 from math import ceil
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple, Union
-from nemo.collections.common.losses.cross_entropy import NLLLoss
-from nemo.core.neural_types.elements import LogprobsType
 
 import numpy as np
 import torch
@@ -26,7 +24,7 @@ from pytorch_lightning import Trainer
 from pytorch_lightning.utilities.types import EPOCH_OUTPUT
 from tqdm import tqdm
 
-from nemo.collections.common.losses import AggregatorLoss, CrossEntropyLoss
+from nemo.collections.common.losses import AggregatorLoss, CrossEntropyLoss, NLLLoss
 from nemo.collections.common.metrics import GlobalAverageLossMetric
 from nemo.collections.nlp.data.token_classification.punctuation_capitalization_dataset import (
     BertPunctuationCapitalizationDataset,
@@ -50,7 +48,7 @@ from nemo.collections.nlp.models.token_classification.punctuation_capitalization
 from nemo.collections.nlp.modules.common import TokenClassifier
 from nemo.core.classes.common import PretrainedModelInfo, typecheck
 from nemo.core.classes.exportable import Exportable
-from nemo.core.neural_types import LogitsType, NeuralType
+from nemo.core.neural_types import LogitsType, NeuralType, LogprobsType
 from nemo.utils import logging
 
 __all__ = ['PunctuationCapitalizationModel']

--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_model.py
@@ -135,7 +135,7 @@ class PunctuationCapitalizationModel(NLPModel, Exportable):
         )
 
         if(self.log_softmax):
-            self.loss = NLLLoss(logits_ndim=3)
+            self.loss = NLLLoss(log_probs_ndim=3)
         else:
             self.loss = CrossEntropyLoss(logits_ndim=3)
         self.agg_loss = AggregatorLoss(num_inputs=2)


### PR DESCRIPTION
# What does this PR do ?

Adds a configurable parameter to apply log softmax on output logits for RIVA support

**Collection**: [Note which collection this PR will affect]
nlp/models/token_classification/punctuation_capitalization_model.py

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
