### PR TITLE
Updating the default parameters in the example adapters config file

### DIFF
--- a/examples/asr/conf/asr_adapters/asr_adaptation.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation.yaml
@@ -70,13 +70,14 @@ model:
     in_features: ???  # User must provide the output dimension of the layers of the model, which is the input dimension of this adapter.
     dim: 32  # The hidden dimension of the adapter, as chosen by user, but small values are preferred to reduce param count.
     activation: swish
-    norm_position: 'post'  # Can be `pre` or `post`
+    norm_position: 'pre'  # Can be `pre` or `post`
     dropout: 0.0  # float, dropout for the adapter
 
     # Adapter strategy config
     adapter_strategy:
       _target_: nemo.core.classes.mixins.adapter_mixin_strategies.ResidualAddAdapterStrategy
       stochastic_depth: 0.0  # float, setting to > 0 will enable stochastic depth for each adapter block.
+      l2_lambda: 0.0  # float, setting to > 0 will enable l2 norm auxiliary loss for each adapter's output.
 
     # Optional global config available to all adapters at a global level.
     # A global config is shared across every layer of the adapters, defining global properties rather
@@ -146,8 +147,8 @@ model:
       name: CosineAnnealing
 
       # scheduler config override
-      warmup_steps: 100  # Warmup steps should be set, and smaller than the trainer.max_steps set below.
-      warmup_ratio: null
+      warmup_steps: null  # Warmup steps should be set, and smaller than the trainer.max_steps set below.
+      warmup_ratio: 0.1   # Warmup steps will be 10% of the training steps.
       min_lr: 1e-5
       last_epoch: -1
 
@@ -190,6 +191,9 @@ exp_manager:
     name: null
     project: null
     entity: null
+    save_dir: null
+    offline: false # If true, wandb logging will be done offline and would require manual syncing.
+    tags: null # List of tags to assign to the run
 
   resume_if_exists: false
   resume_ignore_no_checkpoint: false


### PR DESCRIPTION
# What does this PR do ?

Updates the default values of the warmup and the layer norm in the example adapter config file. It also adds the option to specify tags as well as offline logging of wandb.

**Collection**: asr

# Changelog 
File modified: `examples/asr/conf/asr_adapters/asr_adaptation.yaml`

- Adapters now use pre-norm by default
- The default number of warmup steps is set to 10% of the training set
- Added two parameters: `offline` and `tags` within the `wandb_logger_kwargs` config to allow specifying offline logging and tags for each run respectively.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in NeMo ASR.
