### PR TITLE
fix type error in rnnt_wer.py, rnnt_wer_bpe.py, wer_bpe.py

### DIFF
--- a/nemo/collections/asr/metrics/rnnt_wer.py
+++ b/nemo/collections/asr/metrics/rnnt_wer.py
@@ -878,8 +878,8 @@ class RNNTWER(Metric):
         targets: torch.Tensor,
         target_lengths: torch.Tensor,
     ) -> torch.Tensor:
-        words = 0.0
-        scores = 0.0
+        words = 0
+        scores = 0
         references = []
         with torch.no_grad():
             # prediction_cpu_tensor = tensors[0].long().cpu()

--- a/nemo/collections/asr/metrics/rnnt_wer_bpe.py
+++ b/nemo/collections/asr/metrics/rnnt_wer_bpe.py
@@ -220,8 +220,8 @@ class RNNTBPEWER(Metric):
         targets: torch.Tensor,
         target_lengths: torch.Tensor,
     ) -> torch.Tensor:
-        words = 0.0
-        scores = 0.0
+        words = 0
+        scores = 0
         references = []
         with torch.no_grad():
             # prediction_cpu_tensor = tensors[0].long().cpu()

--- a/nemo/collections/asr/metrics/wer_bpe.py
+++ b/nemo/collections/asr/metrics/wer_bpe.py
@@ -165,8 +165,8 @@ class WERBPE(Metric):
             target_lengths: an integer torch.Tensor of shape ``[Batch]``
             predictions_lengths: an integer torch.Tensor of shape ``[Batch]``
         """
-        words = 0.0
-        scores = 0.0
+        words = 0
+        scores = 0
         references = []
         with torch.no_grad():
             targets_cpu_tensor = targets.long().cpu()


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

Fix float/integer type error in wer computation. Similar to PR https://github.com/NVIDIA/NeMo/pull/4816 but on different files.

# Changelog 
Fix type errors in file rnnt_wer.py, rnnt_wer_bpe.py, wer_bpe.py. 

# Usage
N/A



# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
