### PR TITLE
remove redundant bias expand

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -1254,9 +1254,6 @@ class ParallelTransformerLayer_(MegatronModule):
                 transformer_block_type=self.transformer_block_type, position_after='attention'
             )
 
-            #if attention_bias is not None:
-            #    attention_bias = attention_bias.expand_as(residual)
-
             layernorm_input = bias_dropout_add_func(attention_output, attention_bias, residual, self.hidden_dropout)
 
             # Post-LN normalization after residual
@@ -1311,9 +1308,6 @@ class ParallelTransformerLayer_(MegatronModule):
 
             residual = layernorm_input
 
-            #if attention_bias is not None:
-            #    attention_bias = attention_bias.expand_as(residual)
-
             bias_dropout_add_func = self._get_bias_droput_add_func(
                 transformer_block_type=self.transformer_block_type, position_after='attention'
             )
@@ -1327,9 +1321,6 @@ class ParallelTransformerLayer_(MegatronModule):
         mlp_output, mlp_bias = self.mlp(normalization_output)
 
         residual = layernorm_input
-
-        #if mlp_bias is not None:
-        #    mlp_bias = mlp_bias.expand_as(residual)
 
         bias_dropout_add_func = self._get_bias_droput_add_func(
             transformer_block_type=self.transformer_block_type, position_after='mlp'

--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -1254,8 +1254,8 @@ class ParallelTransformerLayer_(MegatronModule):
                 transformer_block_type=self.transformer_block_type, position_after='attention'
             )
 
-            if attention_bias is not None:
-                attention_bias = attention_bias.expand_as(residual)
+            #if attention_bias is not None:
+            #    attention_bias = attention_bias.expand_as(residual)
 
             layernorm_input = bias_dropout_add_func(attention_output, attention_bias, residual, self.hidden_dropout)
 
@@ -1311,8 +1311,8 @@ class ParallelTransformerLayer_(MegatronModule):
 
             residual = layernorm_input
 
-            if attention_bias is not None:
-                attention_bias = attention_bias.expand_as(residual)
+            #if attention_bias is not None:
+            #    attention_bias = attention_bias.expand_as(residual)
 
             bias_dropout_add_func = self._get_bias_droput_add_func(
                 transformer_block_type=self.transformer_block_type, position_after='attention'
@@ -1328,8 +1328,8 @@ class ParallelTransformerLayer_(MegatronModule):
 
         residual = layernorm_input
 
-        if mlp_bias is not None:
-            mlp_bias = mlp_bias.expand_as(residual)
+        #if mlp_bias is not None:
+        #    mlp_bias = mlp_bias.expand_as(residual)
 
         bias_dropout_add_func = self._get_bias_droput_add_func(
             transformer_block_type=self.transformer_block_type, position_after='mlp'


### PR DESCRIPTION
Signed-off-by: Xiaowei Ren <xren@nvidia.com>

# What does this PR do ?

Remove redundant bias expand. The bias should be broadcast automatically.

# Changelog 
- deleted redundant code in transformer.py

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
