### PR TITLE
[TTS] Fix off-by-1 bug in Beta Binomial Prior

### DIFF
--- a/nemo/collections/tts/torch/helpers.py
+++ b/nemo/collections/tts/torch/helpers.py
@@ -55,7 +55,7 @@ def beta_binomial_prior_distribution(phoneme_count, mel_count, scaling_factor=1.
     mel_text_probs = []
     for i in range(1, mel_count + 1):
         a, b = scaling_factor * i, scaling_factor * (mel_count + 1 - i)
-        mel_i_prob = betabinom(phoneme_count, a, b).pmf(x)
+        mel_i_prob = betabinom(phoneme_count - 1, a, b).pmf(x)
         mel_text_probs.append(mel_i_prob)
     return np.array(mel_text_probs)
 


### PR DESCRIPTION
# What does this PR do ?

Fix a bug in the prior calculation used in the TTS aligner

**Collection**: [TTS]

# Changelog 
- Fix off-by-1 bug in prior calculation

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information

The prior here is supposed to help the TTS model align by teaching it to place more weight on phonemes along the diagonal, with it always starting on the first phoneme and ending on the last phoneme.

The current logic produces a prior that looks like this, which awkwardly ends earlier than expected with maximum weight on the last phoneme before the end of the sequence:

![image](https://user-images.githubusercontent.com/9942053/181093773-48065280-478d-4d26-9fdd-4ea1d87b8652.png)

After this change, the prior looks like this:

![image](https://user-images.githubusercontent.com/9942053/181093845-bfff79b2-23d6-4cce-8fae-3d0f39f423c5.png)

I think the intuition is that we model the attention as a binomial distribution (eg. coin flips with head being success, tail failure) where each success results in the attention moving on to the next phoneme. To reach the end of a sequence of N phonemes, you only need (N - 1) successes.