### PR TITLE
Quick wav2vec fix. In-place operation adding convolutional positions …

### DIFF
--- a/nemo/collections/asr/modules/wav2vec_modules.py
+++ b/nemo/collections/asr/modules/wav2vec_modules.py
@@ -313,7 +313,7 @@ class Wav2VecTransformerEncoder(TransformerEncoder):
             audio_signal[idx, :, len:] = 0.0
 
         signal_conv = self.pos_conv(audio_signal)  # B, C, T
-        audio_signal += signal_conv
+        audio_signal = audio_signal + signal_conv
 
         audio_signal = audio_signal.transpose(1, 2)  # B, C, T -> B, T, C
         audio_signal = self.layer_norm(audio_signal)


### PR DESCRIPTION
…to encoder was overwriting leaf history. Wasn't caught on previous torch versions.

Signed-off-by: tbartley94 <tbartley@nvidia.com>

# What does this PR do ?

Fixes bug on backward pass with wav2vec module. See https://github.com/NVIDIA/NeMo/issues/4362

**Collection**: [Note which collection this PR will affect]
- ASR

# Changelog 
- Addition of convolutional position changed from inplace operation to standard variable assignment.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [Y ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ N] Did you write any new necessary tests?
- [ N] Did you add or update any necessary documentation?
- [ N] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ Y] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [Y ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
