### PR TITLE
r1.10.0 untie embeddings weights

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2899,7 +2899,9 @@ pipeline {
         model.transformer_block_type='pre_ln' \
         model.data.data_prefix=[.5,/home/TestData/nlp/megatron_t5/data/pile_val_small_bert_tokenizer_text_document,.5,/home/TestData/nlp/megatron_t5/data/pile_val_small_bert_tokenizer_text_document] \
         model.position_embedding_type=relative \
-        model.data.index_mapping_dir=examples/nlp/language_modeling/t5_index_mappings"
+        model.data.index_mapping_dir=examples/nlp/language_modeling/t5_index_mappings \
+        model.share_word_embeddings=False \
+        model.share_decoder_tokens_head_embeddings=False"
         sh "python examples/nlp/language_modeling/megatron_t5_pretraining.py \
         trainer.devices=2 \
         trainer.accelerator=gpu \
@@ -2924,7 +2926,9 @@ pipeline {
         model.transformer_block_type='pre_ln' \
         model.data.data_prefix=[.5,/home/TestData/nlp/megatron_t5/data/pile_val_small_bert_tokenizer_text_document,.5,/home/TestData/nlp/megatron_t5/data/pile_val_small_bert_tokenizer_text_document] \
         model.position_embedding_type=relative \
-        model.data.index_mapping_dir=examples/nlp/language_modeling/t5_index_mappings"
+        model.data.index_mapping_dir=examples/nlp/language_modeling/t5_index_mappings \
+        model.share_word_embeddings=False \
+        model.share_decoder_tokens_head_embeddings=False"
         sh "rm -rf examples/nlp/language_modeling/t5_pretrain_results"
         sh "rm -rf examples/nlp/language_modeling/t5_index_mappings"
       }

--- a/examples/nlp/language_modeling/conf/megatron_bart_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_bart_config.yaml
@@ -83,6 +83,8 @@ model:
   transformer_block_type: 'pre_ln' # Options ['pre_ln', 'post_ln', 'normformer']
   hidden_steps: 32 # Number of latent vectors to use for pereceiver encoders
   num_self_attention_per_cross_attention: 1 # Number of self-attention layers for every cross-attention layer.
+  share_word_embeddings: True # If True share encoder/decoder embeddings
+  share_decoder_tokens_head_embeddings: True # If True share decoder embeddings and decoder projection to logits
 
   tokenizer:
     library: 'megatron'

--- a/examples/nlp/language_modeling/conf/megatron_bart_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_bart_config.yaml
@@ -83,7 +83,7 @@ model:
   transformer_block_type: 'pre_ln' # Options ['pre_ln', 'post_ln', 'normformer']
   hidden_steps: 32 # Number of latent vectors to use for pereceiver encoders
   num_self_attention_per_cross_attention: 1 # Number of self-attention layers for every cross-attention layer.
-  share_word_embeddings: True # If True share encoder/decoder embeddings
+  share_token_embeddings: True # If True share encoder/decoder embeddings
   share_decoder_tokens_head_embeddings: True # If True share decoder embeddings and decoder projection to logits
 
   tokenizer:

--- a/examples/nlp/language_modeling/conf/megatron_t5_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_t5_config.yaml
@@ -85,7 +85,7 @@ model:
   transformer_block_type: 'pre_ln' # Options ['pre_ln', 'post_ln', 'normformer']
   hidden_steps: 32 # Number of latent vectors to use for pereceiver encoders
   num_self_attention_per_cross_attention: 1 # Number of self-attention layers for every cross-attention layer.
-  share_word_embeddings: True # If True share encoder/decoder embeddings
+  share_token_embeddings: True # If True share encoder/decoder embeddings
   share_decoder_tokens_head_embeddings: True # If True share decoder embeddings and decoder projection to logits
 
   tokenizer:

--- a/examples/nlp/language_modeling/conf/megatron_t5_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_t5_config.yaml
@@ -85,6 +85,8 @@ model:
   transformer_block_type: 'pre_ln' # Options ['pre_ln', 'post_ln', 'normformer']
   hidden_steps: 32 # Number of latent vectors to use for pereceiver encoders
   num_self_attention_per_cross_attention: 1 # Number of self-attention layers for every cross-attention layer.
+  share_word_embeddings: True # If True share encoder/decoder embeddings
+  share_decoder_tokens_head_embeddings: True # If True share decoder embeddings and decoder projection to logits
 
   tokenizer:
     library: 'megatron'

--- a/examples/nlp/language_modeling/conf/megatron_ul2_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_ul2_config.yaml
@@ -82,7 +82,7 @@ model:
   transformer_block_type: 'pre_ln' # Options ['pre_ln', 'post_ln', 'normformer']
   hidden_steps: 32 # Number of latent vectors to use for pereceiver encoders
   num_self_attention_per_cross_attention: 1 # Number of self-attention layers for every cross-attention layer.
-  share_word_embeddings: True # If True share encoder/decoder embeddings
+  share_token_embeddings: True # If True share encoder/decoder embeddings
   share_decoder_tokens_head_embeddings: True # If True share decoder embeddings and decoder projection to logits
 
   tokenizer:

--- a/examples/nlp/language_modeling/conf/megatron_ul2_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_ul2_config.yaml
@@ -82,6 +82,8 @@ model:
   transformer_block_type: 'pre_ln' # Options ['pre_ln', 'post_ln', 'normformer']
   hidden_steps: 32 # Number of latent vectors to use for pereceiver encoders
   num_self_attention_per_cross_attention: 1 # Number of self-attention layers for every cross-attention layer.
+  share_word_embeddings: True # If True share encoder/decoder embeddings
+  share_decoder_tokens_head_embeddings: True # If True share decoder embeddings and decoder projection to logits
 
   tokenizer:
     library: 'megatron'

--- a/examples/nlp/machine_translation/conf/aayn_base_megatron.yaml
+++ b/examples/nlp/machine_translation/conf/aayn_base_megatron.yaml
@@ -93,6 +93,8 @@ model:
   transformer_block_type: 'pre_ln' # Options ['pre_ln', 'post_ln', 'normformer']
   hidden_steps: 32 # Number of latent vectors to use for pereceiver encoders
   num_self_attention_per_cross_attention: 1 # Number of self-attention layers for every cross-attention layer.
+  share_token_embeddings: True # If True share encoder/decoder embeddings
+  share_decoder_tokens_head_embeddings: True # If True share decoder embeddings and decoder projection to logits
 
   # precision
   native_amp_init_scale: 4294967296 # 2 ** 32

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -312,7 +312,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         if parallel_state.get_pipeline_model_parallel_world_size() > 1 and (
             parallel_state.is_pipeline_first_stage() or parallel_state.is_pipeline_last_stage()
         ):
-            if self.model.share_word_embeddings:
+            if self.model.share_token_embeddings:
                 word_embeddings_weight = self.model.word_embeddings_weight()
                 if self.megatron_amp_o2:
                     # O2 recipe stores a "main" copy of weights and grads

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -80,6 +80,11 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
                 raise ValueError(
                     f"pipeline_model_parallel_split_rank must be > 0 when using pipeline_model_parallel_size > 1"
                 )
+        if cfg.get('pipeline_model_parallel_size', 1) > 1:
+            if not cfg.get('share_word_embeddings', True) or not cfg.get('share_decoder_tokens_head_embeddings', True):
+                raise ValueError(
+                    "when pipeline_model_parallel_size > 1 we require share_word_embeddings=True and share_decoder_tokens_head_embeddings=True"
+                )
 
         # Make sure trainer.accumulate_grad_batches is 1.
         self._validate_trainer()
@@ -171,6 +176,8 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
             num_self_attention_per_cross_attention=self.cfg.get('num_self_attention_per_cross_attention', 1),
             add_encoder=add_encoder,
             add_decoder=add_decoder,
+            share_word_embeddings=self.cfg.get('share_word_embeddings', True),
+            share_decoder_tokens_head_embeddings=self.cfg.get('share_decoder_tokens_head_embeddings', True),
         )
         return model
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -81,9 +81,9 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
                     f"pipeline_model_parallel_split_rank must be > 0 when using pipeline_model_parallel_size > 1"
                 )
         if cfg.get('pipeline_model_parallel_size', 1) > 1:
-            if not cfg.get('share_word_embeddings', True) or not cfg.get('share_decoder_tokens_head_embeddings', True):
+            if not cfg.get('share_token_embeddings', True) or not cfg.get('share_decoder_tokens_head_embeddings', True):
                 raise ValueError(
-                    "when pipeline_model_parallel_size > 1 we require share_word_embeddings=True and share_decoder_tokens_head_embeddings=True"
+                    "when pipeline_model_parallel_size > 1 we require share_token_embeddings=True and share_decoder_tokens_head_embeddings=True"
                 )
 
         # Make sure trainer.accumulate_grad_batches is 1.
@@ -176,7 +176,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
             num_self_attention_per_cross_attention=self.cfg.get('num_self_attention_per_cross_attention', 1),
             add_encoder=add_encoder,
             add_decoder=add_decoder,
-            share_word_embeddings=self.cfg.get('share_word_embeddings', True),
+            share_token_embeddings=self.cfg.get('share_token_embeddings', True),
             share_decoder_tokens_head_embeddings=self.cfg.get('share_decoder_tokens_head_embeddings', True),
         )
         return model
@@ -396,7 +396,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
         if parallel_state.get_pipeline_model_parallel_world_size() > 1 and (
             parallel_state.is_rank_in_embedding_group()
         ):
-            if self.enc_dec_model.share_word_embeddings:
+            if self.enc_dec_model.share_token_embeddings:
                 word_embeddings_weight = self.enc_dec_model.word_embeddings_weight()
                 if self.megatron_amp_o2:
                     # O2 recipe stores a "main" copy of weights and grads

--- a/nemo/collections/nlp/modules/common/megatron/module.py
+++ b/nemo/collections/nlp/modules/common/megatron/module.py
@@ -43,14 +43,14 @@ class MegatronModule(torch.nn.Module):
     """Megatron specific extensions of torch Module with support
     for pipelining."""
 
-    def __init__(self, share_word_embeddings=True):
+    def __init__(self, share_token_embeddings=True):
         if not HAVE_APEX:
             raise ImportError(
                 "Apex was not found. Please see the NeMo README for installation instructions: https://github.com/NVIDIA/NeMo#megatron-gpt."
             )
         super(MegatronModule, self).__init__()
 
-        self.share_word_embeddings = share_word_embeddings
+        self.share_token_embeddings = share_token_embeddings
 
     def word_embeddings_weight(self):
         if self.pre_process:
@@ -66,9 +66,9 @@ class MegatronModule(torch.nn.Module):
                 )
         else:
             # This is the pipeline parallel last stage.
-            if not self.share_word_embeddings:
+            if not self.share_token_embeddings:
                 raise Exception(
-                    'word_embeddings_weight() called for last ' 'stage, but share_word_embeddings is false'
+                    'word_embeddings_weight() called for last ' 'stage, but share_token_embeddings is false'
                 )
             return self.word_embeddings.weight
 
@@ -89,8 +89,8 @@ class MegatronModule(torch.nn.Module):
             raise ValueError(f"Pre_process is False, there is no position embedding on this rank.")
 
     def initialize_word_embeddings(self, init_method, vocab_size, hidden_size):
-        if not self.share_word_embeddings:
-            raise Exception('initialize_word_embeddings() was called but ' 'share_word_embeddings is false')
+        if not self.share_token_embeddings:
+            raise Exception('initialize_word_embeddings() was called but ' 'share_token_embeddings is false')
 
         # This function just initializes the word embeddings in the final stage
         # when we are using pipeline parallelism. If we aren't using pipeline
@@ -264,9 +264,9 @@ class Float16Module(MegatronModule):
                 )
         else:
             # This is the pipeline parallel last stage.
-            if not self.share_word_embeddings:
+            if not self.share_token_embeddings:
                 raise Exception(
-                    'word_embeddings_weight() called for last ' 'stage, but share_word_embeddings is false'
+                    'word_embeddings_weight() called for last ' 'stage, but share_token_embeddings is false'
                 )
             return self.module.word_embeddings.weight
 

--- a/nemo/collections/nlp/modules/common/megatron/token_level_encoder_decoder.py
+++ b/nemo/collections/nlp/modules/common/megatron/token_level_encoder_decoder.py
@@ -202,6 +202,7 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
         if add_decoder:
             # If this is the decoder first stage
             if pre_process:
+                # FIXME: support untying weights
                 # If the encoder also lies on this rank (PP = 1), then just assign embeddings directly.
                 if hasattr(self, 'encoder_embedding'):
                     self.decoder_embedding = self.encoder_embedding

--- a/nemo/collections/nlp/modules/common/megatron/token_level_encoder_decoder.py
+++ b/nemo/collections/nlp/modules/common/megatron/token_level_encoder_decoder.py
@@ -115,6 +115,8 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
         add_encoder=True,
         add_decoder=True,
         num_self_attention_per_cross_attention=1,
+        share_word_embeddings=True,
+        share_decoder_tokens_head_embeddings=True,
     ):
         super(MegatronTokenLevelEncoderDecoderModule, self).__init__()
 
@@ -129,6 +131,8 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
         self.position_embedding_type = position_embedding_type
         self.relative_attention_num_buckets = relative_attention_num_buckets
         self.relative_attention_max_distance = relative_attention_max_distance
+        self.share_word_embeddings = share_word_embeddings
+        self.share_decoder_tokens_head_embeddings = share_decoder_tokens_head_embeddings
 
         if self.position_embedding_type == 'learned_absolute':
             add_position_embedding = True
@@ -202,9 +206,8 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
         if add_decoder:
             # If this is the decoder first stage
             if pre_process:
-                # FIXME: support untying weights
                 # If the encoder also lies on this rank (PP = 1), then just assign embeddings directly.
-                if hasattr(self, 'encoder_embedding'):
+                if hasattr(self, 'encoder_embedding') and share_word_embeddings:
                     self.decoder_embedding = self.encoder_embedding
                 else:
                     # This is the case where PP > 1 and first decoder first stage.
@@ -220,7 +223,8 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
                         embedding_dropout_prob=hidden_dropout,
                         add_position_embedding=add_position_embedding,
                     )
-                    self.decoder_embedding.zero_parameters()
+                    if share_word_embeddings:
+                        self.decoder_embedding.zero_parameters()
 
                 self._decoder_embedding_key = "decoder_embedding"
 
@@ -274,7 +278,18 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
         )
 
         if add_decoder and post_process:
-            self.tokens_head = MegatronTokenLevelHead(self.word_embeddings_weight().size(0), parallel_output)
+            if not share_decoder_tokens_head_embeddings:
+                self.tokens_head = tensor_parallel.ColumnParallelLinear(
+                    input_size=hidden_size,
+                    output_size=vocab_size,
+                    bias=False,
+                    gather_output=not self.parallel_output,
+                    init_method=init_method_normal(init_method_std),
+                    use_cpu_initialization=use_cpu_initialization,
+                )
+            else:
+                self.tokens_head = MegatronTokenLevelHead(self.word_embeddings_weight().size(0), parallel_output)
+
             self._tokens_head_key = 'tokens_head'
 
     def set_input_tensor(self, input_tensor):
@@ -368,7 +383,10 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
             if self.post_process and self.add_decoder:
                 dec_output, enc_output = output
                 # project decoder output to vocabulary-size dimensions
-                token_logits = self.tokens_head(dec_output, self.word_embeddings_weight())
+                if self.share_decoder_tokens_head_embeddings:
+                    token_logits = self.tokens_head(dec_output, self.word_embeddings_weight())
+                else:
+                    token_logits = self.tokens_head(dec_output)
 
                 if labels is not None:
                     # tensor_parallel.vocab_parallel_cross_entropy performs log_softmax and return log p(x_i|z) per token i
@@ -406,6 +424,7 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
         state_dict_[self._tokens_head_key] = self.tokens_head.state_dict_for_save_checkpoint(
             destination, prefix, keep_vars
         )
+
         return state_dict_
 
     def load_state_dict(self, state_dict, strict=True):

--- a/nemo/collections/nlp/modules/common/megatron/token_level_encoder_decoder.py
+++ b/nemo/collections/nlp/modules/common/megatron/token_level_encoder_decoder.py
@@ -115,7 +115,7 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
         add_encoder=True,
         add_decoder=True,
         num_self_attention_per_cross_attention=1,
-        share_word_embeddings=True,
+        share_token_embeddings=True,
         share_decoder_tokens_head_embeddings=True,
     ):
         super(MegatronTokenLevelEncoderDecoderModule, self).__init__()
@@ -131,7 +131,7 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
         self.position_embedding_type = position_embedding_type
         self.relative_attention_num_buckets = relative_attention_num_buckets
         self.relative_attention_max_distance = relative_attention_max_distance
-        self.share_word_embeddings = share_word_embeddings
+        self.share_token_embeddings = share_token_embeddings
         self.share_decoder_tokens_head_embeddings = share_decoder_tokens_head_embeddings
 
         if self.position_embedding_type == 'learned_absolute':
@@ -207,7 +207,7 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
             # If this is the decoder first stage
             if pre_process:
                 # If the encoder also lies on this rank (PP = 1), then just assign embeddings directly.
-                if hasattr(self, 'encoder_embedding') and share_word_embeddings:
+                if hasattr(self, 'encoder_embedding') and share_token_embeddings:
                     self.decoder_embedding = self.encoder_embedding
                 else:
                     # This is the case where PP > 1 and first decoder first stage, or when not sharing embeddings with encoder
@@ -223,7 +223,7 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
                     )
                     # We initialize decoder embeddings, but set them to zero since we they're tied with the encoder embeddings.
                     # A later initialize_embedding call will synchronize the embeddings.
-                    if share_word_embeddings:
+                    if share_token_embeddings:
                         self.decoder_embedding.zero_parameters()
 
                 self._decoder_embedding_key = "decoder_embedding"
@@ -274,7 +274,7 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
         self._enc_dec_model_key = "enc_dec_model"
 
         # NOTE: Update here when adding support in PP > 1 (function has to be called)
-        if self.share_word_embeddings:
+        if self.share_token_embeddings:
             self.initialize_word_embeddings(
                 init_method=init_method_normal(init_method_std), vocab_size=vocab_size, hidden_size=hidden_size
             )


### PR DESCRIPTION
# What does this PR do ?

This PR adds the config option to prevent weights tying between encoder embeddings, decoder embeddings, and decoder tokens head.
This PR does not support PP, only TP.
## Added configs

```
model:
  share_word_embeddings: True # If True share encoder/decoder embeddings
  share_decoder_tokens_head_embeddings: True # If True share decoder embeddings and decoder projection to logits
```

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
