### PR TITLE
clear access registry when adding if not empty

### DIFF
--- a/nemo/core/classes/mixins/access_mixins.py
+++ b/nemo/core/classes/mixins/access_mixins.py
@@ -50,6 +50,9 @@ class AccessMixin(ABC):
         if not hasattr(self, '_registry'):
             self._registry = []
 
+        if len(self._registry) > 0:
+            self._registry.clear()
+
         self._registry.append(tensor)
 
     @classmethod


### PR DESCRIPTION
Signed-off-by: sam1373 <samuelkriman@gmail.com>

# What does this PR do ?

Clear registry if trying to add when it isn't empty

**Collection**: Core

**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation