### PR TITLE
Fixed output of BERT to be [batch x seq x hidden]

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron/bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/bert_model.py
@@ -112,13 +112,13 @@ def post_language_model_processing(
 
     binary_logits = None
     if binary_head is not None:
+        # binary_logits: [s, b, 2] or [s, b, vocab_size] if binary_head is Identity
         binary_logits = binary_head(pooled_output)
 
     if lm_labels is None:
-        # lm_logits: [s, b, vocab_size] -> [b, s, vocab_size]
-        lm_logits = lm_logits.transpose(0, 1).contiguous()
         return lm_logits, binary_logits
     else:
+        # match shape of labels to lm_logits
         # lm_labels: [b, s] -> [s, b]
         lm_labels = lm_labels.transpose(0, 1).contiguous()
         if fp16_lm_cross_entropy:
@@ -126,8 +126,7 @@ def post_language_model_processing(
             lm_loss = tensor_parallel.vocab_parallel_cross_entropy(lm_logits, lm_labels)
         else:
             lm_loss = tensor_parallel.vocab_parallel_cross_entropy(lm_logits.float(), lm_labels)
-        # lm_loss: [s, b] -> [b, s]
-        lm_loss = lm_loss.transpose(0, 1).contiguous()
+        # lm_loss: [s, b]
         return lm_loss, binary_logits
 
 

--- a/nemo/collections/nlp/models/language_modeling/megatron/bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/bert_model.py
@@ -131,7 +131,10 @@ def post_language_model_processing(
 
 
 class BertModel(MegatronModule):
-    """Bert Language model."""
+    """
+    Bert Language model.
+    Model returns [seq, batch, hidden] shape
+    """
 
     def __init__(
         self,

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -97,8 +97,14 @@ class MegatronBertModel(MegatronBaseModel):
     def forward(self, input_ids, attention_mask, token_type_ids, lm_labels=None):
         output_tensor = self.model(input_ids, attention_mask, token_type_ids=token_type_ids, lm_labels=lm_labels)
 
+        lm_loss_, sop_logits = output_tensor
+
         # Return the output tensor of encoder and transpose from [seq_len, batch, hidden] to [batch, seq_len, hidden]
-        return output_tensor.transpose(1, 0)
+        lm_loss_ = lm_loss_.transpose(1, 0)
+        if sop_logits is not None:
+            sop_logits = sop_logits.transpose(1, 0)
+
+        return output_tensor
 
     def training_step(self, batch, batch_idx):
         tokens, types, sentence_order, loss_mask, lm_labels, padding_mask = self.process_batch(batch)

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -103,7 +103,7 @@ class MegatronBertModel(MegatronBaseModel):
         else:
             lm_loss_, sop_logits = output_tensor
 
-            lm_loss_ = lm_loss_.transpose(1, 0).contiguous() 
+            lm_loss_ = lm_loss_.transpose(1, 0).contiguous()
             if sop_logits is not None:
                 sop_logits = sop_logits.transpose(1, 0).contiguous()
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -99,13 +99,13 @@ class MegatronBertModel(MegatronBaseModel):
 
         # Return the output tensor of encoder and transpose from [seq_len, batch, hidden] to [batch, seq_len, hidden]
         if lm_labels is None:
-            output_tensor = output_tensor
+            output_tensor = output_tensor.transpose(1, 0).contiguous()
         else:
             lm_loss_, sop_logits = output_tensor
 
-            lm_loss_ = lm_loss_.transpose(1, 0)
+            lm_loss_ = lm_loss_.transpose(1, 0).contiguous() 
             if sop_logits is not None:
-                sop_logits = sop_logits.transpose(1, 0)
+                sop_logits = sop_logits.transpose(1, 0).contiguous()
 
             output_tensor = (lm_loss_, sop_logits)
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -45,7 +45,8 @@ except (ImportError, ModuleNotFoundError):
 
 class MegatronBertModel(MegatronBaseModel):
     """
-    Megatron Bert pretraining
+    Megatron Bert pretraining.
+    Model returns [batch, seq, hidden] shape
     """
 
     def __init__(self, cfg: DictConfig, trainer: Trainer):

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -97,12 +97,17 @@ class MegatronBertModel(MegatronBaseModel):
     def forward(self, input_ids, attention_mask, token_type_ids, lm_labels=None):
         output_tensor = self.model(input_ids, attention_mask, token_type_ids=token_type_ids, lm_labels=lm_labels)
 
-        lm_loss_, sop_logits = output_tensor
-
         # Return the output tensor of encoder and transpose from [seq_len, batch, hidden] to [batch, seq_len, hidden]
-        lm_loss_ = lm_loss_.transpose(1, 0)
-        if sop_logits is not None:
-            sop_logits = sop_logits.transpose(1, 0)
+        if lm_labels is None:
+            output_tensor = output_tensor
+        else:
+            lm_loss_, sop_logits = output_tensor
+
+            lm_loss_ = lm_loss_.transpose(1, 0)
+            if sop_logits is not None:
+                sop_logits = sop_logits.transpose(1, 0)
+            
+            output_tensor = (lm_loss_, sop_logits)
 
         return output_tensor
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -106,7 +106,7 @@ class MegatronBertModel(MegatronBaseModel):
             lm_loss_ = lm_loss_.transpose(1, 0)
             if sop_logits is not None:
                 sop_logits = sop_logits.transpose(1, 0)
-            
+
             output_tensor = (lm_loss_, sop_logits)
 
         return output_tensor

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -98,7 +98,7 @@ class MegatronBertModel(MegatronBaseModel):
         output_tensor = self.model(input_ids, attention_mask, token_type_ids=token_type_ids, lm_labels=lm_labels)
 
         # Return the output tensor of encoder and transpose from [seq_len, batch, hidden] to [batch, seq_len, hidden]
-        if lm_labels is None:
+        if torch.is_tensor(output_tensor):
             output_tensor = output_tensor.transpose(1, 0).contiguous()
         else:
             lm_loss_, sop_logits = output_tensor

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -96,7 +96,9 @@ class MegatronBertModel(MegatronBaseModel):
 
     def forward(self, input_ids, attention_mask, token_type_ids, lm_labels=None):
         output_tensor = self.model(input_ids, attention_mask, token_type_ids=token_type_ids, lm_labels=lm_labels)
-        return output_tensor
+
+        # Return the output tensor of encoder and transpose from [seq_len, batch, hidden] to [batch, seq_len, hidden]
+        return output_tensor.transpose(1, 0)
 
     def training_step(self, batch, batch_idx):
         tokens, types, sentence_order, loss_mask, lm_labels, padding_mask = self.process_batch(batch)

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -1023,7 +1023,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
                 data_parallel_size=parallel_state.get_data_parallel_world_size(),
             )
 
-        # Return the output tensor of encoder and transpose from [batch, seq_len, hidden] to [seq_len, batch, hidden]
+        # Return the output tensor of encoder and transpose from [seq_len, batch, hidden] to [batch, seq_len, hidden]
         return output_tensor.transpose(1, 0)
 
     def decode(


### PR DESCRIPTION
Signed-off-by: Micha Livne <mlivne@cs.toronto.edu>

# What does this PR do ?

This PR Fixes the output of BERT to be [batch x seq x hidden] instead of [se x batch x hidden]

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
