### PR TITLE
fix load_from_checkpoint for MTEncDecModel

### DIFF
--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -353,12 +353,14 @@ class NLPModel(ModelPT, Exportable):
             else:
                 model = cls._load_model_state(checkpoint, strict=strict, cfg=cfg, **kwargs)
                 # cfg = checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY].cfg
-            if cfg.tokenizer.get("tokenizer_model") is not None:
-                model.register_artifact("tokenizer.tokenizer_model", cfg.tokenizer.tokenizer_model)
-            if cfg.tokenizer.get("vocab_file") is not None:
-                model.register_artifact("tokenizer.vocab_file", cfg.tokenizer.vocab_file)
-            if cfg.tokenizer.get("merge_file") is not None:
-                model.register_artifact("tokenizer.merge_file", cfg.tokenizer.merge_file)
+
+            if cfg.get("tokenizer") is not None:
+                if cfg.tokenizer.get("tokenizer_model") is not None:
+                    model.register_artifact("tokenizer.tokenizer_model", cfg.tokenizer.tokenizer_model)
+                if cfg.tokenizer.get("vocab_file") is not None:
+                    model.register_artifact("tokenizer.vocab_file", cfg.tokenizer.vocab_file)
+                if cfg.tokenizer.get("merge_file") is not None:
+                    model.register_artifact("tokenizer.merge_file", cfg.tokenizer.merge_file)
 
             checkpoint = model
 


### PR DESCRIPTION
Signed-off-by: Iztok Lebar Bajec <ilb@fri.uni-lj.si>

# What does this PR do ?

MTEncDecModel yaml configs do not declare `model.tokenizer`, hence without this fix restoring from a checkpoint will fail with
```
omegaconf.errors.ConfigAttributeError: Missing key tokenizer
    full_key: cfg.tokenizer
    object_type=dict
``` 

**Collection**: NLP/MT

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
