### PR TITLE
Remove verbose flag from Dali Index Creator

### DIFF
--- a/scripts/speech_recognition/create_dali_tarred_dataset_index.py
+++ b/scripts/speech_recognition/create_dali_tarred_dataset_index.py
@@ -66,7 +66,7 @@ def process_index_path(tar_paths, index_dir):
 
 
 def build_index(tarpath, indexfile):
-    with IndexCreator(tarpath, indexfile, verbose=False) as index:
+    with IndexCreator(tarpath, indexfile) as index:
         index.create_index()
 
 


### PR DESCRIPTION
Signed-off-by: smajumdar <smajumdar@nvidia.com>

# What does this PR do ?

Fix an issue in Dali Index Creator causing a crash.

**Collection**: [ASR]

# Changelog 
- Remove verbose=False arg from DALI Index Creator.

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

