### PR TITLE
Adjust lr for AdamW from LAMB default

### DIFF
--- a/examples/tts/conf/fastpitch_align_44100.yaml
+++ b/examples/tts/conf/fastpitch_align_44100.yaml
@@ -211,7 +211,7 @@ model:
 
   optim:
     name: adamw
-    lr: 1e-1
+    lr: 1e-3
     betas: [0.9, 0.999]
     weight_decay: 1e-6
 

--- a/examples/tts/conf/fastpitch_align_v1.05.yaml
+++ b/examples/tts/conf/fastpitch_align_v1.05.yaml
@@ -211,7 +211,7 @@ model:
 
   optim:
     name: adamw
-    lr: 1e-1
+    lr: 1e-3
     betas: [0.9, 0.999]
     weight_decay: 1e-6
 

--- a/examples/tts/conf/mixer-tts-x.yaml
+++ b/examples/tts/conf/mixer-tts-x.yaml
@@ -209,7 +209,7 @@ model:
 
   optim:
     name: adamw
-    lr: 1e-1
+    lr: 1e-3
     betas: [0.9, 0.999]
     weight_decay: 1e-6
 

--- a/examples/tts/conf/mixer-tts.yaml
+++ b/examples/tts/conf/mixer-tts.yaml
@@ -206,7 +206,7 @@ model:
 
   optim:
     name: adamw
-    lr: 1e-1
+    lr: 1e-3
     betas: [0.9, 0.999]
     weight_decay: 1e-6
 


### PR DESCRIPTION
Signed-off-by: Jocelyn Huang <jocelynh@nvidia.com>

# What does this PR do ?

Adjusts default learning rate down to 1e-3 due to change in default optimizer to AdamW from LAMB (see PR #4233)

**Collection**: TTS

# Changelog 
- Changes default learning rate from 1e-1 to 1e-3 for FastPitch and Mixer-TTS models