### PR TITLE
Remove type annotation

### DIFF
--- a/nemo/collections/asr/parts/submodules/subsampling.py
+++ b/nemo/collections/asr/parts/submodules/subsampling.py
@@ -271,7 +271,14 @@ class ConvSubsampling(torch.nn.Module):
                 torch.nn.init.uniform_(self.out.bias, -fc_scale, fc_scale)
 
 
-def calc_length(lengths, all_paddings, kernel_size, stride, ceil_mode, repeat_num=1):
+def calc_length(
+        lengths: torch.Tensor,
+        all_paddings: float,
+        kernel_size: int,
+        stride: int,
+        ceil_mode: bool,
+        repeat_num: int = 1
+):
     """ Calculates the output length of a Tensor passed through a convolution or max pooling layer"""
     add_pad = all_paddings - kernel_size
     one = 1.0

--- a/nemo/collections/asr/parts/submodules/subsampling.py
+++ b/nemo/collections/asr/parts/submodules/subsampling.py
@@ -273,8 +273,8 @@ class ConvSubsampling(torch.nn.Module):
 
 def calc_length(lengths, all_paddings, kernel_size, stride, ceil_mode, repeat_num=1):
     """ Calculates the output length of a Tensor passed through a convolution or max pooling layer"""
-    add_pad: float = all_paddings - kernel_size
-    one: float = 1.0
+    add_pad = all_paddings - kernel_size
+    one = 1.0
     for i in range(repeat_num):
         lengths = torch.div(lengths.to(dtype=torch.float) + add_pad, stride) + one
         if ceil_mode:


### PR DESCRIPTION
# What does this PR do ?

Remove type annotations in the `calc_length` function since it causes errors when scripting Conformer models.

**Collection**: ASR

This is the error:

```
[NeMo E 2022-08-03 11:47:46 exportable:116] jit.script() failed!\
    Variable 'add_pad' is annotated with type float but is being assigned to a value of type Tensor:
      File "/Users/allabana/.virtualenvs/meval/lib/python3.8/site-packages/nemo/collections/asr/parts/submodules/subsampling.py", line 149
    def calc_length(lengths, padding, kernel_size, stride, ceil_mode, repeat_num=1):
        """ Calculates the output length of a Tensor passed through a convolution or max pooling layer"""
        add_pad: float = (padding * 2) - kernel_size
        ~~~~~~~ <--- HERE
        one: float = 1.0
        for i in range(repeat_num):
```

This is an example usage that causes the error:

```py
pre_trained_model_name = "stt_en_conformer_ctc_small"
model = EncDecCTCModelBPE.from_pretrained(pre_trained_model_name, map_location='cpu')
model.eval()
model.export(f"/tmp/{model._get_name()}.ts", check_trace=True, try_script=True)
```

# Changelog 
- Remove type annotations for `add_pad`/`one` in `nemo.collections.asr.parts.submodules.subsampling.calc_length`
- Add type annotations to `calc_length` method args.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.
