### PR TITLE
Changed total virtual prompt tokens

### DIFF
--- a/examples/nlp/language_modeling/conf/megatron_gpt_prompt_learning_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_gpt_prompt_learning_config.yaml
@@ -72,8 +72,8 @@ model:
 
   - taskname: 'rte'
     prompt_template: '<|VIRTUAL_PROMPT_0|>{text}{answer}'
-    total_virtual_tokens: 10 
-    virtual_token_splits: [10]
+    total_virtual_tokens: 9 
+    virtual_token_splits: [9]
     truncate_field: null
     answer_only_loss: True
     answer_field: 'answer'
@@ -91,7 +91,7 @@ model:
     validation_ds: [data/rte_val.jsonl,]
     add_eos: True
     shuffle: True
-    num_workers: 8
+    num_workers: 1
     pin_memory: True
 
 

--- a/examples/nlp/language_modeling/conf/megatron_gpt_prompt_learning_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_gpt_prompt_learning_config.yaml
@@ -91,7 +91,7 @@ model:
     validation_ds: [data/rte_val.jsonl,]
     add_eos: True
     shuffle: True
-    num_workers: 1
+    num_workers: 8
     pin_memory: True
 
 


### PR DESCRIPTION
Signed-off-by: Virginia Adams <vadams@nvidia.com>

Fix for OOM error in 1.9.0 CI test

**Collection**: BigNLP

# Changelog 
- Changed total_virtual_tokens in example prompt learning config

# Usage
n/a

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
- [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
