### PR TITLE
let sox find wav duration when it is missing (None).

### DIFF
--- a/scripts/speaker_tasks/scp_to_manifest.py
+++ b/scripts/speaker_tasks/scp_to_manifest.py
@@ -132,7 +132,7 @@ def read_manifest(manifest):
 
 def get_duration(json_line):
     dur = json_line['duration']
-    if dur is not None:
+    if dur is None:
         wav_path = json_line['audio_filepath']
         json_line['duration'] = sox.file_info.duration(wav_path)
     return json_line


### PR DESCRIPTION
# What does this PR do ?

bug-fix.  sox must find the wav duration when dur is None.

**Collection**:  speaker_tasks

# Changelog 
L135: this condition should be true when 'dur is None' because it allows sox to get the duration from the wav_file.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
python ../../../scripts/speaker_tasks/scp_to_manifest.py --scp voxceleb12.scp  --id 8 --out TMP 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [] Did you write any new necessary tests?
- [] Did you add or update any necessary documentation?
- [] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
