### PR TITLE
Docs CSS: Update h4 tag style for the right side bar

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -248,6 +248,10 @@ thead td
 		font-size: 1rem;
 	}
 
+	.toc-h4 {
+		font-size: 0.85rem;
+	}
+
 	.header-article .bd-toc {
 		font-size: 18px;
 	}


### PR DESCRIPTION
# What does this PR do ?

Adds style overwrite for the h4 tag located on the right side bar. Currently, the font size is too small

**Collection**: Docs

# Changelog 
- Adds style overwrite for h4 tag on the right side bar. Currently the font is too small
- Example of the issue: https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/asr/asr_language_modeling.html#hyperparameter-grid-search

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [x] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
