### PR TITLE
Add mixed-representation config to PhonemizerTokenizer

### DIFF
--- a/examples/tts/conf/fastpitch_align_ipa.yaml
+++ b/examples/tts/conf/fastpitch_align_ipa.yaml
@@ -69,7 +69,6 @@ model:
   text_tokenizer:
     _target_: nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers.IPATokenizer
     punct: true
-    chars: true
     apostrophe: true
     pad_with_space: true
     g2p:
@@ -79,6 +78,7 @@ model:
       phoneme_probability: 0.8
       # Relies on the heteronyms list for anything that needs to be disambiguated
       ignore_ambiguous_words: false
+      use_chars: true
       use_stresses: true
   train_ds:
     dataset:

--- a/nemo/collections/common/tokenizers/text_to_speech/ipa_lexicon.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/ipa_lexicon.py
@@ -20,8 +20,27 @@ DEFAULT_PUNCTUATION = (
     ')', '[', ']', '{', '}',
 )
 
+GRAPHEME_CHARACTER_SETS = {
+    "en-us": (
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+        'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+        'U', 'V', 'W', 'X', 'Y', 'Z', 'À', 'É'
+    ),
+    "es": (
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+        'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+        'U', 'V', 'W', 'X', 'Y', 'Z', 'Á', 'É', 'Í', 'Ñ',
+        'Ó', 'Ú', 'Ü'
+    ),
+    "de": (
+        'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
+        'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
+        'U', 'V', 'W', 'X', 'Y', 'Z', 'Ä', 'É', 'Ê', 'Ñ',
+        'Ö', 'Ü'
+    ),
+}
 
-CHARACTER_SETS = {
+IPA_CHARACTER_SETS = {
     "en-us": (
         'a', 'b', 'd', 'e', 'f', 'h', 'i', 'j', 'k', 'l',
         'm', 'n', 'o', 'p', 'r', 's', 't', 'u', 'v', 'w',
@@ -46,11 +65,18 @@ CHARACTER_SETS = {
 # fmt: on
 
 
-def get_ipa_character_list(language):
-    if language not in CHARACTER_SETS:
-        raise ValueError(f"Character set not found for language {language}")
-    char_list = list(CHARACTER_SETS[language])
-    return char_list
+def get_grapheme_character_set(language):
+    if language not in GRAPHEME_CHARACTER_SETS:
+        raise ValueError(f"Grapheme character set not found for language {language}")
+    char_set = set(GRAPHEME_CHARACTER_SETS[language])
+    return char_set
+
+
+def get_ipa_character_set(language):
+    if language not in IPA_CHARACTER_SETS:
+        raise ValueError(f"IPA character set not found for language {language}")
+    char_set = set(IPA_CHARACTER_SETS[language])
+    return char_set
 
 
 def get_ipa_punctuation_list(language):

--- a/nemo/collections/common/tokenizers/text_to_speech/ipa_lexicon.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/ipa_lexicon.py
@@ -21,18 +21,18 @@ DEFAULT_PUNCTUATION = (
 )
 
 GRAPHEME_CHARACTER_SETS = {
-    "en-us": (
+    "en-US": (
         'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
         'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
-        'U', 'V', 'W', 'X', 'Y', 'Z', 'À', 'É'
+        'U', 'V', 'W', 'X', 'Y', 'Z'
     ),
-    "es": (
+    "es-ES": (
         'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
         'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
         'U', 'V', 'W', 'X', 'Y', 'Z', 'Á', 'É', 'Í', 'Ñ',
         'Ó', 'Ú', 'Ü'
     ),
-    "de": (
+    "de-DE": (
         'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J',
         'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T',
         'U', 'V', 'W', 'X', 'Y', 'Z', 'Ä', 'É', 'Ê', 'Ñ',
@@ -41,20 +41,20 @@ GRAPHEME_CHARACTER_SETS = {
 }
 
 IPA_CHARACTER_SETS = {
-    "en-us": (
+    "en-US": (
         'a', 'b', 'd', 'e', 'f', 'h', 'i', 'j', 'k', 'l',
         'm', 'n', 'o', 'p', 'r', 's', 't', 'u', 'v', 'w',
         'x', 'z', 'æ', 'ð', 'ŋ', 'ɐ', 'ɑ', 'ɔ', 'ə', 'ɚ',
         'ɛ', 'ɜ', 'ɡ', 'ɪ', 'ɬ', 'ɹ', 'ɾ', 'ʃ', 'ʊ', 'ʌ',
         'ʒ', 'ʔ', 'ʲ', '̃', '̩', 'θ', 'ᵻ'
     ),
-    "es": (
+    "es-ES": (
         'a', 'b', 'd', 'e', 'f', 'h', 'i', 'j', 'k', 'l',
         'm', 'n', 'o', 'p', 'r', 's', 't', 'u', 'w', 'x',
         'ð', 'ŋ', 'ɛ', 'ɡ', 'ɣ', 'ɪ', 'ɲ', 'ɾ', 'ʃ', 'ʊ',
         'ʎ', 'ʒ', 'ʝ', 'β', 'θ'
     ),
-    "de": (
+    "de-DE": (
         '1', 'a', 'b', 'd', 'e', 'f', 'h', 'i', 'j', 'k',
         'l', 'm', 'n', 'o', 'p', 'r', 's', 't', 'u', 'v',
         'w', 'x', 'y', 'z', 'ç', 'ø', 'ŋ', 'œ', 'ɐ', 'ɑ',
@@ -65,28 +65,28 @@ IPA_CHARACTER_SETS = {
 # fmt: on
 
 
-def get_grapheme_character_set(language):
-    if language not in GRAPHEME_CHARACTER_SETS:
-        raise ValueError(f"Grapheme character set not found for language {language}")
-    char_set = set(GRAPHEME_CHARACTER_SETS[language])
+def get_grapheme_character_set(locale):
+    if locale not in GRAPHEME_CHARACTER_SETS:
+        raise ValueError(f"Grapheme character set not found for locale {locale}")
+    char_set = set(GRAPHEME_CHARACTER_SETS[locale])
     return char_set
 
 
-def get_ipa_character_set(language):
-    if language not in IPA_CHARACTER_SETS:
-        raise ValueError(f"IPA character set not found for language {language}")
-    char_set = set(IPA_CHARACTER_SETS[language])
+def get_ipa_character_set(locale):
+    if locale not in IPA_CHARACTER_SETS:
+        raise ValueError(f"IPA character set not found for locale {locale}")
+    char_set = set(IPA_CHARACTER_SETS[locale])
     return char_set
 
 
-def get_ipa_punctuation_list(language):
+def get_ipa_punctuation_list(locale):
     punct_list = list(DEFAULT_PUNCTUATION)
-    if language in ["de", "es"]:
+    if locale in ["de-DE", "es-ES"]:
         # https://en.wikipedia.org/wiki/Guillemet#Uses
         punct_list.extend(['«', '»', '‹', '›'])
-    if language == "de":
+    if locale == "de-DE":
         punct_list.extend(['„', '“'])
-    elif language == "es":
+    elif locale == "es-ES":
         punct_list.extend(['¿', '¡'])
 
     return punct_list

--- a/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
@@ -30,7 +30,8 @@ from nemo_text_processing.g2p.modules import IPAG2P
 from phonemizer.backend import EspeakBackend
 
 from nemo.collections.common.tokenizers.text_to_speech.ipa_lexicon import (
-    get_ipa_character_list,
+    get_grapheme_character_set,
+    get_ipa_character_set,
     get_ipa_punctuation_list,
 )
 from nemo.utils import logging
@@ -407,7 +408,6 @@ class IPATokenizer(BaseTokenizer):
         g2p,
         punct=True,
         non_default_punct_list=None,
-        chars=False,
         *,
         space=' ',
         silence=None,
@@ -423,7 +423,6 @@ class IPATokenizer(BaseTokenizer):
             g2p: Grapheme to phoneme module, should be IPAG2P or some subclass thereof.
             punct: Whether to reserve grapheme for basic punctuation or not.
             non_default_punct_list: List of punctuation marks which will be used instead default, if any.
-            chars: Whether to additionally use chars together with phonemes. It is useful if g2p module can return chars too.
             space: Space token as string.
             silence: Silence token as string (will be disabled if it is None).
             apostrophe: Whether to use apostrophe or not.
@@ -450,20 +449,18 @@ class IPATokenizer(BaseTokenizer):
             self.phoneme_probability = g2p.phoneme_probability
 
         # Build tokens list
-        tokens = sorted(list(g2p.symbols))  # Sort to ensure that vocab is in the same order every time
+        tokens = set(g2p.symbols)
 
-        if chars or self.phoneme_probability is not None:
-            if not chars:
-                logging.warning(
-                    "phoneme_probability was not None, characters will be enabled even though "
-                    "chars was set to False."
-                )
+        if apostrophe:
+            tokens.add("'")
 
-            # Add uppercase chars if G2P class uses them, otherwise use lowercase ones
-            if g2p.set_graphemes_upper:
-                tokens.extend(string.ascii_uppercase)
-            else:
-                tokens.extend(string.ascii_lowercase)
+        if punct:
+            if non_default_punct_list is not None:
+                self.PUNCT_LIST = non_default_punct_list
+            tokens.update(self.PUNCT_LIST)
+
+        # Sort to ensure that vocab is in the same order every time
+        tokens = sorted(list(tokens))
 
         if space in g2p.symbols:
             self.space = tokens.index(space)
@@ -473,17 +470,8 @@ class IPATokenizer(BaseTokenizer):
         if silence is not None:
             self.silence, tokens = len(tokens), tokens + [silence]
 
-        if apostrophe:
-            tokens.append("'")
-
-        if punct:
-            if non_default_punct_list is not None:
-                self.PUNCT_LIST = non_default_punct_list
-            tokens.extend(self.PUNCT_LIST)
-
         super().__init__(tokens, oov=oov, sep=sep, add_blank_at=add_blank_at)
 
-        self.chars = chars if self.phoneme_probability is None else True
         self.punct = punct
         self.pad_with_space = pad_with_space
 
@@ -560,9 +548,10 @@ class PhonemizerTokenizer(IPATokenizer):
         pad_with_space=False,
         non_default_chars=None,
         non_default_punct_list=None,
-        with_stress=True,
+        use_stresses=True,
         ignore_ambiguous_words=True,
         heteronyms=None,
+        phoneme_probability: Optional[float] = None,
         espeak_logging_level=ERROR,
     ):
         """IPA tokenizer using the Phonemizer library with an eSpeak backend
@@ -590,9 +579,11 @@ class PhonemizerTokenizer(IPATokenizer):
             pad_with_space: Whether to pad text with spaces at the beginning and at the end or not.
             non_default_chars: List of characters which will be used instead of default.
             non_default_punct_list: List of punctuation marks which will be used instead of default.
-            with_stress: Whether to include stresses/accents in the IPA output.
+            use_stresses: Whether to include stresses/accents in the IPA output.
             ignore_ambiguous_words: Whether to not handle word via phoneme_dict with ambiguous phoneme sequences.
             heteronyms (str, Path, List): Path to file with heteronyms (every line is new word) or list of words.
+            phoneme_probability (Optional[float]): The probability (0.<var<1.) that each word is phonemized for mixed
+                representation training. Defaults to None which is the same as 1.
             espeak_logging_level: Logging level for eSpeak.
                 Defaults to 'logging.ERROR' (to avoid a lot of unhelpful warning logs).
         """
@@ -604,13 +595,16 @@ class PhonemizerTokenizer(IPATokenizer):
                 "https://github.com/espeak-ng/espeak-ng/blob/master/docs/guide.md#installation"
             )
 
+        use_chars = phoneme_probability is not None
         if non_default_chars:
-            char_list = non_default_chars
+            char_set = non_default_chars
         else:
-            char_list = get_ipa_character_list(language)
-            if with_stress:
-                char_list.extend(self.ESPEAK_SYMBOLS)
-        chars = "".join(char_list)
+            char_set = get_ipa_character_set(language)
+            if use_stresses:
+                char_set.update(self.ESPEAK_SYMBOLS)
+            if use_chars:
+                grapheme_set = get_grapheme_character_set(language)
+                char_set.update(grapheme_set)
 
         if not punct:
             punct_list = []
@@ -622,7 +616,7 @@ class PhonemizerTokenizer(IPATokenizer):
         espeak_logger = getLogger('espeak')
         espeak_logger.setLevel(espeak_logging_level)
         self.espeak_backend = EspeakBackend(
-            language=language, preserve_punctuation=punct, with_stress=with_stress, logger=espeak_logger
+            language=language, preserve_punctuation=punct, with_stress=use_stresses, logger=espeak_logger
         )
 
         ipa_g2p = IPAG2P(
@@ -631,9 +625,13 @@ class PhonemizerTokenizer(IPATokenizer):
             word_tokenize_func=ipa_word_tokenize,
             ignore_ambiguous_words=ignore_ambiguous_words,
             heteronyms=heteronyms,
+            use_chars=use_chars,
+            phoneme_probability=phoneme_probability,
+            use_stresses=use_stresses,
+            set_graphemes_upper=True,
         )
         # Merge chars with all symbols found in the phoneme dictionary.
-        ipa_g2p.symbols.update(chars)
+        ipa_g2p.add_symbols(char_set)
 
         super().__init__(
             g2p=ipa_g2p,

--- a/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
@@ -599,11 +599,12 @@ class PhonemizerTokenizer(IPATokenizer):
         if non_default_chars:
             char_set = non_default_chars
         else:
-            char_set = get_ipa_character_set(language)
+            locale = self._get_locale(language)
+            char_set = get_ipa_character_set(locale)
             if use_stresses:
                 char_set.update(self.ESPEAK_SYMBOLS)
             if use_chars:
-                grapheme_set = get_grapheme_character_set(language)
+                grapheme_set = get_grapheme_character_set(locale)
                 char_set.update(grapheme_set)
 
         if not punct:
@@ -611,7 +612,8 @@ class PhonemizerTokenizer(IPATokenizer):
         elif non_default_punct_list:
             punct_list = non_default_punct_list
         else:
-            punct_list = get_ipa_punctuation_list(language)
+            locale = self._get_locale(language)
+            punct_list = get_ipa_punctuation_list(locale)
 
         espeak_logger = getLogger('espeak')
         espeak_logger.setLevel(espeak_logging_level)
@@ -640,6 +642,18 @@ class PhonemizerTokenizer(IPATokenizer):
             pad_with_space=pad_with_space,
             text_preprocessing_func=lambda text: text,
         )
+
+    @staticmethod
+    def _get_locale(language):
+        # Converts eSpeak language string to ISO language tag
+        if language == "en-us":
+            return "en-US"
+        elif language == "es":
+            return "es-ES"
+        elif language == "de":
+            return "de-DE"
+
+        raise ValueError(f"Language not supported {language}")
 
     def _text_to_phonemes_espeak(self, text):
         phonemes = self.espeak_backend.phonemize([text])[0]

--- a/tests/collections/common/tokenizers/text_to_speech/test_tts_tokenizers.py
+++ b/tests/collections/common/tokenizers/text_to_speech/test_tts_tokenizers.py
@@ -145,7 +145,7 @@ class TestTTSTokenizers:
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
     def test_phonemizer_tokenizer_unsupported_language(self):
-        with pytest.raises(ValueError, match="character set not found"):
+        with pytest.raises(ValueError, match="Language not supported"):
             self._create_tokenizer("pt-BR")
 
     @pytest.mark.skipif(

--- a/tests/nemo_text_processing/g2p/test_modules.py
+++ b/tests/nemo_text_processing/g2p/test_modules.py
@@ -27,7 +27,7 @@ class TestModules:
         phoneme_dict=PHONEME_DICT_PATH,
         apply_to_oov_word=lambda x: x,
         use_chars=False,
-        phoneme_probability=1.0,
+        phoneme_probability=None,
         set_graphemes_upper=True,
     ):
         return IPAG2P(

--- a/tests/nemo_text_processing/g2p/test_modules.py
+++ b/tests/nemo_text_processing/g2p/test_modules.py
@@ -22,13 +22,64 @@ class TestModules:
 
     PHONEME_DICT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "phoneme_dict", "test_dict.txt")
 
+    @staticmethod
+    def _create_g2p(
+        phoneme_dict=PHONEME_DICT_PATH,
+        apply_to_oov_word=lambda x: x,
+        use_chars=False,
+        phoneme_probability=1.0,
+        set_graphemes_upper=True,
+    ):
+        return IPAG2P(
+            phoneme_dict,
+            apply_to_oov_word=apply_to_oov_word,
+            use_chars=use_chars,
+            phoneme_probability=phoneme_probability,
+            set_graphemes_upper=set_graphemes_upper,
+        )
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_g2p_parse_dict(self):
+        # fmt: off
+        expected_symbols = {
+            'h', 'ə', 'ˈ', 'ɫ', 'o', 'ʊ', 'ˈ',
+            'w', 'ɝ', 'ɫ', 'd'
+        }
+        # fmt: on
+        g2p = self._create_g2p()
+
+        assert expected_symbols == g2p.symbols
+        assert len(g2p.phoneme_dict["HELLO"]) == 1
+        assert len(g2p.phoneme_dict["WORLD"]) == 1
+        assert g2p.phoneme_dict["HELLO"][0] == [char for char in "həˈɫoʊ"]
+        assert g2p.phoneme_dict["WORLD"][0] == [char for char in "ˈwɝɫd"]
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_g2p_parse_dict_with_chars(self):
+        # fmt: off
+        expected_symbols = {
+            'H', 'E', 'L', 'L', 'O',
+            'W', 'O', 'R', 'L', 'D',
+            'h', 'ə', 'ˈ', 'ɫ', 'o', 'ʊ',
+            'ˈ', 'w', 'ɝ', 'ɫ', 'd'
+        }
+        # fmt: on
+        g2p = self._create_g2p(use_chars=True)
+
+        assert expected_symbols == g2p.symbols
+        assert len(g2p.phoneme_dict["HELLO"]) == 1
+        assert len(g2p.phoneme_dict["WORLD"]) == 1
+        assert g2p.phoneme_dict["HELLO"][0] == [char for char in "həˈɫoʊ"]
+        assert g2p.phoneme_dict["WORLD"][0] == [char for char in "ˈwɝɫd"]
+
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
     def test_ipa_g2p(self):
         input_text = "Hello world."
         expected_output = [char for char in "həˈɫoʊ ˈwɝɫd."]
-
-        g2p = IPAG2P(self.PHONEME_DICT_PATH)
+        g2p = self._create_g2p()
 
         phonemes = g2p(input_text)
         assert phonemes == expected_output
@@ -38,8 +89,37 @@ class TestModules:
     def test_ipa_g2p_with_oov(self):
         input_text = "Hello Kitty!"
         expected_output = [char for char in "həˈɫoʊ KITTY!"]
+        g2p = self._create_g2p()
 
-        g2p = IPAG2P(self.PHONEME_DICT_PATH)
+        phonemes = g2p(input_text)
+        assert phonemes == expected_output
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_g2p_with_oov_func(self):
+        input_text = "Hello Kitty!"
+        expected_output = [char for char in "həˈɫoʊ test!"]
+        g2p = self._create_g2p(apply_to_oov_word=lambda x: "test")
+
+        phonemes = g2p(input_text)
+        assert phonemes == expected_output
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_g2p_graphemes(self):
+        input_text = "Hello world."
+        expected_output = [char for char in input_text.upper()]
+        g2p = self._create_g2p(use_chars=True, phoneme_probability=0.0)
+
+        phonemes = g2p(input_text)
+        assert phonemes == expected_output
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_g2p_graphemes_lower(self):
+        input_text = "Hello world."
+        expected_output = [char for char in input_text.lower()]
+        g2p = self._create_g2p(use_chars=True, phoneme_probability=0.0, set_graphemes_upper=False)
 
         phonemes = g2p(input_text)
         assert phonemes == expected_output


### PR DESCRIPTION
Signed-off-by: Ryan <rlangman@nvidia.com>

# What does this PR do ?

Extends the IPATokenizer and PhonemizerTokenizer classes so we can do mixed-representation grapheme/phoneme training for non-English languages.

**Collection**: [TTS]

# Changelog 
- Add phoneme_probability argument to PhonemizerTokenizer, with code changes to add the grapheme set for each language. The grapheme set was obtained by taking all graphemes in the words of each language's pronunciation dictionary.
- Removed "use_chars" logic in IPATokenizer, which currently adds hardcoded list of English ASCII chars, in favor of parsing them from the user-provided phoneme dictionary in IPAG2P (similar to how it infers its phoneme set from the dictionary).
- In IPAG2P I added accented characters & locale-agnostic digit to the word/token checker. In an earlier commit, I accidentally added this to the EnglishG2p instead (when refactoring the PR around the tokenizer file directory change). Though I don't see any reason to remove it from EnglishG2p.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

# Additional Information

