### PR TITLE
Avoid storing extra copy of params in distributed Adam optimizer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,10 +34,10 @@ RUN apt-get update && \
 
 # FIXME a workaround to update apex. Remove when base image is updated
 WORKDIR /tmp/
-RUN git clone https://github.com/ericharper/apex.git && \
+RUN git clone https://github.com/timmoon10/apex.git && \
     cd apex && \
-    git checkout 19e4f55eb402452f74dead19f68b65d6291cfdb2 && \
-    pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" --global-option="--fast_layer_norm" ./
+    git checkout 2d5ebb793ca212773bc0af4b15afaee2cea5e82f && \
+    pip install -v --disable-pip-version-check --no-cache-dir --global-option="--cpp_ext" --global-option="--cuda_ext" --global-option="--fast_layer_norm" --global-option="--distributed_adam" --global-option="--deprecated_fused_adam" ./
 
 # uninstall stuff from base container
 RUN pip uninstall -y sacrebleu torchtext

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -187,6 +187,13 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             optim_kwargs['process_group'] = parallel_state.get_data_parallel_group()
             optim_kwargs['param_sync_dtype'] = self.autocast_dtype
             optim_kwargs['contiguous_grad_buffer'] = True
+            if self.autocast_dtype == torch.float:
+                optim_kwargs['store_params'] = False
+            elif self.autocast_dtype == torch.float16:
+                optim_kwargs['store_params'] = True
+            elif self.autocast_dtype == torch.bfloat16:
+                optim_kwargs['store_params'] = False
+                optim_kwargs['store_param_remainders'] = True
         return super().setup_optimization(optim_config=optim_config, optim_kwargs=optim_kwargs)
 
     def forward(self, tokens, text_position_ids, attention_mask, labels):

--- a/nemo/core/optim/optimizers.py
+++ b/nemo/core/optim/optimizers.py
@@ -60,7 +60,6 @@ if HAVE_APEX:
 
         # Try importing Apex distributed Adam optimizer
         from apex.contrib.optimizers.distributed_fused_adam import DistributedFusedAdam
-        import fused_adam_cuda, distributed_adam_cuda  # Required kernels
 
         HAVE_APEX_DISTRIBUTED_ADAM = True
 


### PR DESCRIPTION
# What does this PR do ?

https://github.com/NVIDIA/apex/pull/1463 adds an option to the distributed Adam optimizer that reduces memory usage for BF16 models. Instead of storing FP32 main params in the optimizer, we can just store 16-bit param remainders and reconstruct the FP32 main params from the BF16 model params.

**Collection**: NLP

# Changelog 
- Store 16-bit param remainders in dist Adam instead of full FP32 main params
- Update Dockerfile to build Apex with dist Adam support

# Usage
Set optimizer to `distributed_fused_adam` in config file:
https://github.com/NVIDIA/NeMo/blob/c0bfa6f07f766a3abd1804f5b666474887e0a1e4/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml#L150

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

Pinging @ericharper and @yaoyu-33.

# Additional Information
* Depends on https://github.com/NVIDIA/apex/pull/1463
