### PR TITLE
WaveGlow input type fixes

### DIFF
--- a/nemo/collections/tts/models/waveglow.py
+++ b/nemo/collections/tts/models/waveglow.py
@@ -88,9 +88,7 @@ class WaveGlowModel(GlowVocoder, Exportable):
     ) -> torch.Tensor:
         with self.nemo_infer():
             self.waveglow.remove_weightnorm()
-            audio = self.waveglow(
-                spec=spec.to(self.waveglow.upsample.weight.dtype), run_inverse=True, audio=None, sigma=sigma
-            )
+            audio = self.waveglow(spec=spec.to(self.waveglow.upsample.weight.dtype), sigma=sigma)
             if denoise:
                 audio = self.denoise(audio=audio, strength=denoiser_strength)
 

--- a/nemo/collections/tts/modules/waveglow.py
+++ b/nemo/collections/tts/modules/waveglow.py
@@ -134,12 +134,13 @@ class WaveGlowModule(NeuralModule, Exportable):
         if self.mode == OperationMode.infer:
             return {
                 "spec": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
-                "z": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
+                "z": NeuralType(('B', 'D', 'T'), MelSpectrogramType(), optional=True),
+                "sigma": NeuralType(optional=True),
             }
         else:
             return {
                 "spec": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
-                "z": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
+                "z": NeuralType(('B', 'D', 'T'), MelSpectrogramType(), optional=True),
                 "audio": NeuralType(('B', 'T'), AudioSignal(), optional=True),
                 "run_inverse": NeuralType(elements_type=IntType(), optional=True),
                 "sigma": NeuralType(optional=True),


### PR DESCRIPTION
Signed-off-by: Jocelyn Huang <jocelynh@nvidia.com>

Fix WaveGlow input types to match what gets passed in during training and inference.

**Collection**: TTS

# Changelog 
- Made `z` optional, as it's not passed in during training and inference, and only during export
- Removed extraneous inputs to the WaveGlow module in `convert_spectrogram_to_audio()`
- Added `sigma` to optional inputs for inference, since it is a default argument for the base `convert_spectrogram_to_audio()` function

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
