### PR TITLE
Update pynini library to fix MacOS build

### DIFF
--- a/requirements/requirements_nemo_text_processing.txt
+++ b/requirements/requirements_nemo_text_processing.txt
@@ -1,4 +1,4 @@
 inflect
 regex
-pynini==2.1.4
+pynini==2.1.5
 transformers>=4.0.1


### PR DESCRIPTION
# What does this PR do ?

Update pynini from `2.1.4` to `2.1.5` to fix MacOS build

**Collection**: [Text Processing]

# Changelog 
- Update pynini from `2.1.4` to `2.1.5`

# Reason

Pynini 2.1.4 can't be installed on MacOS (Intel processor, Conda, python 3.8). Using version `2.1.5` fixes the issue.
```
Building wheels for collected packages: pynini
  Building wheel for pynini (setup.py) ... error
  error: subprocess-exited-with-error
  
  × python setup.py bdist_wheel did not run successfully.
  │ exit code: 1
  ╰─> [55 lines of output]
...
      building '_pywrapfst' extension
      creating build/temp.macosx-10.9-x86_64-3.8
      creating build/temp.macosx-10.9-x86_64-3.8/extensions
      clang -Wno-unused-result -Wsign-compare -Wunreachable-code -DNDEBUG -fwrapv -O2 -Wall -fPIC -O2 -isystem /<user_dir>/anaconda3/envs/ml38/include -fPIC -O2 -isystem /<user_dir>/anaconda3/envs/ml38/include -I/<user_dir>/anaconda3/envs/ml38/include/python3.8 -c extensions/_pywrapfst.cpp -o build/temp.macosx-10.9-x86_64-3.8/extensions/_pywrapfst.o -std=c++17 -Wno-register -Wno-deprecated-declarations -Wno-unused-function -Wno-unused-local-typedefs -funsigned-char -stdlib=libc++ -mmacosx-version-min=10.7
      extensions/_pywrapfst.cpp:753:10: fatal error: 'fst/types.h' file not found
      #include <fst/types.h>
               ^~~~~~~~~~~~~
      1 error generated.
      error: command 'clang' failed with exit status 1
      [end of output]
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?
@yzhang123 

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
