### PR TITLE
Support load_adapters with just adapter_name

### DIFF
--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -773,9 +773,26 @@ class AdapterModelPTMixin(AdapterModuleMixin):
 
         # For all module:adapter names (note, for global modules, we ignore the module: part)
         for module_adapter_name in name:
+            # Extract current config as copy
+            internal_adapter_cfg = None
+            if hasattr(self, 'adapter_cfg') and self.adapter_cfg is not None:
+                internal_adapter_cfg = self.adapter_cfg
+
+            # Override internal adapter config with restoration config
+            self.adapter_cfg = config
+
             # Resolve the adapter name and extract the adapter's config from the checkpoint.
             module_name, adapter_name = self.resolve_adapter_module_name_(module_adapter_name)
             adapter_cfg = config[adapter_name]
+
+            # Recreate the module:adapter_name
+            if module_name is '':
+                module_adapter_name = adapter_name
+            else:
+                module_adapter_name = f'{module_name}:{adapter_name}'
+
+            # Reset internal adapter config
+            self.adapter_cfg = internal_adapter_cfg
 
             # Skip the global config key
             if adapter_name == self.adapter_global_cfg_key:

--- a/tests/core/mixins/adapters/test_adapter_model_mixin.py
+++ b/tests/core/mixins/adapters/test_adapter_model_mixin.py
@@ -1031,11 +1031,11 @@ class TestAdapterModelMixin:
 
             # restore adapter to new model (without any decoder adapter)
             new_model = DefaultAdapterModel(cfg)
+            # load adapter with partial name only - just adapter_0 - should work
+            new_model.load_adapters(outer_adapter_path, name='adapter_0')
 
-            # load adapter with partial name only - just adapter_0 - should fail
-            with pytest.raises(KeyError):
-                new_model.load_adapters(outer_adapter_path, name='adapter_0')
-
+            # restore adapter to new model (without any decoder adapter)
+            new_model = DefaultAdapterModel(cfg)
             # properly load with correct key
             new_model.load_adapters(outer_adapter_path, name='decoder:adapter_0')
 


### PR DESCRIPTION
Signed-off-by: smajumdar <smajumdar@nvidia.com>

# What does this PR do ?

Adds support for load_adapters to load any module adapter with just the adapter_name

**Collection**: [Core, ASR]

# Changelog 
- Update code and tests

# Usage
```python
model = ModelWithAdapterSupport()
model.add_adapters("module:adapter_name", adapter_cfg)
model.save_adapters("adapters.pt")

new_model = ModelWithAdaptersSupport()
new_model.load_adapters("adapters.pt", name="adapter_name")
```

**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
