### PR TITLE
[TTS] fix wrong g2p path.

### DIFF
--- a/nemo/collections/tts/models/fastpitch.py
+++ b/nemo/collections/tts/models/fastpitch.py
@@ -46,7 +46,7 @@ from nemo.utils import logging, model_utils
 
 @dataclass
 class G2PConfig:
-    _target_: str = "nemo.collections.common.tokenizers.text_to_speech.g2ps.EnglishG2p"
+    _target_: str = "nemo_text_processing.g2p.modules.EnglishG2p"
     phoneme_dict: str = "scripts/tts_dataset_files/cmudict-0.7b_nv22.08"
     heteronyms: str = "scripts/tts_dataset_files/heteronyms-052722"
     phoneme_probability: float = 0.5

--- a/nemo/collections/tts/torch/g2ps.py
+++ b/nemo/collections/tts/torch/g2ps.py
@@ -11,4 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# TODO (xueyang): deprecate this file since no other places import modules from here anymore. However,
+#  all checkpoints uploaded in ngc used this path. So it requires to update all ngc checkpoints g2p path as well.
 from nemo_text_processing.g2p.modules import IPAG2P, BaseG2p, EnglishG2p

--- a/nemo/collections/tts/torch/tts_dataset.yaml
+++ b/nemo/collections/tts/torch/tts_dataset.yaml
@@ -41,6 +41,6 @@ tts_dataset:
     add_blank_at: null
     pad_with_space: True
     g2p:
-      _target_: nemo.collections.common.tokenizers.text_to_speech.g2ps.EnglishG2p
+      _target_: nemo_text_processing.g2p.modules.EnglishG2p
       phoneme_dict: "scripts/tts_dataset_files/cmudict-0.7b_nv22.08"
       heteronyms: "scripts/tts_dataset_files/heteronyms-052722"

--- a/nemo/collections/tts/torch/tts_tokenizers.py
+++ b/nemo/collections/tts/torch/tts_tokenizers.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# TODO (xueyang): deprecate this file since no other places import modules from here anymore. However,
+#  all checkpoints uploaded in ngc used this path. So it requires to update all ngc checkpoints path as well.
 from nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers import (
     BaseCharsTokenizer,
     BaseTokenizer,


### PR DESCRIPTION
Signed-off-by: Xuesong Yang <1646669+XuesongYang@users.noreply.github.com>

# What does this PR do ?

fixed wrong g2p path. Previously in https://github.com/NVIDIA/NeMo/pull/4690, g2p modules were moved to `nemo_text_processing.g2p.modules`. 

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
