### PR TITLE
[TTS] FastPitch training: speed up align_prior_matrix calculation

### DIFF
--- a/nemo/collections/tts/torch/data.py
+++ b/nemo/collections/tts/torch/data.py
@@ -521,7 +521,7 @@ class TTSDataset(Dataset):
             if self.use_beta_binomial_interpolator:
                 align_prior_matrix = torch.from_numpy(self.beta_binomial_interpolator(mel_len, text_length.item()))
             else:
-                align_prior_matrix = beta_binomial_prior_distribution(text_length, mel_len)
+                align_prior_matrix = torch.from_numpy(beta_binomial_prior_distribution(text_length, mel_len))
 
         non_exist_voiced_index = []
         my_var = locals()

--- a/nemo/collections/tts/torch/data.py
+++ b/nemo/collections/tts/torch/data.py
@@ -153,7 +153,6 @@ class TTSDataset(Dataset):
             highfreq (Optional[int]): The highfreq input to the mel filter calculation. Defaults to None.
         Keyword Args:
             log_mel_folder (Optional[Union[Path, str]]): The folder that contains or will contain log mel spectrograms.
-            align_prior_matrix_folder (Optional[Union[Path, str]]): The folder that contains or will contain align prior matrices.
             pitch_folder (Optional[Union[Path, str]]): The folder that contains or will contain pitch.
             voiced_mask_folder (Optional[Union[Path, str]]): The folder that contains or will contain voiced mask of the pitch
             p_voiced_folder (Optional[Union[Path, str]]): The folder that contains or will contain p_voiced(probability) of the pitch
@@ -390,15 +389,6 @@ class TTSDataset(Dataset):
                 )
 
     def add_align_prior_matrix(self, **kwargs):
-        self.align_prior_matrix_folder = kwargs.pop('align_prior_matrix_folder', None)
-
-        if self.align_prior_matrix_folder is None:
-            self.align_prior_matrix_folder = Path(self.sup_data_path) / AlignPriorMatrix.name
-        elif isinstance(self.align_prior_matrix_folder, str):
-            self.align_prior_matrix_folder = Path(self.align_prior_matrix_folder)
-
-        self.align_prior_matrix_folder.mkdir(exist_ok=True, parents=True)
-
         self.use_beta_binomial_interpolator = kwargs.pop('use_beta_binomial_interpolator', False)
         if not self.cache_text:
             if 'use_beta_binomial_interpolator' in kwargs and not self.use_beta_binomial_interpolator:
@@ -527,19 +517,11 @@ class TTSDataset(Dataset):
         # Load alignment prior matrix if needed
         align_prior_matrix = None
         if AlignPriorMatrix in self.sup_data_types_set:
+            mel_len = self.get_log_mel(audio).shape[2]
             if self.use_beta_binomial_interpolator:
-                mel_len = self.get_log_mel(audio).shape[2]
                 align_prior_matrix = torch.from_numpy(self.beta_binomial_interpolator(mel_len, text_length.item()))
             else:
-                prior_path = self.align_prior_matrix_folder / f"{rel_audio_path_as_text_id}.pt"
-
-                if prior_path.exists():
-                    align_prior_matrix = torch.load(prior_path)
-                else:
-                    mel_len = self.get_log_mel(audio).shape[2]
-                    align_prior_matrix = beta_binomial_prior_distribution(text_length, mel_len)
-                    align_prior_matrix = torch.from_numpy(align_prior_matrix)
-                    torch.save(align_prior_matrix, prior_path)
+                align_prior_matrix = beta_binomial_prior_distribution(text_length, mel_len)
 
         non_exist_voiced_index = []
         my_var = locals()

--- a/nemo/collections/tts/torch/helpers.py
+++ b/nemo/collections/tts/torch/helpers.py
@@ -16,14 +16,15 @@ from pathlib import Path
 
 import numpy as np
 import torch
+from einops import rearrange
 from scipy import ndimage
-from scipy.stats import betabinom
+from torch.special import gammaln
 
 
 class BetaBinomialInterpolator:
     """
-        This module calculates alignment prior matrices (based on beta-binomial distribution) using cached popular sizes and image interpolation.
-        The implementation is taken from https://github.com/NVIDIA/DeepLearningExamples/blob/master/PyTorch/SpeechSynthesis/FastPitch/fastpitch/data_function.py
+    This module calculates alignment prior matrices (based on beta-binomial distribution) using cached popular sizes and image interpolation.
+    The implementation is taken from https://github.com/NVIDIA/DeepLearningExamples/blob/master/PyTorch/SpeechSynthesis/FastPitch/fastpitch/data_function.py
     """
 
     def __init__(self, round_mel_len_to=50, round_text_len_to=10, cache_size=500):
@@ -38,7 +39,7 @@ class BetaBinomialInterpolator:
     def __call__(self, w, h):
         bw = BetaBinomialInterpolator.round(w, to=self.round_mel_len_to)
         bh = BetaBinomialInterpolator.round(h, to=self.round_text_len_to)
-        ret = ndimage.zoom(self.bank(bw, bh).T, zoom=(w / bw, h / bh), order=1)
+        ret = ndimage.zoom(self.bank(bw, bh).numpy().T, zoom=(w / bw, h / bh), order=1)
         assert ret.shape[0] == w, ret.shape
         assert ret.shape[1] == h, ret.shape
         return ret
@@ -50,14 +51,29 @@ def general_padding(item, item_len, max_len, pad_value=0):
     return item
 
 
-def beta_binomial_prior_distribution(phoneme_count, mel_count, scaling_factor=1.0):
-    x = np.arange(0, phoneme_count)
-    mel_text_probs = []
-    for i in range(1, mel_count + 1):
-        a, b = scaling_factor * i, scaling_factor * (mel_count + 1 - i)
-        mel_i_prob = betabinom(phoneme_count - 1, a, b).pmf(x)
-        mel_text_probs.append(mel_i_prob)
-    return np.array(mel_text_probs)
+def logbeta(x, y):
+    return gammaln(x) + gammaln(y) - gammaln(x + y)
+
+
+def logcombinations(n, k):
+    return gammaln(n + 1) - gammaln(k + 1) - gammaln(n - k + 1)   
+
+
+def logbetabinom(n, a, b, x):
+    return logcombinations(n, x) + logbeta(x + a, n - x + b) - logbeta(a, b)
+
+
+@torch.no_grad()
+def beta_binomial_prior_distribution(
+    phoneme_count: int, mel_count: int, scaling_factor: float = 1.0
+) -> torch.FloatTensor:
+    x = rearrange(torch.arange(0, phoneme_count), "b -> 1 b")
+    y = rearrange(torch.arange(1, mel_count + 1), "b -> b 1")
+    a = scaling_factor * y
+    b = scaling_factor * (mel_count + 1 - y)
+    n = torch.FloatTensor([phoneme_count - 1])
+
+    return logbetabinom(n, a, b, x).exp()
 
 
 def get_base_dir(paths):

--- a/nemo/collections/tts/torch/helpers.py
+++ b/nemo/collections/tts/torch/helpers.py
@@ -56,16 +56,14 @@ def logbeta(x, y):
 
 
 def logcombinations(n, k):
-    return gammaln(n + 1) - gammaln(k + 1) - gammaln(n - k + 1)   
+    return gammaln(n + 1) - gammaln(k + 1) - gammaln(n - k + 1)
 
 
 def logbetabinom(n, a, b, x):
     return logcombinations(n, x) + logbeta(x + a, n - x + b) - logbeta(a, b)
 
 
-def beta_binomial_prior_distribution(
-    phoneme_count: int, mel_count: int, scaling_factor: float = 1.0
-) -> np.array:
+def beta_binomial_prior_distribution(phoneme_count: int, mel_count: int, scaling_factor: float = 1.0) -> np.array:
     x = rearrange(torch.arange(0, phoneme_count), "b -> 1 b")
     y = rearrange(torch.arange(1, mel_count + 1), "b -> b 1")
     a = scaling_factor * y

--- a/nemo/collections/tts/torch/helpers.py
+++ b/nemo/collections/tts/torch/helpers.py
@@ -39,7 +39,7 @@ class BetaBinomialInterpolator:
     def __call__(self, w, h):
         bw = BetaBinomialInterpolator.round(w, to=self.round_mel_len_to)
         bh = BetaBinomialInterpolator.round(h, to=self.round_text_len_to)
-        ret = ndimage.zoom(self.bank(bw, bh).numpy().T, zoom=(w / bw, h / bh), order=1)
+        ret = ndimage.zoom(self.bank(bw, bh).T, zoom=(w / bw, h / bh), order=1)
         assert ret.shape[0] == w, ret.shape
         assert ret.shape[1] == h, ret.shape
         return ret
@@ -63,17 +63,16 @@ def logbetabinom(n, a, b, x):
     return logcombinations(n, x) + logbeta(x + a, n - x + b) - logbeta(a, b)
 
 
-@torch.no_grad()
 def beta_binomial_prior_distribution(
     phoneme_count: int, mel_count: int, scaling_factor: float = 1.0
-) -> torch.FloatTensor:
+) -> np.array:
     x = rearrange(torch.arange(0, phoneme_count), "b -> 1 b")
     y = rearrange(torch.arange(1, mel_count + 1), "b -> b 1")
     a = scaling_factor * y
     b = scaling_factor * (mel_count + 1 - y)
     n = torch.FloatTensor([phoneme_count - 1])
 
-    return logbetabinom(n, a, b, x).exp()
+    return logbetabinom(n, a, b, x).exp().numpy()
 
 
 def get_base_dir(paths):

--- a/requirements/requirements_common.txt
+++ b/requirements/requirements_common.txt
@@ -2,4 +2,3 @@ sentencepiece<1.0.0
 youtokentome>=1.0.5
 pandas
 sacremoses>=0.0.43
-einops

--- a/requirements/requirements_common.txt
+++ b/requirements/requirements_common.txt
@@ -2,3 +2,4 @@ sentencepiece<1.0.0
 youtokentome>=1.0.5
 pandas
 sacremoses>=0.0.43
+einops

--- a/requirements/requirements_torch_tts.txt
+++ b/requirements/requirements_torch_tts.txt
@@ -5,3 +5,4 @@ pystoi
 pesq
 pandas
 inflect
+einops


### PR DESCRIPTION
# What does this PR do ?

Speed up align_prior_matrix calculation and don't save it to disk. They take lots of space (tens of gigabytes per experiment) and it is perfectly fine to compute them on-the-fly. Matrix calculation speed-up is significant.

```python
%timeit beta_binomial_prior_distribution_numpy_old(80, 300)
226 ms ± 5.86 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)

%timeit beta_binomial_prior_distribution_new_torch(80, 300)
586 µs ± 22 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

**Collection**: TTS

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below



# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
