### PR TITLE
Fixing bugs in calling method ctc_decoder_predictions_tensor.

### DIFF
--- a/examples/asr/quantization/speech_to_text_quant_infer.py
+++ b/examples/asr/quantization/speech_to_text_quant_infer.py
@@ -202,7 +202,7 @@ def evaluate(asr_model, labels_map, wer):
             log_probs, encoded_len, greedy_predictions = asr_model(
                 input_signal=test_batch[0], input_signal_length=test_batch[1]
             )
-        hypotheses += wer.ctc_decoder_predictions_tensor(greedy_predictions)
+        hypotheses += wer.decoding.ctc_decoder_predictions_tensor(greedy_predictions)
         for batch_ind in range(greedy_predictions.shape[0]):
             seq_len = test_batch[3][batch_ind].cpu().detach().numpy()
             seq_ids = test_batch[2][batch_ind].cpu().detach().numpy()

--- a/examples/asr/quantization/speech_to_text_quant_infer.py
+++ b/examples/asr/quantization/speech_to_text_quant_infer.py
@@ -202,7 +202,7 @@ def evaluate(asr_model, labels_map, wer):
             log_probs, encoded_len, greedy_predictions = asr_model(
                 input_signal=test_batch[0], input_signal_length=test_batch[1]
             )
-        hypotheses += wer.decoding.ctc_decoder_predictions_tensor(greedy_predictions)
+        hypotheses += wer.decoding.ctc_decoder_predictions_tensor(greedy_predictions)[0]
         for batch_ind in range(greedy_predictions.shape[0]):
             seq_len = test_batch[3][batch_ind].cpu().detach().numpy()
             seq_ids = test_batch[2][batch_ind].cpu().detach().numpy()

--- a/examples/asr/quantization/speech_to_text_quant_infer_trt.py
+++ b/examples/asr/quantization/speech_to_text_quant_infer_trt.py
@@ -212,7 +212,7 @@ def evaluate(asr_model, asr_onnx, labels_map, wer, qat):
                 input_signal=processed_signal,
                 input_signal_length=processed_signal_length,
             )
-            hypotheses += wer.decoding.ctc_decoder_predictions_tensor(greedy_predictions)
+            hypotheses += wer.decoding.ctc_decoder_predictions_tensor(greedy_predictions)[0]
             for batch_ind in range(greedy_predictions.shape[0]):
                 seq_len = test_batch[3][batch_ind].cpu().detach().numpy()
                 seq_ids = test_batch[2][batch_ind].cpu().detach().numpy()

--- a/examples/asr/quantization/speech_to_text_quant_infer_trt.py
+++ b/examples/asr/quantization/speech_to_text_quant_infer_trt.py
@@ -212,7 +212,7 @@ def evaluate(asr_model, asr_onnx, labels_map, wer, qat):
                 input_signal=processed_signal,
                 input_signal_length=processed_signal_length,
             )
-            hypotheses += wer.ctc_decoder_predictions_tensor(greedy_predictions)
+            hypotheses += wer.decoding.ctc_decoder_predictions_tensor(greedy_predictions)
             for batch_ind in range(greedy_predictions.shape[0]):
                 seq_len = test_batch[3][batch_ind].cpu().detach().numpy()
                 seq_ids = test_batch[2][batch_ind].cpu().detach().numpy()

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -592,7 +592,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
         else:
             log_probs, encoded_len, predictions = self.forward(input_signal=signal, input_signal_length=signal_len)
 
-        transcribed_texts = self._wer.decoding.ctc_decoder_predictions_tensor(
+        transcribed_texts, _ = self._wer.decoding.ctc_decoder_predictions_tensor(
             predictions=log_probs, predictions_len=encoded_len, return_hypotheses=False,
         )
 

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -592,7 +592,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
         else:
             log_probs, encoded_len, predictions = self.forward(input_signal=signal, input_signal_length=signal_len)
 
-        transcribed_texts = self._wer.ctc_decoder_predictions_tensor(
+        transcribed_texts = self._wer.decoding.ctc_decoder_predictions_tensor(
             predictions=log_probs, predictions_len=encoded_len, return_hypotheses=False,
         )
 

--- a/nemo/collections/asr/parts/utils/decoder_timestamps_utils.py
+++ b/nemo/collections/asr/parts/utils/decoder_timestamps_utils.py
@@ -450,7 +450,7 @@ class ASR_TIMESTAMPS:
                     log_prob = torch.from_numpy(logit_np)
                     logits_len = torch.from_numpy(np.array([log_prob.shape[0]]))
                     greedy_predictions = log_prob.argmax(dim=-1, keepdim=False).unsqueeze(0)
-                    text, char_ts = wer_ts.ctc_decoder_predictions_tensor_with_ts(
+                    text, char_ts = wer_ts.decoding.ctc_decoder_predictions_tensor_with_ts(
                         greedy_predictions, predictions_len=logits_len
                     )
                     trans, char_ts_in_feature_frame_idx = self.clean_trans_and_TS(text[0], char_ts[0])
@@ -573,7 +573,7 @@ class ASR_TIMESTAMPS:
                     log_prob = torch.from_numpy(logit_np)
                     greedy_predictions = log_prob.argmax(dim=-1, keepdim=False).unsqueeze(0)
                     logits_len = torch.from_numpy(np.array([log_prob.shape[0]]))
-                    text, char_ts, word_ts = werbpe_ts.ctc_decoder_predictions_tensor_with_ts(
+                    text, char_ts, word_ts = werbpe_ts.decoding.ctc_decoder_predictions_tensor_with_ts(
                         self.model_stride_in_secs, greedy_predictions, predictions_len=logits_len
                     )
                     hyp_words, word_ts = text[0].split(), word_ts[0]
@@ -676,7 +676,7 @@ class ASR_TIMESTAMPS:
                     logits_len = torch.from_numpy(np.array([len(greedy_predictions_list)]))
                     greedy_predictions_list = greedy_predictions_list[onset_delay:]
                     greedy_predictions = torch.from_numpy(np.array(greedy_predictions_list)).unsqueeze(0)
-                    text, char_ts, word_ts = werbpe_ts.ctc_decoder_predictions_tensor_with_ts(
+                    text, char_ts, word_ts = werbpe_ts.decoding.ctc_decoder_predictions_tensor_with_ts(
                         self.model_stride_in_secs, greedy_predictions, predictions_len=logits_len
                     )
                     hyp_words, word_ts = text[0].split(), word_ts[0]

--- a/nemo/collections/asr/parts/utils/decoder_timestamps_utils.py
+++ b/nemo/collections/asr/parts/utils/decoder_timestamps_utils.py
@@ -450,7 +450,7 @@ class ASR_TIMESTAMPS:
                     log_prob = torch.from_numpy(logit_np)
                     logits_len = torch.from_numpy(np.array([log_prob.shape[0]]))
                     greedy_predictions = log_prob.argmax(dim=-1, keepdim=False).unsqueeze(0)
-                    text, char_ts = wer_ts.decoding.ctc_decoder_predictions_tensor_with_ts(
+                    text, char_ts = wer_ts.ctc_decoder_predictions_tensor_with_ts(
                         greedy_predictions, predictions_len=logits_len
                     )
                     trans, char_ts_in_feature_frame_idx = self.clean_trans_and_TS(text[0], char_ts[0])
@@ -573,7 +573,7 @@ class ASR_TIMESTAMPS:
                     log_prob = torch.from_numpy(logit_np)
                     greedy_predictions = log_prob.argmax(dim=-1, keepdim=False).unsqueeze(0)
                     logits_len = torch.from_numpy(np.array([log_prob.shape[0]]))
-                    text, char_ts, word_ts = werbpe_ts.decoding.ctc_decoder_predictions_tensor_with_ts(
+                    text, char_ts, word_ts = werbpe_ts.ctc_decoder_predictions_tensor_with_ts(
                         self.model_stride_in_secs, greedy_predictions, predictions_len=logits_len
                     )
                     hyp_words, word_ts = text[0].split(), word_ts[0]
@@ -676,7 +676,7 @@ class ASR_TIMESTAMPS:
                     logits_len = torch.from_numpy(np.array([len(greedy_predictions_list)]))
                     greedy_predictions_list = greedy_predictions_list[onset_delay:]
                     greedy_predictions = torch.from_numpy(np.array(greedy_predictions_list)).unsqueeze(0)
-                    text, char_ts, word_ts = werbpe_ts.decoding.ctc_decoder_predictions_tensor_with_ts(
+                    text, char_ts, word_ts = werbpe_ts.ctc_decoder_predictions_tensor_with_ts(
                         self.model_stride_in_secs, greedy_predictions, predictions_len=logits_len
                     )
                     hyp_words, word_ts = text[0].split(), word_ts[0]

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -74,7 +74,7 @@ def transcribe_partial_audio(
                     lg = logits[idx][: logits_len[idx]]
                     hypotheses.append(lg.cpu().numpy())
             else:
-                current_hypotheses = asr_model._wer.ctc_decoder_predictions_tensor(
+                current_hypotheses = asr_model._wer.decoding.ctc_decoder_predictions_tensor(
                     greedy_predictions, predictions_len=logits_len, return_hypotheses=return_hypotheses,
                 )
 

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -74,7 +74,7 @@ def transcribe_partial_audio(
                     lg = logits[idx][: logits_len[idx]]
                     hypotheses.append(lg.cpu().numpy())
             else:
-                current_hypotheses = asr_model._wer.decoding.ctc_decoder_predictions_tensor(
+                current_hypotheses, _ = asr_model._wer.decoding.ctc_decoder_predictions_tensor(
                     greedy_predictions, predictions_len=logits_len, return_hypotheses=return_hypotheses,
                 )
 

--- a/scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram.py
+++ b/scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram.py
@@ -280,7 +280,7 @@ def main():
     for batch_idx, probs in enumerate(all_probs):
         preds = np.argmax(probs, axis=1)
         preds_tensor = torch.tensor(preds, device='cpu').unsqueeze(0)
-        pred_text = asr_model._wer.decoding.ctc_decoder_predictions_tensor(preds_tensor)[0]
+        pred_text = asr_model._wer.decoding.ctc_decoder_predictions_tensor(preds_tensor)[0][0]
 
         pred_split_w = pred_text.split()
         target_split_w = target_transcripts[batch_idx].split()

--- a/scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram.py
+++ b/scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram.py
@@ -280,7 +280,7 @@ def main():
     for batch_idx, probs in enumerate(all_probs):
         preds = np.argmax(probs, axis=1)
         preds_tensor = torch.tensor(preds, device='cpu').unsqueeze(0)
-        pred_text = asr_model._wer.ctc_decoder_predictions_tensor(preds_tensor)[0]
+        pred_text = asr_model._wer.decoding.ctc_decoder_predictions_tensor(preds_tensor)[0]
 
         pred_split_w = pred_text.split()
         target_split_w = target_transcripts[batch_idx].split()

--- a/scripts/asr_language_modeling/ngram_lm/install_beamsearch_decoders.sh
+++ b/scripts/asr_language_modeling/ngram_lm/install_beamsearch_decoders.sh
@@ -1,6 +1,10 @@
+#!/usr/bin/env bash
 # install Boost package
 sudo apt-get install build-essential libboost-all-dev cmake zlib1g-dev libbz2-dev liblzma-dev
-git clone https://github.com/NVIDIA/OpenSeq2Seq -b ctc-decoders
+git clone https://github.com/NVIDIA/OpenSeq2Seq
+cd OpenSeq2Seq
+git checkout ctc-decoders
+cd ..
 mv OpenSeq2Seq/decoders .
 rm -rf OpenSeq2Seq
 cd decoders

--- a/tutorials/asr/ASR_with_NeMo.ipynb
+++ b/tutorials/asr/ASR_with_NeMo.ipynb
@@ -1090,7 +1090,7 @@
                 "        logits = torch.from_numpy(alogits[0])\n",
                 "        greedy_predictions = logits.argmax(dim=-1, keepdim=False)\n",
                 "        wer = WER(vocabulary=quartznet.decoder.vocabulary, batch_dim_index=0, use_cer=False, ctc_decode=True)\n",
-                "        hypotheses = wer.ctc_decoder_predictions_tensor(greedy_predictions)\n",
+                "        hypotheses = wer.decoding.ctc_decoder_predictions_tensor(greedy_predictions)\n",
                 "        print(hypotheses)\n",
                 "        break\n"
             ],

--- a/tutorials/asr/ASR_with_NeMo.ipynb
+++ b/tutorials/asr/ASR_with_NeMo.ipynb
@@ -1090,7 +1090,7 @@
                 "        logits = torch.from_numpy(alogits[0])\n",
                 "        greedy_predictions = logits.argmax(dim=-1, keepdim=False)\n",
                 "        wer = WER(vocabulary=quartznet.decoder.vocabulary, batch_dim_index=0, use_cer=False, ctc_decode=True)\n",
-                "        hypotheses = wer.decoding.ctc_decoder_predictions_tensor(greedy_predictions)\n",
+                "        hypotheses, _ = wer.decoding.ctc_decoder_predictions_tensor(greedy_predictions)\n",
                 "        print(hypotheses)\n",
                 "        break\n"
             ],


### PR DESCRIPTION
# What does this PR do ?

Fixed a bug in calling the ctc_decoder_predictions_tensor method from the WER objects instead of WER.decoding.

# Changelog 
- Changed all the wer.ctc_decoder_predictions_tensor to wer.decoding.ctc_decoder_predictions_tensor .

**PR Type**:
- [ ] New Feature
- [x ] Bugfix
- [ ] Documentation

