### PR TITLE
fix wrong requirement

### DIFF
--- a/requirements/requirements_common.txt
+++ b/requirements/requirements_common.txt
@@ -1,3 +1,4 @@
 sentencepiece<1.0.0
 youtokentome>=1.0.5
 pandas
+sacremoses>=0.0.43

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -6,7 +6,6 @@ rapidfuzz
 gdown
 inflect
 sacrebleu[ja]
-sacremoses>=0.0.43
 nltk>=3.6.5
 fasttext
 opencc


### PR DESCRIPTION
Signed-off-by: Yang Zhang <yangzhang@nvidia.com>

sacremoses is used and imported in [common/tokenizers](https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/common/tokenizers/moses_tokenizers.py#L17)
so need to go into common requirements