### PR TITLE
Fix Megatron NMT consumed samples and ckpt_to_nemo split rank

### DIFF
--- a/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
+++ b/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
@@ -104,10 +104,7 @@ def convert(local_rank, rank, world_size, args):
     app_state.pipeline_model_parallel_size = args.pipeline_model_parallel_size
     app_state.tensor_model_parallel_size = args.tensor_model_parallel_size
     # Auto set split rank for T5, BART, NMT if split rank is None.
-    if (
-        args.pipeline_model_parallel_size > 1
-        and args.model_type in ['t5', 'bart', 'nmt']
-    ):
+    if args.pipeline_model_parallel_size > 1 and args.model_type in ['t5', 'bart', 'nmt']:
         if args.pipeline_model_parallel_split_rank is not None:
             app_state.pipeline_model_parallel_split_rank = args.pipeline_model_parallel_split_rank
         else:

--- a/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
+++ b/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
@@ -106,7 +106,6 @@ def convert(local_rank, rank, world_size, args):
     # Auto set split rank for T5, BART, NMT if split rank is None.
     if (
         args.pipeline_model_parallel_size > 1
-        and args.pipeline_model_parallel_split_rank is None
         and args.model_type in ['t5', 'bart', 'nmt']
     ):
         if args.pipeline_model_parallel_split_rank is not None:
@@ -119,6 +118,9 @@ def convert(local_rank, rank, world_size, args):
             else:
                 # If split rank is not set, then we set it to be pipeline_model_parallel_size // 2 - this is because in most cases we have the same number of enc/dec layers.
                 app_state.pipeline_model_parallel_split_rank = args.pipeline_model_parallel_size // 2
+    else:
+        app_state.pipeline_model_parallel_split_rank = None
+
     app_state.model_parallel_size = app_state.tensor_model_parallel_size * app_state.pipeline_model_parallel_size
 
     parallel_state.initialize_model_parallel(

--- a/nemo/collections/nlp/models/machine_translation/megatron_nmt_model.py
+++ b/nemo/collections/nlp/models/machine_translation/megatron_nmt_model.py
@@ -328,13 +328,6 @@ class MegatronNMTModel(MegatronLMEncoderDecoderModel):
         if isinstance(outputs[0], dict):
             outputs = [outputs]
 
-        self.log(
-            'consumed_samples',
-            self.compute_consumed_samples(self.trainer.global_step - self.init_global_step),
-            rank_zero_only=True,
-        )
-        self.log('global_step', self.trainer.global_step, prog_bar=True, rank_zero_only=True)
-
         loss_list = []
         bleu_score_list = []
         for dataloader_idx, output in enumerate(outputs):


### PR DESCRIPTION
Signed-off-by: MaximumEntropy <sandeep.subramanian.1@umontreal.ca>

# What does this PR do ?

Fixes bugs in Megatron NMT due to incorrect split rank in the checkpoint file and split rank in ckpt->nemo conversion.

**Collection**: NLP

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
