### PR TITLE
Fixing the speed slow-down for speech models.

### DIFF
--- a/examples/asr/conf/asr_adapters/asr_adaptation.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation.yaml
@@ -170,6 +170,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False  # Provided by exp_manager
   logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 
 exp_manager:

--- a/examples/asr/conf/carnelinet/carnelinet_384.yaml
+++ b/examples/asr/conf/carnelinet/carnelinet_384.yaml
@@ -243,7 +243,7 @@ trainer:
   val_check_interval: 1.0 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
   precision: 32 # If AMP is available, change to 16 to gain training speed increase and lower memory consumption (preferred).
   sync_batchnorm: false
-  benchmark: false
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null

--- a/examples/asr/conf/citrinet/citrinet_1024.yaml
+++ b/examples/asr/conf/citrinet/citrinet_1024.yaml
@@ -454,7 +454,7 @@ trainer:
   check_val_every_n_epoch: 1
   precision: 32
   sync_batchnorm: false
-  benchmark: false
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -472,10 +472,3 @@ exp_manager:
     entity: null
   resume_if_exists: false
   resume_ignore_no_checkpoint: false
-
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/conf/citrinet/citrinet_384.yaml
+++ b/examples/asr/conf/citrinet/citrinet_384.yaml
@@ -409,7 +409,7 @@ trainer:
   check_val_every_n_epoch: 1
   precision: 32
   sync_batchnorm: false
-  benchmark: false
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -427,10 +427,3 @@ exp_manager:
     entity: null
   resume_if_exists: false
   resume_ignore_no_checkpoint: false
-
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/conf/citrinet/citrinet_512.yaml
+++ b/examples/asr/conf/citrinet/citrinet_512.yaml
@@ -414,7 +414,7 @@ trainer:
   check_val_every_n_epoch: 1
   precision: 32
   sync_batchnorm: false
-  benchmark: false
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -433,9 +433,3 @@ exp_manager:
   resume_if_exists: false
   resume_ignore_no_checkpoint: false
 
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/conf/citrinet/config_bpe.yaml
+++ b/examples/asr/conf/citrinet/config_bpe.yaml
@@ -170,6 +170,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -181,9 +182,3 @@ exp_manager:
     name: null
     project: null
 
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -173,6 +173,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0 # check once per epoch .25 for 4 times per epoch
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -180,9 +181,3 @@ exp_manager:
   create_tensorboard_logger: True
   create_checkpoint_callback: True
 
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/conf/conformer/conformer_ctc_bpe.yaml
+++ b/examples/asr/conf/conformer/conformer_ctc_bpe.yaml
@@ -175,6 +175,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False  # Provided by exp_manager
   logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null

--- a/examples/asr/conf/conformer/conformer_ctc_bpe_multilang.yaml
+++ b/examples/asr/conf/conformer/conformer_ctc_bpe_multilang.yaml
@@ -181,6 +181,7 @@ trainer:
   sync_batchnorm: true
   checkpoint_callback: false  # Provided by exp_manager
   logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null

--- a/examples/asr/conf/conformer/conformer_ctc_char.yaml
+++ b/examples/asr/conf/conformer/conformer_ctc_char.yaml
@@ -150,6 +150,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False  # Provided by exp_manager
   logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 
 exp_manager:

--- a/examples/asr/conf/conformer/conformer_transducer_bpe.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_bpe.yaml
@@ -225,6 +225,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False  # Provided by exp_manager
   logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 
 exp_manager:

--- a/examples/asr/conf/conformer/conformer_transducer_bpe_multilang.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_bpe_multilang.yaml
@@ -231,6 +231,7 @@ trainer:
   sync_batchnorm: true
   checkpoint_callback: false  # Provided by exp_manager
   logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 
 exp_manager:

--- a/examples/asr/conf/conformer/conformer_transducer_char.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_char.yaml
@@ -220,6 +220,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False  # Provided by exp_manager
   logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 
 exp_manager:

--- a/examples/asr/conf/contextnet_rnnt/config_rnnt.yaml
+++ b/examples/asr/conf/contextnet_rnnt/config_rnnt.yaml
@@ -239,6 +239,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null

--- a/examples/asr/conf/contextnet_rnnt/config_rnnt_bpe.yaml
+++ b/examples/asr/conf/contextnet_rnnt/config_rnnt_bpe.yaml
@@ -239,6 +239,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
@@ -23,7 +23,7 @@
 name: &name "ContextNet-8x-Stride-RNNT"
 
 model:
-  sample_rate: &sample_rate 16000
+  sample_rate: 16000
   compute_eval_loss: false  # eval samples can be very long and exhaust memory. Disable computation of transducer loss during validation/testing with this flag.
 
   train_ds:
@@ -487,7 +487,7 @@ trainer:
   precision: 32  # RNNT requires a lot of memory, so precision 16 is very important. Use very small batch size for precision 32.
   gradient_clip_val: 1.0  # Gradient norm clip value
   sync_batchnorm: true
-  benchmark: false
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 
 exp_manager:

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_char.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_char.yaml
@@ -23,7 +23,7 @@
 name: &name "ContextNet-8x-Stride-RNNT"
 
 model:
-  sample_rate: &sample_rate 16000
+  sample_rate: 16000
   compute_eval_loss: false  # eval samples can be very long and exhause memory. Disable computation of transducer loss during validation/testing with this flag.
 
   labels: [ " ", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", "'" ]
@@ -489,7 +489,7 @@ trainer:
   precision: 32  # RNNT requires a lot of memory, so precision 16 is very important. Use very small batch size for precision 32.
   gradient_clip_val: 1.0  # Gradient norm clip value
   sync_batchnorm: true
-  benchmark: false
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 
 exp_manager:

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_multilang.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_multilang.yaml
@@ -24,7 +24,7 @@
 name: &name "ContextNet-8x-Stride-RNNT-mla"
 
 model:
-  sample_rate: &sample_rate 16000
+  sample_rate: 16000
   compute_eval_loss: false  # eval samples can be very long and exhaust memory. Disable computation of transducer loss during validation/testing with this flag.
 
   train_ds:
@@ -493,7 +493,7 @@ trainer:
   precision: 32  # RNNT requires a lot of memory, so precision 16 is very important. Use very small batch size for precision 32.
   gradient_clip_val: 1.0  # Gradient norm clip value
   sync_batchnorm: true
-  benchmark: false
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 
 exp_manager:

--- a/examples/asr/conf/jasper/jasper_10x5dr.yaml
+++ b/examples/asr/conf/jasper/jasper_10x5dr.yaml
@@ -195,6 +195,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null

--- a/examples/asr/conf/lstm/lstm_ctc_bpe.yaml
+++ b/examples/asr/conf/lstm/lstm_ctc_bpe.yaml
@@ -138,6 +138,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False  # Provided by exp_manager
   logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 
 exp_manager:

--- a/examples/asr/conf/lstm/lstm_transducer_bpe.yaml
+++ b/examples/asr/conf/lstm/lstm_transducer_bpe.yaml
@@ -201,6 +201,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False  # Provided by exp_manager
   logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 
 exp_manager:

--- a/examples/asr/conf/marblenet/marblenet_3x2x64.yaml
+++ b/examples/asr/conf/marblenet/marblenet_3x2x64.yaml
@@ -167,6 +167,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -178,9 +179,3 @@ exp_manager:
     name: null
     project: null
 
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v1.yaml
+++ b/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v1.yaml
@@ -179,6 +179,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -189,10 +190,3 @@ exp_manager:
   wandb_logger_kwargs:
     name: null
     project: null
-
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v2.yaml
+++ b/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v2.yaml
@@ -179,6 +179,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -190,9 +191,3 @@ exp_manager:
     name: null
     project: null
 
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/conf/quartznet/quartznet_15x5.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5.yaml
@@ -264,6 +264,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -278,9 +279,3 @@ exp_manager:
     name: null
     project: null
 
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/conf/quartznet/quartznet_15x5_aug.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5_aug.yaml
@@ -276,6 +276,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -287,9 +288,3 @@ exp_manager:
     name: null
     project: null
 
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/conf/quartznet/quartznet_15x5_ru.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5_ru.yaml
@@ -267,6 +267,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -281,9 +282,3 @@ exp_manager:
     name: null
     project: null
 
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/conf/quartznet/quartznet_15x5_zh.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5_zh.yaml
@@ -466,6 +466,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -480,9 +481,3 @@ exp_manager:
     name: null
     project: null
 
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/conf/ssl/citrinet/citrinet_ssl_1024.yaml
+++ b/examples/asr/conf/ssl/citrinet/citrinet_ssl_1024.yaml
@@ -471,6 +471,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False # Provided by exp_manager
   logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null

--- a/examples/asr/conf/ssl/citrinet/citrinet_ssl_ci.yaml
+++ b/examples/asr/conf/ssl/citrinet/citrinet_ssl_ci.yaml
@@ -441,7 +441,7 @@ trainer:
   check_val_every_n_epoch: 1
   precision: 32
   sync_batchnorm: false
-  benchmark: false
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null

--- a/examples/asr/conf/ssl/conformer/conformer_ssl.yaml
+++ b/examples/asr/conf/ssl/conformer/conformer_ssl.yaml
@@ -195,6 +195,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False # Provided by exp_manager
   logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null

--- a/examples/asr/conf/ssl/contextnet/contextnet_ssl.yaml
+++ b/examples/asr/conf/ssl/contextnet/contextnet_ssl.yaml
@@ -439,6 +439,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False # Provided by exp_manager
   logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null

--- a/examples/asr/experimental/k2/conf/citrinet/citrinet_mmi_1024.yaml
+++ b/examples/asr/experimental/k2/conf/citrinet/citrinet_mmi_1024.yaml
@@ -466,7 +466,7 @@ trainer:
   check_val_every_n_epoch: 1
   precision: 32
   sync_batchnorm: false
-  benchmark: false
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null

--- a/examples/asr/experimental/structured/conf/quartznet_15x5.yaml
+++ b/examples/asr/experimental/structured/conf/quartznet_15x5.yaml
@@ -231,6 +231,7 @@ trainer:
   accumulate_grad_batches: 1
   log_every_n_steps: 1  # Interval of logging.
   val_check_interval: 1.0  # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   name: *name

--- a/examples/asr/experimental/wav2vec/configs/wav2vecCTC.yaml
+++ b/examples/asr/experimental/wav2vec/configs/wav2vecCTC.yaml
@@ -133,6 +133,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False # Provided by exp_manager
   logger: false # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null

--- a/examples/asr/experimental/wav2vec/configs/wav2vecCTC_large.yaml
+++ b/examples/asr/experimental/wav2vec/configs/wav2vecCTC_large.yaml
@@ -131,6 +131,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False # Provided by exp_manager
   logger: false # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -144,9 +145,3 @@ exp_manager:
   resume_if_exists: false
   resume_ignore_no_checkpoint: false
 
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/experimental/wav2vec/configs/wav2vec_pretrain.yaml
+++ b/examples/asr/experimental/wav2vec/configs/wav2vec_pretrain.yaml
@@ -133,6 +133,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False # Provided by exp_manager
   logger: false # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null
@@ -146,9 +147,3 @@ exp_manager:
   resume_if_exists: false
   resume_ignore_no_checkpoint: false
 
-hydra:
-  run:
-    dir: .
-  job_logging:
-    root:
-      handlers: null

--- a/examples/asr/experimental/wav2vec/configs/wav2vec_pretrain_large.yaml
+++ b/examples/asr/experimental/wav2vec/configs/wav2vec_pretrain_large.yaml
@@ -132,6 +132,7 @@ trainer:
   sync_batchnorm: true
   enable_checkpointing: False # Provided by exp_manager
   logger: false # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
 
 exp_manager:
   exp_dir: null


### PR DESCRIPTION
Signed-off-by: vahidoox <vnoroozi@nvidia.com>

# What does this PR do ?

There was a slow down in speech models when upgraded to PTL 1.6. They changed the default of trainer.benchmark to True which slows down model with variable input lengths including speech models. This PR set all the trainer.benchmark to false for all speech models.

# Changelog 
Fixed the speed slow-down for speech models by setting benchmark=false for all speech configs.

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation