### PR TITLE
Support listing Hugging Face model info

### DIFF
--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -668,9 +668,27 @@ class Model(Typing, Serialization, FileIO):
         pass
 
     @classmethod
-    def list_available_models_on_hf(cls, model_filter: Optional[ModelFilter] = None) -> List[ModelInfo]:
+    def list_available_models_on_hf(cls, model_filter: Optional[ModelFilter] = None, resolve_card_data: bool = False) -> List[ModelInfo]:
         """
         Should list all pre-trained models available via Hugging Face Hub.
+
+        Usage:
+            # Get default ModelFilter
+            filt = <ModelSubclass>.get_hf_model_filter()
+
+            # Make any modifications to the filter as necessary
+            filt.language = [...]
+            filt.task = ...
+            filt.tags = [...]
+
+            # Obtain model info
+            model_infos = <ModelSubclass>.list_available_models_on_hf(model_filter=filt)
+
+            # Browse through cards and select an appropriate one
+            card = model_infos[0]
+
+            # Restore model using `modelId` of the card.
+            model = ModelPT.from_pretrained(card.modelId)
 
         Args:
             model_filter: Optional ModelFilter (from Hugging Face Hub) that filters the returned list of compatible

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -679,8 +679,11 @@ class Model(Typing, Serialization, FileIO):
             resolve_card_info: Bool flag, if set, returns the model card metadata. Default: False.
             limit_results: Optional int, limits the number of results returned.
 
-        Usage:
+        .. code-block:: python
+
             # You can replace <DomainSubclass> with any subclass of ModelPT.
+            from nemo.core import ModelPT
+
             # Get default ModelFilter
             filt = <DomainSubclass>.get_hf_model_filter()
 

--- a/tests/core/test_save_restore.py
+++ b/tests/core/test_save_restore.py
@@ -619,11 +619,11 @@ class TestSaveRestore:
         filt = ModelPT.get_hf_model_filter()
 
         # check no override results
-        model_infos = ModelPT.list_available_models_on_hf(model_filter=None)
+        model_infos = ModelPT.search_huggingface_models(model_filter=None)
         assert len(model_infos) > 0
 
         # check with default override results (should match above)
-        default_model_infos = ModelPT.list_available_models_on_hf(model_filter=filt)
+        default_model_infos = ModelPT.search_huggingface_models(model_filter=filt)
         assert len(model_infos) == len(default_model_infos)
 
     @pytest.mark.with_downloads()
@@ -632,27 +632,27 @@ class TestSaveRestore:
         filt = ModelPT.get_hf_model_filter()
 
         # check no override results
-        model_infos = ModelPT.list_available_models_on_hf(model_filter=filt)
+        model_infos = ModelPT.search_huggingface_models(model_filter=filt)
         assert len(model_infos) > 0
         assert not hasattr(model_infos[0], 'cardData')
 
         # check overriden defaults
         filt.resolve_card_info = True
-        model_infos = ModelPT.list_available_models_on_hf(model_filter=filt)
+        model_infos = ModelPT.search_huggingface_models(model_filter=filt)
         assert len(model_infos) > 0
         assert hasattr(model_infos[0], 'cardData') and model_infos[0].cardData is not None
 
-    # @pytest.mark.with_downloads()
+    @pytest.mark.with_downloads()
     @pytest.mark.unit
     def test_hf_model_info_with_limited_results(self):
         filt = ModelPT.get_hf_model_filter()
 
         # check no override results
-        model_infos = ModelPT.list_available_models_on_hf(model_filter=filt)
+        model_infos = ModelPT.search_huggingface_models(model_filter=filt)
         assert len(model_infos) > 0
 
         # check overriden defaults
         filt.limit_results = 5
-        new_model_infos = ModelPT.list_available_models_on_hf(model_filter=filt)
+        new_model_infos = ModelPT.search_huggingface_models(model_filter=filt)
         assert len(new_model_infos) <= 5
         assert len(new_model_infos) < len(model_infos)

--- a/tests/core/test_save_restore.py
+++ b/tests/core/test_save_restore.py
@@ -625,3 +625,34 @@ class TestSaveRestore:
         # check with default override results (should match above)
         default_model_infos = ModelPT.list_available_models_on_hf(model_filter=filt)
         assert len(model_infos) == len(default_model_infos)
+
+    @pytest.mark.with_downloads()
+    @pytest.mark.unit
+    def test_hf_model_info_with_card_data(self):
+        filt = ModelPT.get_hf_model_filter()
+
+        # check no override results
+        model_infos = ModelPT.list_available_models_on_hf(model_filter=filt)
+        assert len(model_infos) > 0
+        assert not hasattr(model_infos[0], 'cardData')
+
+        # check overriden defaults
+        filt.resolve_card_info = True
+        model_infos = ModelPT.list_available_models_on_hf(model_filter=filt)
+        assert len(model_infos) > 0
+        assert hasattr(model_infos[0], 'cardData') and model_infos[0].cardData is not None
+
+    # @pytest.mark.with_downloads()
+    @pytest.mark.unit
+    def test_hf_model_info_with_limited_results(self):
+        filt = ModelPT.get_hf_model_filter()
+
+        # check no override results
+        model_infos = ModelPT.list_available_models_on_hf(model_filter=filt)
+        assert len(model_infos) > 0
+
+        # check overriden defaults
+        filt.limit_results = 5
+        new_model_infos = ModelPT.list_available_models_on_hf(model_filter=filt)
+        assert len(new_model_infos) <= 5
+        assert len(new_model_infos) < len(model_infos)


### PR DESCRIPTION
Signed-off-by: smajumdar <smajumdar@nvidia.com>

# What does this PR do ?

Add new apis to filter and obtain NeMo hugging face models via code.

**Collection**: [Core]

# Changelog 
- Adds two methods `get_hf_model_filter()` and `search_huggingface_models(model_filter=None)` to ModelPT.
- First method returns a basic ModelFilter object, can be overridden by the user. Used as default to next method if nothing is provided.
- Add support for metadata attributes to the filter to modify the result list of ModelInfo.
- `list_available_models_on_hf()` lists the nemo models that satisfy the filter.

# Usage

```python
from nemo.core import ModelPT

# You can replace <DomainSubclass> with any subclass of ModelPT.
# Get default ModelFilter
filt = <DomainSubclass>.get_hf_model_filter()

# Make any modifications to the filter as necessary
filt.language = [...]
filt.task = ...
filt.tags = [...]

# Add any metadata to the filter as needed
filt.limit_results = 5

# Obtain model info
model_infos = <DomainSubclass>.search_huggingface_models(model_filter=filt)

# Browse through cards and select an appropriate one
card = model_infos[0]

# Restore model using `modelId` of the card.
model = ModelPT.from_pretrained(card.modelId)

```


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
