### PR TITLE
Make saving prompt encoder embeddings non-configurable

### DIFF
--- a/examples/nlp/language_modeling/conf/megatron_gpt_prompt_learning_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_gpt_prompt_learning_config.yaml
@@ -79,7 +79,6 @@ model:
   p_tuning: # P-tuning specific params
     dropout: 0.0
     num_layers: 2
-    save_tuned_prompts_to_prompt_table: True
 
   data:
     train_ds: [data/squad_train.jsonl,]

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -459,7 +459,7 @@ class MegatronGPTPromptLearningModel(MegatronBaseModel, TextGeneration):
 
     def on_train_end(self):
         # Save p-tuned prompts to prompt table for inference or future task training
-        if self.virtual_prompt_style == "p-tuning" and self.cfg.p_tuning.save_tuned_prompts_to_prompt_table:
+        if self.virtual_prompt_style == "p-tuning":
             self.add_ptuned_prompts_to_prompt_table()
             logging.info(f"All p-tuned prompts where moved to the prompt table.")
 


### PR DESCRIPTION
Signed-off-by: Virginia Adams <vadams@nvidia.com>

Made saving prompt encoder embeddings to prompt table non-configurable

Add a one line overview of what this PR aims to accomplish.

# Changelog 
- updated MegatronGPTPromptLearning class
- removed line from example config

# Usage
removed `save_tuned_prompts_to_prompt_table`
```python
p_tuning:
  dropout: 0.0
  num_layers: 2
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation? (Updated in separate PR)
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
- [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
