### PR TITLE
Add silence handling for speaker diarization pipeline

### DIFF
--- a/nemo/collections/asr/models/clustering_diarizer.py
+++ b/nemo/collections/asr/models/clustering_diarizer.py
@@ -266,7 +266,7 @@ class ClusteringDiarizer(Model, DiarizationMixin):
                 AUDIO_VAD_RTTM_MAP[key] = deepcopy(self.AUDIO_RTTM_MAP[key])
                 AUDIO_VAD_RTTM_MAP[key]['rttm_filepath'] = os.path.join(table_out_dir, key + ".txt")
             else:
-                logging.warning(f"no .frame file found for {key} due to zero or negative duration")
+                logging.warning(f"no vad file found for {key} due to zero or negative duration")
 
         write_rttm2manifest(AUDIO_VAD_RTTM_MAP, self._vad_out_file)
         self._speaker_manifest_path = self._vad_out_file

--- a/nemo/collections/asr/models/clustering_diarizer.py
+++ b/nemo/collections/asr/models/clustering_diarizer.py
@@ -266,9 +266,7 @@ class ClusteringDiarizer(Model, DiarizationMixin):
                 AUDIO_VAD_RTTM_MAP[key] = deepcopy(self.AUDIO_RTTM_MAP[key])
                 AUDIO_VAD_RTTM_MAP[key]['rttm_filepath'] = os.path.join(table_out_dir, key + ".txt")
             else:
-                logging.warning(
-                    f"Ignoring uniq_id: {key} for diarization, since no .frame file found for it due to zero or negative duration"
-                )
+                logging.warning(f"no .frame file found for {key} due to zero or negative duration")
 
         write_rttm2manifest(AUDIO_VAD_RTTM_MAP, self._vad_out_file)
         self._speaker_manifest_path = self._vad_out_file

--- a/nemo/collections/asr/models/clustering_diarizer.py
+++ b/nemo/collections/asr/models/clustering_diarizer.py
@@ -259,9 +259,16 @@ class ClusteringDiarizer(Model, DiarizationMixin):
             shift_length_in_sec=self._vad_shift_length_in_sec,
             num_workers=self._cfg.num_workers,
         )
-        AUDIO_VAD_RTTM_MAP = deepcopy(self.AUDIO_RTTM_MAP.copy())
-        for key in AUDIO_VAD_RTTM_MAP:
-            AUDIO_VAD_RTTM_MAP[key]['rttm_filepath'] = os.path.join(table_out_dir, key + ".txt")
+
+        AUDIO_VAD_RTTM_MAP = {}
+        for key in self.AUDIO_RTTM_MAP:
+            if os.path.exists(os.path.join(table_out_dir, key + ".txt")):
+                AUDIO_VAD_RTTM_MAP[key] = deepcopy(self.AUDIO_RTTM_MAP[key])
+                AUDIO_VAD_RTTM_MAP[key]['rttm_filepath'] = os.path.join(table_out_dir, key + ".txt")
+            else:
+                logging.warning(
+                    f"Ignoring uniq_id: {key} for diarization, since no .frame file found for it due to zero or negative duration"
+                )
 
         write_rttm2manifest(AUDIO_VAD_RTTM_MAP, self._vad_out_file)
         self._speaker_manifest_path = self._vad_out_file

--- a/nemo/collections/asr/models/clustering_diarizer.py
+++ b/nemo/collections/asr/models/clustering_diarizer.py
@@ -37,6 +37,7 @@ from nemo.collections.asr.parts.utils.speaker_utils import (
     perform_clustering,
     score_labels,
     segments_manifest_to_subsegments_manifest,
+    validate_vad_manifest,
     write_rttm2manifest,
 )
 from nemo.collections.asr.parts.utils.vad_utils import (
@@ -314,8 +315,9 @@ class ClusteringDiarizer(Model, DiarizationMixin):
             self._speaker_manifest_path = write_rttm2manifest(self.AUDIO_RTTM_MAP, self._speaker_manifest_path)
         else:
             raise ValueError(
-                "Only one of diarizer.oracle_vad, vad.model_path or vad.external_vad_manifest must be passed"
+                "Only one of diarizer.oracle_vad, vad.model_path or vad.external_vad_manifest must be passed from config"
             )
+        validate_vad_manifest(self.AUDIO_RTTM_MAP, vad_manifest=self._speaker_manifest_path)
 
     def _extract_embeddings(self, manifest_file: str):
         """

--- a/nemo/collections/asr/parts/utils/speaker_utils.py
+++ b/nemo/collections/asr/parts/utils/speaker_utils.py
@@ -615,8 +615,9 @@ def isOverlap(rangeA, rangeB):
 
 def validate_vad_manifest(AUDIO_RTTM_MAP, vad_manifest):
     """
-    This function will validate the manifest file from NeMo voice activity detection or Oracle VAD to the uniq_ids present 
-    in provided audio manifest file. If there is a mis-match we ignore those uniq_ids from clustering.
+    This function will check the valid speech segments in the manifest file which is either generated from NeMo voice activity detection
+    (VAD) or oracle VAD. If the audio file does not contain any valid speech segments, 
+    we ignore the audio files (indexed by uniq_id) for the rest of the processing steps.
     """
     vad_uniq_ids = set()
     with open(vad_manifest, 'r') as vad_file:
@@ -630,7 +631,7 @@ def validate_vad_manifest(AUDIO_RTTM_MAP, vad_manifest):
     silence_ids = provided_uniq_ids - vad_uniq_ids
     for uniq_id in silence_ids:
         del AUDIO_RTTM_MAP[uniq_id]
-        logging.warning(f"{uniq_id} ignored due to silence detected in the session.")
+        logging.warning(f"{uniq_id} is ignored since the file does not contain any speech signal to be processed.")
 
     if len(AUDIO_RTTM_MAP) == 0:
         raise ValueError("All files present in manifest contains silence, aborting next steps")

--- a/nemo/collections/asr/parts/utils/speaker_utils.py
+++ b/nemo/collections/asr/parts/utils/speaker_utils.py
@@ -630,7 +630,10 @@ def validate_vad_manifest(AUDIO_RTTM_MAP, vad_manifest):
     silence_ids = provided_uniq_ids - vad_uniq_ids
     for uniq_id in silence_ids:
         del AUDIO_RTTM_MAP[uniq_id]
-        logging.warning(f"{uniq_id} ignored due to silence detected in uniq_id")
+        logging.warning(f"{uniq_id} ignored due to silence detected in the session.")
+
+    if len(AUDIO_RTTM_MAP) == 0:
+        raise ValueError("All files present in manifest contains silence, aborting next steps")
 
 
 def getOverlapRange(rangeA, rangeB):
@@ -760,15 +763,6 @@ def getMergedRanges(label_list_A: List, label_list_B: List, deci: int = 3) -> Li
         label_list_B = [[fl2int(x[0] + 1, deci), fl2int(x[1], deci)] for x in label_list_B]
         combined = combine_int_overlaps(label_list_A + label_list_B)
         return [[int2fl(x[0] - 1, deci), int2fl(x[1], deci)] for x in combined]
-
-
-def getMinMaxOfRangeList(ranges):
-    """
-    Get the min and max of a given range list.
-    """
-    _max = max([x[1] for x in ranges])
-    _min = min([x[0] for x in ranges])
-    return _min, _max
 
 
 def getSubRangeList(target_range, source_range_list) -> List:

--- a/nemo/collections/asr/parts/utils/speaker_utils.py
+++ b/nemo/collections/asr/parts/utils/speaker_utils.py
@@ -615,9 +615,10 @@ def isOverlap(rangeA, rangeB):
 
 def validate_vad_manifest(AUDIO_RTTM_MAP, vad_manifest):
     """
-    This function will check the valid speech segments in the manifest file which is either generated from NeMo voice activity detection
-    (VAD) or oracle VAD. If the audio file does not contain any valid speech segments, 
-    we ignore the audio files (indexed by uniq_id) for the rest of the processing steps.
+    This function will check the valid speech segments in the manifest file which is either 
+    generated from NeMo voice activity detection(VAD) or oracle VAD. 
+    If an audio file does not contain any valid speech segments, we ignore the audio file 
+    (indexed by uniq_id) for the rest of the processing steps.
     """
     vad_uniq_ids = set()
     with open(vad_manifest, 'r') as vad_file:

--- a/scripts/speaker_tasks/pathfiles_to_diarize_manifest.py
+++ b/scripts/speaker_tasks/pathfiles_to_diarize_manifest.py
@@ -126,7 +126,7 @@ def main(
 
         duration = None
         if add_duration:
-            y, sr = librosa.get_duration(filename=audio_line, sr=None)
+            y, sr = librosa.load(audio_line, sr=None)
             duration = librosa.get_duration(y=y, sr=sr)
         meta = [
             {


### PR DESCRIPTION
Signed-off-by: nithinraok <nithinrao.koluguri@gmail.com>

# What does this PR do ?

Provides fix for handling silence wav files for diarization

**Collection**: [ASR - Speaker Diarization]

# Changelog 
- Added `validate_vad_manifest` function to compare the uniq_ids in vad manifest file to manifest file provided by user for diarization
- Fixed an issue to check for a VAD `.frame` file, even if the duration of that audio is <=0. 

# Usage

```bash
python offline_diarization.py
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
