### PR TITLE
[Add] support for prepending data prefix

### DIFF
--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -6,8 +6,11 @@ separable: &separable true
 labels: &labels [" ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
          "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'"]
 
+data_prefix: null
+
 model:
   train_ds:
+    data_prefix: ${data_prefix}
     manifest_filepath: ???
     sample_rate: 16000
     labels: *labels
@@ -24,6 +27,7 @@ model:
     bucketing_batch_size: null
 
   validation_ds:
+    data_prefix: ${data_prefix}
     manifest_filepath: ???
     sample_rate: 16000
     labels: *labels

--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -6,11 +6,9 @@ separable: &separable true
 labels: &labels [" ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
          "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'"]
 
-data_prefix: null
-
 model:
   train_ds:
-    data_prefix: ${data_prefix}
+    data_prefix: null
     manifest_filepath: ???
     sample_rate: 16000
     labels: *labels
@@ -27,7 +25,7 @@ model:
     bucketing_batch_size: null
 
   validation_ds:
-    data_prefix: ${data_prefix}
+    data_prefix: null
     manifest_filepath: ???
     sample_rate: 16000
     labels: *labels

--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -121,11 +121,13 @@ class ASRManifestProcessor:
         eos_id: Optional[int] = None,
         pad_id: int = 0,
         index_by_file_id: bool = False,
+        data_prefix: Optional[str] = None
     ):
         self.parser = parser
 
         self.collection = collections.ASRAudioText(
             manifests_files=manifest_filepath,
+            data_prefix=data_prefix,
             parser=parser,
             min_duration=min_duration,
             max_duration=max_duration,
@@ -259,12 +261,17 @@ class _AudioTextDataset(Dataset):
         eos_id: Optional[int] = None,
         pad_id: int = 0,
         return_sample_id: bool = False,
+        data_prefix: Optional[str] = None
     ):
         if type(manifest_filepath) == str:
             manifest_filepath = manifest_filepath.split(",")
 
+        if isinstance(data_prefix, str):
+            data_prefix = data_prefix.split(",")
+
         self.manifest_processor = ASRManifestProcessor(
             manifest_filepath=manifest_filepath,
+            data_prefix=data_prefix,
             parser=parser,
             max_duration=max_duration,
             min_duration=min_duration,
@@ -370,6 +377,7 @@ class AudioToCharDataset(_AudioTextDataset):
         pad_id: int = 0,
         parser: Union[str, Callable] = 'en',
         return_sample_id: bool = False,
+        data_prefix: Optional[str] = None,
     ):
         self.labels = labels
 
@@ -391,6 +399,7 @@ class AudioToCharDataset(_AudioTextDataset):
             eos_id=eos_id,
             pad_id=pad_id,
             return_sample_id=return_sample_id,
+            data_prefix=data_prefix,
         )
 
 

--- a/nemo/collections/asr/data/audio_to_text_dataset.py
+++ b/nemo/collections/asr/data/audio_to_text_dataset.py
@@ -85,6 +85,7 @@ def get_char_dataset(config: dict, augmentor: Optional['AudioAugmentor'] = None)
 
     dataset = audio_to_text.AudioToCharDataset(
         manifest_filepath=config['manifest_filepath'],
+        data_prefix=config.get('data_prefix', None),
         labels=config.get('labels', None),
         sample_rate=config['sample_rate'],
         int_values=config.get('int_values', False),
@@ -99,6 +100,7 @@ def get_char_dataset(config: dict, augmentor: Optional['AudioAugmentor'] = None)
         parser=config.get('parser', 'en'),
         return_sample_id=config.get('return_sample_id', False),
     )
+
     return dataset
 
 

--- a/nemo/collections/common/parts/preprocessing/collections.py
+++ b/nemo/collections/common/parts/preprocessing/collections.py
@@ -203,7 +203,7 @@ class ASRAudioText(AudioText):
         """
 
         ids, audio_files, durations, texts, offsets, speakers, orig_srs, langs = [], [], [], [], [], [], [], []
-        for item in manifest.item_iter(manifests_files, data_prefix):
+        for item in manifest.item_iter(manifests_files, data_prefix=data_prefix):
             ids.append(item['id'])
             audio_files.append(item['audio_file'])
             durations.append(item['duration'])

--- a/nemo/collections/common/parts/preprocessing/collections.py
+++ b/nemo/collections/common/parts/preprocessing/collections.py
@@ -192,7 +192,7 @@ class AudioText(_Collection):
 class ASRAudioText(AudioText):
     """`AudioText` collector from asr structured json files."""
 
-    def __init__(self, manifests_files: Union[str, List[str]], *args, **kwargs):
+    def __init__(self, manifests_files: Union[str, List[str]], data_prefix: Union[str, List[str]] = None, *args, **kwargs):
         """Parse lists of audio files, durations and transcripts texts.
 
         Args:
@@ -203,7 +203,7 @@ class ASRAudioText(AudioText):
         """
 
         ids, audio_files, durations, texts, offsets, speakers, orig_srs, langs = [], [], [], [], [], [], [], []
-        for item in manifest.item_iter(manifests_files):
+        for item in manifest.item_iter(manifests_files, data_prefix):
             ids.append(item['id'])
             audio_files.append(item['audio_file'])
             durations.append(item['duration'])

--- a/nemo/collections/common/parts/preprocessing/manifest.py
+++ b/nemo/collections/common/parts/preprocessing/manifest.py
@@ -32,8 +32,9 @@ class ManifestEN:
 
 
 def item_iter(
-    manifests_files: Union[str, List[str]], data_prefix: Optional[Union[str, List[str]]] = None, 
-    parse_func: Callable[[str, Optional[str]], Dict[str, Any]] = None
+    manifests_files: Union[str, List[str]], 
+    parse_func: Callable[[str, Optional[str]], Dict[str, Any]] = None,
+    data_prefix: Optional[Union[str, List[str]]] = None, 
 ) -> Iterator[Dict[str, Any]]:
     """Iterate through json lines of provided manifests.
 
@@ -48,12 +49,12 @@ def item_iter(
         manifests_files: Either single string file or list of such -
             manifests to yield items from.
 
-        data_prefix: Either single string prefix or list of such -
-            prefix to append to each manifest.
-
         parse_func: A callable function which accepts as input a single line
             of a manifest and optionally the manifest file itself,
             and parses it, returning a dictionary mapping from str -> Any.
+            
+        data_prefix: Either single string prefix or list of such -
+            prefix to append to each manifest.
 
     Yields:
         Parsed key to value item dicts.

--- a/nemo/collections/common/parts/preprocessing/manifest.py
+++ b/nemo/collections/common/parts/preprocessing/manifest.py
@@ -16,6 +16,7 @@ import json
 from os.path import expanduser
 from typing import Any, Callable, Dict, Iterator, List, Optional, Union
 from pathlib import Path
+from nemo.utils import logging
 
 class ManifestBase:
     def __init__(self, *args, **kwargs):
@@ -86,7 +87,15 @@ def item_iter(
 
     k = -1
     for manifest_file, prefix in zip(manifests_files, data_prefix):
-        manifest_file = str(Path(prefix) / Path(manifest_file))
+        if not Path(manifest_file).is_file():
+            logging.info(f"Manifest not found: {manifest_file}")
+            manifest_file = str(Path(prefix) / Path(manifest_file))
+            logging.info(f"Try adding prefix {prefix}: {manifest_file}")
+            if Path(manifest_file).is_file():
+                logging.info(f"Found alternate manifest: {manifest_file}")
+            else:
+                raise ValueError(f"Manifest not found: {manifest_file}")
+
         with open(expanduser(manifest_file), 'r') as f:
             for line in f:
                 k += 1


### PR DESCRIPTION
# Add support for prepending data prefix to manifests paths and `audio_paths`

This feature is to add support for automatically adding prefix to manifest paths as well as the `audio_filepath` field in the manifest. The simple trick is by adding a `data_prefix` in the top level of your yaml config file. The program has a default value of `None` for  `data_prefix`, so that it's compatible with all previous config files.

# Features
- Adding single prefix to all input manifests. Each train/val/test dataset can have their own data prefix.
- Add different prefix to different input manifests, where the number of specified prefix must match the number of input manifests.
- Fully compatible with previous manifest, since `data_prefix=None` by default.

# Why Data Prefix?

Consider the following dataset folder:
```
/home/steve/libri_speech/
----------------------------->: train_manifest.json
----------------------------->: wav/
------------------------------------->: 11111.wav
------------------------------------->: 22222.wav
```
and the content of ` train_manifest.json` is:
```
{"audio_filepath": "/home/steve/libri_speech/wav/11111.wav", duration: "2.3",  "text": "one one one one one"}
```

If say, Kevin, wants to use my dataset on his project by copying my folder : `cp -r /home/steve/libri_speech/  /home/kevin/`, then he must also change all the `audio_filepath` in  the manifest `/home/steve/libri_speech/train_manifest.json`, which is certainly a tedious work.

However, if we allow `audio_filepath` to be relative paths to the data folder, then we can have a more flexible `train_manifest.json`:
```
{"audio_filepath": "wav/11111.wav", duration: "2.3",  "text": "one one one one one"}
```

Also, when added with a `data_prefix`, we can move the dataset to anywhere without modifying the manifest. For example, all Kevin has to do is simply:
```
python train.py \
    --config-path=../conf/conformer --config-name=config \ 
    model.train_ds.data_prefix=/home/kevin/libri_speech \
    model.train_ds.manifest_filepath="train_manifest.json"
```

And the program will automatically resolve the path for manifest as `/home/kevin/libri_speech/train_manifest.json`, and all `audio_filepath` in the manifest will also be added with the prefix: 
```
{"audio_filepath": "wav/11111.wav", duration: "2.3",  "text": "one one one one one"}
becomes
{"audio_filepath": "/home/kevin/libri_speech/wav/11111.wav", duration: "2.3",  "text": "one one one one one"}

```

# Example Usage

Take the `examples/asr/conf/config.yaml` as an example. We just need to add `data_prefix` as follows:
```yaml
name: &name "QuartzNet15x5"
sample_rate: &sample_rate 16000
repeat: &repeat 1
dropout: &dropout 0.0
separable: &separable true
labels: &labels [" ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m",
         "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'"]

data_prefix: null

model:
  train_ds:
    data_prefix: null
    manifest_filepath: ???
    .......(other params)

  validation_ds:
    data_prefix: null
    manifest_filepath: ???
    ......(other params)
```

Then suppose the data folder is `/home/heh/libri_speech`, and the `audio_filepath` are relative paths to the data folder, we can run the program by:

```bash
python speech_to_text_ctc.py \
    --config-path=../conf --config-name=config \
    model.train_ds.data_prefix="/home/heh/libri_speech" \
    model.train_ds.manifest_filepath="train_manifest.json" \
    model.validation_ds.data_prefix="/home/heh/libri_speech" \
    model.validation_ds.manifest_filepath="train_manifest.json" \
    trainer.devices=2 \
    trainer.max_epochs=2 \
```

# Change Log
- [5/10/2022] Modified config example: remove global `data_prefix`, and let `model.train_ds`, `model.validation_ds` and `model.test_ds` have their own `data_prefix`.
- [5/10/2022] Prioritize absolute path for manifest over relative path resolution. Now the `item_iter()` first try to locate the original manifest file, and will try to prepend `data_prefix` to the manifest path only if the file is not found at the original manifest path.

# Suggested Future Change
- In data downloading scripts, change all absolute `audio_filepath` to relative paths.