### PR TITLE
[TTS] Fix text normalizer bugs in TTS data loader

### DIFF
--- a/nemo/collections/tts/torch/data.py
+++ b/nemo/collections/tts/torch/data.py
@@ -188,11 +188,18 @@ class TTSDataset(Dataset):
             self.tokens = tokens
         self.cache_text = True if self.phoneme_probability is None else False
 
-        # Initialize text normalizer is specified
+        # Initialize text normalizer if specified
         self.text_normalizer = text_normalizer
-        self.text_normalizer_call = (
-            self.text_normalizer.normalize if isinstance(self.text_normalizer, Normalizer) else self.text_normalizer
-        )
+        if self.text_normalizer is None:
+            self.text_normalizer_call = None
+        elif not PYNINI_AVAILABLE:
+            raise ImportError("pynini is not installed, please install via nemo_text_processing/install_pynini.sh")
+        else:
+            self.text_normalizer_call = (
+                self.text_normalizer.normalize
+                if isinstance(self.text_normalizer, Normalizer)
+                else self.text_normalizer
+            )
         self.text_normalizer_call_kwargs = (
             text_normalizer_call_kwargs if text_normalizer_call_kwargs is not None else {}
         )
@@ -219,15 +226,15 @@ class TTSDataset(Dataset):
                         "is_phoneme": item["is_phoneme"] if "is_phoneme" in item else None,
                     }
 
-                    if ("text_normalized" not in item) or ("normalized_text" not in item):
+                    if "normalized_text" in item:
+                        file_info["normalized_text"] = item["normalized_text"]
+                    elif "text_normalized" in item:
+                        file_info["normalized_text"] = item["text_normalized"]
+                    else:
                         text = item["text"]
                         if self.text_normalizer is not None:
                             text = self.text_normalizer_call(text, **self.text_normalizer_call_kwargs)
                         file_info["normalized_text"] = text
-                    elif "normalized_text" in item:
-                        file_info["normalized_text"] = item["normalized_text"]
-                    else:
-                        file_info["normalized_text"] = item["text_normalized"]
 
                     if self.cache_text:
                         file_info["text_tokens"] = self.text_tokenizer(file_info["normalized_text"])


### PR DESCRIPTION
Signed-off-by: Ryan <rlangman@nvidia.com>

# What does this PR do ?

Fixes two bugs recently introduced into the TTS data loader initialization.

1. When pynini is not installed, then Normalizer = None. This causes `isinstance(self.text_normalizer, Normalizer)` to throw an exception.
2. The statement `("text_normalized" not in item) or ("normalized_text" not in item)` should be an `and `rather than an `or`. But rather than make that specific change, I rewrote the condition checks to be less confusing/error prone.

**Collection**:  [TTS]

# Changelog 
- Avoid TypeError when user does not use a text normalizer and pynini is not installed.
- Avoid applying text normalization when "text_normalized" is provided as a field

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.