### PR TITLE
Add reconfigure on validation epoch start

### DIFF
--- a/examples/nlp/question_answering/conf/question_answering_squad_config.yaml
+++ b/examples/nlp/question_answering/conf/question_answering_squad_config.yaml
@@ -130,7 +130,7 @@ exp_manager:
   name: *name # name of experiment
   create_tensorboard_logger: True
   create_checkpoint_callback: True
-  create_wandb_logger: True
+  create_wandb_logger: False
   wandb_logger_kwargs:
     name: ???
     project: QA

--- a/nemo/collections/nlp/models/machine_translation/megatron_nmt_model.py
+++ b/nemo/collections/nlp/models/machine_translation/megatron_nmt_model.py
@@ -649,6 +649,16 @@ class MegatronNMTModel(MegatronLMEncoderDecoderModel):
                 data_parallel_size=parallel_state.get_data_parallel_world_size(),
             )
 
+    def on_validation_epoch_start(self):
+        app_state = AppState()
+        _reconfigure_microbatch_calculator(
+            rank=app_state.global_rank,
+            rampup_batch_size=None,
+            global_batch_size=parallel_state.get_data_parallel_world_size(),
+            micro_batch_size=1,
+            data_parallel_size=parallel_state.get_data_parallel_world_size(),
+        )
+
     @torch.no_grad()
     def translate(
         self,

--- a/nemo/collections/nlp/models/machine_translation/megatron_nmt_model.py
+++ b/nemo/collections/nlp/models/machine_translation/megatron_nmt_model.py
@@ -651,6 +651,9 @@ class MegatronNMTModel(MegatronLMEncoderDecoderModel):
 
     def on_validation_epoch_start(self):
         app_state = AppState()
+        import ipdb
+
+        ipdb.set_trace()
         _reconfigure_microbatch_calculator(
             rank=app_state.global_rank,
             rampup_batch_size=None,

--- a/nemo/collections/nlp/models/machine_translation/megatron_nmt_model.py
+++ b/nemo/collections/nlp/models/machine_translation/megatron_nmt_model.py
@@ -651,9 +651,6 @@ class MegatronNMTModel(MegatronLMEncoderDecoderModel):
 
     def on_validation_epoch_start(self):
         app_state = AppState()
-        import ipdb
-
-        ipdb.set_trace()
         _reconfigure_microbatch_calculator(
             rank=app_state.global_rank,
             rampup_batch_size=None,


### PR DESCRIPTION
Signed-off-by: MaximumEntropy <sandeep.subramanian.1@umontreal.ca>

# What does this PR do ?

- Reconfigures micro-batch sizes for validation datasets on validation start in Megatron NMT

**Collection**: NLP

# Changelog 
- Add an `on_validation_epoch_start()` hook to reconfigure batch sizes.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
