### PR TITLE
[ASR] Fix for multi-channel signals in AudioSegment

### DIFF
--- a/nemo/collections/asr/data/audio_to_text_dataset.py
+++ b/nemo/collections/asr/data/audio_to_text_dataset.py
@@ -98,6 +98,7 @@ def get_char_dataset(config: dict, augmentor: Optional['AudioAugmentor'] = None)
         trim=config.get('trim_silence', False),
         parser=config.get('parser', 'en'),
         return_sample_id=config.get('return_sample_id', False),
+        channel_selector=config.get('channel_selector', None),
     )
     return dataset
 
@@ -128,6 +129,7 @@ def get_bpe_dataset(
         trim=config.get('trim_silence', False),
         use_start_end_token=config.get('use_start_end_token', True),
         return_sample_id=config.get('return_sample_id', False),
+        channel_selector=config.get('channel_selector', None),
     )
     return dataset
 

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -186,6 +186,7 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
             'shuffle': False,
             'num_workers': config.get('num_workers', min(batch_size, os.cpu_count() - 1)),
             'pin_memory': True,
+            'channel_selector': config.get('channel_selector', None),
             'use_start_end_token': self.cfg.validation_ds.get('use_start_end_token', False),
         }
 

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -30,6 +30,7 @@ from nemo.collections.asr.metrics.wer import WER, CTCDecoding, CTCDecodingConfig
 from nemo.collections.asr.models.asr_model import ASRModel, ExportableEncDecModel
 from nemo.collections.asr.parts.mixins import ASRModuleMixin
 from nemo.collections.asr.parts.preprocessing.perturb import process_augmentations
+from nemo.collections.asr.parts.utils.audio_utils import ChannelSelectorType
 from nemo.core.classes.common import PretrainedModelInfo, typecheck
 from nemo.core.classes.mixins import AccessMixin
 from nemo.core.neural_types import AudioSignal, LabelsType, LengthsType, LogprobsType, NeuralType, SpectrogramType
@@ -114,6 +115,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
         logprobs: bool = False,
         return_hypotheses: bool = False,
         num_workers: int = 0,
+        channel_selector: Optional[ChannelSelectorType] = None,
     ) -> List[str]:
         """
         Uses greedy decoding to transcribe audio files. Use this method for debugging and prototyping.
@@ -128,6 +130,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
             return_hypotheses: (bool) Either return hypotheses or text
                 With hypotheses can do some postprocessing like getting timestamp or rescoring
             num_workers: (int) number of workers for DataLoader
+            channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels from multi-channel audio. If set to `'average'`, it performs averaging across channels. Disabled if set to `None`. Defaults to `None`.
 
         Returns:
             A list of transcriptions (or raw log probabilities if logprobs is True) in the same order as paths2audio_files
@@ -176,6 +179,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
                     'batch_size': batch_size,
                     'temp_dir': tmpdir,
                     'num_workers': num_workers,
+                    'channel_selector': channel_selector,
                 }
 
                 temporary_datalayer = self._setup_transcribe_dataloader(config)

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -508,6 +508,7 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
             'shuffle': False,
             'num_workers': config.get('num_workers', min(batch_size, os.cpu_count() - 1)),
             'pin_memory': True,
+            'channel_selector': config.get('channel_selector', None),
             'use_start_end_token': self.cfg.validation_ds.get('use_start_end_token', False),
         }
 

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -32,6 +32,7 @@ from nemo.collections.asr.models.asr_model import ASRModel
 from nemo.collections.asr.modules.rnnt import RNNTDecoderJoint
 from nemo.collections.asr.parts.mixins import ASRModuleMixin
 from nemo.collections.asr.parts.preprocessing.perturb import process_augmentations
+from nemo.collections.asr.parts.utils.audio_utils import ChannelSelectorType
 from nemo.core.classes import Exportable
 from nemo.core.classes.common import PretrainedModelInfo, typecheck
 from nemo.core.classes.mixins import AccessMixin
@@ -212,6 +213,7 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, Exportable):
         return_hypotheses: bool = False,
         partial_hypothesis: Optional[List['Hypothesis']] = None,
         num_workers: int = 0,
+        channel_selector: Optional[ChannelSelectorType] = None,
     ) -> (List[str], Optional[List['Hypothesis']]):
         """
         Uses greedy decoding to transcribe audio files. Use this method for debugging and prototyping.
@@ -226,6 +228,7 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, Exportable):
             return_hypotheses: (bool) Either return hypotheses or text
         With hypotheses can do some postprocessing like getting timestamp or rescoring
             num_workers: (int) number of workers for DataLoader
+            channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels from multi-channel audio. If set to `'average'`, it performs averaging across channels. Disabled if set to `None`. Defaults to `None`. Uses zero-based indexing.
 
         Returns:
             A list of transcriptions in the same order as paths2audio_files. Will also return
@@ -268,6 +271,7 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, Exportable):
                     'batch_size': batch_size,
                     'temp_dir': tmpdir,
                     'num_workers': num_workers,
+                    'channel_selector': channel_selector,
                 }
 
                 temporary_datalayer = self._setup_transcribe_dataloader(config)

--- a/nemo/collections/asr/parts/preprocessing/features.py
+++ b/nemo/collections/asr/parts/preprocessing/features.py
@@ -119,6 +119,7 @@ class WaveformFeaturizer(object):
         trim_frame_length=2048,
         trim_hop_length=512,
         orig_sr=None,
+        channel_selector=None,
     ):
         audio = AudioSegment.from_file(
             file_path,
@@ -132,6 +133,7 @@ class WaveformFeaturizer(object):
             trim_frame_length=trim_frame_length,
             trim_hop_length=trim_hop_length,
             orig_sr=orig_sr,
+            channel_selector=channel_selector,
         )
         return self.process_segment(audio)
 

--- a/nemo/collections/asr/parts/preprocessing/segment.py
+++ b/nemo/collections/asr/parts/preprocessing/segment.py
@@ -40,6 +40,7 @@ import librosa
 import numpy as np
 import soundfile as sf
 
+from nemo.collections.asr.parts.utils.audio_utils import select_channels
 from nemo.utils import logging
 
 # TODO @blisc: Perhaps refactor instead of import guarding
@@ -75,23 +76,38 @@ class AudioSegment(object):
         trim_frame_length=2048,
         trim_hop_length=512,
         orig_sr=None,
+        channel_selector=None,
     ):
         """Create audio segment from samples.
         Samples are convert float32 internally, with int scaled to [-1, 1].
         """
         samples = self._convert_samples_to_float32(samples)
+
+        # Check if channel selector is necessary
+        if samples.ndim == 1 and channel_selector not in [None, 0, 'average']:
+            raise ValueError(
+                'Input signal is one-dimensional, channel selector (%s) cannot not be used.', str(channel_selector)
+            )
+        elif samples.ndim == 2:
+            samples = select_channels(samples, channel_selector)
+        elif samples.ndim >= 3:
+            raise NotImplementedError(
+                'Signals with more than two dimensions (sample, channel) are currently not supported.'
+            )
+
         if target_sr is not None and target_sr != sample_rate:
-            samples = librosa.core.resample(samples, orig_sr=sample_rate, target_sr=target_sr)
+            # resample along the temporal dimension (axis=0)
+            samples = librosa.core.resample(samples, orig_sr=sample_rate, target_sr=target_sr, axis=0)
             sample_rate = target_sr
         if trim:
+            # librosa is using channels-first layout (num_channels, num_samples), which is transpose of AudioSegment's layout
+            samples = samples.transpose()
             samples, _ = librosa.effects.trim(
                 samples, top_db=trim_top_db, ref=trim_ref, frame_length=trim_frame_length, hop_length=trim_hop_length
             )
+            samples = samples.transpose()
         self._samples = samples
         self._sample_rate = sample_rate
-        if self._samples.ndim >= 2:
-            self._samples = np.mean(self._samples, 1)
-
         self._orig_sr = orig_sr if orig_sr is not None else sample_rate
 
     def __eq__(self, other):
@@ -112,13 +128,24 @@ class AudioSegment(object):
 
     def __str__(self):
         """Return human-readable representation of segment."""
-        return "%s: num_samples=%d, sample_rate=%d, duration=%.2fsec, rms=%.2fdB" % (
-            type(self),
-            self.num_samples,
-            self.sample_rate,
-            self.duration,
-            self.rms_db,
-        )
+        if self.num_channels == 1:
+            return "%s: num_samples=%d, sample_rate=%d, duration=%.2fsec, rms=%.2fdB" % (
+                type(self),
+                self.num_samples,
+                self.sample_rate,
+                self.duration,
+                self.rms_db,
+            )
+        else:
+            rms_db_str = ', '.join([f'{rms:.2f}dB' for rms in self.rms_db])
+            return "%s: num_samples=%d, sample_rate=%d, duration=%.2fsec, num_channels=%d, rms=[%s]" % (
+                type(self),
+                self.num_samples,
+                self.sample_rate,
+                self.duration,
+                self.num_channels,
+                rms_db_str,
+            )
 
     @staticmethod
     def _convert_samples_to_float32(samples):
@@ -150,6 +177,7 @@ class AudioSegment(object):
         trim_frame_length=2048,
         trim_hop_length=512,
         orig_sr=None,
+        channel_selector=None,
     ):
         """
         Load a file supported by librosa and return as an AudioSegment.
@@ -165,6 +193,9 @@ class AudioSegment(object):
         :param trim_frame_length: the number of samples per analysis frame
         :param trim_hop_length: the number of samples between analysis frames
         :param orig_sr: the original sample rate
+        :param channel selector: string denoting the downmix mode, an integer denoting the channel to be selected, or an iterable
+                                 of integers denoting a subset of channels. Channel selector is using zero-based indexing.
+                                 If set to `None`, the original signal will be used.
         :return: numpy array of samples
         """
         samples = None
@@ -179,7 +210,6 @@ class AudioSegment(object):
                         samples = f.read(int(duration * sample_rate), dtype=dtype)
                     else:
                         samples = f.read(dtype=dtype)
-                samples = samples.transpose()
             except RuntimeError as e:
                 logging.error(
                     f"Loading {audio_file} via SoundFile raised RuntimeError: `{e}`. "
@@ -190,6 +220,7 @@ class AudioSegment(object):
             try:
                 samples = Audio.from_file(audio_file)
                 sample_rate = samples.frame_rate
+                num_channels = samples.channels
                 if offset > 0:
                     # pydub does things in milliseconds
                     seconds = offset * 1000
@@ -198,6 +229,9 @@ class AudioSegment(object):
                     seconds = duration * 1000
                     samples = samples[: int(seconds)]
                 samples = np.array(samples.get_array_of_samples())
+                # For multi-channel signals, channels are stacked in a one-dimensional vector
+                if num_channels > 1:
+                    samples = np.reshape(samples, (-1, num_channels))
             except CouldntDecodeError as err:
                 logging.error(f"Loading {audio_file} via pydub raised CouldntDecodeError: `{err}`.")
 
@@ -215,10 +249,13 @@ class AudioSegment(object):
             trim_frame_length=trim_frame_length,
             trim_hop_length=trim_hop_length,
             orig_sr=orig_sr,
+            channel_selector=channel_selector,
         )
 
     @classmethod
-    def segment_from_file(cls, audio_file, target_sr=None, n_segments=0, trim=False, orig_sr=None):
+    def segment_from_file(
+        cls, audio_file, target_sr=None, n_segments=0, trim=False, orig_sr=None, channel_selector=None,
+    ):
         """Grabs n_segments number of samples from audio_file randomly from the
         file as opposed to at a specified offset.
 
@@ -234,12 +271,12 @@ class AudioSegment(object):
                     samples = f.read(n_segments, dtype='float32')
                 else:
                     samples = f.read(dtype='float32')
-            samples = samples.transpose()
         except RuntimeError as e:
             logging.error(f"Loading {audio_file} via SoundFile raised RuntimeError: `{e}`.")
 
-        samples = samples.transpose()
-        return cls(samples, sample_rate, target_sr=target_sr, trim=trim, orig_sr=orig_sr)
+        return cls(
+            samples, sample_rate, target_sr=target_sr, trim=trim, orig_sr=orig_sr, channel_selector=channel_selector
+        )
 
     @property
     def samples(self):
@@ -250,16 +287,25 @@ class AudioSegment(object):
         return self._sample_rate
 
     @property
+    def num_channels(self):
+        if self._samples.ndim == 1:
+            return 1
+        else:
+            return self._samples.shape[-1]
+
+    @property
     def num_samples(self):
         return self._samples.shape[0]
 
     @property
     def duration(self):
-        return self._samples.shape[0] / float(self._sample_rate)
+        return self.num_samples / float(self._sample_rate)
 
     @property
     def rms_db(self):
-        mean_square = np.mean(self._samples ** 2)
+        """Return per-channel RMS value.
+        """
+        mean_square = np.mean(self._samples ** 2, axis=0)
         return 10 * np.log10(mean_square)
 
     @property
@@ -276,7 +322,18 @@ class AudioSegment(object):
         `pad_size`
         zeros will be added only to the end.
         """
-        self._samples = np.pad(self._samples, (pad_size if symmetric else 0, pad_size), mode='constant',)
+        samples_ndim = self._samples.ndim
+        if samples_ndim == 1:
+            pad_width = pad_size if symmetric else (0, pad_size)
+        elif samples_ndim == 2:
+            # pad samples, keep channels
+            pad_width = ((pad_size, pad_size), (0, 0)) if symmetric else ((0, pad_size), (0, 0))
+        else:
+            raise NotImplementedError(
+                f"Padding not implemented for signals with more that 2 dimensions. Current samples dimension: {samples_ndim}."
+            )
+        # apply padding
+        self._samples = np.pad(self._samples, pad_width, mode='constant',)
 
     def subsegment(self, start_time=None, end_time=None):
         """Cut the AudioSegment between given boundaries.

--- a/nemo/collections/asr/parts/utils/audio_utils.py
+++ b/nemo/collections/asr/parts/utils/audio_utils.py
@@ -1,0 +1,83 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Iterable, Optional, Union
+
+import numpy as np
+import numpy.typing as npt
+
+from nemo.utils import logging
+
+ChannelSelectorType = Union[int, Iterable[int], str]
+
+
+def select_channels(signal: npt.NDArray, channel_selector: Optional[ChannelSelectorType] = None) -> npt.NDArray:
+    """
+    Convert a multi-channel signal to a single-channel signal by averaging over channels or selecting a single channel,
+    or pass-through multi-channel signal when channel_selector is `None`.
+    
+    Args:
+        signal: numpy array with shape (..., num_channels)
+        channel selector: string denoting the downmix mode, an integer denoting the channel to be selected, or an iterable
+                          of integers denoting a subset of channels. Channel selector is using zero-based indexing.
+                          If set to `None`, the original signal will be returned. Uses zero-based indexing.
+
+    Returns:
+        numpy array
+    """
+    if signal.ndim == 1:
+        # For one-dimensional input, return the input signal.
+        if channel_selector not in [None, 0, 'average']:
+            raise ValueError(
+                'Input signal is one-dimensional, channel selector (%s) cannot not be used.', str(channel_selector)
+            )
+        return signal
+
+    num_channels = signal.shape[-1]
+    num_samples = signal.size // num_channels  # handle multi-dimensional signals
+
+    if num_channels >= num_samples:
+        logging.warning(
+            'Number of channels (%d) is greater or equal than number of samples (%d). Check for possible transposition.',
+            num_channels,
+            num_samples,
+        )
+
+    # Samples are arranged as (num_channels, ...)
+    if channel_selector is None:
+        # keep the original multi-channel signal
+        pass
+    elif channel_selector == 'average':
+        # default behavior: downmix by averaging across channels
+        signal = np.mean(signal, axis=-1)
+    elif isinstance(channel_selector, int):
+        # select a single channel
+        if channel_selector >= num_channels:
+            raise ValueError(f'Cannot select channel {channel_selector} from a signal with {num_channels} channels.')
+        signal = signal[..., channel_selector]
+    elif isinstance(channel_selector, Iterable):
+        # select multiple channels
+        if max(channel_selector) >= num_channels:
+            raise ValueError(
+                f'Cannot select channel subset {channel_selector} from a signal with {num_channels} channels.'
+            )
+        signal = signal[..., channel_selector]
+        # squeeze the channel dimension if a single-channel is selected
+        # this is done to have the same shape as when using integer indexing
+        if len(channel_selector) == 1:
+            signal = np.squeeze(signal, axis=-1)
+    else:
+        raise ValueError(f'Unexpected value for channel_selector ({channel_selector})')
+
+    return signal

--- a/tests/collections/asr/test_asr_ctc_encoder_model_bpe.py
+++ b/tests/collections/asr/test_asr_ctc_encoder_model_bpe.py
@@ -302,6 +302,7 @@ class TestEncDecCTCModel:
             'bucketing_batch_size',
             'bucketing_strategy',
             'bucketing_weights',
+            'channel_selector',
         ]
 
         REMAP_ARGS = {'trim_silence': 'trim', 'labels': 'tokenizer'}

--- a/tests/collections/asr/test_asr_ctcencdec_model.py
+++ b/tests/collections/asr/test_asr_ctcencdec_model.py
@@ -272,6 +272,7 @@ class TestEncDecCTCModel:
             'bucketing_batch_size',
             'bucketing_strategy',
             'bucketing_weights',
+            'channel_selector',
         ]
 
         REMAP_ARGS = {'trim_silence': 'trim'}

--- a/tests/collections/asr/test_preprocessing_segment.py
+++ b/tests/collections/asr/test_preprocessing_segment.py
@@ -1,0 +1,122 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import tempfile
+from typing import List, Type, Union
+
+import numpy as np
+import pytest
+import soundfile as sf
+
+from nemo.collections.asr.parts.preprocessing.segment import AudioSegment
+from nemo.collections.asr.parts.utils.audio_utils import select_channels
+
+
+class TestAudioSegment:
+
+    sample_rate = 16000
+    signal_duration_sec = 2
+    max_diff_tol = 1e-9
+
+    @property
+    def num_samples(self):
+        return self.sample_rate * self.signal_duration_sec
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("num_channels", [1, 4])
+    @pytest.mark.parametrize("channel_selector", [None, 'average', 0, 1, [0, 1]])
+    def test_init_single_channel(self, num_channels: int, channel_selector: Type[Union[str, int, List[int]]]):
+        """Test the constructor directly.
+        """
+        if num_channels == 1:
+            # samples is a one-dimensional vector for single-channel signal
+            samples = np.random.rand(self.num_samples)
+        else:
+            samples = np.random.rand(self.num_samples, num_channels)
+
+        if (isinstance(channel_selector, int) and channel_selector >= num_channels) or (
+            isinstance(channel_selector, list) and max(channel_selector) >= num_channels
+        ):
+            # Expect a failure if looking for a different channel when input is 1D
+            with pytest.raises(ValueError):
+                # Construct UUT
+                uut = AudioSegment(samples=samples, sample_rate=self.sample_rate, channel_selector=channel_selector)
+        else:
+            # Construct UUT
+            uut = AudioSegment(samples=samples, sample_rate=self.sample_rate, channel_selector=channel_selector)
+
+            # Create golden reference
+            # Note: AudioSegment converts input samples to float32
+            golden_samples = select_channels(samples.astype('float32'), channel_selector)
+            expected_num_channels = 1 if golden_samples.ndim == 1 else golden_samples.shape[1]
+
+            # Test UUT
+            assert uut.num_channels == expected_num_channels
+            assert uut.num_samples == self.num_samples
+            assert uut.sample_rate == self.sample_rate
+            assert uut.duration == self.signal_duration_sec
+            max_diff = np.max(np.abs(uut.samples - golden_samples))
+            assert max_diff < self.max_diff_tol
+
+            # Test zero padding
+            pad_length = 42
+            uut.pad(pad_length, symmetric=False)
+            # compare to golden references
+            assert uut.num_samples == self.num_samples + pad_length
+            assert np.all(uut.samples[-pad_length:] == 0.0)
+            max_diff = np.max(np.abs(uut.samples[:-pad_length] - golden_samples))
+            assert max_diff < self.max_diff_tol
+
+            # Test subsegment
+            start_time = 0.2 * self.signal_duration_sec
+            end_time = 0.5 * self.signal_duration_sec
+            uut.subsegment(start_time=start_time, end_time=end_time)
+            # compare to golden references
+            start_sample = int(round(start_time * self.sample_rate))
+            end_sample = int(round(end_time * self.sample_rate))
+            max_diff = np.max(np.abs(uut.samples - golden_samples[start_sample:end_sample]))
+            assert max_diff < self.max_diff_tol
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("num_channels", [1, 4])
+    @pytest.mark.parametrize("channel_selector", [None, 'average', 0])
+    def test_from_file(self, num_channels, channel_selector):
+        """Test loading a signal from a file.
+        """
+        with tempfile.TemporaryDirectory() as test_dir:
+            # Prepare a wav file
+            audio_file = os.path.join(test_dir, 'audio.wav')
+            if num_channels == 1:
+                # samples is a one-dimensional vector for single-channel signal
+                samples = np.random.rand(self.num_samples)
+            else:
+                samples = np.random.rand(self.num_samples, num_channels)
+            sf.write(audio_file, samples, self.sample_rate, 'float')
+
+            # Create UUT
+            uut = AudioSegment.from_file(audio_file, channel_selector=channel_selector)
+
+            # Create golden reference
+            # Note: AudioSegment converts input samples to float32
+            golden_samples = select_channels(samples.astype('float32'), channel_selector)
+            expected_num_channels = 1 if golden_samples.ndim == 1 else golden_samples.shape[1]
+
+            # Test UUT
+            assert uut.num_channels == expected_num_channels
+            assert uut.num_samples == self.num_samples
+            assert uut.sample_rate == self.sample_rate
+            assert uut.duration == self.signal_duration_sec
+            max_diff = np.max(np.abs(uut.samples - golden_samples))
+            assert max_diff < self.max_diff_tol

--- a/tests/collections/asr/utils/test_audio_utils.py
+++ b/tests/collections/asr/utils/test_audio_utils.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Type, Union
+
+import numpy as np
+import pytest
+
+from nemo.collections.asr.parts.utils.audio_utils import select_channels
+
+
+class TestSelectChannels:
+    num_samples = 1000
+    max_diff_tol = 1e-9
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("channel_selector", [None, 'average', 0, 1, [0, 1]])
+    def test_single_channel_input(self, channel_selector: Type[Union[str, int, List[int]]]):
+        """Cover the case with single-channel input signal.
+        Channel selector should not do anything in this case.
+        """
+        golden_out = signal_in = np.random.rand(self.num_samples)
+
+        if channel_selector not in [None, 0, 'average']:
+            # Expect a failure if looking for a different channel when input is 1D
+            with pytest.raises(ValueError):
+                # UUT
+                signal_out = select_channels(signal_in, channel_selector)
+        else:
+            # UUT
+            signal_out = select_channels(signal_in, channel_selector)
+
+            # Check difference
+            max_diff = np.max(np.abs(signal_out - golden_out))
+            assert max_diff < self.max_diff_tol
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("num_channels", [2, 4])
+    @pytest.mark.parametrize("channel_selector", [None, 'average', 0, [1], [0, 1]])
+    def test_multi_channel_input(self, num_channels: int, channel_selector: Type[Union[str, int, List[int]]]):
+        """Cover the case with multi-channel input signal and single-
+        or multi-channel output.
+        """
+        num_samples = 1000
+        signal_in = np.random.rand(self.num_samples, num_channels)
+
+        # calculate golden output
+        if channel_selector is None:
+            golden_out = signal_in
+        elif channel_selector == 'average':
+            golden_out = np.mean(signal_in, axis=1)
+        else:
+            golden_out = signal_in[:, channel_selector].squeeze()
+
+        # UUT
+        signal_out = select_channels(signal_in, channel_selector)
+
+        # Check difference
+        max_diff = np.max(np.abs(signal_out - golden_out))
+        assert max_diff < self.max_diff_tol
+
+    @pytest.mark.unit
+    @pytest.mark.parametrize("num_channels", [1, 2])
+    @pytest.mark.parametrize("channel_selector", [2, [1, 2]])
+    def test_select_more_channels_than_available(
+        self, num_channels: int, channel_selector: Type[Union[str, int, List[int]]]
+    ):
+        """This test is expecting the UUT to fail because we ask for more channels
+        than available in the input signal.
+        """
+        num_samples = 1000
+        signal_in = np.random.rand(self.num_samples, num_channels)
+
+        # expect failure since we ask for more channels than available
+        with pytest.raises(ValueError):
+            # UUT
+            signal_out = select_channels(signal_in, channel_selector)


### PR DESCRIPTION
Signed-off-by: Ante Jukić <ajukic@nvidia.com>

# What does this PR do ?

Currently, `AudioSegment` aims to do channel averaging for multi-channel audio signals:
```
if self._samples.ndim >= 2:
  self._samples = np.mean(self._samples, 1)
```
However, samples in its constructor are arranged as `(num_channels, num_samples)`, instead of the assumed `(num_samples, num_channels)`. This means that `samples` of the created `AudioSegment` will have an unexpected size, and also ASR will fail when running `transcribe` on a multi-channel audio signal.

This can be tested by running `test_audiosegment.py` and `test_asr_multi_channel_audio.py` from the attached scripts in [test_audiosegment_with_channel_selector.zip](https://github.com/NVIDIA/NeMo/files/9458412/test_audiosegment_with_channel_selector.zip)

**Collection**: ASR

# Changelog 

### Necessary fix in `AudioSegment`
- correction to dimension ordering for multi-channel audio
- added a new parameter `channel_selector` which can be used to select a single-channel (or a subset of channels) from a multi-channel audio signal
- added unit tests for both channel selector and AudioSegment

Changes above are in `segment.py` and `audio_utils.py` and tests are in `test_preprocessing_segment.py` and `test_audio_utils.py`.

### Nice to have: `channel_selector` for `transcribe`
- Added a `channel_selector` option to `transcribe`, and forwarded it through models, audio-to-text dataset and `WaveformFeaturizer` to `AudioSegment`
- This is a convenience when running an existing model on a multi-channel audio file, we can select either one of the channels or the channel-wise average.

If preferred, this can be removed from the PR.

# Usage
* Check the attached scripts: [test_audiosegment_with_channel_selector.zip](https://github.com/NVIDIA/NeMo/files/9458412/test_audiosegment_with_channel_selector.zip)

## Example: `AudioSegment`
- Check `test_audiosegment.py`
```python
AudioSegment.from_file(audio_file) # loads the complete signal (including all channels)
AudioSegment.from_file(audio_file, channel_selector='average') # loads a single-channel signal (average across channels)
AudioSegment.from_file(audio_file, channel_selector=0) # loads only first channel
```

## Example: `AudioSegment`
- Check `test_asr_with_channel_selector.py`

```python
asr_model.transcribe(mc_files, channel_selector='average') # apply channel averaging when loading audio
```

# Tests

- Existing unit tests + newly-added unit tests
- Compared transcription using single-channel signal matches between `main` and `fix` branch for wav, flac, mp3 input (`test_asr_formats.py`, attached)
- Compared transcription of a channel from a multi-channel signal is matching transcription using a single-channel input signal (`test_asr_with_channel_selector.py`, attached)
- Tutorials `ASR_with_NeMo.ipynb` and `ASR_with_Transducers.ipynb` running fine with the `fix` branch

# Before your PR is "Ready for review"
**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* n/a
