### PR TITLE
Fix hanging issue by multiprocessing in SD tutorial and add ETA for VAD processing

### DIFF
--- a/nemo/collections/asr/parts/utils/vad_utils.py
+++ b/nemo/collections/asr/parts/utils/vad_utils.py
@@ -15,6 +15,7 @@ import glob
 import json
 import math
 import multiprocessing
+from tqdm import tqdm
 import os
 import shutil
 from itertools import repeat
@@ -78,11 +79,11 @@ def prepare_manifest(config: dict) -> str:
     }
 
     if config.get('num_workers') is not None and config['num_workers'] > 1:
-        p = multiprocessing.Pool(processes=config['num_workers'])
-        results = p.starmap(write_vad_infer_manifest, zip(input_list, repeat(args_func)))
-        p.close()
+        with multiprocessing.Pool(processes=config['num_workers']) as p:
+            inputs = zip(input_list, repeat(args_func))
+            results = list(tqdm(p.imap(write_vad_infer_manifest_star, inputs), total=len(input_list)))
     else:
-        results = [write_vad_infer_manifest(input_el, args_func) for input_el in input_list]
+        results = [write_vad_infer_manifest(input_el, args_func) for input_el in tqdm(input_list)]
 
     if os.path.exists(manifest_vad_input):
         logging.info("The prepared manifest file exists. Overwriting!")
@@ -95,6 +96,13 @@ def prepare_manifest(config: dict) -> str:
                 fout.write('\n')
                 fout.flush()
     return manifest_vad_input
+
+
+def write_vad_infer_manifest_star(args):
+    """
+    A workaround for tqdm with starmap of multiprocessing
+    """
+    return write_vad_infer_manifest(*args)
 
 
 def write_vad_infer_manifest(file: dict, args_func: dict) -> list:
@@ -256,15 +264,23 @@ def generate_overlap_vad_seq(
         "smoothing_method": smoothing_method,
     }
     if num_workers is not None and num_workers > 1:
-        p = multiprocessing.Pool(processes=num_workers)
-        p.starmap(generate_overlap_vad_seq_per_file, zip(frame_filepathlist, repeat(per_args)))
-        p.close()
-        p.join()
+        with multiprocessing.Pool(processes=num_workers) as p:
+            inputs = zip(frame_filepathlist, repeat(per_args))
+            # p.starmap(generate_overlap_vad_seq_per_file, tqdm(inputs, total=len(frame_filepathlist)), chunksize=100)
+            results = list(tqdm(p.imap(generate_overlap_vad_seq_per_file_star, inputs), total=len(frame_filepathlist)))
+
     else:
-        for frame_filepath in frame_filepathlist:
+        for frame_filepath in tqdm(frame_filepathlist):
             generate_overlap_vad_seq_per_file(frame_filepath, per_args)
 
     return overlap_out_dir
+
+
+def generate_overlap_vad_seq_per_file_star(args):
+    """
+    A workaround for tqdm with starmap of multiprocessing
+    """
+    return generate_overlap_vad_seq_per_file(*args)
 
 
 @torch.jit.script
@@ -691,15 +707,22 @@ def generate_vad_segment_table(
     per_args = {**per_args, **postprocessing_params}
 
     if num_workers is not None and num_workers > 1:
-        p = multiprocessing.Pool(processes=num_workers)
-        p.starmap(generate_vad_segment_table_per_file, zip(vad_pred_filepath_list, repeat(per_args)))
-        p.close()
-        p.join()
+        with multiprocessing.Pool(num_workers) as p:
+            inputs = zip(vad_pred_filepath_list, repeat(per_args))
+            list(tqdm(p.imap(generate_vad_segment_table_per_file_star, inputs), total=len(vad_pred_filepath_list)))
+
     else:
-        for vad_pred_filepath in vad_pred_filepath_list:
+        for vad_pred_filepath in tqdm(vad_pred_filepath_list):
             generate_vad_segment_table_per_file(vad_pred_filepath, per_args)
 
     return table_out_dir
+
+
+def generate_vad_segment_table_per_file_star(args):
+    """
+    A workaround for tqdm with starmap of multiprocessing
+    """
+    return generate_vad_segment_table_per_file(*args)
 
 
 def vad_construct_pyannote_object_per_file(

--- a/tutorials/speaker_tasks/Speaker_Diarization_Inference.ipynb
+++ b/tutorials/speaker_tasks/Speaker_Diarization_Inference.ipynb
@@ -386,7 +386,9 @@
             "source": [
                 "Note in this tutorial, we use the VAD model MarbleNet-3x2 introduced and published in [ICASSP MarbleNet](https://arxiv.org/pdf/2010.13886.pdf). You might need to tune on dev set similar to your dataset if you would like to improve the performance.\n",
                 "\n",
-                "And the speakerNet-M-Diarization model achieves 7.3% confusion error rate on CH109 set with oracle vad. This model is trained on voxceleb1, voxceleb2, Fisher, SwitchBoard datasets. So for more improved performance specific to your dataset, finetune speaker verification model with a devset similar to your test set."
+                "And the speakerNet-M-Diarization model achieves 7.3% confusion error rate on CH109 set with oracle vad. This model is trained on voxceleb1, voxceleb2, Fisher, SwitchBoard datasets. So for more improved performance specific to your dataset, finetune speaker verification model with a devset similar to your test set.\n",
+		"\n",
+		"Python mulitprocessing with jupyter notebook would hang for a couple cases. In this tutorial, we set num_workers=1, please use script in `NeMo/examples/speaker_tasks/` with num_workers larger than 1 for faster process."
             ]
         },
         {
@@ -395,6 +397,8 @@
             "metadata": {},
             "outputs": [],
             "source": [
+		"config.num_workers = 1 # Workaround for multiprocessing hanging with ipython issue \n",
+		"\n",
                 "output_dir = os.path.join(ROOT,'outputs')\n",
                 "config.diarizer.manifest_filepath = 'data/input_manifest.json'\n",
                 "config.diarizer.out_dir = output_dir #Directory to store intermediate files and prediction outputs\n",


### PR DESCRIPTION
# What does this PR do ?

Fix hanging/deadlock issue caused by multiprocessing in SD tutorial and add tdqm that informs ETA to reduce false alarm of hanging. 
reflected review in https://github.com/NVIDIA/NeMo/pull/4378

**Collection**: ASR

# Changelog 
Cherry pick updates to r1.10.0 https://github.com/NVIDIA/NeMo/pull/4317, (modify the code in place here to avoid sign-off issue) 
Add instruction and set num_workers=1 in SD tutorial as a workaround for python multiprocessing would hang with python in some cases.
Add tqdm that informs ETA for VAD processing

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
