### PR TITLE
fix to fetch config file

### DIFF
--- a/tutorials/speaker_tasks/Speaker_Identification_Verification.ipynb
+++ b/tutorials/speaker_tasks/Speaker_Identification_Verification.ipynb
@@ -596,7 +596,8 @@
    "metadata": {
     "colab": {},
     "colab_type": "code",
-    "id": "HvYhsOWuSpL_"
+    "id": "HvYhsOWuSpL_",
+    "scrolled": false
    },
    "outputs": [],
    "source": [
@@ -768,7 +769,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# !wget -P conf https://raw.githubusercontent.com/NVIDIA/NeMo/$BRANCH/examples/speaker_tasks/recognition/conf/titanet-finetune.yaml\n",
+    "!wget -P conf https://raw.githubusercontent.com/NVIDIA/NeMo/$BRANCH/examples/speaker_tasks/recognition/conf/titanet-finetune.yaml\n",
     "MODEL_CONFIG = os.path.join(NEMO_ROOT,'conf/titanet-finetune.yaml')\n",
     "finetune_config = OmegaConf.load(MODEL_CONFIG)\n",
     "print(OmegaConf.to_yaml(finetune_config))"


### PR DESCRIPTION
Signed-off-by: nithinraok <nithinrao.koluguri@gmail.com>

# What does this PR do ?

Fix to get the titanet-finetune.conf file before running it. 

**Collection**: Speaker Tasks

# Changelog 
Previous code line was commented, now uncommented to get the required config file

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

