### PR TITLE
Fix compat override for TalkNet Aligner

### DIFF
--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -714,3 +714,18 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
 
         temporary_datalayer = self._setup_dataloader_from_config(config=DictConfig(dl_config))
         return temporary_datalayer
+
+    def load_state_dict(self, state_dict, strict=True):
+        """Stopgap measure to keep old checkpoints working before full model deprecation.
+
+        This override fiddles with the state_dict in order to keep functionality from old checkpoints after the
+        switch from torch_stft. It will be removed when the TalkNet Aligner model is deprecated.
+        """
+        # TODO: Remove this function once TalkNet Aligner is deprecated in 1.9.0
+        if 'preprocessor.featurizer.stft.forward_basis' in state_dict:
+            logging.warning("Loading old checkpoint, defaulting to hann window.")
+            window_dim = state_dict['preprocessor.featurizer.stft.forward_basis'].shape[-1]
+            state_dict['preprocessor.featurizer.window'] = torch.hann_window(window_dim)
+            del state_dict['preprocessor.featurizer.stft.forward_basis']
+            del state_dict['preprocessor.featurizer.stft.inverse_basis']
+        super().load_state_dict(state_dict, strict=strict)

--- a/nemo/collections/tts/models/talknet.py
+++ b/nemo/collections/tts/models/talknet.py
@@ -415,17 +415,3 @@ class TalkNetSpectModel(SpectrogramGenerator, Exportable):
         model.add_module('_pitch_model', TalkNetPitchModel.from_pretrained(model_name, *args, **kwargs))
         model.add_module('_durs_model', TalkNetDursModel.from_pretrained(model_name, *args, **kwargs))
         return model
-
-    def load_state_dict(self, state_dict, strict=True):
-        """Stopgap measure to keep old checkpoints working before full model deprecation.
-
-        This override fiddles with the state_dict in order to keep functionality from old checkpoints after the
-        switch from torch_stft. It will be removed when this model is deprecated.
-        """
-        if 'preprocessor.featurizer.stft.forward_basis' in state_dict:
-            logging.warning("Loading old checkpoint, defaulting to hann window.")
-            window_dim = state_dict['preprocessor.featurizer.stft.forward_basis'].shape[-1]
-            state_dict['preprocessor.featurizer.window'] = torch.hann_window(window_dim)
-            del state_dict['preprocessor.featurizer.stft.forward_basis']
-            del state_dict['preprocessor.featurizer.stft.inverse_basis']
-        super().load_state_dict(state_dict, strict=strict)


### PR DESCRIPTION
# What does this PR do ?

Moves the override to `load_state_dict()` from TalkNet (which doesn't need it) to EncDecCTCModel for compatibility with the TalkNet Aligner checkpoint.

This should be removed in 1.9.0 when the TalkNet Aligner model is deprecated.

**Collection**: TTS, ASR

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation