### PR TITLE
Correct branch name for github page source

### DIFF
--- a/.github/workflows/gh-docs.yml
+++ b/.github/workflows/gh-docs.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v3
         if: github.event.repository.fork == false
         with:
-          ref: gh-pages
+          ref: gh-pages-src
 
       - name: "Correct github config"
         if: github.event.repository.fork == false


### PR DESCRIPTION
Signed-off-by: smajumdar <smajumdar@nvidia.com>

# What does this PR do ?

Updates URL of github page source to `gh-pages-src`. 

# NOTE
Push all changes to docs to this branch only.

**Collection**: [Docs]
