### PR TITLE
Add sentencepiece legacy arg to megatron tokenizer configs

### DIFF
--- a/examples/nlp/language_modeling/conf/megatron_bart_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_bart_config.yaml
@@ -69,6 +69,7 @@ model:
     vocab_file: null
     merge_file: null
     num_sentinel_tokens: 0 # expected to be 0 for BART
+    sentencepiece_legacy: True # Legacy=True allows you to add special tokens to sentencepiece tokenizers.
 
   # weight init
   embedding_init_method_std: 0.02 # Standard deviation of the zero mean normal distribution used for weight initialization.')

--- a/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml
@@ -73,6 +73,7 @@ model:
     vocab_file: null
     merge_file: null 
     delimiter: null # only used for tabular tokenizer
+    sentencepiece_legacy: false # Legacy=True allows you to add special tokens to sentencepiece tokenizers.
 
   # precision
   native_amp_init_scale: 4294967296 # 2 ** 32

--- a/examples/nlp/language_modeling/conf/megatron_t5_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_t5_config.yaml
@@ -69,6 +69,7 @@ model:
     vocab_file: null
     merge_file: null
     num_sentinel_tokens: 100
+    sentencepiece_legacy: True # Legacy=True allows you to add special tokens to sentencepiece tokenizers.
 
   # weight init
   embedding_init_method_std: 0.02 # Standard deviation of the zero mean normal distribution used for weight initialization.')

--- a/examples/nlp/language_modeling/conf/megatron_ul2_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_ul2_config.yaml
@@ -68,6 +68,7 @@ model:
     vocab_file: null
     merge_file: null
     num_sentinel_tokens: 100
+    sentencepiece_legacy: True # Legacy=True allows you to add special tokens to sentencepiece tokenizers.
 
   # weight init
   embedding_init_method_std: 0.02 # Standard deviation of the zero mean normal distribution used for weight initialization.')

--- a/examples/nlp/machine_translation/conf/aayn_base_megatron.yaml
+++ b/examples/nlp/machine_translation/conf/aayn_base_megatron.yaml
@@ -167,7 +167,7 @@ model:
     special_tokens: null
     training_sample_size: null # valid for sentencepiece tokenizer
     r2l: false
-    sentencepiece_legacy: True
+    sentencepiece_legacy: True # Legacy=True allows you to add special tokens to sentencepiece tokenizers.
 
   decoder_tokenizer:
     library: yttm

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -137,6 +137,10 @@ class MegatronBaseModel(NLPModel):
         All tokenizers are expected to provide compatible interface.
         Override default Encoder-decoder tokenizer to use legacy=True for sentencepiece.
         """
+        if hasattr(self._cfg.tokenizer, "sentencepiece_legacy"):
+            legacy = self._cfg.tokenizer.sentencepiece_legacy
+        else:
+            legacy = True if self._cfg.tokenizer.library == 'sentencepiece' else False
         self.tokenizer = get_nmt_tokenizer(
             library=self._cfg.tokenizer.library,
             model_name=self._cfg.tokenizer.type,
@@ -144,7 +148,7 @@ class MegatronBaseModel(NLPModel):
             vocab_file=self.register_artifact("tokenizer.vocab_file", self._cfg.tokenizer.vocab_file),
             merges_file=self.register_artifact("tokenizer.merge_file", self._cfg.tokenizer.merge_file),
             delimiter=self.cfg.tokenizer.get('delimiter', None),
-            legacy=True if self._cfg.tokenizer.library == 'sentencepiece' else False,
+            legacy=legacy,
         )
 
     def _build_vocab(self):


### PR DESCRIPTION
Signed-off-by: MaximumEntropy <sandeep.subramanian.1@umontreal.ca>

# What does this PR do ?

Makes the sentencepiece legacy arg configurable. This fixes GPT training with sentencepiece.

**Collection**: NLP

# Changelog 
- Makes the sentencepiece legacy arg configurable.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
