### PR TITLE
Tacotron2 1.9.0 bugfixes

### DIFF
--- a/examples/tts/conf/tacotron2.yaml
+++ b/examples/tts/conf/tacotron2.yaml
@@ -11,7 +11,7 @@ sup_data_types: null
 
 phoneme_dict_path: "scripts/tts_dataset_files/cmudict-0.7b_nv22.01"
 heteronyms_path: "scripts/tts_dataset_files/heteronyms-030921"
-whitelist_path: "nemo_text_processing/text_normalization/en/data/whitelist_lj_speech.tsv"
+whitelist_path: "nemo_text_processing/text_normalization/en/data/whitelist/lj_speech.tsv"
 
 
 

--- a/examples/tts/conf/tacotron2.yaml
+++ b/examples/tts/conf/tacotron2.yaml
@@ -1,6 +1,4 @@
-# This config contains the default values for training Tacotron2 model on LJSpeech dataset.
-# If you want to train model on other dataset, you can change config values according to your dataset.
-# Most dataset-specific arguments are in the head of the config file, see below.
+# This config contains the default values for training Tacotron2.
 
 name: Tacotron2
 
@@ -16,9 +14,6 @@ whitelist_path: "nemo_text_processing/text_normalization/en/data/whitelist/lj_sp
 
 
 model:
-  pitch_fmin: 65.40639132514966
-  pitch_fmax: 2093.004522404789
-
   sample_rate: 22050
   n_mel_channels: 80
   n_window_size: 1024
@@ -71,8 +66,6 @@ model:
       min_duration: 0.1
       ignore_file: null
       trim: False
-      pitch_fmin: ${model.pitch_fmin}
-      pitch_fmax: ${model.pitch_fmax}
     dataloader_params:
       drop_last: false
       shuffle: true
@@ -98,8 +91,6 @@ model:
       min_duration: 0.1
       ignore_file: null
       trim: False
-      pitch_fmin: ${model.pitch_fmin}
-      pitch_fmax: ${model.pitch_fmax}
     dataloader_params:
       drop_last: false
       shuffle: false

--- a/examples/tts/conf/tacotron2_44100.yaml
+++ b/examples/tts/conf/tacotron2_44100.yaml
@@ -1,116 +1,137 @@
-# TODO(Oktai15): update this config in 1.8.0 version
+# This config contains the default values for training Tacotron2 model on LJSpeech dataset.
+# If you want to train model on other dataset, you can change config values according to your dataset.
+# Most dataset-specific arguments are in the head of the config file, see below.
+# This config is for training with sample rate 44.1kHz.
 
 name: Tacotron2
-sample_rate: 44100
-# <PAD>, <BOS>, <EOS> will be added by the tacotron2.py script
-labels:
-- ' '
-- '!'
-- '"'
-- ''''
-- (
-- )
-- ','
-- '-'
-- .
-- ':'
-- ;
-- '?'
-- a
-- b
-- c
-- d
-- e
-- f
-- g
-- h
-- i
-- j
-- k
-- l
-- m
-- 'n'
-- o
-- p
-- q
-- r
-- s
-- t
-- u
-- v
-- w
-- x
-- 'y'
-- z
-n_fft: 2048
-n_mels: 80
-fmax: null
-n_stride: 512
-pad_value: -11.52
+
 train_dataset: ???
 validation_datasets: ???
+sup_data_path: null
+sup_data_types: null
+
+phoneme_dict_path: "scripts/tts_dataset_files/cmudict-0.7b_nv22.01"
+heteronyms_path: "scripts/tts_dataset_files/heteronyms-030921"
+whitelist_path: "nemo_text_processing/text_normalization/en/data/whitelist/lj_speech.tsv"
+
+
 
 model:
-  labels: ${labels}
+  pitch_fmin: 65.40639132514966
+  pitch_fmax: 2093.004522404789
+
+  sample_rate: 44100
+  n_mel_channels: 80
+  n_window_size: 2048
+  n_window_stride: 512
+  n_fft: 2048
+  lowfreq: 0
+  highfreq: null
+  window: hann
+  pad_value: -11.52
+
+
+  text_normalizer:
+    _target_: nemo_text_processing.text_normalization.normalize.Normalizer
+    lang: en
+    input_case: cased
+    whitelist: ${whitelist_path}
+
+  text_normalizer_call_kwargs:
+    verbose: false
+    punct_pre_process: true
+    punct_post_process: true
+
+  text_tokenizer:
+    _target_: nemo.collections.tts.torch.tts_tokenizers.EnglishPhonemesTokenizer
+    punct: true
+    stresses: true
+    chars: true
+    apostrophe: true
+    pad_with_space: true
+    g2p:
+      _target_: nemo.collections.tts.torch.g2ps.EnglishG2p
+      phoneme_dict: ${phoneme_dict_path}
+      heteronyms: ${heteronyms_path}
+
   train_ds:
     dataset:
-      _target_: "nemo.collections.asr.data.audio_to_text.AudioToCharDataset"
+      _target_: "nemo.collections.tts.torch.data.TTSDataset"
       manifest_filepath: ${train_dataset}
+      sample_rate: ${model.sample_rate}
+      sup_data_path: ${sup_data_path}
+      sup_data_types: ${sup_data_types}
+      n_fft: ${model.n_fft}
+      win_length: ${model.n_window_size}
+      hop_length: ${model.n_window_stride}
+      window: ${model.window}
+      n_mels: ${model.n_mel_channels}
+      lowfreq: ${model.lowfreq}
+      highfreq: ${model.highfreq}
       max_duration: null
       min_duration: 0.1
-      trim: false
-      int_values: false
-      normalize: true
-      sample_rate: ${sample_rate}
-      # bos_id: 66
-      # eos_id: 67
-      # pad_id: 68  These parameters are added automatically in Tacotron2
+      ignore_file: null
+      trim: False
+      pitch_fmin: ${model.pitch_fmin}
+      pitch_fmax: ${model.pitch_fmax}
     dataloader_params:
       drop_last: false
       shuffle: true
       batch_size: 48
       num_workers: 4
-
-
+      pin_memory: false
+  
   validation_ds:
     dataset:
-      _target_: "nemo.collections.asr.data.audio_to_text.AudioToCharDataset"
-      manifest_filepath: ${validation_datasets}
+      _target_: "nemo.collections.tts.torch.data.TTSDataset"
+      manifest_filepath: ${train_dataset}
+      sample_rate: ${model.sample_rate}
+      sup_data_path: ${sup_data_path}
+      sup_data_types: ${sup_data_types}
+      n_fft: ${model.n_fft}
+      win_length: ${model.n_window_size}
+      hop_length: ${model.n_window_stride}
+      window: ${model.window}
+      n_mels: ${model.n_mel_channels}
+      lowfreq: ${model.lowfreq}
+      highfreq: ${model.highfreq}
       max_duration: null
       min_duration: 0.1
-      int_values: false
-      normalize: true
-      sample_rate: ${sample_rate}
-      trim: false
-      # bos_id: 66
-      # eos_id: 67
-      # pad_id: 68  These parameters are added automatically in Tacotron2
+      ignore_file: null
+      trim: False
+      pitch_fmin: ${model.pitch_fmin}
+      pitch_fmax: ${model.pitch_fmax}
     dataloader_params:
       drop_last: false
       shuffle: false
-      batch_size: 48
+      batch_size: 24
       num_workers: 8
+      pin_memory: false
 
   preprocessor:
     _target_: nemo.collections.asr.parts.preprocessing.features.FilterbankFeatures
-    dither: 0.0
-    nfilt: ${n_mels}
-    frame_splicing: 1
-    highfreq: ${fmax}
+    nfilt: ${model.n_mel_channels}
+    highfreq: ${model.highfreq}
     log: true
     log_zero_guard_type: clamp
     log_zero_guard_value: 1e-05
-    lowfreq: 0
-    mag_power: 1.0
-    n_fft: ${n_fft}
-    n_window_size: 2048
-    n_window_stride: ${n_stride}
-    normalize: null
+    lowfreq: ${model.lowfreq}
+    n_fft: ${model.n_fft}
+    n_window_size: ${model.n_window_size}
+    n_window_stride: ${model.n_window_stride}
     pad_to: 16
-    pad_value: ${pad_value}
+    pad_value: ${model.pad_value}
+    sample_rate: ${model.sample_rate}
+    window: ${model.window}
+    normalize: null
     preemph: null
-    sample_rate: ${sample_rate}
-    window: hann
+    dither: 0.0
+    frame_splicing: 1
+    stft_conv: false
+    nb_augmentation_prob : 0
+    mag_power: 1.0
+    exact_pad: true
+    use_grads: false
 
   encoder:
     _target_: nemo.collections.tts.modules.tacotron2.Encoder
@@ -125,7 +146,7 @@ model:
     gate_threshold: 0.5
     max_decoder_steps: 1000
     n_frames_per_step: 1  # currently only 1 is supported
-    n_mel_channels: ${n_mels}
+    n_mel_channels: ${model.n_mel_channels}
     p_attention_dropout: 0.1
     p_decoder_dropout: 0.1
     prenet_dim: 256
@@ -140,7 +161,7 @@ model:
 
   postnet:
     _target_: nemo.collections.tts.modules.tacotron2.Postnet
-    n_mel_channels: ${n_mels}
+    n_mel_channels: ${model.n_mel_channels}
     p_dropout: 0.5
     postnet_embedding_dim: 512
     postnet_kernel_size: 5
@@ -167,11 +188,15 @@ trainer:
   enable_checkpointing: False  # Provided by exp_manager
   logger: False  # Provided by exp_manager
   gradient_clip_val: 1.0
-  log_every_n_steps: 200
-  check_val_every_n_epoch: 25
+  log_every_n_steps: 60
+  check_val_every_n_epoch: 2
+
 
 exp_manager:
   exp_dir: null
   name: ${name}
-  create_tensorboard_logger: True
-  create_checkpoint_callback: True
+  create_tensorboard_logger: true
+  create_checkpoint_callback: true
+  checkpoint_callback_params:
+    monitor: val_loss
+    mode: min

--- a/examples/tts/conf/tacotron2_44100.yaml
+++ b/examples/tts/conf/tacotron2_44100.yaml
@@ -1,6 +1,4 @@
-# This config contains the default values for training Tacotron2 model on LJSpeech dataset.
-# If you want to train model on other dataset, you can change config values according to your dataset.
-# Most dataset-specific arguments are in the head of the config file, see below.
+# This config contains the default values for training Tacotron2.
 # This config is for training with sample rate 44.1kHz.
 
 name: Tacotron2
@@ -17,9 +15,6 @@ whitelist_path: "nemo_text_processing/text_normalization/en/data/whitelist/lj_sp
 
 
 model:
-  pitch_fmin: 65.40639132514966
-  pitch_fmax: 2093.004522404789
-
   sample_rate: 44100
   n_mel_channels: 80
   n_window_size: 2048
@@ -72,8 +67,6 @@ model:
       min_duration: 0.1
       ignore_file: null
       trim: False
-      pitch_fmin: ${model.pitch_fmin}
-      pitch_fmax: ${model.pitch_fmax}
     dataloader_params:
       drop_last: false
       shuffle: true
@@ -99,8 +92,6 @@ model:
       min_duration: 0.1
       ignore_file: null
       trim: False
-      pitch_fmin: ${model.pitch_fmin}
-      pitch_fmax: ${model.pitch_fmax}
     dataloader_params:
       drop_last: false
       shuffle: false

--- a/tutorials/tts/Tacotron2_Training.ipynb
+++ b/tutorials/tts/Tacotron2_Training.ipynb
@@ -54,7 +54,7 @@
     "3. Connect to an instance with a GPU (Runtime -> Change runtime type -> select \"GPU\" for hardware accelerator)\n",
     "4. Run this cell to set up dependencies# .\n",
     "\"\"\"\n",
-    "BRANCH = 'main'\n",
+    "BRANCH = 'r1.9.0'\n",
     "# # If you're using Colab and not running locally, uncomment and run this cell.\n",
     "# !apt-get install sox libsndfile1 ffmpeg\n",
     "# !pip install wget unidecode\n",
@@ -155,7 +155,22 @@
     "# NeMo's training scripts are stored inside the examples/ folder. Let's grab the tacotron2.py file\n",
     "# as well as the tacotron2.yaml file\n",
     "!wget https://raw.githubusercontent.com/NVIDIA/NeMo/$BRANCH/examples/tts/tacotron2.py\n",
-    "!mkdir -p conf && cd conf && wget https://raw.githubusercontent.com/NVIDIA/NeMo/$BRANCH/examples/tts/conf/tacotron2.yaml && cd .."
+    "!(mkdir -p conf \\\n",
+    "  && cd conf \\\n",
+    "  && wget https://raw.githubusercontent.com/NVIDIA/NeMo/$BRANCH/examples/tts/conf/tacotron2.yaml \\\n",
+    "  && cd ..)\n",
+    "\n",
+    "# We will also need a few extra files for handling text.\n",
+    "!(mkdir -p scripts/tts_dataset_files \\\n",
+    "  && cd scripts/tts_dataset_files \\\n",
+    "  && wget https://raw.githubusercontent.com/NVIDIA/NeMo/$BRANCH/scripts/tts_dataset_files/cmudict-0.7b_nv22.01 \\\n",
+    "  && wget wget https://raw.githubusercontent.com/NVIDIA/NeMo/$BRANCH/scripts/tts_dataset_files/heteronyms-030921 \\\n",
+    "  && cd ..)\n",
+    "        \n",
+    "!(mkdir -p nemo_text_processing/text_normalization/en/data/whitelist/ \\\n",
+    "  && cd nemo_text_processing/text_normalization/en/data/whitelist/ \\\n",
+    "  && wget https://raw.githubusercontent.com/NVIDIA/NeMo/$BRANCH/nemo_text_processing/text_normalization/en/data/whitelist/lj_speech.tsv \\\n",
+    "  && cd ..)"
    ]
   },
   {
@@ -218,7 +233,7 @@
     "\n",
     "phoneme_dict_path: \"scripts/tts_dataset_files/cmudict-0.7b_nv22.01\"\n",
     "heteronyms_path: \"scripts/tts_dataset_files/heteronyms-030921\"\n",
-    "whitelist_path: \"nemo_text_processing/text_normalization/en/data/whitelist_lj_speech.tsv\"\n",
+    "whitelist_path: \"nemo_text_processing/text_normalization/en/data/whitelist/lj_speech.tsv\"\n",
     "```\n",
     "\n",
     "The first part of the yaml defines dataset parameters used by Tacotron. Then in the head of 'model' section there are processing - related parameters. You can see\n",
@@ -257,14 +272,37 @@
    },
    "outputs": [],
    "source": [
-    "!wget https://github.com/NVIDIA/NeMo/releases/download/v0.11.0/test_data.tar.gz && mkdir -p tests/data && tar xzf test_data.tar.gz -C tests/data\n",
+    "!wget https://github.com/NVIDIA/NeMo/releases/download/v0.11.0/test_data.tar.gz \\\n",
+    "&& mkdir -p tests/data \\\n",
+    "&& tar xzf test_data.tar.gz -C tests/data\n",
     "\n",
     "# Just like ASR, the Tacotron2 require .json files to define the training and validation data.\n",
-    "!cat tests/data/asr/an4_val.json\n",
+    "!cat tests/data/asr/an4_val.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now that we have some sample data, we can try training Tacotron 2!\n",
     "\n",
-    "# Now that we have some sample data, we can try training Tacotron 2\n",
-    "# NOTE: The sample data is not enough data to properly train a Tacotron 2. This will not result in a trained Tacotron 2 and is used to illustrate how to train Tacotron 2 model\n",
-    "!python tacotron2.py sample_rate=16000 train_dataset=tests/data/asr/an4_train.json validation_datasets=tests/data/asr/an4_val.json trainer.max_epochs=3 trainer.accelerator=null trainer.check_val_every_n_epoch=1"
+    "Note that the sample data is not enough data to fully train a Tacotron 2 model. The following code uses a toy dataset to illustrate how the pipeline for training would work."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!(python tacotron2.py \\\n",
+    "  model.sample_rate=16000 \\\n",
+    "  train_dataset=tests/data/asr/an4_train.json \\\n",
+    "  validation_datasets=tests/data/asr/an4_val.json \\\n",
+    "  trainer.max_epochs=3 \\\n",
+    "  trainer.accelerator=null \\\n",
+    "  trainer.check_val_every_n_epoch=1 \\\n",
+    " +trainer.gpus=1)"
    ]
   },
   {
@@ -315,7 +353,7 @@
    "provenance": []
   },
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -329,7 +367,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
# What does this PR do ?

Update Tacotron2 training tutorial and config to work with r.1.9.0

**Collection**: TTS

# Changelog 
- Updated 44kHz config to use TTSDataset (now matches with 22kHz config)
- Added file downloads necessary for training to the Tacotron2 notebook
- Minor bugfix to avoid device mismatch during training for the notebook

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
