### PR TITLE
Fix float/integer type error in WER.update()

### DIFF
--- a/nemo/collections/asr/metrics/wer.py
+++ b/nemo/collections/asr/metrics/wer.py
@@ -742,8 +742,8 @@ class WER(Metric):
             target_lengths: an integer torch.Tensor of shape ``[Batch]``
             predictions_lengths: an integer torch.Tensor of shape ``[Batch]``
         """
-        words = 0.0
-        scores = 0.0
+        words = 0
+        scores = 0
         references = []
         with torch.no_grad():
             # prediction_cpu_tensor = tensors[0].long().cpu()


### PR DESCRIPTION



# What does this PR do ?

Without this, `WER.update()` fails with the following exception:

    TypeError: 'float' object cannot be interpreted as an integer

This is because the `score` property is initialized as `tourch.int64`,
but actually is a float value. Fix the initialization so that the
property has the correct type.

*Technical Note:* the actual failing line is line 780 in `nemo/collections/asr/metrics/wer.py`:

```python3
self.scores = torch.tensor(scores, device=self.scores.device, dtype=self.scores.dtype)
```

Since `self.scores.dtype` is `torch.int64` in the current version, this line ended
up something like `torch.tensor(0.5, dtype=torch.int64)`  and fails.

**Collection**: [Note which collection this PR will affect]

ASR

# Changelog 

- Fix TypeError in WER.update()

# Usage

N/A

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [N/A] Did you write any new necessary tests?
- [N/A] Did you add or update any necessary documentation?
- [N/A] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [N/A] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
