### PR TITLE
Add Module-level Adapters, Save-Restore and tests

### DIFF
--- a/examples/asr/asr_adapters/train_asr_adapter.py
+++ b/examples/asr/asr_adapters/train_asr_adapter.py
@@ -118,7 +118,7 @@ def main(cfg):
     if cfg.model.pretrained_model is None and cfg.model.nemo_model is None:
         raise ValueError("Either set `cfg.model.nemo_model` or `cfg.model.pretrained_model`")
     if cfg.model.pretrained_model is not None and cfg.model.nemo_model is not None:
-        raise ValueError("Cannot set `cfg.model.nemo_model` and `cfg.model.pretrained_model`. Select one only.")
+        raise ValueError("Cannot set both `cfg.model.nemo_model` and `cfg.model.pretrained_model`. Select one only.")
 
     trainer = pl.Trainer(**cfg.trainer)
     exp_log_dir = exp_manager(trainer, cfg.get("exp_manager", None))

--- a/examples/asr/asr_adapters/train_asr_adapter.py
+++ b/examples/asr/asr_adapters/train_asr_adapter.py
@@ -142,14 +142,10 @@ def main(cfg):
     model.setup_multiple_validation_data(cfg.model.validation_ds)
 
     # Setup optimizer
-    cfg.model.optim = update_model_cfg(model.cfg.optim, cfg.model.optim)
-    model.cfg.optim = cfg.model.optim  # Update the model's config
     model.setup_optimization(cfg.model.optim)
 
     # Setup spec augmentation
     if 'spec_augment' in cfg.model:
-        cfg.model.spec_augment = update_model_cfg(model.cfg.spec_augment, cfg.model.spec_augment)
-        model.cfg.spec_augment = cfg.model.spec_augment  # Update model's config
         model.spec_augmentation = model.from_config_dict(cfg.model.spec_augment)
 
     # Setup adapters
@@ -186,9 +182,10 @@ def main(cfg):
     # Save the adapter state dict
     if adapter_state_dict_name is not None:
         state_path = exp_log_dir
-        if os.path.exists(state_path / "checkpoints"):
-            state_path = state_path / "checkpoints"
-        state_path = state_path / adapter_state_dict_name
+        ckpt_path = os.path.join(state_path, "checkpoints")
+        if os.path.exists(ckpt_path):
+            state_path = ckpt_path
+        state_path = os.path.join(state_path, adapter_state_dict_name)
 
         # Save the adapter modules in a seperate file
         model.save_adapters(str(state_path))

--- a/examples/asr/asr_adapters/train_asr_adapter.py
+++ b/examples/asr/asr_adapters/train_asr_adapter.py
@@ -147,12 +147,20 @@ def main(cfg):
     # Setup spec augmentation
     if 'spec_augment' in cfg.model:
         model.spec_augmentation = model.from_config_dict(cfg.model.spec_augment)
+    else:
+        model.spec_augmentation = None
+        del model.cfg.spec_augment
 
     # Setup adapters
     with open_dict(cfg.model.adapter):
         # Extract the name of the adapter (must be give for training)
         adapter_name = cfg.model.adapter.pop("adapter_name")
-        adapter_state_dict_name = cfg.model.adapter.pop('adapter_state_dict_name', None)
+        adapter_module_name = cfg.model.adapter.pop("adapter_module_name", None)
+        adapter_state_dict_name = cfg.model.adapter.pop("adapter_state_dict_name", None)
+
+        # augment adapter name with module name, if not provided by user
+        if adapter_module_name is not None and ':' not in adapter_name:
+            adapter_name = f'{adapter_module_name}:{adapter_name}'
 
         # Extract the global adapter config, if provided
         adapter_global_cfg = cfg.model.adapter.pop(model.adapter_global_cfg_key, None)

--- a/examples/asr/asr_adapters/train_asr_adapter.py
+++ b/examples/asr/asr_adapters/train_asr_adapter.py
@@ -181,7 +181,7 @@ def main(cfg):
 
     # Save the adapter state dict
     if adapter_state_dict_name is not None:
-        state_path = exp_log_dir
+        state_path = exp_log_dir if exp_log_dir is not None else os.getcwd()
         ckpt_path = os.path.join(state_path, "checkpoints")
         if os.path.exists(ckpt_path):
             state_path = ckpt_path

--- a/examples/asr/asr_adapters/train_asr_adapter.py
+++ b/examples/asr/asr_adapters/train_asr_adapter.py
@@ -142,7 +142,14 @@ def main(cfg):
 
     # Setup optimizer
     cfg.model.optim = update_model_cfg(model.cfg.optim, cfg.model.optim)
+    model.cfg.optim = cfg.model.optim  # Update the model's config
     model.setup_optimization(cfg.model.optim)
+
+    # Setup spec augmentation
+    if 'spec_augment' in cfg.model:
+        cfg.model.spec_augment = update_model_cfg(model.cfg.spec_augment, cfg.model.spec_augment)
+        model.cfg.spec_augment = cfg.model.spec_augment  # Update model's config
+        model.spec_augmentation = model.from_config_dict(cfg.model.spec_augment)
 
     # Setup adapters
     with open_dict(cfg.model.adapter):
@@ -167,6 +174,9 @@ def main(cfg):
     model = model.train()
     # Then, Unfreeze just the adapter weights that were enabled above (no part of encoder/decoder/joint/etc)
     model.unfreeze_enabled_adapters()
+
+    # Update model config prior to training
+    model.cfg = model.cfg
 
     # Finally, train model
     trainer.fit(model)

--- a/examples/asr/conf/asr_adapters/asr_adaptation.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation.yaml
@@ -73,6 +73,13 @@ model:
     global_cfg:
       encoder_adapter: True  # ASR adapter key, determines whether to add encoder adapter modules
 
+  spec_augment:
+    _target_: nemo.collections.asr.modules.SpectrogramAugmentation
+    # freq_masks will be merged with model config
+    # time_masks will be merged with model config
+    # freq_width will be merged with model config
+    # time_width will be merged with model config
+
   train_ds:
     # train dataset + dataloader config
     # sample_rate will be merged with model config

--- a/examples/asr/conf/asr_adapters/asr_adaptation.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation.yaml
@@ -66,6 +66,11 @@ model:
     norm_position: 'post'  # Can be `pre` or `post`
     dropout: 0.0  # float, dropout for the adapter
 
+    # Adapter strategy config - must point to a data class for that strategy.
+    adapter_strategy:
+      _target_: nemo.core.classes.mixins.adapter_mixin_strategies.ResidualAddAdapterStrategyConfig
+      stochastic_depth: 0.0  # float, setting to > 0 will enable stochastic depth for each adapter block.
+
     # Optional global config available to all adapters at a global level.
     # A global config is shared across every layer of the adapters, defining global properties rather
     # than properties local to the adapter (as defined above).

--- a/examples/asr/conf/asr_adapters/asr_adaptation.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation.yaml
@@ -64,6 +64,7 @@ model:
     dim: 32  # The hidden dimension of the adapter, as chosen by user, but small values are preferred to reduce param count.
     activation: swish
     norm_position: 'post'  # Can be `pre` or `post`
+    dropout: 0.0  # float, dropout for the adapter
 
     # Optional global config available to all adapters at a global level.
     # A global config is shared across every layer of the adapters, defining global properties rather

--- a/examples/asr/conf/asr_adapters/asr_adaptation.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation.yaml
@@ -60,6 +60,7 @@ model:
   adapter:
     # Config of the adapter training/eval script.
     adapter_name: ???  # Name of the adapter, used by the script
+    adapter_module_name: null  # Name of the preprocessing module, if required. Defaults to None, equivalent to ''.
     adapter_state_dict_name: "adapters.pt"  # If the individual adapters must be saved, a file name can be provided here. null disables this.
 
     # Config of the adapter module itself

--- a/examples/asr/conf/asr_adapters/asr_adaptation.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation.yaml
@@ -83,12 +83,13 @@ model:
     global_cfg:
       encoder_adapter: True  # ASR adapter key, determines whether to add encoder adapter modules
 
+  # Overrides the model's internal spec augment configuration
   spec_augment:
     _target_: nemo.collections.asr.modules.SpectrogramAugmentation
-    # freq_masks will be merged with model config
-    # time_masks will be merged with model config
-    # freq_width will be merged with model config
-    # time_width will be merged with model config
+    freq_masks: 0
+    time_masks: 0
+    freq_width: 27
+    time_width: 0.05
 
   train_ds:
     # train dataset + dataloader config
@@ -130,19 +131,20 @@ model:
 
   optim:
     # optimizer arguments
-    # name will be merged with model config
-    # betas will be merged with model config
-    lr: 0.01  # LR depends on the scheduler used by the base model. Noam prefers 0.5, Cosine Annealing prefers 0.02
+    name: adamw
+    betas: [0.9, 0.98]
+    lr: 0.001  # LR depends on the scheduler used by the base model. Noam prefers 0.5, Cosine Annealing prefers 0.02
     weight_decay: 0  # During adaptation, since training run is short, WD is not required. Can be set if needed.
 
     # scheduler setup
     sched:
-      # name will be merged with model config
-      # d_model will be merged with model config
+      name: CosineAnnealing
+
       # scheduler config override
-      # min_lr will be merged with model config
-      warmup_steps: 1000  # Warmup steps should be set, and smaller than the trainer.max_steps set below.
+      warmup_steps: 100  # Warmup steps should be set, and smaller than the trainer.max_steps set below.
       warmup_ratio: null
+      min_lr: 1e-5
+      last_epoch: -1
 
 trainer:
   devices: -1 # number of GPUs, -1 would use all available GPUs

--- a/examples/asr/conf/asr_adapters/asr_adaptation.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation.yaml
@@ -58,7 +58,11 @@ model:
   nemo_model: null  # path to a ASR model file (.nemo)
 
   adapter:
+    # Config of the adapter training/eval script.
     adapter_name: ???  # Name of the adapter, used by the script
+    adapter_state_dict_name: "adapters.pt"  # If the individual adapters must be saved, a file name can be provided here. null disables this.
+
+    # Config of the adapter module itself
     _target_: nemo.collections.common.parts.adapter_modules.LinearAdapter
     in_features: ???  # User must provide the output dimension of the layers of the model, which is the input dimension of this adapter.
     dim: 32  # The hidden dimension of the adapter, as chosen by user, but small values are preferred to reduce param count.
@@ -66,9 +70,9 @@ model:
     norm_position: 'post'  # Can be `pre` or `post`
     dropout: 0.0  # float, dropout for the adapter
 
-    # Adapter strategy config - must point to a data class for that strategy.
+    # Adapter strategy config
     adapter_strategy:
-      _target_: nemo.core.classes.mixins.adapter_mixin_strategies.ResidualAddAdapterStrategyConfig
+      _target_: nemo.core.classes.mixins.adapter_mixin_strategies.ResidualAddAdapterStrategy
       stochastic_depth: 0.0  # float, setting to > 0 will enable stochastic depth for each adapter block.
 
     # Optional global config available to all adapters at a global level.

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -881,7 +881,7 @@ class ConvASREncoderAdapter(ConvASREncoder, adapter_mixins.AdapterModuleMixin):
             in_planes = cfg['in_features']
 
             if in_planes != block.planes:
-                logging.info(f"Updating Adapter input dim from {in_planes} to {block.planes}")
+                logging.info(f"Updating ConvASR Encoder Adapter input dim from {in_planes} to {block.planes}")
                 in_planes = block.planes
 
             cfg['in_features'] = in_planes

--- a/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
+++ b/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
@@ -145,7 +145,7 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
 
         return enabled_adapters
 
-    def _check_valid_model_with_adapter_support(self):
+    def check_valid_model_with_adapter_support_(self):
         """
         Utility method to test if the subclass of this mixin is an appropriate subclass of ModelPT itself.
         """

--- a/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
+++ b/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
@@ -92,7 +92,17 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
             enabled or disabled, false only if no adapters exist.
         """
         config_contains_adapter = super().is_adapter_available()
-        return self.encoder.is_adapter_available() and config_contains_adapter
+
+        # Try to retrieve global adapter config
+        global_config = DictConfig({})
+        if self.adapter_global_cfg_key in self.cfg.adapters:
+            global_config = self.adapter_cfg[self.adapter_global_cfg_key]
+
+        # Forward the method call to the individual modules
+        if global_config.get('encoder_adapter', True):
+            config_contains_adapter |= self.encoder.is_adapter_available()
+
+        return config_contains_adapter
 
     def set_enabled_adapters(self, name: Optional[str] = None, enabled: bool = True):
         """

--- a/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
+++ b/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
@@ -68,20 +68,19 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
             name: A globally unique name for the adapter. Will be used to access, enable and disable adapters.
             cfg: A DictConfig that contains at the bare minimum `__target__` to instantiate a new Adapter module.
         """
+        # setup the config for adapters
         super().add_adapter(name=name, cfg=cfg)
 
-        # Try to retrieve global adapter config
-        global_config = DictConfig({})
-        if self.adapter_global_cfg_key in self.cfg.adapters:
-            global_config = self.adapter_cfg[self.adapter_global_cfg_key]
+        # Resolve module name and adapter name
+        module_name, _ = self._resolve_adapter_module_name(name)
 
         # Update the model.cfg with information about the new adapter from cfg
         with open_dict(self.cfg):
             # Check if encoder adapters should be added
-            use_encoder_adapters = global_config.get('encoder_adapter', True)
-            if use_encoder_adapters:
+
+            if module_name in ('', 'encoder'):
                 # Dispatch the call to the encoder.
-                self.encoder.add_adapter(name=name, cfg=self.cfg.adapters[name])
+                self.encoder.add_adapter(name=name, cfg=cfg)
 
     def is_adapter_available(self) -> bool:
         """
@@ -93,13 +92,8 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
         """
         config_contains_adapter = super().is_adapter_available()
 
-        # Try to retrieve global adapter config
-        global_config = DictConfig({})
-        if self.adapter_global_cfg_key in self.cfg.adapters:
-            global_config = self.adapter_cfg[self.adapter_global_cfg_key]
-
         # Forward the method call to the individual modules
-        if global_config.get('encoder_adapter', True):
+        if hasattr(self, 'encoder') and isinstance(self.encoder, AdapterModuleMixin):
             config_contains_adapter |= self.encoder.is_adapter_available()
 
         return config_contains_adapter
@@ -124,16 +118,12 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
         """
         super().set_enabled_adapters(name=name, enabled=enabled)
 
-        # Try to retrieve global adapter config
-        global_config = DictConfig({})
-        if self.adapter_global_cfg_key in self.cfg.adapters:
-            global_config = self.cfg.adapters[self.adapter_global_cfg_key]
+        # Resolve the module name and adapter name
+        module_name, _ = self._resolve_adapter_module_name(name)
 
         # Check if encoder adapters should be used
-        use_encoder_adapters = global_config.get('encoder_adapter', True)
-
         # Dispatch the call to the encoder.
-        if use_encoder_adapters:
+        if module_name in ('', 'encoder'):
             self.encoder.set_enabled_adapters(name=name, enabled=enabled)
 
     def get_enabled_adapters(self) -> List[str]:
@@ -145,15 +135,8 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
         """
         enabled_adapters = super().get_enabled_adapters()
 
-        # Try to retrieve global adapter config
-        global_config = DictConfig({})
-        if self.adapter_global_cfg_key in self.cfg.adapters:
-            global_config = self.cfg.adapters[self.adapter_global_cfg_key]
-
-        # Check if encoder adapters should be used
-        use_encoder_adapters = global_config.get('encoder_adapter', True)
-
-        if use_encoder_adapters:
+        # Check if encoder adapters should be used or are enabled
+        if hasattr(self, 'encoder') and isinstance(self.encoder, AdapterModuleMixin):
             enabled_adapters.extend(self.encoder.get_enabled_adapters())
 
         return enabled_adapters
@@ -163,12 +146,7 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
         Utility method to test if the subclass of this mixin is an appropriate subclass of ModelPT itself.
         """
         # Obtain the global adapter config if possible, otherwise use sensible defaults.
-        global_cfg = DictConfig({})
-        if hasattr(self, 'adapter_cfg'):
-            global_cfg = self.adapter_cfg
-
-            if self.adapter_global_cfg_key in global_cfg:
-                global_cfg = global_cfg[self.adapter_global_cfg_key]
+        global_cfg = self._get_global_cfg()
 
         # Test whether the encoder supports adapters
         use_encoder_adapter = global_cfg.get('encoder_adapter', True)
@@ -177,3 +155,37 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
 
         if use_encoder_adapter and not isinstance(self.encoder, AdapterModuleMixin):
             raise ValueError(f'{self.encoder.__class__.__name__} does not implement `AdapterModuleMixin`')
+
+    def _resolve_adapter_module_name(self, name: str) -> (str, str):
+        """
+        Utility method to resolve a given global/module adapter name to its components.
+        Always returns a tuple representing (module_name, adapter_name). ":" is used as the
+        delimiter for denoting the module name vs the adapter name.
+
+        Will attempt to also resolve a given adapter_name alone back to (module_name, adapter_name)
+        if the metadata config exists for access.
+
+        Args:
+            name: A global adapter, or a module adapter name (with structure module_name:adapter_name).
+
+        Returns:
+            A tuple representing (module_name, adapter_name). If a global adapter is provided,
+            module_name is set to ''.
+        """
+        module_name, adapter_name = super()._resolve_adapter_module_name(name)
+
+        # resolve name and module onlt for valid modules
+        valid_module_names = ['', 'encoder']
+        if module_name not in valid_module_names:
+            raise ValueError(f"Provided module name `{module_name}` is not in valid list : {valid_module_names}")
+
+        return (module_name, adapter_name)
+
+    def _get_global_cfg(self):
+        """
+        Utility method, to either extract or construct the global config inside adapters config.
+        """
+        global_config = DictConfig({})
+        if 'adapters' in self.cfg and self.adapter_global_cfg_key in self.cfg.adapters:
+            global_config = self.adapter_cfg[self.adapter_global_cfg_key]
+        return global_config

--- a/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
+++ b/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
@@ -178,7 +178,7 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
         """
         module_name, adapter_name = super().resolve_adapter_module_name_(name)
 
-        # resolve name and module onlt for valid modules
+        # resolve name and module only for valid modules
         valid_module_names = ['', 'encoder']
         if module_name not in valid_module_names:
             raise ValueError(f"Provided module name `{module_name}` is not in valid list : {valid_module_names}")

--- a/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
+++ b/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
@@ -119,11 +119,14 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
         super().set_enabled_adapters(name=name, enabled=enabled)
 
         # Resolve the module name and adapter name
-        module_name, _ = self._resolve_adapter_module_name(name)
+        if name is not None:
+            module_name, _ = self._resolve_adapter_module_name(name)
+        else:
+            module_name = None
 
         # Check if encoder adapters should be used
         # Dispatch the call to the encoder.
-        if module_name in ('', 'encoder'):
+        if name is None or module_name in ('', 'encoder'):
             self.encoder.set_enabled_adapters(name=name, enabled=enabled)
 
     def get_enabled_adapters(self) -> List[str]:

--- a/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
+++ b/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
@@ -72,7 +72,7 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
         super().add_adapter(name=name, cfg=cfg)
 
         # Resolve module name and adapter name
-        module_name, _ = self._resolve_adapter_module_name(name)
+        module_name, _ = self.resolve_adapter_module_name_(name)
 
         # Update the model.cfg with information about the new adapter from cfg
         with open_dict(self.cfg):
@@ -120,7 +120,7 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
 
         # Resolve the module name and adapter name
         if name is not None:
-            module_name, _ = self._resolve_adapter_module_name(name)
+            module_name, _ = self.resolve_adapter_module_name_(name)
         else:
             module_name = None
 
@@ -160,7 +160,7 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
         if use_encoder_adapter and not isinstance(self.encoder, AdapterModuleMixin):
             raise ValueError(f'{self.encoder.__class__.__name__} does not implement `AdapterModuleMixin`')
 
-    def _resolve_adapter_module_name(self, name: str) -> (str, str):
+    def resolve_adapter_module_name_(self, name: str) -> (str, str):
         """
         Utility method to resolve a given global/module adapter name to its components.
         Always returns a tuple representing (module_name, adapter_name). ":" is used as the
@@ -176,7 +176,7 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
             A tuple representing (module_name, adapter_name). If a global adapter is provided,
             module_name is set to ''.
         """
-        module_name, adapter_name = super()._resolve_adapter_module_name(name)
+        module_name, adapter_name = super().resolve_adapter_module_name_(name)
 
         # resolve name and module onlt for valid modules
         valid_module_names = ['', 'encoder']

--- a/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
+++ b/nemo/collections/asr/parts/mixins/asr_adapter_mixins.py
@@ -127,7 +127,8 @@ class ASRAdapterModelMixin(AdapterModelPTMixin):
         # Check if encoder adapters should be used
         # Dispatch the call to the encoder.
         if name is None or module_name in ('', 'encoder'):
-            self.encoder.set_enabled_adapters(name=name, enabled=enabled)
+            if self.encoder.is_adapter_available():
+                self.encoder.set_enabled_adapters(name=name, enabled=enabled)
 
     def get_enabled_adapters(self) -> List[str]:
         """

--- a/nemo/collections/asr/parts/submodules/jasper.py
+++ b/nemo/collections/asr/parts/submodules/jasper.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import Callable, List, Optional, Tuple, Iterable
+from typing import Callable, Iterable, List, Optional, Tuple
 
 import torch
 import torch.nn as nn

--- a/nemo/collections/asr/parts/submodules/jasper.py
+++ b/nemo/collections/asr/parts/submodules/jasper.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple, Iterable
 
 import torch
 import torch.nn as nn
@@ -708,10 +708,10 @@ class JasperBlock(nn.Module, AdapterModuleMixin, AccessMixin):
             raise ValueError("currently only 'same' padding is supported")
 
         kernel_size_factor = float(kernel_size_factor)
-        if type(kernel_size) in (list, tuple):
+        if isinstance(kernel_size, Iterable):
             kernel_size = [compute_new_kernel_size(k, kernel_size_factor) for k in kernel_size]
         else:
-            kernel_size = compute_new_kernel_size(kernel_size, kernel_size_factor)
+            kernel_size = [compute_new_kernel_size(kernel_size, kernel_size_factor)]
 
         if future_context < 0:
             padding_val = get_same_padding(kernel_size[0], stride[0], dilation[0])

--- a/nemo/collections/common/parts/adapter_modules.py
+++ b/nemo/collections/common/parts/adapter_modules.py
@@ -87,7 +87,12 @@ class LinearAdapter(nn.Module):
 
         # The config must have the `_target_` field pointing to the actual adapter strategy class
         # which will load that strategy dynamically to this module.
-        self.adapter_strategy = instantiate(adapter_strategy)
+        if isinstance(adapter_strategy, dict) or OmegaConf.is_config(adapter_strategy):
+            self.adapter_strategy = instantiate(adapter_strategy)
+        elif isinstance(adapter_strategy, adapter_mixin_strategies.AbstractAdapterStrategy):
+            self.adapter_strategy = adapter_strategy
+        else:
+            raise AttributeError(f'`adapter_strategy` provided is invalid : {adapter_strategy}')
 
         # reset parameters
         self.reset_parameters()

--- a/nemo/collections/common/parts/adapter_modules.py
+++ b/nemo/collections/common/parts/adapter_modules.py
@@ -34,7 +34,7 @@ class LinearAdapter(nn.Module):
             will occur in the first layer or the last layer. Certain architectures may prefer one over the other.
     """
 
-    def __init__(self, in_features, dim, activation: str = 'swish', norm_position="post", dropout: float = 0.0):
+    def __init__(self, in_features, dim, activation: str = 'swish', norm_position: str = "post", dropout: float = 0.0):
         super().__init__()
 
         activation = activation_registry[activation]()
@@ -62,7 +62,7 @@ class LinearAdapter(nn.Module):
             )
 
         if dropout > 0.0:
-            self.dropout = nn.Dropout(dropout, inplace=True)
+            self.dropout = nn.Dropout(dropout)
         else:
             self.dropout = None
 

--- a/nemo/collections/common/parts/adapter_modules.py
+++ b/nemo/collections/common/parts/adapter_modules.py
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, is_dataclass
+from typing import Optional
 
 from hydra.utils import instantiate
+from omegaconf import OmegaConf
 from torch import nn as nn
-from typing import Optional
 
 from nemo.collections.common.parts.utils import activation_registry
 from nemo.core.classes.mixins import adapter_mixin_strategies
@@ -79,6 +80,13 @@ class LinearAdapter(nn.Module):
         # set default adapter strategy
         if adapter_strategy is None:
             adapter_strategy = adapter_mixin_strategies.ResidualAddAdapterStrategyConfig()
+
+        if is_dataclass(adapter_strategy):
+            adapter_strategy = OmegaConf.structured(adapter_strategy)
+            OmegaConf.set_struct(adapter_strategy, False)
+
+        # The config must have the `_target_` field pointing to the actual adapter strategy class
+        # which will load that strategy dynamically to this module.
         self.adapter_strategy = instantiate(adapter_strategy)
 
         # reset parameters

--- a/nemo/core/classes/mixins/__init__.py
+++ b/nemo/core/classes/mixins/__init__.py
@@ -13,7 +13,10 @@
 # limitations under the License.
 
 from nemo.core.classes.mixins.access_mixins import AccessMixin, set_access_cfg
-from nemo.core.classes.mixins.adapter_mixin_strategies import ResidualAddAdapterStrategy
+from nemo.core.classes.mixins.adapter_mixin_strategies import (
+    ResidualAddAdapterStrategy,
+    ResidualAddAdapterStrategyConfig,
+)
 from nemo.core.classes.mixins.adapter_mixins import (
     AdapterModelPTMixin,
     AdapterModuleMixin,

--- a/nemo/core/classes/mixins/adapter_mixin_strategies.py
+++ b/nemo/core/classes/mixins/adapter_mixin_strategies.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from abc import ABC
+from dataclasses import dataclass
 
 import torch
 
@@ -49,6 +50,23 @@ class AbstractAdapterStrategy(ABC):
 
 
 class ResidualAddAdapterStrategy(AbstractAdapterStrategy):
+    """
+    An implementation of residual addition of an adapter module with its input.
+    Supports stochastic depth regularization.
+    """
+
+    def __init__(self, stochastic_depth: float = 0.0):
+        """
+        An implementation of residual addition of an adapter module with its input.
+        Performs output = input + adapter(input).
+
+        Args:
+            stochastic_depth: float, when greater than one, can optionally dropout the output of
+                the adapter's forward pass.
+        """
+        super().__init__()
+        self.stochastic_depth = stochastic_depth
+
     def forward(self, input: torch.Tensor, adapter: torch.nn.Module, *, module: 'AdapterModuleMixin'):
         """
         A basic strategy, comprising of a residual connection over the input, after forward pass by
@@ -65,4 +83,31 @@ class ResidualAddAdapterStrategy(AbstractAdapterStrategy):
             The result tensor, after all active adapters have finished their forward passes.
         """
         out = adapter(input)
+
+        # Perform stochastic depth if needed.
+        p = self.stochastic_depth
+        if p < 0.0 or p > 1.0:
+            raise ValueError(f"Stochastic depth probability has to be between 0 and 1, but got {p}")
+
+        # If not in training mode, or probability of stochastic depth is 0, skip step.
+        if not module.training or p == 0.0:
+            pass
+        else:
+            # Apply stochastic depth to the output of adapter.
+            keep_prob = 1.0 - p
+            shape = [1] * out.ndim
+            noise = torch.empty(shape, dtype=input.dtype, device=input.device)
+            noise = noise.bernoulli_(keep_prob)
+            if keep_prob > 0.0:  # Done to normalize activation for inference mode
+                noise.div_(keep_prob)
+
+            out = noise * out
+
+        # Return the residual connection output = input + adapter(input)
         return input + out
+
+
+@dataclass
+class ResidualAddAdapterStrategyConfig:
+    stochastic_depth: float = 0.0
+    _target_: str = "{0}.{1}".format(ResidualAddAdapterStrategy.__module__, ResidualAddAdapterStrategy.__name__)

--- a/nemo/core/classes/mixins/adapter_mixin_strategies.py
+++ b/nemo/core/classes/mixins/adapter_mixin_strategies.py
@@ -110,4 +110,6 @@ class ResidualAddAdapterStrategy(AbstractAdapterStrategy):
 @dataclass
 class ResidualAddAdapterStrategyConfig:
     stochastic_depth: float = 0.0
-    _target_: str = "{0}.{1}".format(ResidualAddAdapterStrategy.__module__, ResidualAddAdapterStrategy.__name__)
+    _target_: str = "{0}.{1}".format(
+        ResidualAddAdapterStrategy.__module__, ResidualAddAdapterStrategy.__name__
+    )  # mandatory field

--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -646,6 +646,9 @@ class AdapterModelPTMixin(AdapterModuleMixin):
                 all adapters will be saved to the file. The name can be either the global name (adapter_name),
                 or the module level name (module:adapter_name).
         """
+        if not hasattr(self, 'cfg') or 'adapters' not in self.cfg:
+            raise AttributeError("No adapters have been added to this model, so no adapters can be saved.")
+
         output_dict = {}
 
         # Normalize the name to a list of strings
@@ -653,7 +656,7 @@ class AdapterModelPTMixin(AdapterModuleMixin):
             name = [name]
 
         if name is None:
-            name = self.adapter_cfg.keys()
+            name = self.cfg.adapters.keys()
 
         # Assert that the config must be present to save and restore the adapters.
         if not hasattr(self.cfg, 'adapters'):

--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -261,13 +261,19 @@ class AdapterModuleMixin(ABC):
         if not self.is_adapter_available():
             return []
 
+        # populate set of available modules (by name)
+        available_module_names = set([])
+        if hasattr(self, 'adapter_layer'):
+            available_module_names.update(list(self.adapter_layer.keys()))
+
         enabled_adapters = []
         for name, config in self.adapter_cfg.items():
             # Skip the global adapter config
             if name == self.adapter_global_cfg_key:
                 continue
 
-            if self.adapter_cfg[name]['enabled']:
+            # If name is in the current available modules, and it is enabled in the config
+            if name in available_module_names and self.adapter_cfg[name]['enabled']:
                 enabled_adapters.append(name)
 
         return enabled_adapters
@@ -571,7 +577,8 @@ class AdapterModelPTMixin(AdapterModuleMixin):
                 # Cannot set the state of the global config for adapters
                 if name == self.adapter_global_cfg_key:
                     raise ValueError(
-                        f'Cannot set the state of the global config of adapters, given name = `{self.adapter_global_cfg_key}`'
+                        f'Cannot set the state of the global config of adapters, '
+                        f'given name = `{self.adapter_global_cfg_key}`'
                     )
 
                 # Otherwise, update just the specified adapter.

--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -590,15 +590,18 @@ class AdapterModelPTMixin(AdapterModuleMixin):
                     logging.info(f"Setting adapter '{key}' status : Enabled = {enabled}")
 
             else:
+                # Resolve the module name and adapter name
+                module_name, adapter_name = self._resolve_adapter_module_name(name)
+
                 # Cannot set the state of the global config for adapters
-                if name == self.adapter_global_cfg_key:
+                if adapter_name == self.adapter_global_cfg_key:
                     raise ValueError(
                         f'Cannot set the state of the global config of adapters, '
                         f'given name = `{self.adapter_global_cfg_key}`'
                     )
 
                 # Otherwise, update just the specified adapter.
-                self.cfg.adapters[name]['enabled'] = enabled
+                self.cfg.adapters[adapter_name]['enabled'] = enabled
                 logging.info(f"Setting adapter '{name}' status : Enabled = {enabled}")
 
             self.update_adapter_cfg(self.cfg.adapters)

--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -198,8 +198,6 @@ class AdapterModuleMixin(ABC):
             cfg['enabled'] = adapter_enabled
             self.adapter_cfg[adapter_name] = cfg
 
-            logging.info(f"Adapter `{adapter_name}` added !")
-
     def is_adapter_available(self) -> bool:
         """
         Checks if any Adapter module has been instantiated.

--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -570,7 +570,7 @@ class AdapterModelPTMixin(AdapterModuleMixin):
             # Set the global config of adapters
             self.update_adapter_cfg(self.cfg.adapters)
 
-            self._check_valid_model_with_adapter_support()
+            self.check_valid_model_with_adapter_support_()
 
     def is_adapter_available(self) -> bool:
         """
@@ -582,7 +582,7 @@ class AdapterModelPTMixin(AdapterModuleMixin):
             bool, determining if any Adapter module has been instantiated. Returns true even if the adapters are
             enabled or disabled, false only if no adapters exist.
         """
-        self._check_valid_model_with_adapter_support()
+        self.check_valid_model_with_adapter_support_()
 
         if 'adapters' in self.cfg:
             self.update_adapter_cfg(self.cfg.adapters)
@@ -610,7 +610,7 @@ class AdapterModelPTMixin(AdapterModuleMixin):
                 If no name is given, then all adapters will be enabled/disabled.
             enabled: Bool, determines if the adapter(s) will be enabled/disabled.
         """
-        self._check_valid_model_with_adapter_support()
+        self.check_valid_model_with_adapter_support_()
 
         # Update the adapter config with information about whether it is enabled/disabled.
         with open_dict(self.cfg.adapters):
@@ -650,13 +650,13 @@ class AdapterModelPTMixin(AdapterModuleMixin):
         Returns:
             A list of str names of each enabled adapter(s).
         """
-        self._check_valid_model_with_adapter_support()
+        self.check_valid_model_with_adapter_support_()
 
         if 'adapters' in self.cfg:
             self.update_adapter_cfg(self.cfg.adapters)
         return []
 
-    def _check_valid_model_with_adapter_support(self):
+    def check_valid_model_with_adapter_support_(self):
         """
         Utility method to test if the subclass of this mixin is an appropriate subclass of ModelPT itself.
 

--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -377,6 +377,22 @@ class AdapterModuleMixin(ABC):
     # Utility methods
 
     def _resolve_adapter_module_name(self, name: str) -> (str, str):
+        """
+        Utility method to resolve a given global/module adapter name to its components.
+        Always returns a tuple representing (module_name, adapter_name). ":" is used as the
+        delimiter for denoting the module name vs the adapter name.
+
+        Will attempt to also resolve a given adapter_name alone back to (module_name, adapter_name)
+        if the metadata config exists for access.
+
+        Args:
+            name: A global adapter, or a module adapter name (with structure module_name:adapter_name).
+
+        Returns:
+            A tuple representing (module_name, adapter_name). If a global adapter is provided,
+            module_name is set to ''.
+        """
+        # Attempt to split into module adapter name, iff : exists in the given name.
         if ':' in name:
             splits = name.split(":")
             module_name = splits[0]

--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -198,6 +198,8 @@ class AdapterModuleMixin(ABC):
             cfg['enabled'] = adapter_enabled
             self.adapter_cfg[adapter_name] = cfg
 
+            logging.info(f"Adapter `{adapter_name}` added !")
+
     def is_adapter_available(self) -> bool:
         """
         Checks if any Adapter module has been instantiated.

--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -182,7 +182,9 @@ class AdapterModuleMixin(ABC):
 
         # Assert that name is globally unique to all adapters.
         if adapter_name in self.adapter_layer:
-            raise ValueError(f"Adapter with name `{name}` already exists !")
+            raise ValueError(
+                f"Adapter with name `{name}` already exists ! Adapter names = {list(self.adapter_layer.keys())}"
+            )
 
         # Assert that name is not `adapter_global_cfg_key`
         if adapter_name == self.adapter_global_cfg_key:

--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -746,6 +746,10 @@ class AdapterModelPTMixin(AdapterModuleMixin):
             module_name, adapter_name = self._resolve_adapter_module_name(module_adapter_name)
             adapter_cfg = config[adapter_name]
 
+            # Skip the global config key
+            if adapter_name == self.adapter_global_cfg_key:
+                continue
+
             # Restore weights with exact key, if it fails, give useful error message.
             try:
                 adapter_state = state_dict[module_adapter_name]

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -1302,11 +1302,6 @@ class ModelPT(LightningModule, Model):
             Please create a new model using an updated config to properly update the model.
         """
         self._set_hparams(OmegaConf.create({'cfg': self._cfg}))
-
-        # TODO: Remove in NeMo 1.7 (or when PTL fixes this on their end)
-        if hasattr(self, '_hparams_initial') and 'cfg' in self._hparams_initial:
-            self._hparams_initial['cfg'] = OmegaConf.to_object(self._cfg)
-
         return self._cfg
 
     @cfg.setter

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -1301,6 +1301,12 @@ class ModelPT(LightningModule, Model):
             Changes to this config are not reflected in the state of the model.
             Please create a new model using an updated config to properly update the model.
         """
+        self._set_hparams(OmegaConf.create({'cfg': self._cfg}))
+
+        # TODO: Remove in NeMo 1.7 (or when PTL fixes this on their end)
+        if hasattr(self, '_hparams_initial') and 'cfg' in self._hparams_initial:
+            self._hparams_initial['cfg'] = OmegaConf.to_object(self._cfg)
+
         return self._cfg
 
     @cfg.setter

--- a/tests/collections/asr/mixins/adapters/test_asr_adapter_mixin.py
+++ b/tests/collections/asr/mixins/adapters/test_asr_adapter_mixin.py
@@ -191,7 +191,7 @@ class TestASRAdapterMixin:
         model.set_enabled_adapters(name=name1, enabled=False)
         new_output = model(input_signal=input_signal, input_signal_length=input_signal_length)[0]
 
-        resolved_name2 = model._resolve_adapter_module_name(name2)
+        resolved_name2 = model._resolve_adapter_module_name(name2)[-1]
         assert model.get_enabled_adapters() == [resolved_name2]
         assert torch.mean(torch.abs(origial_output - new_output)) < 1e-5
 

--- a/tests/collections/asr/mixins/adapters/test_asr_adapter_mixin.py
+++ b/tests/collections/asr/mixins/adapters/test_asr_adapter_mixin.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -105,25 +105,12 @@ class TestASRAdapterMixin:
         assert new_num_params > original_num_params
 
     @pytest.mark.unit
-    def test_linear_adapter_config(self):
-        IGNORED_ARGS = ['_target_']
+    def test_asr_model_constructor_encoder_module(self, model):
+        original_num_params = model.num_weights
 
-        result = config_utils.assert_dataclass_signature_match(
-            adapter_modules.LinearAdapter, adapter_modules.LinearAdapterConfig, ignore_args=IGNORED_ARGS
-        )
-
-        signatures_match, cls_subset, dataclass_subset = result
-
-        assert signatures_match
-        assert cls_subset is None
-        assert dataclass_subset is None
-
-    @pytest.mark.unit
-    def test_adapter_registry_via_adapter_class(self, model):
-        # The encoder is already an adapter compatible class
-        metadata = get_registered_adapter(model.encoder.__class__)
-        assert metadata is not None
-        assert metadata.adapter_class == model.encoder.__class__
+        model.add_adapter(name='encoder:adapter_0', cfg=get_adapter_cfg())
+        new_num_params = model.num_weights
+        assert new_num_params > original_num_params
 
     @pytest.mark.unit
     def test_asr_multiple_adapter(self, model):
@@ -153,7 +140,8 @@ class TestASRAdapterMixin:
         assert torch.mean(torch.abs(origial_output - new_output)) < 1e-5
 
     @pytest.mark.unit
-    def test_asr_forward_linear_post(self, model):
+    @pytest.mark.parametrize('name', ['adapter_0', 'encoder:adapter_0'])
+    def test_asr_forward_linear_post(self, model, name):
         model.eval()
         torch.random.manual_seed(0)
         input_signal = torch.randn(2, 512)
@@ -161,13 +149,15 @@ class TestASRAdapterMixin:
 
         origial_output = model(input_signal=input_signal, input_signal_length=input_signal_length)[0]
 
-        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg(norm_pos='post'))
+        model.add_adapter(name=name, cfg=get_adapter_cfg(norm_pos='post'))
         new_output = model(input_signal=input_signal, input_signal_length=input_signal_length)[0]
 
         assert torch.mean(torch.abs(origial_output - new_output)) < 1e-5
 
     @pytest.mark.unit
-    def test_asr_multi_adapter_forward(self, model):
+    @pytest.mark.parametrize('name1', ['adapter_0', 'encoder:adapter_0'])
+    @pytest.mark.parametrize('name2', ['adapter_1', 'encoder:adapter_1'])
+    def test_asr_multi_adapter_forward(self, model, name1, name2):
         model.eval()
         torch.random.manual_seed(0)
         input_signal = torch.randn(2, 512)
@@ -175,15 +165,19 @@ class TestASRAdapterMixin:
 
         origial_output = model(input_signal=input_signal, input_signal_length=input_signal_length)[0]
 
-        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
-        model.add_adapter(name='adapter_1', cfg=get_adapter_cfg())
+        model.add_adapter(name=name1, cfg=get_adapter_cfg())
+        model.add_adapter(name=name2, cfg=get_adapter_cfg())
         new_output = model(input_signal=input_signal, input_signal_length=input_signal_length)[0]
 
-        assert model.get_enabled_adapters() == ['adapter_0', 'adapter_1']
+        resolved_name1 = model._resolve_adapter_module_name(name1)[-1]
+        resolved_name2 = model._resolve_adapter_module_name(name2)[-1]
+        assert model.get_enabled_adapters() == [resolved_name1, resolved_name2]
         assert torch.mean(torch.abs(origial_output - new_output)) < 1e-5
 
     @pytest.mark.unit
-    def test_asr_multi_adapter_partial_forward(self, model):
+    @pytest.mark.parametrize('name1', ['adapter_0', 'encoder:adapter_0'])
+    @pytest.mark.parametrize('name2', ['adapter_1', 'encoder:adapter_1'])
+    def test_asr_multi_adapter_partial_forward(self, model, name1, name2):
         model.eval()
         torch.random.manual_seed(0)
         input_signal = torch.randn(2, 512)
@@ -191,22 +185,24 @@ class TestASRAdapterMixin:
 
         origial_output = model(input_signal=input_signal, input_signal_length=input_signal_length)[0]
 
-        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
-        model.add_adapter(name='adapter_1', cfg=get_adapter_cfg())
+        model.add_adapter(name=name1, cfg=get_adapter_cfg())
+        model.add_adapter(name=name2, cfg=get_adapter_cfg())
 
-        model.set_enabled_adapters(name='adapter_0', enabled=False)
+        model.set_enabled_adapters(name=name1, enabled=False)
         new_output = model(input_signal=input_signal, input_signal_length=input_signal_length)[0]
 
-        assert model.get_enabled_adapters() == ['adapter_1']
+        resolved_name2 = model._resolve_adapter_module_name(name2)
+        assert model.get_enabled_adapters() == [resolved_name2]
         assert torch.mean(torch.abs(origial_output - new_output)) < 1e-5
 
     @pytest.mark.unit
-    def test_asr_forward_unfrozen_adapters(self, model):
+    @pytest.mark.parametrize('name', ['adapter_0', 'encoder:adapter_0'])
+    def test_asr_forward_unfrozen_adapters(self, model, name):
         model.eval()
         original_num_params = model.num_weights
 
         dim = 10
-        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg(dim=dim))
+        model.add_adapter(name=name, cfg=get_adapter_cfg(dim=dim))
         model.freeze()
         model.unfreeze_enabled_adapters()
 

--- a/tests/collections/asr/mixins/adapters/test_asr_adapter_mixin.py
+++ b/tests/collections/asr/mixins/adapters/test_asr_adapter_mixin.py
@@ -169,8 +169,8 @@ class TestASRAdapterMixin:
         model.add_adapter(name=name2, cfg=get_adapter_cfg())
         new_output = model(input_signal=input_signal, input_signal_length=input_signal_length)[0]
 
-        resolved_name1 = model._resolve_adapter_module_name(name1)[-1]
-        resolved_name2 = model._resolve_adapter_module_name(name2)[-1]
+        resolved_name1 = model.resolve_adapter_module_name_(name1)[-1]
+        resolved_name2 = model.resolve_adapter_module_name_(name2)[-1]
         assert model.get_enabled_adapters() == [resolved_name1, resolved_name2]
         assert torch.mean(torch.abs(origial_output - new_output)) < 1e-5
 
@@ -191,7 +191,7 @@ class TestASRAdapterMixin:
         model.set_enabled_adapters(name=name1, enabled=False)
         new_output = model(input_signal=input_signal, input_signal_length=input_signal_length)[0]
 
-        resolved_name2 = model._resolve_adapter_module_name(name2)[-1]
+        resolved_name2 = model.resolve_adapter_module_name_(name2)[-1]
         assert model.get_enabled_adapters() == [resolved_name2]
         assert torch.mean(torch.abs(origial_output - new_output)) < 1e-5
 

--- a/tests/collections/common/mixins/test_adapter_modules.py
+++ b/tests/collections/common/mixins/test_adapter_modules.py
@@ -1,0 +1,59 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo.collections.common.parts import adapter_modules
+from nemo.core.classes.mixins import adapter_mixin_strategies
+from nemo.utils import config_utils
+
+
+class TestAdapterModules:
+    @pytest.mark.unit
+    def test_linear_adapter_config(self):
+        IGNORED_ARGS = ['_target_']
+
+        result = config_utils.assert_dataclass_signature_match(
+            adapter_modules.LinearAdapter, adapter_modules.LinearAdapterConfig, ignore_args=IGNORED_ARGS
+        )
+
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None
+
+    @pytest.mark.unit
+    def test_linear_adapter_init(self):
+        torch.random.manual_seed(0)
+        x = torch.randn(2, 50)
+
+        adapter = adapter_modules.LinearAdapter(in_features=50, dim=5)
+
+        with torch.no_grad():
+            assert adapter.module[-1].weight.sum() == 0
+            if hasattr(adapter.module[-1], 'bias'):
+                adapter.module[-1].bias.sum() == 0
+
+            out = adapter(x)
+            assert out.sum() <= 1e-8
+
+    @pytest.mark.unit
+    def test_linear_adapter_strategy(self):
+        adapter = adapter_modules.LinearAdapter(in_features=50, dim=5)
+        assert hasattr(adapter, 'adapter_strategy')
+        assert adapter.adapter_strategy is not None
+        # assert default strategy is set
+        assert isinstance(adapter.adapter_strategy, adapter_mixin_strategies.ResidualAddAdapterStrategy)

--- a/tests/collections/common/mixins/test_adapter_modules.py
+++ b/tests/collections/common/mixins/test_adapter_modules.py
@@ -44,8 +44,39 @@ class TestAdapterModules:
 
         with torch.no_grad():
             assert adapter.module[-1].weight.sum() == 0
-            if hasattr(adapter.module[-1], 'bias'):
-                adapter.module[-1].bias.sum() == 0
+            if hasattr(adapter.module[-1], 'bias') and adapter.module[-1].bias is not None:
+                assert adapter.module[-1].bias.sum() == 0
+
+            out = adapter(x)
+            assert out.sum() <= 1e-8
+
+    @pytest.mark.unit
+    def test_linear_adapter_dropout(self):
+        torch.random.manual_seed(0)
+        x = torch.randn(2, 50)
+
+        adapter = adapter_modules.LinearAdapter(in_features=50, dim=5, dropout=0.5)
+
+        with torch.no_grad():
+            assert adapter.module[-1].weight.sum() == 0
+            if hasattr(adapter.module[-1], 'bias') and adapter.module[-1].bias is not None:
+                assert adapter.module[-1].bias.sum() == 0
+
+            out = adapter(x)
+            assert out.sum() <= 1e-8
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('norm_position', ['pre', 'post'])
+    def test_linear_adapter_norm_position(self, norm_position):
+        torch.random.manual_seed(0)
+        x = torch.randn(2, 50)
+
+        adapter = adapter_modules.LinearAdapter(in_features=50, dim=5, norm_position=norm_position)
+
+        with torch.no_grad():
+            assert adapter.module[-1].weight.sum() == 0
+            if hasattr(adapter.module[-1], 'bias') and adapter.module[-1].bias is not None:
+                assert adapter.module[-1].bias.sum() == 0
 
             out = adapter(x)
             assert out.sum() <= 1e-8

--- a/tests/core/mixins/adapters/test_adapter_mixin.py
+++ b/tests/core/mixins/adapters/test_adapter_mixin.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -20,7 +20,7 @@ from nemo.core.classes.mixins import adapter_mixin_strategies
 from nemo.core.classes.mixins.adapter_mixins import AdapterModuleMixin
 
 
-class DefaultModel(NeuralModule, AdapterModuleMixin):
+class DefaultModule(NeuralModule, AdapterModuleMixin):
     def __init__(self):
         super().__init__()
 
@@ -61,7 +61,7 @@ def get_adapter_cfg(in_features=50, dim=100, norm_pos='pre'):
 class TestAdapterMixin:
     @pytest.mark.unit
     def test_single_adapter(self):
-        model = DefaultModel()
+        model = DefaultModule()
         original_num_params = model.num_params()
 
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
@@ -70,7 +70,7 @@ class TestAdapterMixin:
 
     @pytest.mark.unit
     def test_multiple_adapter(self):
-        model = DefaultModel()
+        model = DefaultModule()
         original_num_params = model.num_params()
 
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
@@ -87,7 +87,7 @@ class TestAdapterMixin:
         torch.random.manual_seed(0)
         x = torch.randn(2, 50)
 
-        model = DefaultModel()
+        model = DefaultModule()
         origial_output = model(x)
 
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
@@ -100,7 +100,7 @@ class TestAdapterMixin:
         torch.random.manual_seed(0)
         x = torch.randn(2, 50)
 
-        model = DefaultModel()
+        model = DefaultModule()
         origial_output = model(x)
 
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg(norm_pos='post'))
@@ -113,7 +113,7 @@ class TestAdapterMixin:
         torch.random.manual_seed(0)
         x = torch.randn(2, 50)
 
-        model = DefaultModel()
+        model = DefaultModule()
         origial_output = model(x)
 
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
@@ -128,7 +128,7 @@ class TestAdapterMixin:
         torch.random.manual_seed(0)
         x = torch.randn(2, 50)
 
-        model = DefaultModel()
+        model = DefaultModule()
         origial_output = model(x)
 
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
@@ -142,7 +142,7 @@ class TestAdapterMixin:
 
     @pytest.mark.unit
     def test_forward_unfrozen_adapters(self):
-        model = DefaultModel()
+        model = DefaultModule()
         original_num_params = model.num_params()
 
         dim = 10
@@ -173,7 +173,7 @@ class TestAdapterMixin:
         torch.random.manual_seed(0)
         x = torch.randn(2, 50)
 
-        model = DefaultModel()
+        model = DefaultModule()
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
 
         # delete the strategy
@@ -193,7 +193,7 @@ class TestAdapterMixin:
         torch.random.manual_seed(0)
         x = torch.randn(2, 50)
 
-        model = DefaultModel()
+        model = DefaultModule()
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
 
         # modify the strategy

--- a/tests/core/mixins/adapters/test_adapter_mixin.py
+++ b/tests/core/mixins/adapters/test_adapter_mixin.py
@@ -16,11 +16,11 @@ import pytest
 import torch
 
 from nemo.core import NeuralModule
-from nemo.core.classes.mixins import adapter_mixin_strategies
+from nemo.core.classes.mixins import adapter_mixin_strategies, adapter_mixins
 from nemo.core.classes.mixins.adapter_mixins import AdapterModuleMixin
 
 
-class DefaultModule(NeuralModule, AdapterModuleMixin):
+class DefaultModule(NeuralModule):
     def __init__(self):
         super().__init__()
 
@@ -30,13 +30,6 @@ class DefaultModule(NeuralModule, AdapterModuleMixin):
     def forward(self, x):
         x = self.fc(x)
         x = self.bn(x)
-
-        if self.is_adapter_available():
-            # For testing purposes, cache the adapter names
-            self._adapter_names = self.get_enabled_adapters()
-            # call forward over model adapters, summing them up
-            x = self.forward_enabled_adapters(x)
-
         out = x
         return out
 
@@ -46,6 +39,19 @@ class DefaultModule(NeuralModule, AdapterModuleMixin):
             if p.requires_grad:
                 num += p.numel()
         return num
+
+
+class DefaultModuleAdapter(DefaultModule, AdapterModuleMixin):
+    def forward(self, x):
+        x = super(DefaultModuleAdapter, self).forward(x)
+
+        if self.is_adapter_available():
+            # For testing purposes, cache the adapter names
+            self._adapter_names = self.get_enabled_adapters()
+            # call forward over model adapters, summing them up
+            x = self.forward_enabled_adapters(x)
+
+        return x
 
 
 def get_adapter_cfg(in_features=50, dim=100, norm_pos='pre'):
@@ -58,10 +64,40 @@ def get_adapter_cfg(in_features=50, dim=100, norm_pos='pre'):
     return cfg
 
 
+def get_classpath(cls):
+    return f'{cls.__module__}.{cls.__name__}'
+
+
+if adapter_mixins.get_registered_adapter(DefaultModule) is None:
+    adapter_mixins.register_adapter(DefaultModule, DefaultModuleAdapter)
+
+
 class TestAdapterMixin:
     @pytest.mark.unit
+    def test_module_registered_adapter_by_class_path(self):
+        classpath = get_classpath(DefaultModule)
+        adapter_meta = adapter_mixins.get_registered_adapter(classpath)
+        assert adapter_meta is not None
+        assert adapter_meta.base_class == DefaultModule
+        assert adapter_meta.adapter_class == DefaultModuleAdapter
+
+    @pytest.mark.unit
+    def test_module_registered_adapter_by_class(self):
+        adapter_meta = adapter_mixins.get_registered_adapter(DefaultModule)
+        assert adapter_meta is not None
+        assert adapter_meta.base_class == DefaultModule
+        assert adapter_meta.adapter_class == DefaultModuleAdapter
+
+    @pytest.mark.unit
+    def test_module_registered_adapter_by_adapter_class(self):
+        adapter_meta = adapter_mixins.get_registered_adapter(DefaultModuleAdapter)
+        assert adapter_meta is not None
+        assert adapter_meta.base_class == DefaultModule
+        assert adapter_meta.adapter_class == DefaultModuleAdapter
+
+    @pytest.mark.unit
     def test_single_adapter(self):
-        model = DefaultModule()
+        model = DefaultModuleAdapter()
         original_num_params = model.num_params()
 
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
@@ -70,7 +106,7 @@ class TestAdapterMixin:
 
     @pytest.mark.unit
     def test_multiple_adapter(self):
-        model = DefaultModule()
+        model = DefaultModuleAdapter()
         original_num_params = model.num_params()
 
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
@@ -87,7 +123,7 @@ class TestAdapterMixin:
         torch.random.manual_seed(0)
         x = torch.randn(2, 50)
 
-        model = DefaultModule()
+        model = DefaultModuleAdapter()
         origial_output = model(x)
 
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
@@ -100,7 +136,7 @@ class TestAdapterMixin:
         torch.random.manual_seed(0)
         x = torch.randn(2, 50)
 
-        model = DefaultModule()
+        model = DefaultModuleAdapter()
         origial_output = model(x)
 
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg(norm_pos='post'))
@@ -113,7 +149,7 @@ class TestAdapterMixin:
         torch.random.manual_seed(0)
         x = torch.randn(2, 50)
 
-        model = DefaultModule()
+        model = DefaultModuleAdapter()
         origial_output = model(x)
 
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
@@ -128,7 +164,7 @@ class TestAdapterMixin:
         torch.random.manual_seed(0)
         x = torch.randn(2, 50)
 
-        model = DefaultModule()
+        model = DefaultModuleAdapter()
         origial_output = model(x)
 
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
@@ -142,7 +178,7 @@ class TestAdapterMixin:
 
     @pytest.mark.unit
     def test_forward_unfrozen_adapters(self):
-        model = DefaultModule()
+        model = DefaultModuleAdapter()
         original_num_params = model.num_params()
 
         dim = 10
@@ -173,7 +209,7 @@ class TestAdapterMixin:
         torch.random.manual_seed(0)
         x = torch.randn(2, 50)
 
-        model = DefaultModule()
+        model = DefaultModuleAdapter()
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
 
         # delete the strategy
@@ -193,7 +229,7 @@ class TestAdapterMixin:
         torch.random.manual_seed(0)
         x = torch.randn(2, 50)
 
-        model = DefaultModule()
+        model = DefaultModuleAdapter()
         model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
 
         # modify the strategy

--- a/tests/core/mixins/adapters/test_adapter_model_mixin.py
+++ b/tests/core/mixins/adapters/test_adapter_model_mixin.py
@@ -795,7 +795,8 @@ class TestAdapterModelMixin:
             assert (original_state_dict[ogkey] - restored_state_dict[newkey]).abs().mean() < 1e-6
 
     @pytest.mark.unit
-    def test_single_decoder_save_load_adapter_only_global_name(self):
+    @pytest.mark.parametrize('restore_name', [None, 'adapter_0'])
+    def test_single_decoder_save_load_adapter_only_global_name(self, restore_name):
         # create a model config, but do not add global_cfg to it
         # we want to test just module level adapter
         cfg = get_model_config(in_features=50)
@@ -832,7 +833,7 @@ class TestAdapterModelMixin:
 
             # restore adapter to new model (without any encoder adapter)
             new_model = DefaultAdapterModel(cfg)
-            new_model.load_adapters(outer_adapter_path, name='adapter_0')
+            new_model.load_adapters(outer_adapter_path, name=restore_name)
 
         assert isinstance(new_model, AdapterModelPTMixin)
         assert len(new_model.get_enabled_adapters()) > 0

--- a/tests/core/mixins/adapters/test_adapter_model_mixin.py
+++ b/tests/core/mixins/adapters/test_adapter_model_mixin.py
@@ -699,6 +699,12 @@ class TestAdapterModelMixin:
         assert modules_cfg is not None
         assert modules_cfg[new_model.get_enabled_adapters()[0]] == 'decoder'  # decoder module
 
+        original_state_dict = model.decoder.adapter_layer.state_dict()
+        restored_state_dict = new_model.decoder.adapter_layer.state_dict()
+
+        for ogkey, newkey in zip(original_state_dict.keys(), restored_state_dict.keys()):
+            assert (original_state_dict[ogkey] - restored_state_dict[newkey]).abs().mean() < 1e-6
+
     @pytest.mark.unit
     def test_single_decoder_save_load_adapter_only_global_name(self):
         # create a model config, but do not add global_cfg to it
@@ -751,6 +757,12 @@ class TestAdapterModelMixin:
         assert modules_cfg is not None
         assert modules_cfg[new_model.get_enabled_adapters()[0]] == ''  # global adapter
 
+        original_state_dict = model.encoder.adapter_layer.state_dict()
+        restored_state_dict = new_model.encoder.adapter_layer.state_dict()
+
+        for ogkey, newkey in zip(original_state_dict.keys(), restored_state_dict.keys()):
+            assert (original_state_dict[ogkey] - restored_state_dict[newkey]).abs().mean() < 1e-6
+
     @pytest.mark.unit
     def test_multiple_decoder_save_load_adapter_only_exact_name(self):
         # create a model config, but do not add global_cfg to it
@@ -801,6 +813,12 @@ class TestAdapterModelMixin:
 
         assert modules_cfg is not None
         assert modules_cfg[new_model.get_enabled_adapters()[0]] == 'decoder'  # decoder
+
+        original_state_dict = model.decoder.adapter_layer.state_dict()
+        restored_state_dict = new_model.decoder.adapter_layer.state_dict()
+
+        for ogkey, newkey in zip(original_state_dict.keys(), restored_state_dict.keys()):
+            assert (original_state_dict[ogkey] - restored_state_dict[newkey]).abs().mean() < 1e-6
 
     @pytest.mark.unit
     def test_multiple_decoder_save_load_adapter_dual_name(self):
@@ -853,6 +871,12 @@ class TestAdapterModelMixin:
 
         assert modules_cfg is not None
         assert modules_cfg[new_model.get_enabled_adapters()[0]] == 'decoder'  # decoder
+
+        original_state_dict = model.decoder.adapter_layer.state_dict()
+        restored_state_dict = new_model.decoder.adapter_layer.state_dict()
+
+        for ogkey, newkey in zip(original_state_dict.keys(), restored_state_dict.keys()):
+            assert (original_state_dict[ogkey] - restored_state_dict[newkey]).abs().mean() < 1e-6
 
     @pytest.mark.unit
     def test_single_decoder_save_load_adapter_only_partial_name(self):
@@ -914,3 +938,9 @@ class TestAdapterModelMixin:
 
         assert modules_cfg is not None
         assert modules_cfg[new_model.get_enabled_adapters()[0]] == 'decoder'  # decoder module
+
+        original_state_dict = model.decoder.adapter_layer.state_dict()
+        restored_state_dict = new_model.decoder.adapter_layer.state_dict()
+
+        for ogkey, newkey in zip(original_state_dict.keys(), restored_state_dict.keys()):
+            assert (original_state_dict[ogkey] - restored_state_dict[newkey]).abs().mean() < 1e-6

--- a/tests/core/mixins/adapters/test_adapter_model_mixin.py
+++ b/tests/core/mixins/adapters/test_adapter_model_mixin.py
@@ -92,7 +92,7 @@ class DefaultModelAdapterMixin(AdapterModelPTMixin):
         super().add_adapter(name, cfg)
 
         # Resolve module name and adapter name
-        module_name, adapter_name = self._resolve_adapter_module_name(name)
+        module_name, adapter_name = self.resolve_adapter_module_name_(name)
 
         # Try to retrieve global adapter config
         global_config = self._get_global_cfg()
@@ -111,7 +111,7 @@ class DefaultModelAdapterMixin(AdapterModelPTMixin):
 
         # Resolve module name and adapter name
         if name is not None:
-            module_name, _ = self._resolve_adapter_module_name(name)
+            module_name, _ = self.resolve_adapter_module_name_(name)
         else:
             module_name = None
 
@@ -173,10 +173,10 @@ class DefaultModelAdapterMixin(AdapterModelPTMixin):
         elif decoder_adapter and not isinstance(self.decoder, AdapterModuleMixin):
             raise ValueError("Decoder does not support adapters !")
 
-    def _resolve_adapter_module_name(self, name: str) -> (str, str):
+    def resolve_adapter_module_name_(self, name: str) -> (str, str):
         # resolve name and module
         valid_module_names = ['', 'encoder', 'decoder']
-        module_name, adapter_name = super()._resolve_adapter_module_name(name)
+        module_name, adapter_name = super().resolve_adapter_module_name_(name)
 
         if module_name not in valid_module_names:
             raise ValueError(f"Provided module name `{module_name}` is not in valid list : {valid_module_names}")
@@ -634,7 +634,7 @@ class TestAdapterModelMixin:
         model.set_enabled_adapters(name=name1, enabled=False)
         new_output = model(x)
 
-        resolved_name2 = model._resolve_adapter_module_name(name2)[-1]
+        resolved_name2 = model.resolve_adapter_module_name_(name2)[-1]
         assert model.get_enabled_adapters() == [resolved_name2]
         assert torch.mean(torch.abs(original_output - new_output)) < 1e-5
 

--- a/tests/core/mixins/adapters/test_adapter_model_mixin.py
+++ b/tests/core/mixins/adapters/test_adapter_model_mixin.py
@@ -1,0 +1,495 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+from omegaconf import DictConfig, OmegaConf, open_dict
+from hydra.utils import instantiate
+
+from nemo.core import NeuralModule, ModelPT
+from nemo.core.classes.mixins import adapter_mixins, adapter_mixin_strategies
+from nemo.core.classes.mixins.adapter_mixins import AdapterModuleMixin, AdapterModelPTMixin
+
+
+class DefaultModule(NeuralModule):
+    def __init__(self):
+        super().__init__()
+
+        self.fc = torch.nn.Linear(50, 50)
+        self.bn = torch.nn.BatchNorm1d(50)
+
+    def forward(self, x):
+        x = self.fc(x)
+        x = self.bn(x)
+        out = x
+        return out
+
+    def num_params(self):
+        num: int = 0
+        for p in self.parameters():
+            if p.requires_grad:
+                num += p.numel()
+        return num
+
+
+class DefaultModuleAdapter(DefaultModule, AdapterModuleMixin):
+    def forward(self, x):
+        x = super(DefaultModuleAdapter, self).forward(x)
+
+        if self.is_adapter_available():
+            # For testing purposes, cache the adapter names
+            self._adapter_names = self.get_enabled_adapters()
+            # call forward over model adapters, summing them up
+            x = self.forward_enabled_adapters(x)
+
+        return x
+
+
+class DefaultModelAdapterMixin(AdapterModelPTMixin):
+    def setup_adapters(self):
+        supports_adapters = False
+
+        # Check the inheriting class' modules supports adapters or not
+        if hasattr(self, 'encoder') and isinstance(self.encoder, AdapterModuleMixin):
+            supports_adapters |= True
+
+        if hasattr(self, 'decoder') and isinstance(self.decoder, AdapterModuleMixin):
+            supports_adapters |= True
+
+        if supports_adapters:
+            super().setup_adapters()
+
+    def add_adapter(self, name: str, cfg: DictConfig):
+        # setup the config for adapters
+        super().add_adapter(name, cfg)
+
+        # Try to retrieve global adapter config
+        global_config = DictConfig({})
+        if self.adapter_global_cfg_key in self.cfg.adapters:
+            global_config = self.adapter_cfg[self.adapter_global_cfg_key]
+
+        # forward the method call to the individual modules
+        if global_config.get('encoder_adapter', True):
+            self.encoder.add_adapter(name, cfg)
+
+        if global_config.get('decoder_adapter', False):
+            self.decoder.add_adapter(name, cfg)
+
+    def set_enabled_adapters(self, name=None, enabled: bool = True):
+        # check if valid model with some adapter support
+        super().set_enabled_adapters(name, enabled)
+
+        # Try to retrieve global adapter config
+        global_config = DictConfig({})
+        if self.adapter_global_cfg_key in self.cfg.adapters:
+            global_config = self.adapter_cfg[self.adapter_global_cfg_key]
+
+        # Forward the method call to the individual modules
+        if global_config.get('encoder_adapter', True):
+            self.encoder.set_enabled_adapters(name, enabled)
+
+        if global_config.get('decoder_adapter', False):
+            self.decoder.set_enabled_adapters(name, enabled)
+
+    def get_enabled_adapters(self) -> list:
+        enabled_adapters = super().get_enabled_adapters()
+
+        # Try to retrieve global adapter config
+        global_config = DictConfig({})
+        if self.adapter_global_cfg_key in self.cfg.adapters:
+            global_config = self.adapter_cfg[self.adapter_global_cfg_key]
+
+        # Forward the method call to the individual modules
+        if global_config.get('encoder_adapter', True):
+            encoder_adapters = self.encoder.get_enabled_adapters()
+            enabled_adapters.extend(encoder_adapters)
+
+        if global_config.get('decoder_adapter', True):
+            decoder_adapters = self.decoder.get_enabled_adapters()
+            enabled_adapters.extend(decoder_adapters)
+
+        return enabled_adapters
+
+    def is_adapter_available(self) -> bool:
+        adapters_available = super().is_adapter_available()
+
+        # Try to retrieve global adapter config
+        global_config = DictConfig({})
+        if self.adapter_global_cfg_key in self.cfg.adapters:
+            global_config = self.adapter_cfg[self.adapter_global_cfg_key]
+
+        # Forward the method call to the individual modules
+        if global_config.get('encoder_adapter', True):
+            adapters_available |= self.encoder.is_adapter_available()
+
+        if global_config.get('decoder_adapter', False):
+            adapters_available |= self.decoder.is_adapter_available()
+
+        return adapters_available
+
+    def _check_valid_model_with_adapter_support(self):
+        global_cfg = DictConfig({})
+        if self.adapter_global_cfg_key in self.adapter_cfg:
+            global_cfg = self.adapter_cfg[self.adapter_global_cfg_key]
+
+        encoder_adapter = global_cfg.get('encoder_adapter', True)
+        decoder_adapter = global_cfg.get('decoder_adapter', False)
+
+        if encoder_adapter and not hasattr(self, 'encoder'):
+            raise ValueError("Encoder not available")
+        elif encoder_adapter and not isinstance(self.encoder, AdapterModuleMixin):
+            raise ValueError("Encoder does not support adapters !")
+
+        if decoder_adapter and not hasattr(self, 'decoder'):
+            raise ValueError("Decoder is not available")
+        elif decoder_adapter and not isinstance(self.decoder, AdapterModuleMixin):
+            raise ValueError("Decoder does not support adapters !")
+
+
+class DefaultAdapterModel(ModelPT, DefaultModelAdapterMixin):
+    def __init__(self, cfg, trainer=None):
+        super().__init__(cfg, trainer=trainer)
+
+        self.encoder = instantiate(cfg.encoder)
+        self.decoder = instantiate(cfg.decoder)
+
+        # Required to be called for adapter support
+        self.setup_adapters()
+
+    def forward(self, x):
+        y = self.encoder(x)
+        z = self.decoder(y)
+        return z
+
+    def list_available_models(cls):
+        return None
+
+    def setup_training_data(self, train_data_config):
+        self._update_dataset_config('train', train_data_config)
+        self._train_dl = None
+
+    def setup_validation_data(self, val_data_config):
+        self._update_dataset_config('validation', val_data_config)
+        self._validation_dl = None
+
+
+def get_adapter_cfg(in_features=50, dim=100, norm_pos='pre'):
+    cfg = {
+        '_target_': 'nemo.collections.common.parts.adapter_modules.LinearAdapter',
+        'in_features': in_features,
+        'dim': dim,
+        'norm_position': norm_pos,
+    }
+    return cfg
+
+
+def get_model_config(in_features=50, update_adapter_cfg: bool = True):
+    config = OmegaConf.create(
+        {
+            'in_features': in_features,
+            'encoder': {'_target_': get_classpath(DefaultModule)},
+            'decoder': {'_target_': get_classpath(DefaultModule)},
+        }
+    )
+
+    if update_adapter_cfg:
+        enc_adapter_metadata = adapter_mixins.get_registered_adapter(config.encoder._target_)
+        if enc_adapter_metadata is not None:
+            config.encoder._target_ = enc_adapter_metadata.adapter_class_path
+
+        dec_adapter_metadata = adapter_mixins.get_registered_adapter(config.decoder._target_)
+        if dec_adapter_metadata is not None:
+            config.decoder._target_ = dec_adapter_metadata.adapter_class_path
+
+    return config
+
+
+def update_adapter_global_cfg(cfg: DictConfig, encoder_adapter=True, decoder_adapter=False):
+    if 'adapters' not in cfg:
+        cfg.adapters = adapter_mixins._prepare_default_adapter_config(
+            global_key=AdapterModuleMixin.adapter_global_cfg_key, meta_key=AdapterModuleMixin.adapter_metadata_cfg_key
+        )
+
+    cfg.adapters.global_cfg.encoder_adapter = encoder_adapter
+    cfg.adapters.global_cfg.decoder_adapter = decoder_adapter
+    return cfg
+
+
+def get_classpath(cls):
+    return f'{cls.__module__}.{cls.__name__}'
+
+
+if adapter_mixins.get_registered_adapter(DefaultModule) is None:
+    adapter_mixins.register_adapter(DefaultModule, DefaultModuleAdapter)
+
+
+class TestAdapterModelMixin:
+    @pytest.mark.unit
+    def test_base_model_no_support_for_adapters(self):
+        cfg = get_model_config(in_features=50, update_adapter_cfg=False)
+        model = DefaultAdapterModel(cfg)
+
+        with pytest.raises(ValueError):
+            model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
+
+    @pytest.mark.unit
+    def test_single_adapter(self):
+        cfg = get_model_config(in_features=50)
+
+        model = DefaultAdapterModel(cfg)
+        original_num_params = model.num_weights
+
+        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
+        new_num_params = model.num_weights
+        assert new_num_params > original_num_params
+
+    @pytest.mark.unit
+    def test_all_disabled_adapters(self):
+        cfg = get_model_config(in_features=50)
+        cfg = update_adapter_global_cfg(cfg, encoder_adapter=False, decoder_adapter=False)
+
+        model = DefaultAdapterModel(cfg)
+        original_num_params = model.num_weights
+
+        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
+        new_num_params = model.num_weights
+
+        assert new_num_params == original_num_params
+        assert model.is_adapter_available() is False
+
+    @pytest.mark.unit
+    def test_enc_dec_enabled_adapters(self):
+        cfg = get_model_config(in_features=50)
+        cfg = update_adapter_global_cfg(cfg, encoder_adapter=True, decoder_adapter=False)
+
+        model = DefaultAdapterModel(cfg)
+        original_num_params = model.num_weights
+
+        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
+        new_num_params = model.num_weights
+        assert new_num_params > original_num_params
+
+        cfg = update_adapter_global_cfg(cfg, encoder_adapter=True, decoder_adapter=True)
+        model2 = DefaultAdapterModel(cfg)
+
+        model2.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
+        new_encdec_num_params = model2.num_weights
+
+        assert new_encdec_num_params > new_num_params
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('enc', [True, False])
+    @pytest.mark.parametrize('dec', [True, False])
+    def test_multiple_adapter(self, enc, dec):
+        if enc is False and dec is False:
+            return  # need at least one adapter active
+
+        cfg = get_model_config(in_features=50)
+        cfg = update_adapter_global_cfg(cfg, encoder_adapter=enc, decoder_adapter=dec)
+
+        model = DefaultAdapterModel(cfg)
+        original_num_params = model.num_weights
+
+        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
+        new_num_params = model.num_weights
+        assert new_num_params > original_num_params
+
+        original_num_params = new_num_params
+        model.add_adapter(name='adapter_1', cfg=get_adapter_cfg())
+        new_num_params = model.num_weights
+        assert new_num_params > original_num_params
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('enc', [True, False])
+    @pytest.mark.parametrize('dec', [True, False])
+    def test_forward_linear_pre(self, enc, dec):
+        if enc is False and dec is False:
+            return  # need at least one adapter active
+
+        torch.random.manual_seed(0)
+        x = torch.randn(2, 50)
+
+        cfg = get_model_config(in_features=50)
+        cfg = update_adapter_global_cfg(cfg, encoder_adapter=enc, decoder_adapter=dec)
+
+        model = DefaultAdapterModel(cfg)
+        origial_output = model(x)
+
+        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
+        new_output = model(x)
+
+        assert torch.mean(torch.abs(origial_output - new_output)) < 1e-5
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('enc', [True, False])
+    @pytest.mark.parametrize('dec', [True, False])
+    def test_forward_linear_post(self, enc, dec):
+        if enc is False and dec is False:
+            return  # need at least one adapter active
+
+        torch.random.manual_seed(0)
+        x = torch.randn(2, 50)
+
+        cfg = get_model_config(in_features=50)
+        cfg = update_adapter_global_cfg(cfg, encoder_adapter=enc, decoder_adapter=dec)
+
+        model = DefaultAdapterModel(cfg)
+        origial_output = model(x)
+
+        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg(norm_pos='post'))
+        new_output = model(x)
+
+        assert torch.mean(torch.abs(origial_output - new_output)) < 1e-5
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('enc', [True, False])
+    @pytest.mark.parametrize('dec', [True, False])
+    def test_multi_adapter_forward(self, enc, dec):
+        if enc is False and dec is False:
+            return  # need at least one adapter active
+
+        torch.random.manual_seed(0)
+        x = torch.randn(2, 50)
+
+        cfg = get_model_config(in_features=50)
+        cfg = update_adapter_global_cfg(cfg, encoder_adapter=enc, decoder_adapter=dec)
+
+        model = DefaultAdapterModel(cfg)
+        origial_output = model(x)
+
+        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
+        model.add_adapter(name='adapter_1', cfg=get_adapter_cfg())
+        new_output = model(x)
+
+        if enc:
+            assert model.encoder._adapter_names == ['adapter_0', 'adapter_1']
+        if dec:
+            assert model.decoder._adapter_names == ['adapter_0', 'adapter_1']
+
+        assert torch.mean(torch.abs(origial_output - new_output)) < 1e-5
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('enc', [True, False])
+    @pytest.mark.parametrize('dec', [True, False])
+    def test_multi_adapter_partial_forward(self, enc, dec):
+        if enc is False and dec is False:
+            return  # need at least one adapter active
+
+        torch.random.manual_seed(0)
+        x = torch.randn(2, 50)
+
+        cfg = get_model_config(in_features=50)
+        cfg = update_adapter_global_cfg(cfg, encoder_adapter=enc, decoder_adapter=dec)
+
+        model = DefaultAdapterModel(cfg)
+        origial_output = model(x)
+
+        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
+        model.add_adapter(name='adapter_1', cfg=get_adapter_cfg())
+
+        model.set_enabled_adapters(name='adapter_0', enabled=False)
+        new_output = model(x)
+
+        if enc:
+            assert model.encoder._adapter_names == ['adapter_1']
+        if dec:
+            assert model.decoder._adapter_names == ['adapter_1']
+        assert torch.mean(torch.abs(origial_output - new_output)) < 1e-5
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('enc', [True, False])
+    @pytest.mark.parametrize('dec', [True, False])
+    def test_forward_unfrozen_adapters(self, enc, dec):
+        if enc is False and dec is False:
+            return  # need at least one adapter active
+
+        cfg = get_model_config(in_features=50)
+        cfg = update_adapter_global_cfg(cfg, encoder_adapter=enc, decoder_adapter=dec)
+
+        model = DefaultAdapterModel(cfg)
+        original_num_params = model.num_weights
+
+        dim = 10
+
+        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg(dim=dim))
+        model.freeze()
+        model.unfreeze_enabled_adapters()
+
+        assert original_num_params == 5300
+
+        original_params = 0
+        adapter_params = 0
+        for name, param in model.named_parameters():
+            if 'adapter' not in name:
+                assert param.requires_grad is False
+                original_params += param.numel()
+            else:
+                assert param.requires_grad is True
+                adapter_params += param.numel()
+
+        for mname, module in model.named_modules():
+            if isinstance(module, (torch.nn.BatchNorm1d, torch.nn.BatchNorm2d, torch.nn.BatchNorm3d)):
+                assert module.track_running_stats is False
+
+        assert original_params > adapter_params
+
+        enc_params = model.encoder.num_params()
+        dec_params = model.decoder.num_params()
+        assert adapter_params == enc_params + dec_params
+
+    @pytest.mark.unit
+    def test_forward_linear_no_strategy(self):
+        torch.random.manual_seed(0)
+        x = torch.randn(2, 50)
+
+        cfg = get_model_config(in_features=50)
+        cfg = update_adapter_global_cfg(cfg, encoder_adapter=True, decoder_adapter=False)
+
+        model = DefaultAdapterModel(cfg)
+        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
+
+        # delete the strategy
+        adapter_module = model.encoder.adapter_layer[model.get_enabled_adapters()[0]]
+        del adapter_module.adapter_strategy
+
+        with pytest.raises(AttributeError):
+            _ = model(x)
+
+    @pytest.mark.unit
+    def test_forward_linear_replaced_strategy(self):
+        class MultiplyAdapterStrategy(adapter_mixin_strategies.AbstractAdapterStrategy):
+            def forward(self, input: torch.Tensor, adapter: torch.nn.Module, *, module: AdapterModuleMixin):
+                out = adapter(input)
+                return input * out
+
+        torch.random.manual_seed(0)
+        x = torch.randn(2, 50)
+
+        cfg = get_model_config(in_features=50)
+        # Use decoder only adapter
+        cfg = update_adapter_global_cfg(cfg, encoder_adapter=True, decoder_adapter=True)
+
+        model = DefaultAdapterModel(cfg)
+        model.add_adapter(name='adapter_0', cfg=get_adapter_cfg())
+
+        # modify the strategy of both encoder and decoder
+        adapter_module = model.encoder.adapter_layer[model.get_enabled_adapters()[0]]
+        adapter_module.adapter_strategy = MultiplyAdapterStrategy()
+
+        adapter_module = model.decoder.adapter_layer[model.get_enabled_adapters()[0]]
+        adapter_module.adapter_strategy = MultiplyAdapterStrategy()
+
+        out = model(x)
+        # result of adapter is zero tensor, output multiplied by adapter result should be zero
+        assert (out > 0.0).any() == torch.tensor(False)

--- a/tests/core/mixins/adapters/test_adapter_model_mixin.py
+++ b/tests/core/mixins/adapters/test_adapter_model_mixin.py
@@ -707,6 +707,17 @@ class TestAdapterModelMixin:
         assert (out > 0.0).any() == torch.tensor(False)
 
     @pytest.mark.unit
+    def test_save_adapter_with_no_adapters_added(self):
+        # create a model config, but do not add global_cfg to it
+        # we want to test just module level adapter
+        cfg = get_model_config(in_features=50)
+
+        model = DefaultAdapterModel(cfg)
+
+        with pytest.raises(AttributeError):
+            model.save_adapters(filepath='temp.pt', name=None)
+
+    @pytest.mark.unit
     def test_single_decoder_save_load_adapter_only_exact_name(self):
         # create a model config, but do not add global_cfg to it
         # we want to test just module level adapter

--- a/tests/core/mixins/adapters/test_adapter_model_mixin.py
+++ b/tests/core/mixins/adapters/test_adapter_model_mixin.py
@@ -155,7 +155,7 @@ class DefaultModelAdapterMixin(AdapterModelPTMixin):
 
         return adapters_available
 
-    def _check_valid_model_with_adapter_support(self):
+    def check_valid_model_with_adapter_support_(self):
         global_cfg = DictConfig({})
         if self.adapter_global_cfg_key in self.adapter_cfg:
             global_cfg = self.adapter_cfg[self.adapter_global_cfg_key]

--- a/tests/core/mixins/adapters/test_adapter_model_mixin.py
+++ b/tests/core/mixins/adapters/test_adapter_model_mixin.py
@@ -300,10 +300,18 @@ class TestAdapterModelMixin:
 
             outer_path = os.path.join(outer_tmpdir, 'temp.nemo')
             new_model = DefaultAdapterModel.restore_from(outer_path)  # type: DefaultAdapterModel
-            assert isinstance(new_model, AdapterModelPTMixin)
-            assert len(new_model.get_enabled_adapters()) > 0
-            assert model.num_weights == new_model.num_weights
-            assert new_model.decoder.is_adapter_available() is False
+
+        assert isinstance(new_model, AdapterModelPTMixin)
+        assert len(new_model.get_enabled_adapters()) > 0
+        assert model.num_weights == new_model.num_weights
+        assert new_model.decoder.is_adapter_available() is False
+
+        adapter_cfg = new_model.cfg.adapters
+        meta_cfg = adapter_cfg[model.adapter_global_cfg_key][model.adapter_metadata_cfg_key]
+        modules_cfg = meta_cfg['modules']
+
+        assert modules_cfg is not None
+        assert modules_cfg[model.get_enabled_adapters()[0]] == 'encoder'  # encoder
 
     @pytest.mark.unit
     def test_single_decoder_module_adapter(self):

--- a/tests/core/mixins/adapters/test_adapter_strategy.py
+++ b/tests/core/mixins/adapters/test_adapter_strategy.py
@@ -1,0 +1,154 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+import torch
+
+from nemo.core import NeuralModule
+from nemo.core.classes.mixins import AdapterModuleMixin, adapter_mixin_strategies, adapter_mixins
+from nemo.utils import config_utils
+
+
+class DefaultModule(NeuralModule):
+    def __init__(self):
+        super().__init__()
+
+        self.fc = torch.nn.Linear(50, 50)
+        self.bn = torch.nn.BatchNorm1d(50)
+
+    def forward(self, x):
+        x = self.fc(x)
+        x = self.bn(x)
+        out = x
+        return out
+
+    def num_params(self):
+        num: int = 0
+        for p in self.parameters():
+            if p.requires_grad:
+                num += p.numel()
+        return num
+
+
+class DefaultModuleAdapter(DefaultModule, AdapterModuleMixin):
+    def forward(self, x):
+        x = super(DefaultModuleAdapter, self).forward(x)
+
+        if self.is_adapter_available():
+            # For testing purposes, cache the adapter names
+            self._adapter_names = self.get_enabled_adapters()
+            # call forward over model adapters, summing them up
+            x = self.forward_enabled_adapters(x)
+
+        return x
+
+
+def get_adapter_cfg(in_features=50, dim=100, norm_pos='pre'):
+    cfg = {
+        '_target_': 'nemo.collections.common.parts.adapter_modules.LinearAdapter',
+        'in_features': in_features,
+        'dim': dim,
+        'norm_position': norm_pos,
+    }
+    return cfg
+
+
+def get_classpath(cls):
+    return f'{cls.__module__}.{cls.__name__}'
+
+
+if adapter_mixins.get_registered_adapter(DefaultModule) is None:
+    adapter_mixins.register_adapter(DefaultModule, DefaultModuleAdapter)
+
+
+class TestAdapterStrategy:
+    @pytest.mark.unit
+    def test_ResidualAddAdapterStrategyConfig(self):
+        IGNORED_ARGS = ['_target_']
+
+        result = config_utils.assert_dataclass_signature_match(
+            adapter_mixin_strategies.ResidualAddAdapterStrategy,
+            adapter_mixin_strategies.ResidualAddAdapterStrategyConfig,
+            ignore_args=IGNORED_ARGS,
+        )
+
+        signatures_match, cls_subset, dataclass_subset = result
+
+        assert signatures_match
+        assert cls_subset is None
+        assert dataclass_subset is None
+
+    @pytest.mark.unit
+    def test_strategy_default(self):
+        torch.random.manual_seed(0)
+        x = torch.randn(2, 50)
+
+        module = DefaultModuleAdapter()
+        module.add_adapter(name='temp', cfg=get_adapter_cfg())
+        adapter = module.adapter_layer[module.get_enabled_adapters()[0]]
+
+        # update the strategy
+        adapter_strategy = adapter_mixin_strategies.ResidualAddAdapterStrategy()
+        adapter.adapter_strategy = adapter_strategy
+
+        with torch.no_grad():
+            assert adapter_strategy.stochastic_depth == 0.0
+            out = adapter_strategy.forward(x, adapter, module=module)
+            assert (out - x).abs().mean() < 1e-5
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize('stochastic_depth', [0.0, 1.0])
+    def test_strategy_stochasic_depth(self, stochastic_depth):
+        torch.random.manual_seed(0)
+        x = torch.randn(2, 50)
+
+        module = DefaultModuleAdapter()
+        module.add_adapter(name='temp', cfg=get_adapter_cfg())
+
+        # extract adapter
+        adapter = module.adapter_layer[module.get_enabled_adapters()[0]]
+        # reinitialize the final layer of the adapter module (so that it is not zero init)
+        adapter.module[-1].weight.data += 1
+
+        # get just module output
+        module.set_enabled_adapters('temp', enabled=False)
+        module_out = module(x)
+
+        # get module + adapter output
+        module.set_enabled_adapters('temp', enabled=True)
+        module_adapter_out = module(x)
+
+        assert (
+            module_out - module_adapter_out
+        ).abs().sum() > 0  # results should not be the same after adapter forward now
+
+        adapter_strategy = adapter_mixin_strategies.ResidualAddAdapterStrategy(stochastic_depth=stochastic_depth)
+        adapter.adapter_strategy = adapter_strategy
+
+        module.eval()
+        with torch.inference_mode():  # stochastic depth disabled, no grad tracking
+            assert adapter.adapter_strategy.stochastic_depth == stochastic_depth
+
+            out = adapter_strategy.forward(module_out, adapter, module=module)
+            assert (out - module_adapter_out).abs().mean() < 1e-5
+
+        module.train()
+        with torch.inference_mode():  # stochastic depth enabled, but no grad tracking during training mode
+            out = adapter_strategy.forward(module_out, adapter, module=module)
+
+            if stochastic_depth == 0.0:
+                check = module_adapter_out
+            else:
+                check = module_out
+            assert (out - check).abs().mean() < 1e-5


### PR DESCRIPTION
# What does this PR do ?

Adds significant functionality to adapters, allowing multiple module-specific adapters, save and restore of just the adapters themselves rather than the full model (saving several hundred megabytes-to-gigabytes), and a suite of tests for the new functionality.

**Collection**: [Core, ASR]

# Changelog 
- Adds support for both "global" and "module" specific adapters. Module specific adapters allow for targetted adapters to certain modules, independent of the others.
- Adds support for saving and restoring just the adapter modules, independent of the original model weights. This allows savings of significant disk storage, since just the adapters are usually a tiny fraction of the param count of the models.
- Adds a battery of tests for the new capabilities.
- Add support for dropout to adapter modules
- Add support for stochastic dropout to all adapters via ResidualAddStrategy.

# Usage

Subclass implementations can chose between global adapters, module adapters or both. A basic implementation of Adapters for a toy model is provided in the `tests/core/mixins/adapters/test_adapter_model_mixin.py`

```python
# Global adapters (adds "abc" adapter to all supported modules - encoder+decoder+others1)
model.add_adapter(name="abc", cfg=cfg) 

# Module adapters 
model.add_adapter(name="decoder:abc", cfg=cfg)

# Save all of the adapters (only the adapters themselves)
model.save_adapters("adapters.pt", name=None)
OR
model.save_adapters("adapters.pt", name={global or module adapter name})

# Restore one-or-all adapters (only the adapters themselves)
new_model.load_adapters("adapters.pt", name=None)
OR
new_model.load_adapters("adapters.pt", name={exact module name from state dict}, 
                        map_location='cpu', strict=True)
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
