### PR TITLE
avoid data clipping after convolution with rir samples

### DIFF
--- a/nemo/collections/asr/parts/preprocessing/perturb.py
+++ b/nemo/collections/asr/parts/preprocessing/perturb.py
@@ -332,7 +332,9 @@ class ImpulsePerturbation(Perturbation):
         if not self._shift_impulse:
             impulse_norm = (impulse.samples - min(impulse.samples)) / (max(impulse.samples) - min(impulse.samples))
             data._samples = signal.fftconvolve(data._samples, impulse_norm, "same")
-            data._samples = data._samples / max(abs(data._samples))
+            data._samples = data._samples / max(
+                abs(data._samples)
+            )  # normalize data samples to [-1,1] after rir convolution to avoid nans with fp16 training
         else:
             # Find peak and shift peak to left
             impulse_norm = (impulse.samples - min(impulse.samples)) / (max(impulse.samples) - min(impulse.samples))
@@ -341,7 +343,9 @@ class ImpulsePerturbation(Perturbation):
             impulse_resp = impulse_norm[max_ind:]
             delay_after = len(impulse_resp)
             data._samples = signal.fftconvolve(data._samples, impulse_resp, "full")[:-delay_after]
-            data._samples = data._samples / max(abs(data._samples))
+            data._samples = data._samples / max(
+                abs(data._samples)
+            )  # normalize data samples to [-1,1] after rir convolution to avoid nans with fp16 training
 
 
 class ShiftPerturbation(Perturbation):

--- a/nemo/collections/asr/parts/preprocessing/perturb.py
+++ b/nemo/collections/asr/parts/preprocessing/perturb.py
@@ -332,6 +332,7 @@ class ImpulsePerturbation(Perturbation):
         if not self._shift_impulse:
             impulse_norm = (impulse.samples - min(impulse.samples)) / (max(impulse.samples) - min(impulse.samples))
             data._samples = signal.fftconvolve(data._samples, impulse_norm, "same")
+            data._samples = data._samples / max(abs(data._samples))
         else:
             # Find peak and shift peak to left
             impulse_norm = (impulse.samples - min(impulse.samples)) / (max(impulse.samples) - min(impulse.samples))
@@ -340,6 +341,7 @@ class ImpulsePerturbation(Perturbation):
             impulse_resp = impulse_norm[max_ind:]
             delay_after = len(impulse_resp)
             data._samples = signal.fftconvolve(data._samples, impulse_resp, "full")[:-delay_after]
+            data._samples = data._samples / max(abs(data._samples))
 
 
 class ShiftPerturbation(Perturbation):


### PR DESCRIPTION
Signed-off-by: nithinraok <nithinrao.koluguri@gmail.com>

# What does this PR do ?

Fix nan issue with precision=16

**Collection**: ASR

# Changelog 
- Clip max value of data samples after convolution with rir impulses to 1 

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
