### PR TITLE
[Fix] Relative Audio Paths

### DIFF
--- a/nemo/collections/common/parts/preprocessing/manifest.py
+++ b/nemo/collections/common/parts/preprocessing/manifest.py
@@ -89,14 +89,13 @@ def __parse_item(line: str, manifest_file: str) -> Dict[str, Any]:
             f"Manifest file {manifest_file} has invalid json line structure: {line} without proper audio file key."
         )
 
-    # If the audio path is relative, and not using tarred dataset,
-    # attach the parent directory of manifest to the audio path.
-    # Assume "audio_file" starts with a dir, such as "wavs/xxxxx.wav".
-    # If using a tarred dataset, the "audio_path" is like "_home_data_tarred_wavs_xxxx.wav",
-    # so we will just ignore it.
+    # If the audio path is a relative path and does not exists,
+    # try to attach the parent directory of manifest to the audio path.
+    # Revert to the oiginal path if the new path still doesn't exist.
+    # Assume that the audio paths are like "wavs/xxxxxx.wav".
     manifest_dir = Path(manifest_file).parent
     audio_file = Path(item['audio_file'])
-    if not audio_file.is_file() and not audio_file.is_absolute() and audio_file.parent != Path("."):
+    if not audio_file.is_file() and not audio_file.is_absolute():
         # assume the wavs/ dir and manifest are under the same parent dir
         audio_file = manifest_dir / audio_file
         if audio_file.is_file():

--- a/nemo/collections/common/parts/preprocessing/manifest.py
+++ b/nemo/collections/common/parts/preprocessing/manifest.py
@@ -89,14 +89,14 @@ def __parse_item(line: str, manifest_file: str) -> Dict[str, Any]:
             f"Manifest file {manifest_file} has invalid json line structure: {line} without proper audio file key."
         )
 
-    # If the audio path is a relative path and does not exists,
+    # If the audio path is a relative path and does not exist,
     # try to attach the parent directory of manifest to the audio path.
-    # Revert to the oiginal path if the new path still doesn't exist.
-    # Assume that the audio paths are like "wavs/xxxxxx.wav".
+    # Revert to the original path if the new path still doesn't exist.
+    # Assume that the audio path is like "wavs/xxxxxx.wav".
     manifest_dir = Path(manifest_file).parent
     audio_file = Path(item['audio_file'])
     if not audio_file.is_file() and not audio_file.is_absolute():
-        # assume the wavs/ dir and manifest are under the same parent dir
+        # assume the "wavs/" dir and manifest are under the same parent dir
         audio_file = manifest_dir / audio_file
         if audio_file.is_file():
             item['audio_file'] = str(audio_file.absolute())

--- a/nemo/collections/common/parts/preprocessing/manifest.py
+++ b/nemo/collections/common/parts/preprocessing/manifest.py
@@ -99,7 +99,10 @@ def __parse_item(line: str, manifest_file: str) -> Dict[str, Any]:
     if not audio_file.is_file() and not audio_file.is_absolute() and audio_file.parent != Path("."):
         # assume the wavs/ dir and manifest are under the same parent dir
         audio_file = manifest_dir / audio_file
-        item['audio_file'] = str(audio_file.absolute())
+        if audio_file.is_file():
+            item['audio_file'] = str(audio_file.absolute())
+        else:
+            item['audio_file'] = expanduser(item['audio_file'])
     else:
         item['audio_file'] = expanduser(item['audio_file'])
 


### PR DESCRIPTION
Signed-off-by: stevehuang52 <heh@nvidia.com>

This PR fixes the second problem in this [issue 4455](https://github.com/NVIDIA/NeMo/issues/4455).

Previously, the code will fail when there are "/" in the filepaths of tarred datasets. Now we only add the manifest directory to the audio filepath if the resulting file exists, thus fixing the problem.
