### PR TITLE
Correct support for dataclasses in default module dim

### DIFF
--- a/nemo/collections/asr/parts/utils/adapter_utils.py
+++ b/nemo/collections/asr/parts/utils/adapter_utils.py
@@ -12,13 +12,39 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from dataclasses import is_dataclass
+
 import torch
 from omegaconf import DictConfig, OmegaConf
 
 from nemo.utils import logging
 
 
+def convert_adapter_cfg_to_dict_config(cfg: DictConfig):
+    # Convert to DictConfig from dict or Dataclass
+    if is_dataclass(cfg):
+        cfg = OmegaConf.structured(cfg)
+
+    if not isinstance(cfg, DictConfig):
+        cfg = DictConfig(cfg)
+
+    return cfg
+
+
 def update_adapter_cfg_input_dim(module: torch.nn.Module, cfg: DictConfig, *, module_dim: int):
+    """
+    Update the input dimension of the provided adapter config with some default value.
+
+    Args:
+        module: The module that implements AdapterModuleMixin.
+        cfg: A DictConfig or a Dataclass representing the adapter config.
+        module_dim: A default module dimension, used if cfg has an incorrect input dimension.
+
+    Returns:
+        A DictConfig representing the adapter's config.
+    """
+    cfg = convert_adapter_cfg_to_dict_config(cfg)
+
     if 'in_features' in cfg:
         in_planes = cfg['in_features']
 

--- a/tutorials/asr/asr_adapters/ASR_with_Adapters.ipynb
+++ b/tutorials/asr/asr_adapters/ASR_with_Adapters.ipynb
@@ -567,7 +567,7 @@
         "!python scripts/speech_to_text_eval.py \\\n",
         "  model_path=\"/content/unadapted_model.nemo\" \\\n",
         "  dataset_manifest=$TEST_MANIFEST \\\n",
-        "  output_filename=\"unadapted_predictions.json\" \\\n",
+        "  output_filename=\"/content/unadapted_predictions.json\" \\\n",
         "  batch_size=32 \\\n",
         "  use_cer=False"
       ],


### PR DESCRIPTION
Signed-off-by: smajumdar <smajumdar@nvidia.com>

# What does this PR do ?

Fix issue with adapters where config is a dataclass and cannot be iterated on correctly.

**Collection**: [ASR]

# Changelog 
- Add a check and force cast to Dict Config for input to the function.


# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

