### PR TITLE
[Fix] Hanging for Fully Randomized Bucketing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,7 +15,6 @@ pipeline {
     stage('Add git safe directory'){
       steps{
         sh 'git config --global --add safe.directory /var/lib/jenkins/workspace/NeMo_$GIT_BRANCH'
-        sh 'git config --global --add safe.directory /raid/JenkinsWorkDir/workspace/NeMo_$GIT_BRANCH'
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -15,6 +15,7 @@ pipeline {
     stage('Add git safe directory'){
       steps{
         sh 'git config --global --add safe.directory /var/lib/jenkins/workspace/NeMo_$GIT_BRANCH'
+        sh 'git config --global --add safe.directory /raid/JenkinsWorkDir/workspace/NeMo_$GIT_BRANCH'
       }
     }
 

--- a/nemo/collections/asr/modules/rnnt.py
+++ b/nemo/collections/asr/modules/rnnt.py
@@ -845,8 +845,6 @@ class RNNTJoint(rnnt_abstract.AbstractRNNTJoint, Exportable, AdapterModuleMixin)
                 )
 
             losses = []
-            wer_numer_list = []
-            wer_denom_list = []
             batch_size = int(encoder_outputs.size(0))  # actual batch size
 
             # Iterate over batch using fused_batch_size steps

--- a/nemo/collections/asr/modules/rnnt.py
+++ b/nemo/collections/asr/modules/rnnt.py
@@ -914,31 +914,14 @@ class RNNTJoint(rnnt_abstract.AbstractRNNTJoint, Exportable, AdapterModuleMixin)
                 else:
                     losses = None
 
-                # Compute WER for sub batch
+                # Update WER for sub batch
                 if compute_wer:
                     sub_enc = sub_enc.transpose(1, 2)  # [B, T, D] -> [B, D, T]
                     sub_enc = sub_enc.detach()
                     sub_transcripts = sub_transcripts.detach()
 
-                    original_log_prediction = self.wer.log_prediction
-                    if original_log_prediction and batch_idx == 0:
-                        self.wer.log_prediction = True
-                    else:
-                        self.wer.log_prediction = False
-
-                    # Compute the wer (with logging for just 1st sub-batch)
+                    # Update WER on each process without syncing
                     self.wer.update(sub_enc, sub_enc_lens, sub_transcripts, sub_transcript_lens)
-                    wer, wer_num, wer_denom = self.wer.compute()
-                    self.wer.reset()
-
-                    wer_numer_list.append(wer_num)
-                    wer_denom_list.append(wer_denom)
-
-                    # Reset logging default
-                    self.wer.log_prediction = original_log_prediction
-
-                else:
-                    wer = None
 
                 del sub_enc, sub_transcripts, sub_enc_lens, sub_transcript_lens
 
@@ -951,12 +934,11 @@ class RNNTJoint(rnnt_abstract.AbstractRNNTJoint, Exportable, AdapterModuleMixin)
 
             # Collect sub batch wer results
             if compute_wer:
-                wer_num = torch.tensor(wer_numer_list, dtype=torch.long)
-                wer_denom = torch.tensor(wer_denom_list, dtype=torch.long)
-
-                wer_num = wer_num.sum()  # global sum of correct words/chars
-                wer_denom = wer_denom.sum()  # global sum of all words/chars
+                # Sync and all_reduce on all processes, compute global WER
+                wer, wer_num, wer_denom = self.wer.compute()
+                self.wer.reset()
             else:
+                wer = None
                 wer_num = None
                 wer_denom = None
 


### PR DESCRIPTION
Signed-off-by: stevehuang52 <heh@nvidia.com>

# What does this PR do ?

This PR fixes the problem of the program hanging during training with fully randomized bucketing.

# Why hanging?

When training RNNT models with fully randomized bucketing, and enabling fused batch, the program will hang when calculating training WER: [https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/asr/modules/rnnt.py#L931](https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/asr/modules/rnnt.py#L931)

The bug happens when the GPU with largest batch size is still calculating the forward fused-batch while the other GPUs with smaller batch are already finished:
[https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/asr/modules/rnnt.py#L853-L933](https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/asr/modules/rnnt.py#L853-L933)

This is due to the fact that, when `compute()` is called, PTL will perform synchronization across all devices, which eventually calls `distributed.barrier()`:
[https://github.com/PyTorchLightning/metrics/blob/master/torchmetrics/metric.py#L113](https://github.com/PyTorchLightning/metrics/blob/master/torchmetrics/metric.py#L113), [https://github.com/PyTorchLightning/metrics/blob/master/torchmetrics/metric.py#L485-L513](https://github.com/PyTorchLightning/metrics/blob/master/torchmetrics/metric.py#L485-L513), [https://github.com/PyTorchLightning/metrics/blob/master/torchmetrics/utilities/distributed.py#L122
](https://github.com/PyTorchLightning/metrics/blob/master/torchmetrics/utilities/distributed.py#L122
)

In fully randomized bucketing, different GPUs tend to have different batch sizes, and when some GPUs have finished their batch  earlier than others, the unfinished ones will keep hanging at `distributed.barrier()` to wait for the synchronization that will never happen.

# How we fix it?

The simple fix is to move the `compute()` function call outside of the loop of sub-batches. Note that, theoretically this modification have the same output as the original one, and here's the logic.

Suppose that the there are 3 GPUs and each has 2 sub-batches, where the score produced by each GPU is fixed as its rank:
|                   | GPU 1 | GPU 2 | GPU 3 |
|-------------|--------|--------|---------|
|sub-batch 1|    1      |   2      |    3       |
|sub-batch 2|    1      |     2    |     3      |


In the original code, where `compute()` is called inside the for loop of sub-batches, it's actually syncing across all GPUs in each step, then aggregate across all sub-batches. In other words, it first perform all_reduce() to sync each column for each row, then sum over the rows:

|                   | GPU 1 | GPU 2 | GPU 3 |           
|-------------|--------|--------|---------|   
|sub-batch 1|    1      |   2      |    3       | 

Call `compute()` on each GPU and all_reduce &#8595;

|                   | GPU 1 | GPU 2 | GPU 3 |           
|-------------|--------|--------|---------|   
|sub-batch 1|    6      |   6      |    6      | 

 Run sub-batch 2 &#8595;

|                   | GPU 1 | GPU 2 | GPU 3 |           
|-------------|--------|--------|---------|   
|sub-batch 1|    6      |   6      |    6      | 
|sub-batch 2|    1      |   2      |    3       | 

Call `compute()` on each GPU and all_reduce &#8595;
|                   | GPU 1 | GPU 2 | GPU 3 |           
|-------------|--------|--------|---------|   
|sub-batch 1|    6      |   6      |    6      | 
|sub-batch 2|    6      |   6      |    6       | 

Sum for each GPU &#8595;
|                   | GPU 1 | GPU 2 | GPU 3 |           
|-------------|--------|--------|---------|   
|batch total |   12      |   12      |    12      | 

On the other hand, this PR first aggregate the scores per GPU, then sync across all GPUs after the for loop of sub-batches. In other words, we sum the rows for each column, and then perform all_reduce to  sync across all rows:
|                   | GPU 1 | GPU 2 | GPU 3 |           
|-------------|--------|--------|---------|   
|sub-batch 1|    1      |   2      |    3       | 

update on each GPU &#8595; 

|                   | GPU 1 | GPU 2 | GPU 3 |           
|-------------|--------|--------|---------|   
|batch total|    1      |   2     |    3      | 

run sub-batch 2 &#8595;

|                   | GPU 1 | GPU 2 | GPU 3 |           
|-------------|--------|--------|---------|   
|sub-batch 1|    1     |   2      |    3      | 
|sub-batch 2|    1      |   2      |    3       | 

update on each GPU &#8595;
|                   | GPU 1 | GPU 2 | GPU 3 |           
|-------------|--------|--------|---------|   
batch total |    2      |   4      |    6      | 

Call `compute()` and and all_reduce &#8595;
|                   | GPU 1 | GPU 2 | GPU 3 |           
|-------------|--------|--------|---------|   
|batch total |   12      |   12      |    12      | 


We can see that, two approaches actually have the same results, and it doesn't matter whether we perform the synchronization in or after the for loop of sub-batches. By moving `compute()` outside the for loop, we can guarantee that there is no hanging even when GPUs have different batch sizes. 


