### PR TITLE
forcing conv subsampling to 32 bit

### DIFF
--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -257,6 +257,8 @@ class ConformerEncoder(NeuralModule, Exportable):
         if isinstance(self.pre_encode, nn.Linear):
             audio_signal = self.pre_encode(audio_signal)
         else:
+            # added in order to prevent slowdown in bfloat16 with CUDNN v8 API
+            # to be removed once the above is fixed in cudnn
             with torch.cuda.amp.autocast(dtype=torch.float32)
                 audio_signal, length = self.pre_encode(audio_signal, length)
 

--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -257,10 +257,7 @@ class ConformerEncoder(NeuralModule, Exportable):
         if isinstance(self.pre_encode, nn.Linear):
             audio_signal = self.pre_encode(audio_signal)
         else:
-            # added in order to prevent slowdown in bfloat16 with CUDNN v8 API
-            # to be removed once the above is fixed in cudnn
-            with torch.cuda.amp.autocast(dtype=torch.float32)
-                audio_signal, length = self.pre_encode(audio_signal, length)
+            audio_signal, length = self.pre_encode(audio_signal, length)
 
         audio_signal, pos_emb = self.pos_enc(audio_signal)
         # adjust size

--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -257,7 +257,8 @@ class ConformerEncoder(NeuralModule, Exportable):
         if isinstance(self.pre_encode, nn.Linear):
             audio_signal = self.pre_encode(audio_signal)
         else:
-            audio_signal, length = self.pre_encode(audio_signal, length)
+            with torch.cuda.amp.autocast(dtype=torch.float32)`
+                audio_signal, length = self.pre_encode(audio_signal, length)
 
         audio_signal, pos_emb = self.pos_enc(audio_signal)
         # adjust size

--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -257,7 +257,7 @@ class ConformerEncoder(NeuralModule, Exportable):
         if isinstance(self.pre_encode, nn.Linear):
             audio_signal = self.pre_encode(audio_signal)
         else:
-            with torch.cuda.amp.autocast(dtype=torch.float32)`
+            with torch.cuda.amp.autocast(dtype=torch.float32)
                 audio_signal, length = self.pre_encode(audio_signal, length)
 
         audio_signal, pos_emb = self.pos_enc(audio_signal)

--- a/nemo/collections/asr/parts/submodules/subsampling.py
+++ b/nemo/collections/asr/parts/submodules/subsampling.py
@@ -144,7 +144,7 @@ class ConvSubsampling(torch.nn.Module):
             with torch.cuda.amp.autocast(dtype=torch.float32):
                 x = self.conv(x)
         else:
-             x = self.conv(x)
+            x = self.conv(x)
 
         b, c, t, f = x.size()
         x = self.out(x.transpose(1, 2).reshape(b, t, -1))

--- a/nemo/collections/asr/parts/submodules/subsampling.py
+++ b/nemo/collections/asr/parts/submodules/subsampling.py
@@ -138,7 +138,14 @@ class ConvSubsampling(torch.nn.Module):
             repeat_num=self._sampling_num,
         )
         x = x.unsqueeze(1)
-        x = self.conv(x)
+        if self._subsampling == 'striding':
+            # added in order to prevent slowdown in torch.nn.Conv2d with bfloat16 / CUDNN v8 API
+            # to be removed once the above is fixed in cudnn
+            with torch.cuda.amp.autocast(dtype=torch.float32):
+                x = self.conv(x)
+        else:
+             x = self.conv(x)
+
         b, c, t, f = x.size()
         x = self.out(x.transpose(1, 2).reshape(b, t, -1))
         return x, lengths


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.
Forces 2D conv subsampling to fp32

**Collection**: [Note which collection this PR will affect]
ASR
# Changelog 
- Add specific line by line info of high level changes in this PR.
One liner change in nemo/collections/asr/modules/conformer_encoder.py
# Usage
* You can potentially add a usage example below
No changes
```python
# Add a code snippet demonstrating how to use this 
```
No changes

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
