### PR TITLE
Improve normalize_batch ValueError message

### DIFF
--- a/nemo/collections/asr/parts/preprocessing/features.py
+++ b/nemo/collections/asr/parts/preprocessing/features.py
@@ -55,7 +55,8 @@ def normalize_batch(x, seq_len, normalize_type):
             if x[i, :, : seq_len[i]].shape[1] == 1:
                 raise ValueError(
                     "normalize_batch with `per_feature` normalize_type received a tensor of length 1. This will result "
-                    "in torch.std() returning nan"
+                    "in torch.std() returning nan. Make sure your audio length has enough samples for a single "
+                    "feature (ex. at least `hop_length` for Mel Spectrograms)."
                 )
             x_mean[i, :] = x[i, :, : seq_len[i]].mean(dim=1)
             x_std[i, :] = x[i, :, : seq_len[i]].std(dim=1)


### PR DESCRIPTION
# What does this PR do ?

Improve `normalize_batch` error message with suggestions on how to fix.
Sometimes audio files with zero/small duration sneak by as files with a non-zero duration field, causing this error.

**Collection**: ASR

# Changelog 
* Improve `normalize_batch` `ValueError` message with suggestions on how to fix

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [x] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.
