### PR TITLE
Allow relative paths in manifest

### DIFF
--- a/nemo/collections/common/parts/preprocessing/manifest.py
+++ b/nemo/collections/common/parts/preprocessing/manifest.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import json
-from os.path import expanduser
+from os.path import expanduser, join, split, isabs
 from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 
 
@@ -77,6 +77,7 @@ def item_iter(
 
 def __parse_item(line: str, manifest_file: str) -> Dict[str, Any]:
     item = json.loads(line)
+    manifest_path, _ = split(manifest_file)
 
     # Audio file
     if 'audio_filename' in item:
@@ -88,6 +89,8 @@ def __parse_item(line: str, manifest_file: str) -> Dict[str, Any]:
             f"Manifest file {manifest_file} has invalid json line structure: {line} without proper audio file key."
         )
     item['audio_file'] = expanduser(item['audio_file'])
+    if not isabs(item['audio_file']):
+        item['audio_file'] = join(manifest_path, item['audio_file'])
 
     # Duration.
     if 'duration' not in item:


### PR DESCRIPTION
# What does this PR do ?

 Allow to use relative paths in manifest file.

**Collection**: ASR or any other collection which use manifest file with field "audio_file"  

# Changelog 
- Allow to use relative paths in the ASR manifest file 

# Usage
* Allow to use relative paths in the manifest file. Field audio_file may be relative to the folder of manifest file


# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
