### PR TITLE
[fastpitch][DE] HUI dataset preparation config and model training config on 44100 Hz audios.

### DIFF
--- a/examples/tts/conf/de/fastpitch_align_44100.yaml
+++ b/examples/tts/conf/de/fastpitch_align_44100.yaml
@@ -1,0 +1,237 @@
+# This config contains the default values for training FastPitch model with aligner using 44.1KHz sampling
+# rate. If you want to train model on other dataset, you can change config values according to your dataset.
+# Most dataset-specific arguments are in the head of the config file, see below.
+
+
+name: FastPitch
+
+train_dataset: ???
+validation_datasets: ???
+sup_data_path: ???
+sup_data_types: [ "align_prior_matrix", "pitch" ]
+
+# Default values from librosa.pyin
+pitch_fmin: 65.40639132514966
+pitch_fmax: 2093.004522404789
+
+# Stats (per frame), train (these values depend on pitch_fmin and pitch_fmax)
+# For example, on HUI-Audio-Corpus-German (speaker: Friedrich)
+pitch_mean: 119.04859924316406
+pitch_std: 95.5344009399414
+
+sample_rate: 44100
+n_mel_channels: 80
+n_window_size: 2048
+n_window_stride: 512
+n_fft: 2048
+lowfreq: 0
+highfreq: null
+window: hann
+
+whitelist_path: "nemo_text_processing/text_normalization/de/data/whitelist.tsv"
+
+model:
+  learn_alignment: true
+  bin_loss_warmup_epochs: 100
+
+  n_speakers: 1
+  max_token_duration: 75
+  symbols_embedding_dim: 384
+  pitch_embedding_kernel_size: 3
+
+  pitch_fmin: ${pitch_fmin}
+  pitch_fmax: ${pitch_fmax}
+
+  pitch_mean: ${pitch_mean}
+  pitch_std: ${pitch_std}
+
+  sample_rate: ${sample_rate}
+  n_mel_channels: ${n_mel_channels}
+  n_window_size: ${n_window_size}
+  n_window_stride: ${n_window_stride}
+  n_fft: ${n_fft}
+  lowfreq: ${lowfreq}
+  highfreq: ${highfreq}
+  window: ${window}
+
+  text_normalizer:
+    _target_: nemo_text_processing.text_normalization.normalize.Normalizer
+    lang: de
+    input_case: cased
+    whitelist: ${whitelist_path}
+
+  text_normalizer_call_kwargs:
+    verbose: false
+    punct_pre_process: true
+    punct_post_process: true
+
+  text_tokenizer:
+    _target_: nemo.collections.tts.torch.tts_tokenizers.GermanCharsTokenizer
+    punct: true
+    apostrophe: true
+    pad_with_space: true
+
+  train_ds:
+    dataset:
+      _target_: nemo.collections.tts.torch.data.TTSDataset
+      manifest_filepath: ${train_dataset}
+      sample_rate: ${model.sample_rate}
+      sup_data_path: ${sup_data_path}
+      sup_data_types: ${sup_data_types}
+      n_fft: ${model.n_fft}
+      win_length: ${model.n_window_size}
+      hop_length: ${model.n_window_stride}
+      window: ${model.window}
+      n_mels: ${model.n_mel_channels}
+      lowfreq: ${model.lowfreq}
+      highfreq: ${model.highfreq}
+      max_duration: 15  # change to null to include longer audios.
+      min_duration: 0.1
+      ignore_file: null
+      trim: false
+      pitch_fmin: ${model.pitch_fmin}
+      pitch_fmax: ${model.pitch_fmax}
+      pitch_norm: true
+      pitch_mean: ${model.pitch_mean}
+      pitch_std: ${model.pitch_std}
+
+    dataloader_params:
+      drop_last: false
+      shuffle: true
+      batch_size: 32
+      num_workers: 12
+
+  validation_ds:
+    dataset:
+      _target_: nemo.collections.tts.torch.data.TTSDataset
+      manifest_filepath: ${validation_datasets}
+      sample_rate: ${model.sample_rate}
+      sup_data_path: ${sup_data_path}
+      sup_data_types: ${sup_data_types}
+      n_fft: ${model.n_fft}
+      win_length: ${model.n_window_size}
+      hop_length: ${model.n_window_stride}
+      window: ${model.window}
+      n_mels: ${model.n_mel_channels}
+      lowfreq: ${model.lowfreq}
+      highfreq: ${model.highfreq}
+      max_duration: 15  # change to null to include longer audios.
+      min_duration: 0.1
+      ignore_file: null
+      trim: false
+      pitch_fmin: ${model.pitch_fmin}
+      pitch_fmax: ${model.pitch_fmax}
+      pitch_norm: true
+      pitch_mean: ${model.pitch_mean}
+      pitch_std: ${model.pitch_std}
+
+    dataloader_params:
+      drop_last: false
+      shuffle: false
+      batch_size: 32
+      num_workers: 8
+
+  preprocessor:
+    _target_: nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor
+    features: ${model.n_mel_channels}
+    lowfreq: ${model.lowfreq}
+    highfreq: ${model.highfreq}
+    n_fft: ${model.n_fft}
+    n_window_size: ${model.n_window_size}
+    window_size: false
+    n_window_stride: ${model.n_window_stride}
+    window_stride: false
+    pad_to: 1
+    pad_value: 0
+    sample_rate: ${model.sample_rate}
+    window: ${model.window}
+    normalize: null
+    preemph: null
+    dither: 0.0
+    frame_splicing: 1
+    log: true
+    log_zero_guard_type: add
+    log_zero_guard_value: 1e-05
+    mag_power: 1.0
+
+  input_fft: #n_embed and padding_idx are added by the model
+    _target_: nemo.collections.tts.modules.transformer.FFTransformerEncoder
+    n_layer: 6
+    n_head: 1
+    d_model: ${model.symbols_embedding_dim}
+    d_head: 64
+    d_inner: 1536
+    kernel_size: 3
+    dropout: 0.1
+    dropatt: 0.1
+    dropemb: 0.0
+    d_embed: ${model.symbols_embedding_dim}
+
+  output_fft:
+    _target_: nemo.collections.tts.modules.transformer.FFTransformerDecoder
+    n_layer: 6
+    n_head: 1
+    d_model: ${model.symbols_embedding_dim}
+    d_head: 64
+    d_inner: 1536
+    kernel_size: 3
+    dropout: 0.1
+    dropatt: 0.1
+    dropemb: 0.0
+
+  alignment_module:
+    _target_: nemo.collections.tts.modules.aligner.AlignmentEncoder
+    n_text_channels: ${model.symbols_embedding_dim}
+
+  duration_predictor:
+    _target_: nemo.collections.tts.modules.fastpitch.TemporalPredictor
+    input_size: ${model.symbols_embedding_dim}
+    kernel_size: 3
+    filter_size: 256
+    dropout: 0.1
+    n_layers: 2
+
+  pitch_predictor:
+    _target_: nemo.collections.tts.modules.fastpitch.TemporalPredictor
+    input_size: ${model.symbols_embedding_dim}
+    kernel_size: 3
+    filter_size: 256
+    dropout: 0.1
+    n_layers: 2
+
+  optim:
+    name: lamb
+    lr: 1e-1
+    betas: [0.9, 0.98]
+    weight_decay: 1e-6
+
+    sched:
+      name: NoamAnnealing
+      warmup_steps: 1000
+      last_epoch: -1
+      d_model: 1  # Disable scaling based on model dim
+
+trainer:
+  num_nodes: 1
+  devices: -1  # specify all GPUs regardless of its availability
+  accelerator: gpu
+  strategy: ddp
+  precision: 16
+  max_epochs: 1500
+  accumulate_grad_batches: 1
+  gradient_clip_val: 1000.0
+  enable_checkpointing: false  # Provided by exp_manager
+  logger: false  # Provided by exp_manager
+  log_every_n_steps: 100
+  check_val_every_n_epoch: 5
+
+exp_manager:
+  exp_dir: null
+  name: ${name}
+  create_tensorboard_logger: true
+  create_checkpoint_callback: true
+  checkpoint_callback_params:
+    monitor: v_loss
+  resume_if_exists: false
+  resume_ignore_no_checkpoint: false
+

--- a/scripts/dataset_processing/tts/hui_acg/ds_conf/ds_for_fastpitch_align.yaml
+++ b/scripts/dataset_processing/tts/hui_acg/ds_conf/ds_for_fastpitch_align.yaml
@@ -1,0 +1,43 @@
+name: "ds_for_fastpitch_align"
+
+manifest_filepath: "train_manifest.json"
+sup_data_path: "sup_data"
+sup_data_types: [ "align_prior_matrix", "pitch" ]
+whitelist_path: "nemo_text_processing/text_normalization/de/data/whitelist.tsv"
+
+dataset:
+  _target_: nemo.collections.tts.torch.data.TTSDataset
+  manifest_filepath: ${manifest_filepath}
+  sample_rate: 44100
+  sup_data_path: ${sup_data_path}
+  sup_data_types: ${sup_data_types}
+  n_fft: 2048
+  win_length: 2048
+  hop_length: 512
+  window: "hann"
+  n_mels: 80
+  lowfreq: 0
+  highfreq: null 
+  max_duration: 15
+  min_duration: 0.1
+  ignore_file: null
+  trim: false
+  pitch_fmin: 65.40639132514966
+  pitch_fmax: 2093.004522404789
+
+  text_normalizer:
+    _target_: nemo_text_processing.text_normalization.normalize.Normalizer
+    lang: de
+    input_case: cased
+    whitelist: ${whitelist_path}
+
+  text_normalizer_call_kwargs:
+    verbose: false
+    punct_pre_process: true
+    punct_post_process: true
+
+  text_tokenizer:
+    _target_: nemo.collections.tts.torch.tts_tokenizers.GermanCharsTokenizer
+    punct: true
+    apostrophe: true
+    pad_with_space: true


### PR DESCRIPTION
# What does this PR do ?

* created a dataset config for HUI-ACG.
* created a model config for fastpitch German.

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```bash
# Download the dataset, normalize texts, create manifests for train/val/test splits.
$ python scripts/dataset_processing/tts/hui_acg/get_data.py \
        --data-root /home/xueyang/datasets \
        --set-type clean \
        --speaker Friedrich

# save PITCH_MEAN and PITCH_STD from train split which will be printed in the console. 
# PATH_WHERE_TO_SAVE_SUP_DATA should be general for train/val/test split.
$ python scripts/dataset_processing/tts/extract_sup_data.py \
        --config-path hui_acg/ds_conf \
        --config-name ds_for_fastpitch_align.yaml \
        manifest_filepath=/home/xueyang/datasets/HUI-Audio-Corpus-German/Friedrich_Clean/train_manifest.json \
        sup_data_path=/home/xueyang/datasets/HUI-Audio-Corpus-German/Friedrich_Clean/

# you would see the information in the terminal
/home/xueyang/miniconda3/envs/nemo/lib/python3.8/site-packages/apex/pyprof/__init__.py:5: FutureWarning: pyprof will be removed by the end of June, 2022
  warnings.warn("pyprof will be removed by the end of June, 2022", FutureWarning)
################################################################################
### WARNING, path does not exist: KALDI_ROOT=/mnt/matylda5/iveselyk/Tools/kaldi-trunk
###          (please add 'export KALDI_ROOT=<your_path>' in your $HOME/.profile)
###          (or run as: KALDI_ROOT=<your_path> python <your_script>.py)
################################################################################

[NeMo W 2022-04-20 22:59:42 experimental:27] Module <class 'nemo.collections.nlp.data.language_modeling.megatron.megatron_batch_samplers.MegatronPretrainingRandomBatchSampler'> is experimental, not ready for production and is not fully supported. Use at your own risk.
[NeMo I 2022-04-20 22:59:42 tokenize_and_classify:87] Creating ClassifyFst grammars. This might take some time...
[NeMo I 2022-04-20 22:59:56 data:173] Loading dataset from /home/xueyang/datasets/HUI-Audio-Corpus-German/Friedrich_Clean/train_manifest.json.
9065it [00:00, 37982.47it/s]
[NeMo I 2022-04-20 22:59:56 data:207] Loaded dataset with 9065 files.
[NeMo I 2022-04-20 22:59:56 data:209] Dataset contains 18.92 hours.
[NeMo I 2022-04-20 22:59:56 data:297] Pruned 0 files. Final dataset contains 9065 files
[NeMo I 2022-04-20 22:59:56 data:299] Pruned 0.00 hours. Final dataset contains 18.92 hours.
Processing /home/xueyang/datasets/HUI-Audio-Corpus-German/Friedrich_Clean/train_manifest.json:
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 9065/9065 [3:15:29<00:00,  1.29s/it]
PITCH_MEAN, PITCH_STD = 119.04859924316406, 95.5344009399414
# you will see two new folders generated as well,
$ ls -lt
drwxrwxr-x 2 xueyang xueyang  786432 Apr 21 02:15 pitch
drwxrwxr-x 2 xueyang xueyang  802816 Apr 21 02:15 align_prior_matrix
-rw-rw-r-- 1 xueyang xueyang   87334 Apr 20 17:13 test_manifest.json
-rw-rw-r-- 1 xueyang xueyang 4014423 Apr 20 17:13 train_manifest.json
-rw-rw-r-- 1 xueyang xueyang   44681 Apr 20 17:13 val_manifest.json

# train FastPitch model
$ python examples/tts/fastpitch.py \
        --config-path conf/de \
        --config-name fastpitch_align_44100 \
        model.train_ds.dataloader_params.num_workers=16 \
        model.validation_ds.dataloader_params.num_workers=16 \
        model.train_ds.dataloader_params.batch_size=24 \
        model.validation_ds.dataloader_params.batch_size=24 \
        train_dataset=/home/xueyang/datasets/HUI-Audio-Corpus-German/Friedrich_Clean/train_manifest_ngc.json \
        validation_datasets=/home/xueyang/datasets/HUI-Audio-Corpus-German/Friedrich_Clean/val_manifest_ngc.json \
        sup_data_path=/home/xueyang/datasets/HUI-Audio-Corpus-German/Friedrich_Clean \
        pitch_mean=119.04859924316406 \
        pitch_std=95.5344009399414 \
        trainer.devices=2 \
        trainer.num_nodes=1 \
        trainer.precision=16 \
        trainer.accumulate_grad_batches=2 \
        trainer.log_every_n_steps=10 \
        exp_manager.exp_dir=/home/xueyang/results/in_progress/fastpitch-de-Friedrich_hui_train_A100x2 \
        exp_manager.resume_if_exists=True \
        exp_manager.resume_ignore_no_checkpoint=True \
        +exp_manager.create_wandb_logger=True \
        +exp_manager.wandb_logger_kwargs.name=ml-model.fastpitch-de-Friedrich \
        +exp_manager.wandb_logger_kwargs.project=GermanTTS 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
