### PR TITLE
Bugfix and variable name change for clustering code

### DIFF
--- a/nemo/collections/asr/parts/utils/nmesc_clustering.py
+++ b/nemo/collections/asr/parts/utils/nmesc_clustering.py
@@ -31,11 +31,11 @@
 # https://arxiv.org/pdf/2003.02405.pdf and the implementation from
 # https://github.com/tango4j/Auto-Tuning-Spectral-Clustering.
 
+import multiprocessing
 from collections import Counter
 from typing import Dict, List
 
 import torch
-import multiprocessing
 from torch.linalg import eigh
 
 
@@ -488,6 +488,7 @@ def getLamdaGaplist(lambdas: torch.Tensor):
     if torch.is_complex(lambdas):
         lambdas = torch.real(lambdas)
     return lambdas[1:] - lambdas[:-1]
+
 
 @torch.jit.script
 def addAnchorEmb(emb: torch.Tensor, anchor_sample_n: int, anchor_spk_n: int, sigma: float):

--- a/nemo/collections/asr/parts/utils/nmesc_clustering.py
+++ b/nemo/collections/asr/parts/utils/nmesc_clustering.py
@@ -31,7 +31,6 @@
 # https://arxiv.org/pdf/2003.02405.pdf and the implementation from
 # https://github.com/tango4j/Auto-Tuning-Spectral-Clustering.
 
-import multiprocessing
 from collections import Counter
 from typing import Dict, List
 


### PR DESCRIPTION
Signed-off-by: Taejin Park <tango4j@gmail.com>

# What does this PR do ?

This PR fixes the type casting issue in nmesc_clustering.py. With torch.jit.script decorator, torch.tensor should always strictly match the type when assigining/changing a variable. Without this fix, in some cases torch.jit compiler returns an error at nmesc_clustering.py.


**Collection**: [Note which collection this PR will affect]
ASR

# Changelog 
- changed variable name from random_trial to n_random_trials
- changed variable assignment with a proper type conversion

# Usage
Please refer to [speaker diarization part of the NeMo docs](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/asr/speaker_diarization/datasets.html).

```python
python examples/speaker_tasks/diarization/offline_diarization.py \
    diarizer.manifest_filepath="/path/to/ch109_input_manifest.json" \
    diarizer.oracle_num_speakers=2  \ # Since there are exactly 2 speakers per each CH109 session
    diarizer.oracle_vad=True \ # Use oracle VAD extracted from RTTM files.
    diarizer.collar=0.25 \
    diarizer.ignore_overlap=True \
    diarizer.speaker_embeddings.model_path="titanet_large" \
    diarizer.speaker_embeddings.window_length_in_sec=[1.5,1.0,0.5] # Multiscale setting \
    diarizer.speaker_embeddings.shift_length_in_sec=[0.75,0.5,0.25] # Multiscale setting \
    diarizer.speaker_embeddings.parameters.multiscale_weights=[0.33,0.33,0.33] # Equal weights 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [  ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 


