### PR TITLE
Add option for specifying wandb save_dir from config

### DIFF
--- a/examples/asr/conf/asr_adapters/asr_adaptation.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation.yaml
@@ -190,6 +190,7 @@ exp_manager:
     name: null
     project: null
     entity: null
+    save_dir: null
 
   resume_if_exists: false
   resume_ignore_no_checkpoint: false

--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -667,7 +667,8 @@ def configure_loggers(
             raise ValueError("name and project are required for wandb_logger")
 
         # Update the wandb save_dir
-        wandb_kwargs['save_dir'] = wandb_kwargs.get('save_dir') or exp_dir
+        if wandb_kwargs.get('save_dir', None) is None:
+            wandb_kwargs['save_dir'] = exp_dir
         os.makedirs(wandb_kwargs['save_dir'], exist_ok=True)
         wandb_logger = WandbLogger(version=version, **wandb_kwargs)
 

--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -668,6 +668,7 @@ def configure_loggers(
 
         # Update the wandb save_dir
         wandb_kwargs['save_dir'] = wandb_kwargs.get('save_dir') or exp_dir
+        os.makedirs(wandb_kwargs['save_dir'], exist_ok=True)
         wandb_logger = WandbLogger(version=version, **wandb_kwargs)
 
         logger_list.append(wandb_logger)

--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -665,7 +665,10 @@ def configure_loggers(
             wandb_kwargs = {}
         if "name" not in wandb_kwargs and "project" not in wandb_kwargs:
             raise ValueError("name and project are required for wandb_logger")
-        wandb_logger = WandbLogger(save_dir=exp_dir, version=version, **wandb_kwargs)
+
+        # Update the wandb save_dir
+        wandb_kwargs['save_dir'] = wandb_kwargs.get('save_dir') or exp_dir
+        wandb_logger = WandbLogger(version=version, **wandb_kwargs)
 
         logger_list.append(wandb_logger)
         logging.info("WandBLogger has been set up")


### PR DESCRIPTION
Signed-off-by: Shantanu Acharya <shantanua@nvidia.com>

# What does this PR do ?

A user can now specify the name of the directory to save the wandb logs by setting the value `exp_manager.wandb_logger_kwargs.save_dir` in the config.

**Collection**: [utils]

# Changelog 

Files changed: `nemo/utils/exp_manager.py` (line: 670-671)

```
if wandb_kwargs.get('save_dir', None) is None:
    wandb_kwargs['save_dir'] = exp_dir
os.makedirs(wandb_kwargs['save_dir'], exist_ok=True)
wandb_logger = WandbLogger(version=version, **wandb_kwargs)
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

## Who can review?

Anyone in NeMo
