### PR TITLE
Add benchmark=false to all TTS configs

### DIFF
--- a/examples/tts/conf/aligner.yaml
+++ b/examples/tts/conf/aligner.yaml
@@ -164,6 +164,7 @@ trainer:
   logger: false # Provided by exp_manager
   log_every_n_steps: 100
   check_val_every_n_epoch: 1
+  benchmark: false
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/fastpitch_align_44100.yaml
+++ b/examples/tts/conf/fastpitch_align_44100.yaml
@@ -234,6 +234,7 @@ trainer:
   logger: False  # Provided by exp_manager
   log_every_n_steps: 100
   check_val_every_n_epoch: 5
+  benchmark: false
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/fastpitch_align_v1.05.yaml
+++ b/examples/tts/conf/fastpitch_align_v1.05.yaml
@@ -234,6 +234,7 @@ trainer:
   logger: false # Provided by exp_manager
   log_every_n_steps: 100
   check_val_every_n_epoch: 5
+  benchmark: false
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/hifigan/hifigan.yaml
+++ b/examples/tts/conf/hifigan/hifigan.yaml
@@ -80,6 +80,7 @@ trainer:
   logger: false # Provided by exp_manager
   log_every_n_steps: 100
   check_val_every_n_epoch: 10
+  benchmark: false
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/hifigan/hifigan_44100.yaml
+++ b/examples/tts/conf/hifigan/hifigan_44100.yaml
@@ -80,6 +80,7 @@ trainer:
   logger: false # Provided by exp_manager
   log_every_n_steps: 100
   check_val_every_n_epoch: 10
+  benchmark: false
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/mixer-tts-x.yaml
+++ b/examples/tts/conf/mixer-tts-x.yaml
@@ -232,6 +232,7 @@ trainer:
   logger: false # Provided by exp_manager
   log_every_n_steps: 200
   check_val_every_n_epoch: 1
+  benchmark: false
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/mixer-tts.yaml
+++ b/examples/tts/conf/mixer-tts.yaml
@@ -229,6 +229,7 @@ trainer:
   logger: false # Provided by exp_manager
   log_every_n_steps: 200
   check_val_every_n_epoch: 1
+  benchmark: false
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/tacotron2.yaml
+++ b/examples/tts/conf/tacotron2.yaml
@@ -189,6 +189,7 @@ trainer:
   gradient_clip_val: 1.0
   log_every_n_steps: 60
   check_val_every_n_epoch: 2
+  benchmark: false
 
 
 exp_manager:

--- a/examples/tts/conf/tacotron2_44100.yaml
+++ b/examples/tts/conf/tacotron2_44100.yaml
@@ -169,6 +169,7 @@ trainer:
   gradient_clip_val: 1.0
   log_every_n_steps: 200
   check_val_every_n_epoch: 25
+  benchmark: false
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/univnet/univnet.yaml
+++ b/examples/tts/conf/univnet/univnet.yaml
@@ -86,6 +86,7 @@ trainer:
   logger: false # Provided by exp_manager
   log_every_n_steps: 100
   check_val_every_n_epoch: 10
+  benchmark: false
 
 exp_manager:
   exp_dir: null

--- a/examples/tts/conf/waveglow.yaml
+++ b/examples/tts/conf/waveglow.yaml
@@ -95,6 +95,7 @@ trainer:
   logger: false # Provided by exp_manager
   log_every_n_steps: 200
   check_val_every_n_epoch: 25
+  benchmark: false
 
 exp_manager:
   exp_dir: null


### PR DESCRIPTION
Signed-off-by: Jocelyn Huang <jocelynh@nvidia.com>

# What does this PR do ?

Sets PTL trainer `benchmark` back to default False for all TTS configs (see #4083).

**Collection**: TTS

# Additional Information
* Related to #4083, #4260 