### PR TITLE
amend rnnt word timestamps

### DIFF
--- a/nemo/collections/asr/metrics/rnnt_wer.py
+++ b/nemo/collections/asr/metrics/rnnt_wer.py
@@ -685,10 +685,9 @@ class AbstractRNNTDecoding(ABC):
         # may have different dimensionality.
         # As such, we can't rely on the length of the list of built_token to index offsets.
         if built_token:
-            # start from the last processed token + (1 if anything was processed else 0)
-            start_offset = offsets[
-                previous_token_index + (1 if word_offsets else 0)
-            ]["start_offset"]
+            # start from the previous token index as this hasn't been committed to word_offsets yet
+            # if we still have content in built_token
+            start_offset = offsets[previous_token_index]["start_offset"]
             word_offsets.append(
                 {
                     "word": decode_tokens_to_str(built_token),


### PR DESCRIPTION
# What does this PR do ?

This PR amends the start time for the last token in RNNT decoding because the code aggregates (inclusively) since the previous_token_index all tokens in the current word. This has tripped me up in my own implementations of similar code external to NeMo in the past. My apologies for not catching it in #4779. Without these changes, some transcription invocations fail.

**Collection**: ASR

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [X] Bugfix

@titu1994 I tested this code against an ASR corpus of 163,708 words, and it's looking stable with no more errors thrown. My tests were in WER rather than time stamps. There's a jitter of about 0.1%pt WER on clean English and 0.5%pts on noisy English, which is similar to what I've seen before on repeated invocations of custom models, though perhaps a bit larger for noisy audio. I don't know where to enumerate more test cases in this codebase, but this logic is a bit difficult to exhaustively test. I've seen 200-300 millisecond drifts in word timestamps across different models, so I don't know how to formalize a test for these outputs more specifically.