### PR TITLE
Update frozen model config with amp_o2=False:

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -80,10 +80,21 @@ class MegatronGPTPromptLearningModel(MegatronBaseModel, TextGeneration):
 
         self.cfg = cfg
 
+        frozen_model_cfg = MegatronGPTModel.restore_from(
+            cfg.get('language_model_path'), trainer=trainer, return_config=True
+        )
+
+        # amp o2 not supported
+        with open_dict(frozen_model_cfg):
+            frozen_model_cfg.megatron_amp_O2 = False
+
         # Load pretrained GPT model and tokenizer
         if cfg.get('language_model_path', None):
             self.frozen_model = MegatronGPTModel.restore_from(
-                cfg.get('language_model_path'), trainer=trainer, save_restore_connector=NLPSaveRestoreConnector(),
+                cfg.get('language_model_path'),
+                trainer=trainer,
+                save_restore_connector=NLPSaveRestoreConnector(),
+                override_config_path=frozen_model_cfg,
             )
 
         # Freeze all GPT model weights for prompt-tuning/p-tuning


### PR DESCRIPTION
Signed-off-by: Virginia Adams <vadams@nvidia.com>

Amp_O2 for prompt learning is not supported in the upcoming JoC release. So, megatron_amp_o2 needs to be overwritten and set to False in the GPT model configs that were trained with O2 in order for those models to load for prompt learning.
This will cause a time overhead as the GPT .nemo file will need to be unpacked once to get the config and overwrite it, then unpacked again when the model is restored.

**Collection**: BigNLP

# Changelog 
- Updated PromptLearningGPTModel class to over write megatron amp O2 config.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
