### PR TITLE
[Tutorials] Fix matplotlib version and directory name in Multispeaker_Simulator

### DIFF
--- a/tutorials/tools/Multispeaker_Simulator.ipynb
+++ b/tutorials/tools/Multispeaker_Simulator.ipynb
@@ -17,8 +17,6 @@
     "5. Restart the runtime (Runtime -> Restart Runtime) for any upgraded packages to take effect\n",
     "\"\"\"\n",
     "\n",
-    "import os\n",
-    "\n",
     "NEMO_DIR_PATH = \"NeMo\"\n",
     "BRANCH = 'main'\n",
     "\n",
@@ -38,7 +36,7 @@
     "!apt-get install sox libsndfile1 ffmpeg\n",
     "!pip install wget\n",
     "!pip install unidecode\n",
-    "!pip install matplotlib>=3.3.2"
+    "!pip install \"matplotlib>=3.3.2\""
    ]
   },
   {
@@ -65,6 +63,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
     "# download scripts if not already there \n",
     "if not os.path.exists('NeMo/scripts'):\n",
     "  print(\"Downloading necessary scripts\")\n",
@@ -331,7 +331,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!ls test_closetalk"
+    "!ls simulated_data"
    ]
   }
  ],


### PR DESCRIPTION
Signed-off-by: Ante Jukić <ajukic@nvidia.com>

# What does this PR do ?

Fix a couple minor issues in `Multispeaker_Simulator` notebook

**Collection**: Tutorials

# Changelog 

- added double quotes around the version specification to make sure the expected `matplotlib` is installed
- `ls` the correct directory with created files

# Usage
* n/a

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* n/a
