### PR TITLE
A new fused softmax kernel function

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/fused_kernels/__init__.py
+++ b/nemo/collections/nlp/modules/common/megatron/fused_kernels/__init__.py
@@ -31,8 +31,7 @@ def load():
 
     # Check if cuda 11 is installed for compute capability 8.0
     cc_flag = []
-    _, bare_metal_major, _ = _get_cuda_bare_metal_version(
-        cpp_extension.CUDA_HOME)
+    _, bare_metal_major, _ = _get_cuda_bare_metal_version(cpp_extension.CUDA_HOME)
     if int(bare_metal_major) >= 11:
         cc_flag.append('-gencode')
         cc_flag.append('arch=compute_80,code=sm_80')
@@ -50,27 +49,28 @@ def load():
             sources=sources,
             build_directory=buildpath,
             extra_cflags=['-O3',],
-            extra_cuda_cflags=['-O3',
-                               '-gencode', 'arch=compute_70,code=sm_70',
-                               '--use_fast_math'] + extra_cuda_flags + cc_flag,
-            verbose=True
+            extra_cuda_cflags=['-O3', '-gencode', 'arch=compute_70,code=sm_70', '--use_fast_math']
+            + extra_cuda_flags
+            + cc_flag,
+            verbose=True,
         )
 
-    extra_cuda_flags = ['-U__CUDA_NO_HALF_OPERATORS__',
-                        '-U__CUDA_NO_HALF_CONVERSIONS__',
-                        '--expt-relaxed-constexpr',
-                        '--expt-extended-lambda']
-    
+    extra_cuda_flags = [
+        '-U__CUDA_NO_HALF_OPERATORS__',
+        '-U__CUDA_NO_HALF_CONVERSIONS__',
+        '--expt-relaxed-constexpr',
+        '--expt-extended-lambda',
+    ]
+
     # Masked softmax.
-    sources=[srcpath / 'scaled_masked_softmax.cpp',
-             srcpath / 'scaled_masked_softmax_cuda.cu']
+    sources = [srcpath / 'scaled_masked_softmax.cpp', srcpath / 'scaled_masked_softmax_cuda.cu']
     scaled_masked_softmax_cuda = _cpp_extention_load_helper(
-        "scaled_masked_softmax_cuda_new", sources, extra_cuda_flags)
+        "scaled_masked_softmax_cuda_new", sources, extra_cuda_flags
+    )
 
 
 def _get_cuda_bare_metal_version(cuda_dir):
-    raw_output = subprocess.check_output([cuda_dir + "/bin/nvcc", "-V"],
-                                         universal_newlines=True)
+    raw_output = subprocess.check_output([cuda_dir + "/bin/nvcc", "-V"], universal_newlines=True)
     output = raw_output.split()
     release_idx = output.index("release") + 1
     release = output[release_idx].split(".")
@@ -86,5 +86,6 @@ def _create_build_dir(buildpath):
     except OSError:
         if not os.path.isdir(buildpath):
             print(f"Creation of the build directory {buildpath} failed")
+
 
 load()

--- a/nemo/collections/nlp/modules/common/megatron/fused_kernels/__init__.py
+++ b/nemo/collections/nlp/modules/common/megatron/fused_kernels/__init__.py
@@ -1,0 +1,90 @@
+# coding=utf-8
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import pathlib
+import subprocess
+
+from torch.utils import cpp_extension
+
+# Setting this param to a list has a problem of generating different
+# compilation commands (with diferent order of architectures) and
+# leading to recompilation of fused kernels. Set it to empty string
+# to avoid recompilation and assign arch flags explicity in
+# extra_cuda_cflags below
+os.environ["TORCH_CUDA_ARCH_LIST"] = ""
+
+
+def load():
+
+    # Check if cuda 11 is installed for compute capability 8.0
+    cc_flag = []
+    _, bare_metal_major, _ = _get_cuda_bare_metal_version(
+        cpp_extension.CUDA_HOME)
+    if int(bare_metal_major) >= 11:
+        cc_flag.append('-gencode')
+        cc_flag.append('arch=compute_80,code=sm_80')
+
+    # Build path
+    srcpath = pathlib.Path(__file__).parent.absolute()
+    buildpath = srcpath / 'build'
+    buildpath = '/tmp/'
+    _create_build_dir(buildpath)
+
+    # Helper function to build the kernels.
+    def _cpp_extention_load_helper(name, sources, extra_cuda_flags):
+        return cpp_extension.load(
+            name=name,
+            sources=sources,
+            build_directory=buildpath,
+            extra_cflags=['-O3',],
+            extra_cuda_cflags=['-O3',
+                               '-gencode', 'arch=compute_70,code=sm_70',
+                               '--use_fast_math'] + extra_cuda_flags + cc_flag,
+            verbose=True
+        )
+
+    extra_cuda_flags = ['-U__CUDA_NO_HALF_OPERATORS__',
+                        '-U__CUDA_NO_HALF_CONVERSIONS__',
+                        '--expt-relaxed-constexpr',
+                        '--expt-extended-lambda']
+    
+    # Masked softmax.
+    sources=[srcpath / 'scaled_masked_softmax.cpp',
+             srcpath / 'scaled_masked_softmax_cuda.cu']
+    scaled_masked_softmax_cuda = _cpp_extention_load_helper(
+        "scaled_masked_softmax_cuda_new", sources, extra_cuda_flags)
+
+
+def _get_cuda_bare_metal_version(cuda_dir):
+    raw_output = subprocess.check_output([cuda_dir + "/bin/nvcc", "-V"],
+                                         universal_newlines=True)
+    output = raw_output.split()
+    release_idx = output.index("release") + 1
+    release = output[release_idx].split(".")
+    bare_metal_major = release[0]
+    bare_metal_minor = release[1][0]
+
+    return raw_output, bare_metal_major, bare_metal_minor
+
+
+def _create_build_dir(buildpath):
+    try:
+        os.mkdir(buildpath)
+    except OSError:
+        if not os.path.isdir(buildpath):
+            print(f"Creation of the build directory {buildpath} failed")
+
+load()

--- a/nemo/collections/nlp/modules/common/megatron/fused_kernels/compat.h
+++ b/nemo/collections/nlp/modules/common/megatron/fused_kernels/compat.h
@@ -1,0 +1,31 @@
+/* coding=utf-8
+ * Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*This code is copied fron NVIDIA apex:
+ *     https://github.com/NVIDIA/apex
+ *     with minor changes. */
+
+
+
+#ifndef TORCH_CHECK
+#define TORCH_CHECK AT_CHECK
+#endif
+
+#ifdef VERSION_GE_1_3
+#define DATA_PTR data_ptr
+#else
+#define DATA_PTR data
+#endif

--- a/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax.cpp
+++ b/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax.cpp
@@ -1,0 +1,83 @@
+/* coding=utf-8
+ * Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <cuda_fp16.h>
+#include <torch/extension.h>
+#include <vector>
+
+namespace multihead_attn
+{
+  namespace fused_softmax
+  {
+    namespace scaled_masked_softmax
+    {
+
+      torch::Tensor fwd_cuda(
+          torch::Tensor const &input,
+          torch::Tensor const &mask,
+          float scale_factor);
+
+      torch::Tensor bwd_cuda(
+          torch::Tensor const &output_grads,
+          torch::Tensor const &softmax_results,
+          float scale_factor);
+
+      torch::Tensor fwd(
+          torch::Tensor const &input,
+          torch::Tensor const &mask,
+          float scale_factor)
+      {
+        AT_ASSERTM(input.dim() == 4, "expected 4D tensor");
+        AT_ASSERTM((input.scalar_type() == at::ScalarType::Half) ||
+                       (input.scalar_type() == at::ScalarType::BFloat16),
+                   "Only fp16 and bf16 are supported");
+        AT_ASSERTM(mask.dim() == 4, "expected 4D tensor");
+
+        return fwd_cuda(input, mask, scale_factor);
+      }
+
+      torch::Tensor bwd(
+          torch::Tensor const &output_grads,
+          torch::Tensor const &softmax_results,
+          float scale_factor)
+      {
+
+        AT_ASSERTM(output_grads.dim() == 4, "expected 3D tensor");
+        AT_ASSERTM(softmax_results.dim() == 4, "expected 3D tensor");
+
+        AT_ASSERTM((output_grads.scalar_type() == at::ScalarType::Half) ||
+                       (output_grads.scalar_type() == at::ScalarType::BFloat16),
+                   "Only fp16 and bf16 are supported");
+        AT_ASSERTM((softmax_results.scalar_type() == at::ScalarType::Half) ||
+                       (softmax_results.scalar_type() == at::ScalarType::BFloat16),
+                   "Only fp16 and bf16 are supported");
+
+        return bwd_cuda(output_grads, softmax_results, scale_factor);
+      }
+
+    } // end namespace scaled_masked_softmax
+  }   // end namespace fused_softmax
+} // end namespace multihead_attn
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("forward", 
+        &multihead_attn::fused_softmax::scaled_masked_softmax::fwd, 
+	"Self Multihead Attention scaled, time masked softmax -- Forward.");
+
+  m.def("backward",
+        &multihead_attn::fused_softmax::scaled_masked_softmax::bwd,
+	"Self Multihead Attention scaled, time masked softmax -- Backward.");
+}

--- a/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax.h
+++ b/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax.h
@@ -111,7 +111,7 @@ __global__ void scaled_masked_softmax_warp_backward_new(
             val = 0.0;
         }
         val = warp_reduce_new<acc_t, C10_WARP_SIZE, Add>(val);
-        if (lane==0) {
+        if (lane==0 && wid + warps_per_thread_block * i < (element_count - 1) / C10_WARP_SIZE + 1) {
             shared[wid + warps_per_thread_block*i] = val;
         }
         __syncthreads();
@@ -251,7 +251,7 @@ __global__ void scaled_masked_softmax_warp_forward_new(
 
         val = warp_reduce_new<acc_t, C10_WARP_SIZE, Max>(val);
 
-        if (lane==0) {
+        if (lane==0 && wid + warps_per_thread_block * i < (element_count - 1) / C10_WARP_SIZE + 1) {
             shared[wid + warps_per_thread_block*i] = val;
         }
         __syncthreads();
@@ -310,7 +310,7 @@ __global__ void scaled_masked_softmax_warp_forward_new(
             val = 0.0;
         }
         val = warp_reduce_new<acc_t, C10_WARP_SIZE, Add>(val);
-        if (lane==0) {
+        if (lane==0 && wid + warps_per_thread_block * i < (element_count - 1) / C10_WARP_SIZE + 1) {
             shared[wid + warps_per_thread_block*i] = val;
         }
         __syncthreads();

--- a/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax.h
+++ b/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax.h
@@ -1,0 +1,371 @@
+/* coding=utf-8
+ * Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <assert.h>
+#include <cuda_fp16.h>
+#include <cfloat>
+#include <limits>
+#include <stdint.h>
+#include <cuda_fp16.h>
+#include <c10/macros/Macros.h>
+#include <stdio.h>
+
+namespace {
+
+template<typename T>
+struct Add {
+  __device__ __forceinline__ T operator()(T a, T b) const {
+    return a + b;
+  }
+};
+
+template<typename T>
+struct Max {
+  __device__ __forceinline__ T operator()(T a, T b) const {
+    return a < b ? b : a;
+  }
+};
+
+template <typename T>
+__device__ __forceinline__ T WARP_SHFL_DOWN_NATIVE(T value, int laneMask, int width = warpSize, unsigned int mask = 0xffffffff)
+{
+#if CUDA_VERSION >= 9000
+    return __shfl_down_sync(mask, value, laneMask, width);
+#else
+    return __shfl_down(value, laneMask, width);
+#endif
+}
+
+template <typename acc_t, int WARP_SIZE, template<typename> class ReduceOp>
+__device__ __forceinline__ acc_t warp_reduce_new(acc_t val) {
+  ReduceOp<acc_t> r;
+  #pragma unroll
+  for (int offset = WARP_SIZE / 2; offset > 0; offset /= 2)
+  {
+      val = r(val, WARP_SHFL_DOWN_NATIVE(val, offset, WARP_SIZE));
+  }
+  return val;
+}
+
+
+template <typename input_t, typename output_t, typename acc_t, int log2_elements>
+__global__ void scaled_masked_softmax_warp_backward_new(
+    output_t *gradInput, //[batches, attn_heads, q_len, k_len]
+    input_t *grad, 
+    const input_t *output, //[batches, attn_heads, q_len, k_len]
+    acc_t scale, 
+    int element_count)
+{
+    int threads_per_block = blockDim.x; 
+    //the first element_count*2 elements are used for cache, the last 128 is used for reduction
+    extern __shared__ acc_t shared_data[];
+    input_t *local_data = (input_t *)shared_data;
+    input_t *output_data = &local_data[element_count];
+    // maximum shared cached 128, enough for 4096 elements reduction into 4096/32= 128 elements
+    acc_t *shared = (acc_t *)(&(local_data[element_count*2]));
+
+    int num_reductions =  (element_count - 1) / threads_per_block + 1;
+
+    int offset = blockIdx.x * element_count;
+
+    int local_idx = threadIdx.x;
+    int lane = threadIdx.x % C10_WARP_SIZE;
+    int wid = threadIdx.x / C10_WARP_SIZE;
+    int warps_per_thread_block = threads_per_block / C10_WARP_SIZE; 
+
+    // load the data to local data
+    acc_t val = 0.0;
+    for (int i = local_idx; i < element_count; i += threads_per_block)
+    {
+        val = output[offset + i];
+        output_data[i] = val;
+        local_data[i] = val * grad[offset + i];
+    }
+
+    // find the sum 
+    for (int i = local_idx; i < 128; i += threads_per_block){
+        shared[i] = 0.0;
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for (int i = 0; i < num_reductions; i++){
+        if (i*threads_per_block + local_idx < element_count){
+            val = local_data[i*threads_per_block + local_idx];
+        }
+        else{
+            val = 0.0;
+        }
+        val = warp_reduce_new<acc_t, C10_WARP_SIZE, Add>(val);
+        if (lane==0) {
+            shared[wid + warps_per_thread_block*i] = val;
+        }
+        __syncthreads();
+    }
+
+    // final shared reduction
+    if (local_idx < 128) {
+        val = shared[local_idx];
+        val = warp_reduce_new<acc_t, C10_WARP_SIZE, Add>(val);
+        if (lane==0) {
+            shared[wid] = val;
+        }
+    }
+
+    __syncthreads();
+
+    if (local_idx < C10_WARP_SIZE) {
+        val = shared[local_idx];
+        val = warp_reduce_new<acc_t, 4, Add>(val);
+        if (lane==0) {
+            shared[wid] = val;
+        }
+    }
+    __syncthreads();
+    val = shared[0];
+
+    //acc_t reduced_val = (shared[0] + shared[1]) + (shared[2] + shared[3]);
+
+    #pragma unroll
+    for (int i = local_idx; i < element_count; i += threads_per_block){
+        gradInput[offset + i] = (output_t)(scale*(local_data[i] - output_data[i]*val)); 
+    }
+}
+
+} // end of anonymous namespace
+
+template<typename input_t, typename output_t, typename acc_t>
+void dispatch_scaled_masked_softmax_backward_new(
+    output_t *grad_input, 
+    input_t *grad, 
+    const input_t *output, 
+    const acc_t scale, 
+    int query_seq_len, 
+    int key_seq_len, 
+    int batches,
+    int attn_heads)
+{
+    TORCH_INTERNAL_ASSERT(key_seq_len >= 0 && key_seq_len <= 4096);
+    if (key_seq_len == 0)
+    {
+        return;
+    }
+    else
+    {
+        int batch_count = batches * attn_heads * query_seq_len;
+        // use 128 threads per block to maximimize gpu utilization
+        constexpr int threads_per_block = 128;
+        dim3 blocks(batch_count, 1, 1);
+        dim3 threads(threads_per_block, 1, 1);
+
+        scaled_masked_softmax_warp_backward_new<input_t, output_t, acc_t, 12>
+            <<<blocks, threads, sizeof(input_t)*key_seq_len*2 + sizeof(acc_t)*128, at::cuda::getCurrentCUDAStream()>>>(grad_input, grad, output, scale, key_seq_len);
+    }
+}
+
+/*
+ * Extended softmax (from native aten pytorch) with following additional features
+ * 1) input scaling
+ * 2) Explicit masking
+ */	
+template <typename input_t, typename output_t, typename acc_t>
+__global__ void scaled_masked_softmax_warp_forward_new(
+    output_t *dst, 
+    const input_t *src,
+    const uint8_t *mask, 
+    const acc_t scale, 
+    int query_len,          // query_len
+    int attn_heads,
+    int element_count,      // key_len
+    int pad_batches)        // mask batch size 
+{
+    // min threawds_per_block has to be bigger than 128
+    int threads_per_block = blockDim.x; 
+    //  the first element_count is used for cache, the last 128 is used for reduction
+    extern __shared__ acc_t local_data[];
+    // maximum shared cached 128, enough for 4096 elements reduction into 4096/32= 128 elements
+    acc_t *shared = &(local_data[element_count]);
+    // number of 1024 threads reductions 
+    int num_reductions =  (element_count - 1) / threads_per_block + 1;
+
+    int offset = blockIdx.x * element_count;
+    int mask_offset;
+    int query_id = blockIdx.x % query_len; 
+    if (pad_batches == 1){
+        // broadcaste the mask tensor 
+        mask_offset = query_id * element_count; 
+    }
+    else{
+        int mask_batch_id = blockIdx.x / attn_heads / query_len;
+        mask_offset = (mask_batch_id * query_len + query_id) * element_count;
+    }
+
+    int local_idx = threadIdx.x;
+    int lane = threadIdx.x % C10_WARP_SIZE;
+    int wid = threadIdx.x / C10_WARP_SIZE;
+    int warps_per_thread_block = threads_per_block / C10_WARP_SIZE; 
+
+    // load the data to local data
+    for (int i = local_idx; i < element_count; i += threads_per_block)
+    {
+        // TODO, use the copy vector method
+        if (mask[mask_offset + i] == 1)
+        {
+            local_data[i] = -10000.0;
+        }
+        else
+        {
+            local_data[i] = src[offset + i] * scale;
+        }
+    }
+
+    // first find the max value
+    for (int i = local_idx; i < 128; i += threads_per_block){
+        shared[i] = -10000.0;
+    }
+    __syncthreads();
+    acc_t val = -10000.0;
+    #pragma unroll
+    for (int i = 0; i < num_reductions; i++){
+        if (i*threads_per_block + local_idx < element_count){
+            val = local_data[i*threads_per_block + local_idx];
+        }
+        else{
+            val = -10000.0;
+        }
+
+        val = warp_reduce_new<acc_t, C10_WARP_SIZE, Max>(val);
+
+        if (lane==0) {
+            shared[wid + warps_per_thread_block*i] = val;
+        }
+        __syncthreads();
+    }
+    // final shared reduction
+    if (local_idx < 128) {
+        val = shared[local_idx];
+        val = warp_reduce_new<acc_t, C10_WARP_SIZE, Max>(val);
+        if (lane==0) {
+            shared[wid] = val;
+        }
+    }
+    __syncthreads();
+
+    if (local_idx < C10_WARP_SIZE) {
+        val = shared[local_idx];
+        val = warp_reduce_new<acc_t, 4, Max>(val);
+        if (lane==0) {
+            shared[wid] = val;
+        }
+    }
+    __syncthreads();
+    acc_t reduced_val = shared[0];
+
+    if (reduced_val < -10000.0 + 0.1){
+        // if everything is masked, pay attention to nothing
+        #pragma unroll
+        for (int i = local_idx; i < element_count; i += threads_per_block){
+             dst[offset + i] = 0.0;
+        }
+        return;
+    }
+
+    // update the values
+    #pragma unroll
+    for (int i = local_idx; i < element_count; i += threads_per_block){
+        local_data[i] = std::exp(local_data[i] - reduced_val);
+    }
+
+    // find the sum 
+    for (int i = local_idx; i < 128; i += threads_per_block){
+        shared[i] = 0.0;
+    }
+    __syncthreads();
+
+    #pragma unroll
+    for (int i = 0; i < num_reductions; i++){
+        if (i*threads_per_block + local_idx < element_count){
+            val = local_data[i*threads_per_block + local_idx];
+        }
+        else{
+            val = 0.0;
+        }
+        val = warp_reduce_new<acc_t, C10_WARP_SIZE, Add>(val);
+        if (lane==0) {
+            shared[wid + warps_per_thread_block*i] = val;
+        }
+        __syncthreads();
+    }
+    // final shared reduction
+    if (local_idx < 128) {
+        val = shared[local_idx];
+        val = warp_reduce_new<acc_t, C10_WARP_SIZE, Add>(val);
+        if (lane==0) {
+            shared[wid] = val;
+        }
+    }
+
+    __syncthreads();
+
+    if (local_idx < C10_WARP_SIZE) {
+        val = shared[local_idx];
+        val = warp_reduce_new<acc_t, 4, Add>(val);
+        if (lane==0) {
+            shared[wid] = val;
+        }
+    }
+    __syncthreads();
+    reduced_val = shared[0];
+    //if (local_idx<32){
+    //    printf("bid %d, lid %d, offset %d, blocks %d, v: %f, mask_offset %d\n", blockIdx.x, local_idx, offset, gridDim.x, reduced_val, mask_offset);
+    //}
+
+    #pragma unroll
+    for (int i = local_idx; i < element_count; i += threads_per_block){
+         dst[offset + i] = local_data[i] / reduced_val;
+    }
+}
+
+
+template<typename input_t, typename output_t, typename acc_t>
+void dispatch_scaled_masked_softmax_forward_new(
+    output_t *dst, 
+    const input_t *src, 
+    const uint8_t *mask,
+    const input_t scale, 
+    int query_seq_len, 
+    int key_seq_len, 
+    int batches,
+    int attn_heads,
+    int pad_batches)
+{
+    TORCH_INTERNAL_ASSERT(key_seq_len >= 0 && key_seq_len <= 4096 );
+    if (key_seq_len == 0) {
+        return;
+    } else {
+        int batch_count = batches * attn_heads * query_seq_len;
+
+        // use 128 threads per block to maximimize gpu utilization
+        constexpr int threads_per_block = 128;
+
+        dim3 blocks(batch_count, 1, 1);
+        dim3 threads(threads_per_block, 1, 1);
+        scaled_masked_softmax_warp_forward_new<input_t, output_t, acc_t>
+            <<<blocks, threads, sizeof(acc_t) * (key_seq_len + 128), at::cuda::getCurrentCUDAStream()>>>(dst, src, mask, scale, query_seq_len, attn_heads, key_seq_len, pad_batches);
+    }
+}

--- a/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax.h
+++ b/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax.h
@@ -160,7 +160,6 @@ void dispatch_scaled_masked_softmax_backward_new(
     int batches,
     int attn_heads)
 {
-    TORCH_INTERNAL_ASSERT(key_seq_len >= 0 && key_seq_len <= 4096);
     if (key_seq_len == 0)
     {
         return;
@@ -359,7 +358,6 @@ void dispatch_scaled_masked_softmax_forward_new(
     int attn_heads,
     int pad_batches)
 {
-    TORCH_INTERNAL_ASSERT(key_seq_len >= 0);
     if (key_seq_len == 0) {
         return;
     } else {

--- a/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax.h
+++ b/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax.h
@@ -97,7 +97,7 @@ __global__ void scaled_masked_softmax_warp_backward_new(
     }
 
     // find the sum 
-    for (int i = local_idx; i < 128; i += threads_per_block){
+    for (int i = local_idx; i < (element_count - 1) / C10_WARP_SIZE + 1; i += threads_per_block){
         shared[i] = 0.0;
     }
     __syncthreads();
@@ -125,7 +125,7 @@ __global__ void scaled_masked_softmax_warp_backward_new(
         #pragma unroll
         for(int i = local_idx; i < num_warps * C10_WARP_SIZE; i += threads_per_block){
             if (i < shared_mem_len){
-                val = shared[local_idx];
+                val = shared[i];
             }
             else{
                 val = 0.0;
@@ -235,7 +235,7 @@ __global__ void scaled_masked_softmax_warp_forward_new(
     }
 
     // first find the max value
-    for (int i = local_idx; i < 128; i += threads_per_block){
+    for (int i = local_idx; i < (element_count - 1) / C10_WARP_SIZE + 1; i += threads_per_block){
         shared[i] = -10000.0;
     }
     __syncthreads();
@@ -264,7 +264,7 @@ __global__ void scaled_masked_softmax_warp_forward_new(
         #pragma unroll
         for(int i = local_idx; i < num_warps * C10_WARP_SIZE; i += threads_per_block){
             if (i < shared_mem_len){
-                val = shared[local_idx];
+                val = shared[i];
             }
             else{
                 val = -10000.0;
@@ -296,7 +296,7 @@ __global__ void scaled_masked_softmax_warp_forward_new(
     }
 
     // find the sum 
-    for (int i = local_idx; i < 128; i += threads_per_block){
+    for (int i = local_idx; i < (element_count - 1) / C10_WARP_SIZE + 1; i += threads_per_block){
         shared[i] = 0.0;
     }
     __syncthreads();
@@ -322,7 +322,7 @@ __global__ void scaled_masked_softmax_warp_forward_new(
         #pragma unroll
         for(int i = local_idx; i < num_warps * C10_WARP_SIZE; i += threads_per_block){
             if (i < shared_mem_len){
-                val = shared[local_idx];
+                val = shared[i];
             }
             else{
                 val = 0.0;

--- a/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax_cuda.cu
+++ b/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax_cuda.cu
@@ -39,8 +39,6 @@ torch::Tensor fwd_cuda(
   const int attn_heads = input.size(1);
   const int query_seq_len = input.size(2);
   const int key_seq_len = input.size(3);
-  TORCH_INTERNAL_ASSERT(key_seq_len <= 4096);
-  //TORCH_INTERNAL_ASSERT(query_seq_len > 1);
   TORCH_INTERNAL_ASSERT(pad_batches == 1 || pad_batches == batches);
   TORCH_INTERNAL_ASSERT(mask.size(1) == 1);
   TORCH_INTERNAL_ASSERT(mask.size(2) == query_seq_len);

--- a/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax_cuda.cu
+++ b/nemo/collections/nlp/modules/common/megatron/fused_kernels/scaled_masked_softmax_cuda.cu
@@ -1,0 +1,116 @@
+/* coding=utf-8
+ * Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <ATen/ATen.h>
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <cuda_fp16.h>
+#include <cuda_profiler_api.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+#include "scaled_masked_softmax.h"
+#include "type_shim.h"
+
+namespace multihead_attn {
+namespace fused_softmax {
+namespace scaled_masked_softmax {
+
+torch::Tensor fwd_cuda(
+    torch::Tensor const& input,
+    torch::Tensor const& mask,
+    float scale_factor)
+{
+  // input is a 4d tensor with dimensions [batches, attn_heads, seq_len, seq_len]
+  const int batches = input.size(0);
+  const int pad_batches = mask.size(0);
+  const int attn_heads = input.size(1);
+  const int query_seq_len = input.size(2);
+  const int key_seq_len = input.size(3);
+  TORCH_INTERNAL_ASSERT(key_seq_len <= 4096);
+  //TORCH_INTERNAL_ASSERT(query_seq_len > 1);
+  TORCH_INTERNAL_ASSERT(pad_batches == 1 || pad_batches == batches);
+  TORCH_INTERNAL_ASSERT(mask.size(1) == 1);
+  TORCH_INTERNAL_ASSERT(mask.size(2) == query_seq_len);
+  TORCH_INTERNAL_ASSERT(mask.size(3) == key_seq_len);
+
+  // Output 
+  auto act_options = input.options().requires_grad(false);
+  torch::Tensor softmax_results = 
+      torch::empty({batches, attn_heads, query_seq_len, key_seq_len}, act_options);
+
+  // Softmax Intermediate Result Ptr
+  void* input_ptr = static_cast<void*>(input.data_ptr());
+  void* mask_ptr = static_cast<void*>(mask.data_ptr());
+  void* softmax_results_ptr = static_cast<void*>(softmax_results.data_ptr());
+
+  DISPATCH_HALF_AND_BFLOAT(
+      input.scalar_type(),
+      "dispatch_scaled_masked_softmax_forward",
+      dispatch_scaled_masked_softmax_forward_new<scalar_t, scalar_t, float>(
+          reinterpret_cast<scalar_t*>(softmax_results_ptr),
+	  reinterpret_cast<const scalar_t*>(input_ptr),
+	  reinterpret_cast<const uint8_t*>(mask_ptr),
+	  scale_factor,
+	  query_seq_len,
+	  key_seq_len,
+	  batches,
+	  attn_heads,
+	  pad_batches);
+      );
+  return softmax_results;
+}
+
+torch::Tensor bwd_cuda(
+    torch::Tensor const& output_grads_, 
+    torch::Tensor const& softmax_results_, 
+    float scale_factor)  {
+
+  auto output_grads = output_grads_.contiguous();
+  auto softmax_results = softmax_results_.contiguous();
+
+  //output grads is a 4d tensor with dimensions [batches, attn_heads, seq_len, seq_len]
+  const int batches = output_grads.size(0);
+  const int attn_heads = output_grads.size(1);
+  const int query_seq_len = output_grads.size(2);
+  const int key_seq_len = output_grads.size(3);
+
+  auto act_options = output_grads.options();
+  torch::Tensor input_grad = 
+      torch::empty({batches, attn_heads, query_seq_len, key_seq_len}, act_options);
+
+  void* output_grads_ptr = static_cast<void*>(output_grads.data_ptr());
+
+  //Softmax Grad
+  DISPATCH_HALF_AND_BFLOAT(
+      output_grads_.scalar_type(),
+      "dispatch_scaled_masked_softmax_backward",
+      dispatch_scaled_masked_softmax_backward_new<scalar_t, scalar_t, float>(
+          reinterpret_cast<scalar_t*>(static_cast<void*>(input_grad.data_ptr())), 
+	  reinterpret_cast<scalar_t*>(output_grads_ptr), 
+	  reinterpret_cast<scalar_t const*>(softmax_results.data_ptr()),
+	  scale_factor,
+	  query_seq_len,
+	  key_seq_len,
+	  batches,
+	  attn_heads);
+			   );
+  
+  //backward pass is completely in-place
+  return input_grad;
+}
+}
+}
+}

--- a/nemo/collections/nlp/modules/common/megatron/fused_kernels/type_shim.h
+++ b/nemo/collections/nlp/modules/common/megatron/fused_kernels/type_shim.h
@@ -1,0 +1,117 @@
+/* coding=utf-8
+ * Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#include <ATen/ATen.h>
+#include "compat.h"
+
+
+#define DISPATCH_HALF_AND_BFLOAT(TYPE, NAME, ...)			\
+  switch(TYPE)								\
+    {									\
+    case at::ScalarType::Half:						\
+      {									\
+	using scalar_t = at::Half;					\
+	__VA_ARGS__;							\
+	break;								\
+      }									\
+    case at::ScalarType::BFloat16:					\
+      {									\
+	using scalar_t = at::BFloat16;					\
+	__VA_ARGS__;							\
+	break;								\
+      }									\
+    default:								\
+      AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");	\
+      }
+
+
+#define DISPATCH_HALF_BFLOAT_AND_FLOAT(TYPE, NAME, ...)			\
+  switch(TYPE)								\
+    {									\
+    case at::ScalarType::Half:						\
+      {									\
+	using scalar_t = at::Half;					\
+	__VA_ARGS__;							\
+	break;								\
+      }									\
+    case at::ScalarType::BFloat16:					\
+      {									\
+	using scalar_t = at::BFloat16;					\
+	__VA_ARGS__;							\
+	break;								\
+      }									\
+    case at::ScalarType::Float:						\
+      {									\
+	using scalar_t = float;					\
+	__VA_ARGS__;							\
+	break;								\
+      }									\
+    default:								\
+      AT_ERROR(#NAME, " not implemented for '", toString(TYPE), "'");	\
+      }
+
+
+
+#define DISPATCH_FLOAT_HALF_AND_BFLOAT_INOUT_TYPES(TYPEIN, TYPEOUT, NAME, ...) \
+  switch(TYPEIN)							\
+    {									\
+    case at::ScalarType::Float:						\
+      {									\
+	using scalar_t_in = float;					\
+	switch(TYPEOUT)							\
+	  {								\
+	  case at::ScalarType::Float:					\
+	    {								\
+	      using scalar_t_out = float;				\
+	      __VA_ARGS__;						\
+	      break;							\
+	    }								\
+	  case at::ScalarType::Half:					\
+	    {								\
+	      using scalar_t_out = at::Half;				\
+	      __VA_ARGS__;						\
+	      break;							\
+	    }								\
+	  case at::ScalarType::BFloat16:				\
+	    {								\
+	      using scalar_t_out = at::BFloat16;			\
+	      __VA_ARGS__;						\
+	      break;							\
+	    }								\
+	  default:							\
+	    AT_ERROR(#NAME, " not implemented for '", toString(TYPEOUT), "'"); \
+	  }								\
+	break;								\
+      }									\
+    case at::ScalarType::Half:						\
+      {									\
+	using scalar_t_in = at::Half;					\
+	using scalar_t_out = at::Half;					\
+	__VA_ARGS__;							\
+	break;								\
+      }									\
+    case at::ScalarType::BFloat16:					\
+      {									\
+	using scalar_t_in = at::BFloat16;				\
+	using scalar_t_out = at::BFloat16;				\
+	__VA_ARGS__;							\
+	break;								\
+      }									\
+    default:								\
+      AT_ERROR(#NAME, " not implemented for '", toString(TYPEIN), "'");	\
+    }
+

--- a/nemo/collections/nlp/modules/common/megatron/fused_softmax.py
+++ b/nemo/collections/nlp/modules/common/megatron/fused_softmax.py
@@ -14,9 +14,6 @@
 
 import torch
 
-# this triggers kernel compiling
-import nemo.collections.nlp.modules.common.megatron.fused_kernels
-
 try:
     from apex._autocast_utils import _cast_if_autocast_enabled
 
@@ -73,6 +70,9 @@ class FusedScaleMaskSoftmax(torch.nn.Module):
         self, input_in_fp16, input_in_bf16, scaled_masked_softmax_fusion, mask_func, softmax_in_fp32, scale,
     ):
         super().__init__()
+        if torch.cuda.is_available():
+            # this triggers kernel compiling
+            import nemo.collections.nlp.modules.common.megatron.fused_kernels
         self.input_in_fp16 = input_in_fp16
         self.input_in_bf16 = input_in_bf16
         if self.input_in_fp16 and self.input_in_bf16:

--- a/nemo/collections/nlp/modules/common/megatron/fused_softmax.py
+++ b/nemo/collections/nlp/modules/common/megatron/fused_softmax.py
@@ -14,14 +14,15 @@
 
 import torch
 
+# this triggers kernel compiling
+import nemo.collections.nlp.modules.common.megatron.fused_kernels
+
 try:
     from apex._autocast_utils import _cast_if_autocast_enabled
+
     HAVE_APEX = True
 except (ImportError, ModuleNotFoundError):
     HAVE_APEX = False
-
-# this triggers kernel compiling
-import nemo.collections.nlp.modules.common.megatron.fused_kernels
 
 
 class ScaledMaskedSoftmax(torch.autograd.Function):

--- a/nemo/collections/nlp/modules/common/megatron/fused_softmax.py
+++ b/nemo/collections/nlp/modules/common/megatron/fused_softmax.py
@@ -13,7 +13,12 @@
 # limitations under the License.
 
 import torch
-from apex._autocast_utils import _cast_if_autocast_enabled
+
+try:
+    from apex._autocast_utils import _cast_if_autocast_enabled
+    HAVE_APEX = True
+except (ImportError, ModuleNotFoundError):
+    HAVE_APEX = False
 
 # this triggers kernel compiling
 import nemo.collections.nlp.modules.common.megatron.fused_kernels
@@ -90,7 +95,7 @@ class FusedScaleMaskSoftmax(torch.nn.Module):
             return self.forward_torch_softmax(input, mask)
 
     def is_kernel_available(self, mask, b, np, sq, sk):
-        if self.scaled_masked_softmax_fusion and 0 < sk <= 4096:  # user want to fuse  # sk must be 1 ~ 4096
+        if self.scaled_masked_softmax_fusion and 0 < sk:  # user want to fuse  # sk must be 1 ~
             return True
         return False
 

--- a/nemo/collections/nlp/modules/common/megatron/fused_softmax.py
+++ b/nemo/collections/nlp/modules/common/megatron/fused_softmax.py
@@ -1,0 +1,126 @@
+import torch
+from apex._autocast_utils import _cast_if_autocast_enabled
+# this triggers kernel compiling
+import nemo.collections.nlp.modules.common.megatron.fused_kernels 
+
+
+class ScaledMaskedSoftmax(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, inputs, mask, scale):
+        import scaled_masked_softmax_cuda_new
+        scale_t = torch.tensor([scale])
+        softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, mask, scale_t[0])
+        ctx.save_for_backward(softmax_results, scale_t)
+        return softmax_results
+
+    @staticmethod
+    def backward(ctx, output_grads):
+        import scaled_masked_softmax_cuda_new
+
+        softmax_results, scale_t = ctx.saved_tensors
+
+        input_grads = scaled_masked_softmax_cuda_new.backward(
+            output_grads, softmax_results, scale_t[0]
+        )
+        return input_grads, None, None
+
+
+def scaled_masked_softmax(inputs, mask, scale):
+    # input is 4D tensor (b, np, sq, sk)
+    args = _cast_if_autocast_enabled(inputs, mask, scale)
+    with torch.cuda.amp.autocast(enabled=False):
+        return ScaledMaskedSoftmax.apply(*args)
+
+
+class FusedScaleMaskSoftmax(torch.nn.Module):
+    """
+    Drop-in replacement for apex FusedSacleMaskSoftmax.
+    It removes the seq-len limitations compares with apex one.
+    It handles the case that all tokens are masked, it returns zeros for attention score.
+
+    fused operation: scaling + mask + softmax
+
+    Arguments:
+        input_in_fp16: flag to indicate if input in fp16 data format.
+        input_in_bf16: flag to indicate if input in bf16 data format.
+        scaled_masked_softmax_fusion: flag to indicate user want to use softmax fusion
+        mask_func: mask function to be applied.
+        softmax_in_fp32: if true, softmax in performed at fp32 precision.
+        scale: scaling factor used in input tensor scaling.
+    """
+
+    def __init__(
+        self,
+        input_in_fp16,
+        input_in_bf16,
+        scaled_masked_softmax_fusion,
+        mask_func,
+        softmax_in_fp32,
+        scale,
+    ):
+        super().__init__()
+        self.input_in_fp16 = input_in_fp16
+        self.input_in_bf16 = input_in_bf16
+        if self.input_in_fp16 and self.input_in_bf16:
+            raise RuntimeError(
+                "both fp16 and bf16 flags cannot be active at the same time."
+            )
+        self.input_in_float16 = self.input_in_fp16 or self.input_in_bf16
+        self.mask_func = mask_func
+        self.softmax_in_fp32 = softmax_in_fp32
+        self.scale = scale
+        self.scaled_masked_softmax_fusion = scaled_masked_softmax_fusion
+
+        if not (self.scale is None or softmax_in_fp32):
+            raise RuntimeError("softmax should be in fp32 when scaled")
+        self.fused_softmax_func = scaled_masked_softmax
+
+    def forward(self, input, mask):
+        # [b, np, sq, sk]
+        assert input.dim() == 4
+
+        if self.is_kernel_available(mask, *input.size()):
+            res = self.forward_fused_softmax(input, mask)
+            control = self.forward_torch_softmax(input, mask).detach()
+            all_k_masked = mask.all(axis=-1)
+            zero_attention_mask = (1.0 - all_k_masked.float())[:, :, :, None]
+            control = zero_attention_mask * control
+            if (res - control).abs().max() > 1e-2:
+                torch.save(input, '/results/input.pth')
+                torch.save(mask, '/results/mask.pth')
+                torch.save(self.scale, '/results/scale.pth')
+                import sys
+                sys.exit(0)
+            return self.forward_fused_softmax(input, mask)
+        else:
+            return self.forward_torch_softmax(input, mask)
+
+    def is_kernel_available(self, mask, b, np, sq, sk):
+        if (
+            self.scaled_masked_softmax_fusion  # user want to fuse
+            and 16 < sk <= 4096  # sk must be 16 ~ 2048
+        ):
+            return True
+        return False
+
+    def forward_fused_softmax(self, input, mask):
+        # input.shape = [b, np, sq, sk]
+        scale = self.scale if self.scale is not None else 1.0
+        return self.fused_softmax_func(input, mask, scale)
+
+    def forward_torch_softmax(self, input, mask):
+        if self.input_in_float16 and self.softmax_in_fp32:
+            input = input.float()
+
+        if self.scale is not None:
+            input = input * self.scale
+        mask_output = self.mask_func(input, mask) if mask is not None else input
+        probs = torch.nn.Softmax(dim=-1)(mask_output)
+
+        if self.input_in_float16 and self.softmax_in_fp32:
+            if self.input_in_fp16:
+                probs = probs.half()
+            else:
+                probs = probs.bfloat16()
+
+        return probs

--- a/tests/collections/nlp/test_fused_softmax_kernel.py
+++ b/tests/collections/nlp/test_fused_softmax_kernel.py
@@ -33,13 +33,9 @@ def forward_torch_softmax(input, mask, scale):
 
 @pytest.mark.run_only_on('GPU')
 class TestFusedSoftmaxKernel:
-    @classmethod
-    def setup_class(cls):
-        # this line will trigger building the kernels
-        import nemo.collections.nlp.modules.common.megatron.fused_kernels
-
     @pytest.mark.unit
     def test_forward(self):
+        import nemo.collections.nlp.modules.common.megatron.fused_kernels
         import scaled_masked_softmax_cuda_new
 
         batch = 2
@@ -48,7 +44,28 @@ class TestFusedSoftmaxKernel:
         klen = 3123
         scale_t = torch.tensor([1.0])
         for qlen in [2348, 2322, 1234, 1, 2]:
-            for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096, 7234, 8192, 10232]:
+            for klen in [
+                3123,
+                1234,
+                2,
+                4,
+                8,
+                3,
+                1,
+                5,
+                10,
+                11,
+                13,
+                128,
+                256,
+                1200,
+                2048,
+                4096,
+                7234,
+                8192,
+                10232,
+                4128,
+            ]:
                 inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
                 masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
                 softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())
@@ -58,6 +75,7 @@ class TestFusedSoftmaxKernel:
 
     @pytest.mark.unit
     def test_backward(self):
+        import nemo.collections.nlp.modules.common.megatron.fused_kernels
         import scaled_masked_softmax_cuda_new
 
         batch = 2
@@ -66,7 +84,28 @@ class TestFusedSoftmaxKernel:
         klen = 3123
         scale_t = torch.tensor([1.0])
         for qlen in [2348, 2322, 1234, 1, 2]:
-            for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096, 7234, 8192, 10232]:
+            for klen in [
+                3123,
+                1234,
+                2,
+                4,
+                8,
+                3,
+                1,
+                5,
+                10,
+                11,
+                13,
+                128,
+                256,
+                1200,
+                2048,
+                4096,
+                7234,
+                8192,
+                10232,
+                4128,
+            ]:
                 inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
                 backward = torch.rand_like(inputs, dtype=torch.float16, device='cuda:0')
                 masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
@@ -81,6 +120,7 @@ class TestFusedSoftmaxKernel:
 
     @pytest.mark.unit
     def test_allmasked(self):
+        import nemo.collections.nlp.modules.common.megatron.fused_kernels
         import scaled_masked_softmax_cuda_new
 
         batch = 2
@@ -89,7 +129,28 @@ class TestFusedSoftmaxKernel:
         klen = 3123
         scale_t = torch.tensor([1.0])
         for qlen in [2348, 2322, 1234, 1, 2]:
-            for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096, 7234, 8192, 10232]:
+            for klen in [
+                3123,
+                1234,
+                2,
+                4,
+                8,
+                3,
+                1,
+                5,
+                10,
+                11,
+                13,
+                128,
+                256,
+                1200,
+                2048,
+                4096,
+                7234,
+                8192,
+                10232,
+                4128,
+            ]:
                 inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
                 masks = torch.ones((batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
                 softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())

--- a/tests/collections/nlp/test_fused_softmax_kernel.py
+++ b/tests/collections/nlp/test_fused_softmax_kernel.py
@@ -157,3 +157,48 @@ class TestFusedSoftmaxKernel:
                 softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
                 error = (softmax_results_torch - softmax_results).abs().max()
                 assert error < 2e-3
+
+    @pytest.mark.unit
+    def test_allmask_backward(self):
+        import nemo.collections.nlp.modules.common.megatron.fused_kernels
+        import scaled_masked_softmax_cuda_new
+
+        batch = 2
+        attn = 16
+        qlen = 2348
+        klen = 3123
+        scale_t = torch.tensor([1.0])
+        for qlen in [2348, 2322, 1234, 1, 2]:
+            for klen in [
+                3123,
+                1234,
+                2,
+                4,
+                8,
+                3,
+                1,
+                5,
+                10,
+                11,
+                13,
+                128,
+                256,
+                1200,
+                2048,
+                4096,
+                7234,
+                8192,
+                10232,
+                4128,
+            ]:
+                inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
+                backward = torch.rand_like(inputs, dtype=torch.float16, device='cuda:0')
+                masks = torch.ones((batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
+                softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())
+                back_grad = scaled_masked_softmax_cuda_new.backward(backward, softmax_results, scale_t[0].item())
+
+                inputs.requires_grad = True
+                softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
+                softmax_results_torch.backward(backward)
+                error = (back_grad - inputs.grad).abs().max()
+                assert error < 1e-3

--- a/tests/collections/nlp/test_fused_softmax_kernel.py
+++ b/tests/collections/nlp/test_fused_softmax_kernel.py
@@ -48,7 +48,7 @@ class TestFusedSoftmaxKernel:
         klen = 3123
         scale_t = torch.tensor([1.0])
         for qlen in [2348, 2322, 1234, 1, 2]:
-            for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096]:
+            for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096, 7234, 8192, 10232]:
                 inputs = torch.rand((batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
                 masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
                 softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())
@@ -66,7 +66,7 @@ class TestFusedSoftmaxKernel:
         klen = 3123
         scale_t = torch.tensor([1.0])
         for qlen in [2348, 2322, 1234, 1, 2]:
-            for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096]:
+            for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096, 7234, 8192, 10232]:
                 inputs = torch.rand((batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
                 backward = torch.rand_like(inputs, dtype=torch.float16, device='cuda:0')
                 masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
@@ -89,7 +89,7 @@ class TestFusedSoftmaxKernel:
         klen = 3123
         scale_t = torch.tensor([1.0])
         for qlen in [2348, 2322, 1234, 1, 2]:
-            for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096]:
+            for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096, 7234, 8192, 10232]:
                 inputs = torch.rand((batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
                 masks = torch.ones((batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
                 softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())

--- a/tests/collections/nlp/test_fused_softmax_kernel.py
+++ b/tests/collections/nlp/test_fused_softmax_kernel.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import torch
-import nemo.collections.nlp.modules.common.megatron.fused_kernels 
-import scaled_masked_softmax_cuda_new
 import pytest
+import scaled_masked_softmax_cuda_new
+import torch
+
+import nemo.collections.nlp.modules.common.megatron.fused_kernels
 
 
 def attention_mask_func(attention_scores, attention_mask):
@@ -35,10 +36,9 @@ def forward_torch_softmax(input, mask, scale):
 
 @pytest.mark.run_only_on('GPU')
 class TestFusedSoftmaxKernel:
-
     @pytest.mark.unit
     def test_forward(self):
-        batch = 2 
+        batch = 2
         attn = 16
         qlen = 2348
         klen = 3123
@@ -46,7 +46,7 @@ class TestFusedSoftmaxKernel:
         for qlen in [2348, 2322, 1234, 1, 2]:
             for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096]:
                 inputs = torch.rand((batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
-                masks =  torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
+                masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
                 softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())
                 softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
                 error = (softmax_results_torch - softmax_results).abs().max()
@@ -54,7 +54,7 @@ class TestFusedSoftmaxKernel:
 
     @pytest.mark.unit
     def test_backward(self):
-        batch = 2 
+        batch = 2
         attn = 16
         qlen = 2348
         klen = 3123
@@ -63,7 +63,7 @@ class TestFusedSoftmaxKernel:
             for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096]:
                 inputs = torch.rand((batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
                 backward = torch.rand_like(inputs, dtype=torch.float16, device='cuda:0')
-                masks =  torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
+                masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
                 softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())
                 back_grad = scaled_masked_softmax_cuda_new.backward(backward, softmax_results, scale_t[0].item())
 
@@ -75,7 +75,7 @@ class TestFusedSoftmaxKernel:
 
     @pytest.mark.unit
     def test_allmasked(self):
-        batch = 2 
+        batch = 2
         attn = 16
         qlen = 2348
         klen = 3123
@@ -83,7 +83,7 @@ class TestFusedSoftmaxKernel:
         for qlen in [2348, 2322, 1234, 1, 2]:
             for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096]:
                 inputs = torch.rand((batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
-                masks =  torch.ones((batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
+                masks = torch.ones((batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
                 softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())
                 softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
                 error = (softmax_results_torch - softmax_results).abs().max()

--- a/tests/collections/nlp/test_fused_softmax_kernel.py
+++ b/tests/collections/nlp/test_fused_softmax_kernel.py
@@ -13,10 +13,7 @@
 # limitations under the License.
 
 import pytest
-import scaled_masked_softmax_cuda_new
 import torch
-
-import nemo.collections.nlp.modules.common.megatron.fused_kernels
 
 
 def attention_mask_func(attention_scores, attention_mask):
@@ -36,8 +33,15 @@ def forward_torch_softmax(input, mask, scale):
 
 @pytest.mark.run_only_on('GPU')
 class TestFusedSoftmaxKernel:
+
+    @classmethod
+    def setup_class(cls):
+        # this line will trigger building the kernels
+        import nemo.collections.nlp.modules.common.megatron.fused_kernels
+
     @pytest.mark.unit
     def test_forward(self):
+        import scaled_masked_softmax_cuda_new
         batch = 2
         attn = 16
         qlen = 2348
@@ -54,6 +58,7 @@ class TestFusedSoftmaxKernel:
 
     @pytest.mark.unit
     def test_backward(self):
+        import scaled_masked_softmax_cuda_new
         batch = 2
         attn = 16
         qlen = 2348
@@ -75,6 +80,7 @@ class TestFusedSoftmaxKernel:
 
     @pytest.mark.unit
     def test_allmasked(self):
+        import scaled_masked_softmax_cuda_new
         batch = 2
         attn = 16
         qlen = 2348

--- a/tests/collections/nlp/test_fused_softmax_kernel.py
+++ b/tests/collections/nlp/test_fused_softmax_kernel.py
@@ -33,7 +33,6 @@ def forward_torch_softmax(input, mask, scale):
 
 @pytest.mark.run_only_on('GPU')
 class TestFusedSoftmaxKernel:
-
     @classmethod
     def setup_class(cls):
         # this line will trigger building the kernels
@@ -42,6 +41,7 @@ class TestFusedSoftmaxKernel:
     @pytest.mark.unit
     def test_forward(self):
         import scaled_masked_softmax_cuda_new
+
         batch = 2
         attn = 16
         qlen = 2348
@@ -59,6 +59,7 @@ class TestFusedSoftmaxKernel:
     @pytest.mark.unit
     def test_backward(self):
         import scaled_masked_softmax_cuda_new
+
         batch = 2
         attn = 16
         qlen = 2348
@@ -81,6 +82,7 @@ class TestFusedSoftmaxKernel:
     @pytest.mark.unit
     def test_allmasked(self):
         import scaled_masked_softmax_cuda_new
+
         batch = 2
         attn = 16
         qlen = 2348

--- a/tests/collections/nlp/test_fused_softmax_kernel.py
+++ b/tests/collections/nlp/test_fused_softmax_kernel.py
@@ -49,7 +49,7 @@ class TestFusedSoftmaxKernel:
         scale_t = torch.tensor([1.0])
         for qlen in [2348, 2322, 1234, 1, 2]:
             for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096, 7234, 8192, 10232]:
-                inputs = torch.rand((batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
+                inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
                 masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
                 softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())
                 softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
@@ -67,7 +67,7 @@ class TestFusedSoftmaxKernel:
         scale_t = torch.tensor([1.0])
         for qlen in [2348, 2322, 1234, 1, 2]:
             for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096, 7234, 8192, 10232]:
-                inputs = torch.rand((batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
+                inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
                 backward = torch.rand_like(inputs, dtype=torch.float16, device='cuda:0')
                 masks = torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
                 softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())
@@ -90,9 +90,9 @@ class TestFusedSoftmaxKernel:
         scale_t = torch.tensor([1.0])
         for qlen in [2348, 2322, 1234, 1, 2]:
             for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096, 7234, 8192, 10232]:
-                inputs = torch.rand((batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
+                inputs = torch.normal(0, 2, (batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
                 masks = torch.ones((batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
                 softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())
                 softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
                 error = (softmax_results_torch - softmax_results).abs().max()
-                assert error < 1e-3
+                assert error < 2e-3

--- a/tests/collections/nlp/test_fused_softmax_kernel.py
+++ b/tests/collections/nlp/test_fused_softmax_kernel.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import nemo.collections.nlp.modules.common.megatron.fused_kernels 
+import scaled_masked_softmax_cuda_new
+import pytest
+
+
+def attention_mask_func(attention_scores, attention_mask):
+    attention_scores.masked_fill_(attention_mask, -10000.0)
+    return attention_scores
+
+
+def forward_torch_softmax(input, mask, scale):
+    input = input * scale
+    mask_output = attention_mask_func(input, mask) if mask is not None else input
+    probs = torch.nn.Softmax(dim=-1)(mask_output)
+    all_k_masked = mask.all(axis=-1)
+    zero_attention_mask = (1.0 - all_k_masked.float())[:, :, :, None]
+    probs = probs * zero_attention_mask
+    return probs
+
+
+@pytest.mark.run_only_on('GPU')
+class TestFusedSoftmaxKernel:
+
+    @pytest.mark.unit
+    def test_forward(self):
+        batch = 2 
+        attn = 16
+        qlen = 2348
+        klen = 3123
+        scale_t = torch.tensor([1.0])
+        for qlen in [2348, 2322, 1234, 1, 2]:
+            for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096]:
+                inputs = torch.rand((batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
+                masks =  torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
+                softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())
+                softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
+                error = (softmax_results_torch - softmax_results).abs().max()
+                assert error < 1e-3
+
+    @pytest.mark.unit
+    def test_backward(self):
+        batch = 2 
+        attn = 16
+        qlen = 2348
+        klen = 3123
+        scale_t = torch.tensor([1.0])
+        for qlen in [2348, 2322, 1234, 1, 2]:
+            for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096]:
+                inputs = torch.rand((batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
+                backward = torch.rand_like(inputs, dtype=torch.float16, device='cuda:0')
+                masks =  torch.randint(0, 2, (batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
+                softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())
+                back_grad = scaled_masked_softmax_cuda_new.backward(backward, softmax_results, scale_t[0].item())
+
+                inputs.requires_grad = True
+                softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
+                softmax_results_torch.backward(backward)
+                error = (back_grad - inputs.grad).abs().max()
+                assert error < 1e-3
+
+    @pytest.mark.unit
+    def test_allmasked(self):
+        batch = 2 
+        attn = 16
+        qlen = 2348
+        klen = 3123
+        scale_t = torch.tensor([1.0])
+        for qlen in [2348, 2322, 1234, 1, 2]:
+            for klen in [3123, 1234, 2, 4, 8, 3, 1, 5, 10, 11, 13, 128, 256, 1200, 2048, 4096]:
+                inputs = torch.rand((batch, attn, qlen, klen), dtype=torch.float16, device='cuda:0')
+                masks =  torch.ones((batch, 1, qlen, klen), dtype=torch.bool, device='cuda:0')
+                softmax_results = scaled_masked_softmax_cuda_new.forward(inputs, masks, scale_t[0].item())
+                softmax_results_torch = forward_torch_softmax(inputs, masks, scale_t[0].item())
+                error = (softmax_results_torch - softmax_results).abs().max()
+                assert error < 1e-3


### PR DESCRIPTION
# What does this PR do ?
Implemented the fused softmax GPU kernel that can be a drop-in replacement of the `apex`'s FusedScaleMaskSoftmax`. It addresses the following issues:
1. Removed the sequence length limitation. It works with tensor of any length.
2. Fix the `grad_input` modification issue https://github.com/NVIDIA/apex/issues/1430
3. Fix the problem when all keys are masked https://github.com/NVIDIA/apex/issues/1390

It uses the torch.cppextension to build the kernel dynamically like MegatronLM repo does. The kernels will be saved in the `/tmp` directory so it can be used in slurm with enroot clusters too.
It includes a unit test to cover a few cases.
The performance is comparable to the apex one. Here is a training step time graph when it is tested with training a RETRO model.
![image](https://user-images.githubusercontent.com/43824965/180662857-712f48e4-dc9b-40f7-aad5-13e82004a30b.png)
The blue curve is pytorch softmax. The bottom red curve is apex fused kernel and the middle red curve the fused kernel in this PR.


