### PR TITLE
[bugfix][TTS] pitch, voiced_mask, prob_voiced have the same values which is not expected.

### DIFF
--- a/tests/collections/tts/test_torch_tts.py
+++ b/tests/collections/tts/test_torch_tts.py
@@ -12,13 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
+from pathlib import Path
 
+import numpy as np
 import pytest
 import torch
 
 from nemo.collections.tts.torch.data import TTSDataset
 from nemo.collections.tts.torch.g2ps import EnglishG2p
+from nemo.collections.tts.torch.helpers import get_base_dir
 from nemo.collections.tts.torch.tts_tokenizers import EnglishPhonemesTokenizer
 
 
@@ -92,3 +96,89 @@ class TestTTSDataset:
                     g2p=EnglishG2p(),
                 ),
             )
+
+    @pytest.mark.unit
+    @pytest.mark.torch_tts
+    @pytest.mark.parametrize("sup_data_type", ["voiced_mask", "p_voiced"])
+    def test_raise_exception_on_missing_pitch_sup_data_type_if_use_voiced(self, test_data_dir, sup_data_type):
+        manifest_path = os.path.join(test_data_dir, 'tts/mini_ljspeech/manifest.json')
+        sup_path = os.path.join(test_data_dir, 'tts/mini_ljspeech/sup')
+        with pytest.raises(ValueError):
+            dataset = TTSDataset(
+                manifest_filepath=manifest_path,
+                sample_rate=22050,
+                sup_data_types=[sup_data_type],
+                sup_data_path=sup_path,
+                window="hann",
+                text_tokenizer=EnglishPhonemesTokenizer(
+                    punct=True,
+                    stresses=True,
+                    chars=True,
+                    space=' ',
+                    apostrophe=True,
+                    pad_with_space=True,
+                    g2p=EnglishG2p(),
+                ),
+            )
+
+    @pytest.mark.unit
+    @pytest.mark.torch_tts
+    @pytest.mark.parametrize(
+        "sup_data_types, output_indices",
+        [
+            (["p_voiced", "pitch", "voiced_mask"], [-4, -3, -1]),
+            (["voiced_mask", "pitch"], [-3, -2]),
+            (["pitch", "p_voiced"], [-3, -1]),
+            (["pitch"], [-2]),
+        ],
+    )
+    def test_save_voiced_items_if_pt_file_not_exist(self, test_data_dir, sup_data_types, output_indices, tmp_path):
+        manifest_path = os.path.join(test_data_dir, 'tts/mini_ljspeech/manifest.json')
+        sup_path = tmp_path / "sup_data"
+        print(f"sup_path={sup_path}")
+        dataset = TTSDataset(
+            manifest_filepath=manifest_path,
+            sample_rate=22050,
+            sup_data_types=sup_data_types,
+            sup_data_path=sup_path,
+            text_tokenizer=EnglishPhonemesTokenizer(
+                punct=True,
+                stresses=True,
+                chars=True,
+                space=' ',
+                apostrophe=True,
+                pad_with_space=True,
+                g2p=EnglishG2p(),
+            ),
+        )
+
+        # load manifest
+        audio_filepaths = []
+        with open(manifest_path, 'r', encoding="utf-8") as fjson:
+            for line in fjson:
+                audio_filepaths.append(json.loads(line)["audio_filepath"])
+        base_data_dir = get_base_dir(audio_filepaths)
+
+        dataloader = torch.utils.data.DataLoader(dataset=dataset, batch_size=1, collate_fn=dataset._collate_fn)
+        for batch, audio_filepath in zip(dataloader, audio_filepaths):
+            rel_audio_path = Path(audio_filepath).relative_to(base_data_dir).with_suffix("")
+            rel_audio_path_as_text_id = str(rel_audio_path).replace("/", "_")
+
+            for sup_data_type, output_index in zip(sup_data_types, output_indices):
+                sup_data = batch[output_index]
+                sup_data = sup_data.squeeze(0)
+                assert sup_data is not None
+                assert torch.equal(sup_data, torch.load(f"{sup_path}/{sup_data_type}/{rel_audio_path_as_text_id}.pt"))
+
+                if sup_data_type == "pitch":
+                    pitch_lengths = batch[output_index + 1]
+                    pitch_lengths = pitch_lengths.squeeze(0)
+                    assert pitch_lengths is not None
+
+            # test pitch, voiced_mask, and p_voiced do not have the same values.
+            if len(sup_data_types) == 3:
+                x = torch.load(f"{sup_path}/{sup_data_types[0]}/{rel_audio_path_as_text_id}.pt")
+                y = torch.load(f"{sup_path}/{sup_data_types[1]}/{rel_audio_path_as_text_id}.pt")
+                z = torch.load(f"{sup_path}/{sup_data_types[2]}/{rel_audio_path_as_text_id}.pt")
+                assert not torch.equal(x, y)
+                assert not torch.equal(x, z)

--- a/tests/test_data_dir.py
+++ b/tests/test_data_dir.py
@@ -21,7 +21,7 @@ import pytest
 class TestDataDir:
     @pytest.mark.unit
     def test_test_data_dir(self, test_data_dir):
-        """" Just a dummy tests showing how to use the test_data_dir fixture. """
+        """Just a dummy tests showing how to use the test_data_dir fixture."""
         # test_data_dir contains the absolute path to nemo -> tests/.data
         assert exists(test_data_dir)
         assert exists(join(test_data_dir, "test_data.tar.gz"))


### PR DESCRIPTION
# What does this PR do ?

pitch, voiced_mask, and prob_voiced are return values for the func `librosa.pyin`, but we always returned the value of `voiced_mask` after going through `load_from_dir()` no matter which one of the three variables were requested.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```bash
(nemo) xueyang@aiapps-031622:~/workspace/NeMo$ pytest --cpu tests/collections/tts/test_torch_tts.py::TestTTSDataset::test_save_voiced_items_if_pt_file_not_exist
A valid `test_data.tar.gz` test archive (7343147B) found in the `/home/xueyang/workspace/NeMo/tests/.data` folder.
/home/xueyang/miniconda3/envs/nemo/lib/python3.8/site-packages/apex/pyprof/__init__.py:5: FutureWarning: pyprof will be removed by the end of June, 2022
  warnings.warn("pyprof will be removed by the end of June, 2022", FutureWarning)
Setting numba compat : True
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.8.13, pytest-7.1.1, pluggy-1.0.0 -- /home/xueyang/miniconda3/envs/nemo/bin/python
cachedir: .pytest_cache
rootdir: /home/xueyang/workspace/NeMo, configfile: setup.cfg
plugins: hydra-core-1.1.1, anyio-3.6.1
collected 4 items

tests/collections/tts/test_torch_tts.py::TestTTSDataset::test_save_voiced_items_if_pt_file_not_exist[sup_data_types0-output_indices0] PASSED                                              [ 25%]
tests/collections/tts/test_torch_tts.py::TestTTSDataset::test_save_voiced_items_if_pt_file_not_exist[sup_data_types1-output_indices1] PASSED                                              [ 50%]
tests/collections/tts/test_torch_tts.py::TestTTSDataset::test_save_voiced_items_if_pt_file_not_exist[sup_data_types2-output_indices2] PASSED                                              [ 75%]
tests/collections/tts/test_torch_tts.py::TestTTSDataset::test_save_voiced_items_if_pt_file_not_exist[sup_data_types3-output_indices3] PASSED                                              [100%]

======================================================================================= slowest durations =======================================================================================
14.02s call     tests/collections/tts/test_torch_tts.py::TestTTSDataset::test_save_voiced_items_if_pt_file_not_exist[sup_data_types0-output_indices0]
14.00s call     tests/collections/tts/test_torch_tts.py::TestTTSDataset::test_save_voiced_items_if_pt_file_not_exist[sup_data_types3-output_indices3]
13.99s call     tests/collections/tts/test_torch_tts.py::TestTTSDataset::test_save_voiced_items_if_pt_file_not_exist[sup_data_types2-output_indices2]
13.90s call     tests/collections/tts/test_torch_tts.py::TestTTSDataset::test_save_voiced_items_if_pt_file_not_exist[sup_data_types1-output_indices1]

(8 durations < 0.005s hidden.  Use -vv to show these durations.)
====================================================================================== 4 passed in 57.14s =======================================================================================
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
