### PR TITLE
[Draft] [TTS] Remove AudioToCharWithPriorAndPitchDataset dependency from fastpitch

### DIFF
--- a/nemo/collections/tts/models/fastpitch.py
+++ b/nemo/collections/tts/models/fastpitch.py
@@ -16,11 +16,10 @@ from typing import Optional
 
 import torch
 from hydra.utils import instantiate
-from omegaconf import DictConfig, open_dict
+from omegaconf import DictConfig, open_dict, OmegaConf
 from pytorch_lightning import Trainer
 from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
 
-from nemo.collections.asr.data.audio_to_text import AudioToCharWithDursF0Dataset
 from nemo.collections.common.parts.preprocessing import parsers
 from nemo.collections.tts.helpers.helpers import plot_alignment_to_numpy, plot_spectrogram_to_numpy
 from nemo.collections.tts.losses.aligner_loss import BinLoss, ForwardSumLoss
@@ -66,12 +65,17 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
             self.vocab = None
             self.ds_class_name = cfg.train_ds.dataset._target_.split(".")[-1]
 
-            if self.ds_class_name == "AudioToCharWithPriorAndPitchDataset":
-                self.vocab = AudioToCharWithDursF0Dataset.make_vocab(**cfg.train_ds.dataset.vocab)
-                input_fft_kwargs["n_embed"] = len(self.vocab.labels)
-                input_fft_kwargs["padding_idx"] = self.vocab.pad
-            elif self.ds_class_name == "TTSDataset":
+            if self.ds_class_name == "TTSDataset":
                 self._setup_tokenizer(cfg)
+                assert self.vocab is not None
+                input_fft_kwargs["n_embed"] = len(self.vocab.tokens)
+                input_fft_kwargs["padding_idx"] = self.vocab.pad
+            elif self.ds_class_name == "AudioToCharWithPriorAndPitchDataset":
+                logging.warning("AudioToCharWithPriorAndPitchDataset class has been deprecated. No support for" \
+                " training or finetuning. Only inference is supported.")
+                default_tokenizer_yaml = self._get_default_text_tokenizer()
+                tokenizer_conf = OmegaConf.create(default_tokenizer_yaml)
+                self._setup_tokenizer(tokenizer_conf)
                 assert self.vocab is not None
                 input_fft_kwargs["n_embed"] = len(self.vocab.tokens)
                 input_fft_kwargs["padding_idx"] = self.vocab.pad
@@ -121,6 +125,26 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
             cfg.n_mel_channels,
         )
         self._input_types = self._output_types = None
+
+
+    def _get_default_text_tokenizer(self):
+        default_text_tokenizer = """
+            text_tokenizer:
+                _target_: nemo.collections.tts.torch.tts_tokenizers.EnglishPhonemesTokenizer
+                punct: true
+                stresses: true
+                chars: true
+                apostrophe: true
+                pad_with_space: true
+                add_blank_at: true
+                g2p:
+                    _target_: nemo.collections.tts.torch.g2ps.EnglishG2p
+                    phoneme_dict: "scripts/tts_dataset_files/cmudict-0.7b_nv22.01"
+                    heteronyms: "scripts/tts_dataset_files/heteronyms-030921"
+                    phoneme_probability: 0.5
+            """
+        return default_text_tokenizer
+
 
     def _setup_normalizer(self, cfg):
         if "text_normalizer" in cfg:
@@ -177,14 +201,17 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
         if self.learn_alignment:
             ds_class_name = self._cfg.train_ds.dataset._target_.split(".")[-1]
 
-            # TODO(Oktai15): remove it in 1.8.0 version
-            if ds_class_name == "AudioToCharWithPriorAndPitchDataset" or ds_class_name == "TTSDataset":
+            if ds_class_name == "TTSDataset":
+                self._parser = self.vocab.encode
+            elif ds_class_name == "AudioToCharWithPriorAndPitchDataset":
+                if self.vocab is None:
+                    default_tokenizer_yaml = self._get_default_text_tokenizer()
+                    tokenizer_conf = OmegaConf.create(default_tokenizer_yaml)
+                    self._setup_tokenizer(tokenizer_conf)
                 self._parser = self.vocab.encode
             else:
                 raise ValueError(f"Unknown dataset class: {ds_class_name}")
         else:
-            # TODO(Oktai15): remove it in 1.8.0 version
-            # ds_class_name == "FastPitchDataset"
             self._parser = parsers.make_parser(
                 labels=self._cfg.labels,
                 name='en',
@@ -212,7 +239,6 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
             with eval_phon_mode:
                 tokens = self.parser(str_input)
         else:
-            # TODO(Oktai15): remove it in 1.8.0 version
             tokens = self.parser(str_input)
 
         x = torch.tensor(tokens).unsqueeze_(0).long().to(self.device)
@@ -270,10 +296,7 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
     def training_step(self, batch, batch_idx):
         attn_prior, durs, speaker = None, None, None
         if self.learn_alignment:
-            # TODO(Oktai15): remove it in 1.8.0 version
-            if self.ds_class_name == "AudioToCharWithPriorAndPitchDataset":
-                audio, audio_lens, text, text_lens, attn_prior, pitch, speaker = batch
-            elif self.ds_class_name == "TTSDataset":
+            if self.ds_class_name == "TTSDataset":
                 if SpeakerID in self._train_dl.dataset.sup_data_types_set:
                     audio, audio_lens, text, text_lens, attn_prior, pitch, _, speaker = batch
                 else:
@@ -281,7 +304,6 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
             else:
                 raise ValueError(f"Unknown vocab class: {self.vocab.__class__.__name__}")
         else:
-            # TODO(Oktai15): remove it in 1.8.0 version
             audio, audio_lens, text, text_lens, durs, pitch, speaker = batch
 
         mels, spec_len = self.preprocessor(input_signal=audio, length=audio_lens)
@@ -349,10 +371,7 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
     def validation_step(self, batch, batch_idx):
         attn_prior, durs, speaker = None, None, None
         if self.learn_alignment:
-            # TODO(Oktai15): remove it in 1.8.0 version
-            if self.ds_class_name == "AudioToCharWithPriorAndPitchDataset":
-                audio, audio_lens, text, text_lens, attn_prior, pitch, speaker = batch
-            elif self.ds_class_name == "TTSDataset":
+            if self.ds_class_name == "TTSDataset":
                 if SpeakerID in self._train_dl.dataset.sup_data_types_set:
                     audio, audio_lens, text, text_lens, attn_prior, pitch, _, speaker = batch
                 else:
@@ -360,7 +379,6 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
             else:
                 raise ValueError(f"Unknown vocab class: {self.vocab.__class__.__name__}")
         else:
-            # TODO(Oktai15): remove it in 1.8.0 version
             audio, audio_lens, text, text_lens, durs, pitch, speaker = batch
 
         mels, mel_lens = self.preprocessor(input_signal=audio, length=audio_lens)
@@ -438,10 +456,7 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
         elif not shuffle_should_be and cfg.dataloader_params.shuffle:
             logging.error(f"The {name} dataloader for {self} has shuffle set to True!!!")
 
-        # TODO(Oktai15): remove it in 1.8.0 version
-        if cfg.dataset._target_ == "nemo.collections.asr.data.audio_to_text.FastPitchDataset":
-            dataset = instantiate(cfg.dataset, parser=self.parser)
-        elif cfg.dataset._target_ == "nemo.collections.tts.torch.data.TTSDataset":
+        if cfg.dataset._target_ == "nemo.collections.tts.torch.data.TTSDataset":
             phon_mode = contextlib.nullcontext()
             if hasattr(self.vocab, "set_phone_prob"):
                 phon_mode = self.vocab.set_phone_prob(prob=None if name == "val" else self.vocab.phoneme_probability)
@@ -454,7 +469,6 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
                     text_tokenizer=self.vocab,
                 )
         else:
-            # TODO(Oktai15): remove it in 1.8.0 version
             dataset = instantiate(cfg.dataset)
 
         return torch.utils.data.DataLoader(dataset, collate_fn=dataset.collate_fn, **cfg.dataloader_params)

--- a/nemo/collections/tts/models/fastpitch.py
+++ b/nemo/collections/tts/models/fastpitch.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
-from typing import Optional
 from dataclasses import dataclass, is_dataclass
+from typing import Optional
 
 import torch
 from hydra.utils import instantiate
-from omegaconf import DictConfig, open_dict, OmegaConf
+from omegaconf import DictConfig, OmegaConf, open_dict
 from pytorch_lightning import Trainer
 from pytorch_lightning.loggers import LoggerCollection, TensorBoardLogger
 
@@ -43,6 +43,7 @@ from nemo.core.neural_types.elements import (
 from nemo.core.neural_types.neural_type import NeuralType
 from nemo.utils import logging, model_utils
 
+
 @dataclass
 class G2PConfig:
     _target_: str = "nemo.collections.tts.torch.g2ps.EnglishG2p"
@@ -61,6 +62,7 @@ class TextTokenizer:
     pad_with_space: bool = True
     add_blank_at: bool = True
     g2p: G2PConfig = G2PConfig()
+
 
 @dataclass
 class TextTokenizerConfig:
@@ -95,8 +97,10 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
                 input_fft_kwargs["n_embed"] = len(self.vocab.tokens)
                 input_fft_kwargs["padding_idx"] = self.vocab.pad
             elif self.ds_class_name == "AudioToCharWithPriorAndPitchDataset":
-                logging.warning("AudioToCharWithPriorAndPitchDataset class has been deprecated. No support for" \
-                " training or finetuning. Only inference is supported.")
+                logging.warning(
+                    "AudioToCharWithPriorAndPitchDataset class has been deprecated. No support for" \
+                    " training or finetuning. Only inference is supported."
+                )
                 tokenizer_conf = self._get_default_text_tokenizer_conf()
                 self._setup_tokenizer(tokenizer_conf)
                 assert self.vocab is not None
@@ -149,10 +153,9 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
         )
         self._input_types = self._output_types = None
 
-
     def _get_default_text_tokenizer_conf(self):
         text_tokenizer: TextTokenizerConfig = TextTokenizerConfig()
-        return OmegaConf.create( OmegaConf.to_yaml( text_tokenizer) )
+        return OmegaConf.create(OmegaConf.to_yaml( text_tokenizer))
 
     def _setup_normalizer(self, cfg):
         if "text_normalizer" in cfg:

--- a/nemo/collections/tts/models/fastpitch.py
+++ b/nemo/collections/tts/models/fastpitch.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass
 from typing import Optional
 
 import torch

--- a/nemo/collections/tts/models/fastpitch.py
+++ b/nemo/collections/tts/models/fastpitch.py
@@ -98,7 +98,7 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
                 input_fft_kwargs["padding_idx"] = self.vocab.pad
             elif self.ds_class_name == "AudioToCharWithPriorAndPitchDataset":
                 logging.warning(
-                    "AudioToCharWithPriorAndPitchDataset class has been deprecated. No support for" \
+                    "AudioToCharWithPriorAndPitchDataset class has been deprecated. No support for"
                     " training or finetuning. Only inference is supported."
                 )
                 tokenizer_conf = self._get_default_text_tokenizer_conf()
@@ -155,7 +155,7 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
 
     def _get_default_text_tokenizer_conf(self):
         text_tokenizer: TextTokenizerConfig = TextTokenizerConfig()
-        return OmegaConf.create(OmegaConf.to_yaml( text_tokenizer))
+        return OmegaConf.create(OmegaConf.to_yaml(text_tokenizer))
 
     def _setup_normalizer(self, cfg):
         if "text_normalizer" in cfg:


### PR DESCRIPTION
# What does this PR do ?

AudioToCharWithDursF0Dataset class will be deprecated so this PR adds code and config to use old FastPitch checkpoint (checkpoint that was trained using AudioToCharWithDursF0Dataset class which is now deprecated) with new code (TTSDataset) to support inference.

**Collection**: tts.models.fastpitch

# Changelog 
- Adds Warning when using old checkpoint
- Adds config file to be used with old checkpoint

# Usage
* Fastpitch will only support inference using the old fastpitch checkpoint


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
