### PR TITLE
[Fix] Relative Audio Path

### DIFF
--- a/nemo/collections/common/parts/preprocessing/manifest.py
+++ b/nemo/collections/common/parts/preprocessing/manifest.py
@@ -95,7 +95,7 @@ def __parse_item(line: str, manifest_file: str) -> Dict[str, Any]:
     # Assume that the audio path is like "wavs/xxxxxx.wav".
     manifest_dir = Path(manifest_file).parent
     audio_file = Path(item['audio_file'])
-    if not audio_file.is_file() and not audio_file.is_absolute():
+    if (len(str(audio_file)) < 255) and not audio_file.is_file() and not audio_file.is_absolute():
         # assume the "wavs/" dir and manifest are under the same parent dir
         audio_file = manifest_dir / audio_file
         if audio_file.is_file():


### PR DESCRIPTION
Fix the too long audio filenames for tarred datasets. If the audio filename is too long, just keep it as it is.