### PR TITLE
Fix uppercasing mismatch for IPA heteronyms

### DIFF
--- a/nemo/collections/tts/torch/g2ps.py
+++ b/nemo/collections/tts/torch/g2ps.py
@@ -341,6 +341,9 @@ class IPAG2P(BaseG2p):
             if isinstance(heteronyms, str) or isinstance(heteronyms, pathlib.Path)
             else heteronyms
         )
+        if set_graphemes_upper:
+            self.heteronyms = [het.upper() for het in self.heteronyms]
+
         self.phoneme_probability = phoneme_probability
         self._rng = random.Random()
 


### PR DESCRIPTION
Signed-off-by: Jocelyn Huang <jocelynh@nvidia.com>

# What does this PR do ?

Fixes bug where lowercase heteronyms wouldn't match with uppercased graphemes in IPA G2P. (Graphemes were uppercased to avoid conflicts with IPA symbols, but the heteronyms list is lowercased, so they would never match.)

**Collection**: TTS

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation