### PR TITLE
IPA G2P bugfixes

### DIFF
--- a/examples/tts/conf/fastpitch_align_ipa.yaml
+++ b/examples/tts/conf/fastpitch_align_ipa.yaml
@@ -73,7 +73,7 @@ model:
     apostrophe: true
     pad_with_space: true
     g2p:
-      _target_: nemo.collections.common.tokenizers.text_to_speech.g2ps.IPAG2P
+      _target_: nemo_text_processing.g2p.modules.IPAG2P
       phoneme_dict: ${phoneme_dict_path}
       heteronyms: ${heteronyms_path}
       phoneme_probability: 0.8

--- a/nemo_text_processing/g2p/modules.py
+++ b/nemo_text_processing/g2p/modules.py
@@ -343,6 +343,9 @@ class IPAG2P(BaseG2p):
             if isinstance(heteronyms, str) or isinstance(heteronyms, pathlib.Path)
             else heteronyms
         )
+        if set_graphemes_upper:
+            self.heteronyms = [het.upper() for het in self.heteronyms]
+
         self.phoneme_probability = phoneme_probability
         self._rng = random.Random()
 


### PR DESCRIPTION
Fix uppercasing bug that led to heteronyms list mismatch, bad path in IPA FastPitch config

Signed-off-by: Jocelyn Huang <jocelynh@nvidia.com>

**Collection**: TTS

# Changelog 
- The IPA G2P class uppercases words by default (to avoid IPA symbol conflicts), but they would not match anything in the  lowercased heteronyms file. Fixed by uppercasing heteronyms when loading the file.
- IPA FastPitch config fixed to point to the updated location of the IPA G2P class.

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information
* The first fix is identical to the one merged into the r1.11.0 branch (#4860), reproduced here since the file has been moved in `main`.
