### PR TITLE
Fix MixerTTS data loading index error

### DIFF
--- a/nemo/collections/tts/torch/data.py
+++ b/nemo/collections/tts/torch/data.py
@@ -805,6 +805,7 @@ class MixerTTSXDataset(TTSDataset):
         if LMTokens in self.sup_data_types_set:
             lm_tokens = torch.tensor(self.id2lm_tokens[index]).long()
 
+        # Note: Please change the indices in _collate_fn if any items are added/removed.
         return (
             audio,
             audio_length,
@@ -826,8 +827,8 @@ class MixerTTSXDataset(TTSDataset):
 
     def _collate_fn(self, batch):
         batch = list(zip(*batch))
-        data_dict = self.general_collate_fn(list(zip(*batch[:13])))
-        lm_tokens_list = batch[13]
+        data_dict = self.general_collate_fn(list(zip(*batch[:15])))
+        lm_tokens_list = batch[15]
 
         if LMTokens in self.sup_data_types_set:
             lm_tokens = torch.full(


### PR DESCRIPTION
Signed-off-by: Jocelyn Huang <jocelynh@nvidia.com>

# What does this PR do ?

Fixes indexing error in MixerTTS-X data loading introduced by adding items to the TTS datasets

**Collection**: TTS

# Changelog 
- Changed indexing from 13 to 15 due to two additional items `voiced_mask` and `p_voiced`

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation