### PR TITLE
Add support for ASR Adapter Auxiliary Losses

### DIFF
--- a/examples/asr/conf/asr_adapters/asr_adaptation.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation.yaml
@@ -77,6 +77,7 @@ model:
     adapter_strategy:
       _target_: nemo.core.classes.mixins.adapter_mixin_strategies.ResidualAddAdapterStrategy
       stochastic_depth: 0.0  # float, setting to > 0 will enable stochastic depth for each adapter block.
+      l2_lambda: 0.0  # float, setting to > 0 will enable l2 norm auxiliary loss for each adapter's output.
 
     # Optional global config available to all adapters at a global level.
     # A global config is shared across every layer of the adapters, defining global properties rather

--- a/nemo/collections/asr/models/asr_model.py
+++ b/nemo/collections/asr/models/asr_model.py
@@ -66,13 +66,14 @@ class ASRModel(ModelPT, ABC):
 
     def add_auxiliary_losses(self, loss: torch.Tensor, reset_registry: bool = True) -> torch.Tensor:
         """
+        Utility method to enable calculation of auxiliary losses for ASR training.
 
         Args:
-            loss:
-            reset_registry:
+            loss: The output loss value prior to addition with auxiliary losses.
+            reset_registry: Bool, whether to reset the AccessMixin registry after adding auxiliary losses.
 
         Returns:
-
+            Loss tensor used for back propagation.
         """
         # Add adapter auxiliary losses, if registered
         if AccessMixin.is_access_enabled():

--- a/nemo/collections/asr/models/asr_model.py
+++ b/nemo/collections/asr/models/asr_model.py
@@ -64,7 +64,7 @@ class ASRModel(ModelPT, ABC):
         list_of_models = model_utils.resolve_subclass_pretrained_model_info(cls)
         return list_of_models
 
-    def add_auxiliary_losses(self, loss: torch.Tensor, reset_registry: bool = True) -> torch.Tensor:
+    def add_auxiliary_losses(self, loss: torch.Tensor, reset_registry: bool = False) -> torch.Tensor:
         """
         Utility method to enable calculation of auxiliary losses for ASR training.
 

--- a/nemo/collections/asr/models/asr_model.py
+++ b/nemo/collections/asr/models/asr_model.py
@@ -20,7 +20,7 @@ import torch
 from nemo.core.classes import ModelPT
 from nemo.core.classes.exportable import Exportable
 from nemo.core.classes.mixins import AccessMixin
-from nemo.utils import model_utils, logging
+from nemo.utils import logging, model_utils
 from nemo.utils.export_utils import cast_all
 
 __all__ = ['ASRModel']

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -548,7 +548,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
 
     # PTL-specific methods
     def training_step(self, batch, batch_nb):
-        # reset AccessMixin cache
+        # Reset access registry
         if AccessMixin.is_access_enabled():
             AccessMixin.reset_registry(self)
 
@@ -566,6 +566,10 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
 
         # Add auxiliary losses, if registered
         loss_value = self.add_auxiliary_losses(loss_value)
+
+        # Reset access registry
+        if AccessMixin.is_access_enabled():
+            AccessMixin.reset_registry(self)
 
         tensorboard_logs = {
             'train_loss': loss_value,

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -31,6 +31,7 @@ from nemo.collections.asr.models.asr_model import ASRModel, ExportableEncDecMode
 from nemo.collections.asr.parts.mixins import ASRModuleMixin
 from nemo.collections.asr.parts.preprocessing.perturb import process_augmentations
 from nemo.core.classes.common import PretrainedModelInfo, typecheck
+from nemo.core.classes.mixins import AccessMixin
 from nemo.core.neural_types import AudioSignal, LabelsType, LengthsType, LogprobsType, NeuralType, SpectrogramType
 from nemo.utils import logging
 
@@ -547,6 +548,10 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
 
     # PTL-specific methods
     def training_step(self, batch, batch_nb):
+        # reset AccessMixin cache
+        if AccessMixin.is_access_enabled():
+            AccessMixin.reset_registry(self)
+
         signal, signal_len, transcript, transcript_len = batch
         if isinstance(batch, DALIOutputs) and batch.has_processed_signal:
             log_probs, encoded_len, predictions = self.forward(
@@ -558,6 +563,9 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
         loss_value = self.loss(
             log_probs=log_probs, targets=transcript, input_lengths=encoded_len, target_lengths=transcript_len
         )
+
+        # Add auxiliary losses, if registered
+        loss_value = self.add_auxiliary_losses(loss_value)
 
         tensorboard_logs = {
             'train_loss': loss_value,
@@ -593,7 +601,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
             log_probs, encoded_len, predictions = self.forward(input_signal=signal, input_signal_length=signal_len)
 
         transcribed_texts, _ = self._wer.decoding.ctc_decoder_predictions_tensor(
-            predictions=log_probs, predictions_len=encoded_len, return_hypotheses=False,
+            decoder_outputs=log_probs, decoder_lengths=encoded_len, return_hypotheses=False,
         )
 
         sample_id = sample_id.cpu().detach().numpy()

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -661,7 +661,7 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, Exportable):
 
     # PTL-specific methods
     def training_step(self, batch, batch_nb):
-        # reset AccessMixin cache
+        # Reset access registry
         if AccessMixin.is_access_enabled():
             AccessMixin.reset_registry(self)
 
@@ -695,6 +695,10 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, Exportable):
             # Add auxiliary losses, if registered
             loss_value = self.add_auxiliary_losses(loss_value)
 
+            # Reset access registry
+            if AccessMixin.is_access_enabled():
+                AccessMixin.reset_registry(self)
+
             tensorboard_logs = {
                 'train_loss': loss_value,
                 'learning_rate': self._optimizer.param_groups[0]['lr'],
@@ -726,6 +730,10 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, Exportable):
 
             # Add auxiliary losses, if registered
             loss_value = self.add_auxiliary_losses(loss_value)
+
+            # Reset access registry
+            if AccessMixin.is_access_enabled():
+                AccessMixin.reset_registry(self)
 
             tensorboard_logs = {'train_loss': loss_value, 'learning_rate': self._optimizer.param_groups[0]['lr']}
 

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -34,6 +34,7 @@ from nemo.collections.asr.parts.mixins import ASRModuleMixin
 from nemo.collections.asr.parts.preprocessing.perturb import process_augmentations
 from nemo.core.classes import Exportable
 from nemo.core.classes.common import PretrainedModelInfo, typecheck
+from nemo.core.classes.mixins import AccessMixin
 from nemo.core.neural_types import AcousticEncodedRepresentation, AudioSignal, LengthsType, NeuralType, SpectrogramType
 from nemo.utils import logging
 
@@ -660,6 +661,10 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, Exportable):
 
     # PTL-specific methods
     def training_step(self, batch, batch_nb):
+        # reset AccessMixin cache
+        if AccessMixin.is_access_enabled():
+            AccessMixin.reset_registry(self)
+
         signal, signal_len, transcript, transcript_len = batch
 
         # forward() only performs encoder forward
@@ -686,6 +691,9 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, Exportable):
             loss_value = self.loss(
                 log_probs=joint, targets=transcript, input_lengths=encoded_len, target_lengths=target_length
             )
+
+            # Add auxiliary losses, if registered
+            loss_value = self.add_auxiliary_losses(loss_value)
 
             tensorboard_logs = {
                 'train_loss': loss_value,
@@ -715,6 +723,9 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, Exportable):
                 transcript_lengths=transcript_len,
                 compute_wer=compute_wer,
             )
+
+            # Add auxiliary losses, if registered
+            loss_value = self.add_auxiliary_losses(loss_value)
 
             tensorboard_logs = {'train_loss': loss_value, 'learning_rate': self._optimizer.param_groups[0]['lr']}
 

--- a/nemo/collections/asr/models/ssl_models.py
+++ b/nemo/collections/asr/models/ssl_models.py
@@ -105,6 +105,7 @@ class SpeechEncDecSelfSupervisedModel(ModelPT, ASRModuleMixin, AccessMixin):
                 self.transpose_encoded[decoder_loss_name] = decoder_loss_cfg.get("transpose_encoded", False)
 
                 if self.output_from_layer[decoder_loss_name] is not None:
+                    self.access_cfg['save_encoder_tensors'] = True
                     self.set_access_enabled(access_enabled=True)
 
             self.decoder_losses = nn.ModuleDict(self.decoder_losses)
@@ -408,7 +409,7 @@ class SpeechEncDecSelfSupervisedModel(ModelPT, ASRModuleMixin, AccessMixin):
                     dec_input = encoded
                 else:
                     # extract output from specified layer using AccessMixin registry
-                    dec_input = registry[self.output_from_layer[dec_loss_name]][-1]
+                    dec_input = registry[self.output_from_layer[dec_loss_name]]['encoder'][-1]
                 if self.transpose_encoded[dec_loss_name]:
                     dec_input = dec_input.transpose(-2, -1)
 

--- a/nemo/collections/asr/models/ssl_models.py
+++ b/nemo/collections/asr/models/ssl_models.py
@@ -307,8 +307,6 @@ class SpeechEncDecSelfSupervisedModel(ModelPT, ASRModuleMixin, AccessMixin):
             3) The encoded features tensor of shape [B, D, T].
             2) The lengths of the acoustic sequence after propagation through the encoder, of shape [B].
         """
-        # reset module registry from AccessMixin
-        self.reset_registry()
 
         has_input_signal = input_signal is not None and input_signal_length is not None
         has_processed_signal = processed_signal is not None and processed_signal_length is not None
@@ -457,10 +455,15 @@ class SpeechEncDecSelfSupervisedModel(ModelPT, ASRModuleMixin, AccessMixin):
 
     # PTL-specific methods
     def training_step(self, batch, batch_nb):
-        if self.output_from_layer is not None and len(self.output_from_layer) > 0:
-            self.reset_registry()
-            self.access_cfg['save_encoder_tensors'] = True
-            self.set_access_enabled(access_enabled=True)
+        # reset module registry from AccessMixin
+        if self.decoder_losses is not None and self.output_from_layer is not None and len(self.output_from_layer) > 0:
+            layer_names = list(self.output_from_layer.values())
+            register_layer = any([name is not None for name in layer_names])
+
+            if register_layer:
+                self.reset_registry()
+                self.access_cfg['save_encoder_tensors'] = True
+                self.set_access_enabled(access_enabled=True)
 
         signal, signal_len, targets, target_lengths = batch
         spectrograms, spec_masks, encoded, encoded_len = self.forward(

--- a/nemo/collections/asr/models/ssl_models.py
+++ b/nemo/collections/asr/models/ssl_models.py
@@ -307,6 +307,11 @@ class SpeechEncDecSelfSupervisedModel(ModelPT, ASRModuleMixin, AccessMixin):
             3) The encoded features tensor of shape [B, D, T].
             2) The lengths of the acoustic sequence after propagation through the encoder, of shape [B].
         """
+        # Reset access registry
+        if self.is_access_enabled():
+            self.reset_registry()
+
+        # Check for special flag for validation step
         if hasattr(self, '_in_validation_step'):
             in_validation_step = self._in_validation_step
         else:
@@ -323,7 +328,6 @@ class SpeechEncDecSelfSupervisedModel(ModelPT, ASRModuleMixin, AccessMixin):
             register_layer = any([name is not None for name in layer_names])
 
             if register_layer:
-                self.reset_registry()
                 self.access_cfg['save_encoder_tensors'] = True
                 self.set_access_enabled(access_enabled=True)
 

--- a/nemo/collections/asr/parts/submodules/conformer_modules.py
+++ b/nemo/collections/asr/parts/submodules/conformer_modules.py
@@ -126,8 +126,8 @@ class ConformerLayer(torch.nn.Module, AdapterModuleMixin, AccessMixin):
             # Call the adapters
             x = self.forward_enabled_adapters(x)
 
-        if self.is_access_enabled():
-            self.register_accessible_tensor(tensor=x)
+        if self.is_access_enabled() and self.access_cfg.get('save_encoder_tensors', False):
+            self.register_accessible_tensor(name='encoder', tensor=x)
 
         return x
 

--- a/nemo/collections/asr/parts/submodules/jasper.py
+++ b/nemo/collections/asr/parts/submodules/jasper.py
@@ -1042,8 +1042,8 @@ class JasperBlock(nn.Module, AdapterModuleMixin, AccessMixin):
 
                 out = out.transpose(1, 2)  # (B, C, T)
 
-        if self.is_access_enabled():
-            self.register_accessible_tensor(tensor=out)
+        if self.is_access_enabled() and self.access_cfg.get('save_encoder_tensors', False):
+            self.register_accessible_tensor(name='encoder', tensor=out)
 
         if self.res is not None and self.dense_residual:
             return xs + [out], lens

--- a/nemo/collections/common/parts/adapter_modules.py
+++ b/nemo/collections/common/parts/adapter_modules.py
@@ -20,10 +20,10 @@ from omegaconf import OmegaConf
 from torch import nn as nn
 
 from nemo.collections.common.parts.utils import activation_registry
-from nemo.core.classes.mixins import adapter_mixin_strategies
+from nemo.core.classes.mixins import access_mixins, adapter_mixin_strategies
 
 
-class AbstractAdapterModule(nn.Module):
+class AbstractAdapterModule(nn.Module, access_mixins.AccessMixin):
     """
     Base class of Adapter Modules, providing common functionality to all Adapter Modules.
     """

--- a/nemo/core/classes/__init__.py
+++ b/nemo/core/classes/__init__.py
@@ -29,7 +29,7 @@ from nemo.core.classes.common import (
 from nemo.core.classes.dataset import Dataset, IterableDataset
 from nemo.core.classes.exportable import Exportable, ExportFormat
 from nemo.core.classes.loss import Loss
-from nemo.core.classes.mixins import adapter_mixins
+from nemo.core.classes.mixins import access_mixins, adapter_mixins
 from nemo.core.classes.modelPT import ModelPT
 from nemo.core.classes.module import NeuralModule
 from nemo.utils import exceptions

--- a/nemo/core/classes/mixins/access_mixins.py
+++ b/nemo/core/classes/mixins/access_mixins.py
@@ -68,7 +68,7 @@ class AccessMixin(ABC):
                 module_registry[name] = m._registry
         return module_registry
 
-    def reset_registry(self):
+    def reset_registry(self: torch.nn.Module):
         """
         Reset the registries of all named sub-modules
         """
@@ -87,10 +87,12 @@ class AccessMixin(ABC):
         global _ACCESS_CFG
         return _ACCESS_CFG
 
-    def is_access_enabled(self):
+    @classmethod
+    def is_access_enabled(cls):
         global _ACCESS_ENABLED
         return _ACCESS_ENABLED
 
-    def set_access_enabled(self, access_enabled: bool):
+    @classmethod
+    def set_access_enabled(cls, access_enabled: bool):
         global _ACCESS_ENABLED
         _ACCESS_ENABLED = access_enabled

--- a/nemo/core/classes/mixins/access_mixins.py
+++ b/nemo/core/classes/mixins/access_mixins.py
@@ -92,6 +92,11 @@ class AccessMixin(ABC):
         return _ACCESS_CFG
 
     @classmethod
+    def update_access_cfg(cls, cfg: dict):
+        global _ACCESS_CFG
+        _ACCESS_CFG.update(cfg)
+
+    @classmethod
     def is_access_enabled(cls):
         global _ACCESS_ENABLED
         return _ACCESS_ENABLED

--- a/nemo/core/classes/mixins/access_mixins.py
+++ b/nemo/core/classes/mixins/access_mixins.py
@@ -51,10 +51,6 @@ class AccessMixin(ABC):
         if not hasattr(self, '_registry'):
             self._registry = {}
 
-        # incorrect logic
-        # if len(self._registry) > 0:
-        #     self._registry.clear()
-
         if name not in self._registry:
             self._registry[name] = []
 

--- a/nemo/core/classes/mixins/access_mixins.py
+++ b/nemo/core/classes/mixins/access_mixins.py
@@ -35,9 +35,9 @@ class AccessMixin(ABC):
 
     def __init__(self):
         super().__init__()
-        self._registry = []
+        self._registry = {}  # dictionary of lists
 
-    def register_accessible_tensor(self, tensor):
+    def register_accessible_tensor(self, name, tensor):
         """
         Register tensor for later use.
         """
@@ -48,12 +48,16 @@ class AccessMixin(ABC):
             tensor = tensor.detach()
 
         if not hasattr(self, '_registry'):
-            self._registry = []
+            self._registry = {}
 
-        if len(self._registry) > 0:
-            self._registry.clear()
+        # incorrect logic
+        # if len(self._registry) > 0:
+        #     self._registry.clear()
 
-        self._registry.append(tensor)
+        if name not in self._registry:
+            self._registry[name] = []
+
+        self._registry[name].append(tensor)
 
     @classmethod
     def get_module_registry(cls, module: torch.nn.Module):

--- a/tests/collections/asr/mixins/adapters/test_asr_adapter_mixin.py
+++ b/tests/collections/asr/mixins/adapters/test_asr_adapter_mixin.py
@@ -423,12 +423,12 @@ class TestASRAdapterMixin:
         model.train()  # set training mode to true
 
         with torch.no_grad():
+            AccessMixin.reset_registry(model)
             _ = model(input_signal=x, input_signal_length=x_len)
 
             # extract losses
             auxiliary_losses = AccessMixin.get_module_registry(model)
 
-            assert len(auxiliary_losses) == 1  # 1 layer
             loss = list(auxiliary_losses.values())[0]
             assert 'adapter_loss' in loss
             assert loss['adapter_loss'][0] == torch.tensor(0.0)  # initially adapter is 0 init, no loss required.

--- a/tests/collections/asr/mixins/adapters/test_asr_adapter_mixin.py
+++ b/tests/collections/asr/mixins/adapters/test_asr_adapter_mixin.py
@@ -424,6 +424,7 @@ class TestASRAdapterMixin:
 
         with torch.no_grad():
             AccessMixin.reset_registry(model)
+            AccessMixin.update_access_cfg({'save_encoder_tensors': False})
             _ = model(input_signal=x, input_signal_length=x_len)
 
             # extract losses
@@ -432,3 +433,5 @@ class TestASRAdapterMixin:
             loss = list(auxiliary_losses.values())[0]
             assert 'adapter_loss' in loss
             assert loss['adapter_loss'][0] == torch.tensor(0.0)  # initially adapter is 0 init, no loss required.
+
+            AccessMixin.reset_registry(model)

--- a/tests/collections/asr/mixins/adapters/test_asr_adapter_mixin.py
+++ b/tests/collections/asr/mixins/adapters/test_asr_adapter_mixin.py
@@ -18,6 +18,7 @@ from omegaconf import DictConfig, ListConfig, OmegaConf
 
 from nemo.collections.asr.models import ASRModel, EncDecCTCModel, EncDecRNNTModel
 from nemo.collections.common.parts import adapter_modules
+from nemo.core.classes.mixins.access_mixins import AccessMixin
 from nemo.core.classes.mixins.adapter_mixins import AdapterModuleMixin, get_registered_adapter
 from nemo.core.utils import numba_utils
 from nemo.core.utils.numba_utils import __NUMBA_MINIMUM_VERSION__
@@ -405,3 +406,29 @@ class TestASRAdapterMixin:
         model.freeze()
         model.unfreeze_enabled_adapters()
         assert model.num_weights < 1e5
+
+    @pytest.mark.unit
+    def test_asr_model_adapter_loss(self, model):
+        original_num_params = model.num_weights
+        x = torch.randn(2, 512)
+        x_len = torch.tensor([256, 512], dtype=torch.int32)
+
+        adapter_cfg = get_adapter_cfg()  # type: adapter_modules.LinearAdapterConfig
+        adapter_cfg.adapter_strategy.l2_lambda = 0.01
+
+        model.add_adapter(name='adapter_0', cfg=adapter_cfg)
+        new_num_params = model.num_weights
+        assert new_num_params > original_num_params
+
+        model.train()  # set training mode to true
+
+        with torch.no_grad():
+            _ = model(input_signal=x, input_signal_length=x_len)
+
+            # extract losses
+            auxiliary_losses = AccessMixin.get_module_registry(model)
+
+            assert len(auxiliary_losses) == 1  # 1 layer
+            loss = list(auxiliary_losses.values())[0]
+            assert 'adapter_loss' in loss
+            assert loss['adapter_loss'][0] == torch.tensor(0.0)  # initially adapter is 0 init, no loss required.

--- a/tests/core/mixins/adapters/test_adapter_strategy.py
+++ b/tests/core/mixins/adapters/test_adapter_strategy.py
@@ -16,7 +16,7 @@ import pytest
 import torch
 
 from nemo.core import NeuralModule
-from nemo.core.classes.mixins import AdapterModuleMixin, adapter_mixin_strategies, adapter_mixins
+from nemo.core.classes.mixins import AdapterModuleMixin, access_mixins, adapter_mixin_strategies, adapter_mixins
 from nemo.utils import config_utils
 
 
@@ -152,3 +152,32 @@ class TestAdapterStrategy:
             else:
                 check = module_out
             assert (out - check).abs().mean() < 1e-5
+
+    @pytest.mark.unit
+    def test_strategy_l2_lambda(self):
+        torch.random.manual_seed(0)
+        x = torch.randn(2, 50)
+
+        module = DefaultModuleAdapter()
+        module.add_adapter(name='temp', cfg=get_adapter_cfg())
+        module.train()
+        adapter = module.adapter_layer[module.get_enabled_adapters()[0]]
+
+        # update the strategy
+        adapter_strategy = adapter_mixin_strategies.ResidualAddAdapterStrategy(l2_lambda=0.01)
+        adapter.adapter_strategy = adapter_strategy
+
+        with torch.no_grad():
+            access_mixins.AccessMixin.reset_registry(module)
+
+            assert adapter_strategy.stochastic_depth == 0.0
+            assert adapter_strategy.l2_lambda > 0.0
+
+            out = adapter_strategy.forward(x, adapter, module=module)
+            assert (out - x).abs().mean() < 1e-5
+
+            # extract losses
+            auxiliary_losses = access_mixins.AccessMixin.get_module_registry(module)
+            loss = list(auxiliary_losses.values())[0]
+            assert 'adapter_loss' in loss
+            assert loss['adapter_loss'][0] == torch.tensor(0.0)  # initially adapter is 0 init, no loss required.

--- a/tests/core/mixins/adapters/test_adapter_strategy.py
+++ b/tests/core/mixins/adapters/test_adapter_strategy.py
@@ -169,6 +169,7 @@ class TestAdapterStrategy:
 
         with torch.no_grad():
             access_mixins.AccessMixin.reset_registry(module)
+            assert access_mixins.AccessMixin.is_access_enabled() is False
 
             assert adapter_strategy.stochastic_depth == 0.0
             assert adapter_strategy.l2_lambda > 0.0
@@ -177,6 +178,7 @@ class TestAdapterStrategy:
             assert (out - x).abs().mean() < 1e-5
 
             # extract losses
+            assert access_mixins.AccessMixin.is_access_enabled() is True
             auxiliary_losses = access_mixins.AccessMixin.get_module_registry(module)
             loss = list(auxiliary_losses.values())[0]
             assert 'adapter_loss' in loss


### PR DESCRIPTION
# What does this PR do ?

Add support for auxiliary regularization losses to ASR adapters.

**Collection**: [ASR]

# Changelog 
- Add support for access mixin to all adapter modules
- Add utility methods for gathering the loss from auxiliary models
- Add tests for adapter modules

# Usage

```python

# Currently, setting the config value of `l2_lambda` for the Adapter strategy adds auxiliary losses.
python train_adapters.py \
  ... \
  model.adapter.adapter_strategy.l2_lambda=0.001
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

