### PR TITLE
Adoptive lookahead for streaming Conformer encoder

### DIFF
--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -16,9 +16,9 @@ import contextlib
 import glob
 import json
 import os
-from dataclasses import dataclass, is_dataclass, field
+from dataclasses import dataclass, field, is_dataclass
 from pathlib import Path
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 import pytorch_lightning as pl
 import torch

--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -241,7 +241,7 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable):
                     self.chunk_size = self.att_context_size[1] + 1
 
                 elif isinstance(self.att_context_size[1], list):
-                    if self.att_context_size[0] % (min(self.att_context_size[1]) + 1) > 0:
+                    if self.att_context_size[0] % (self.att_context_size[1][0] + 1) > 0:
                         raise ValueError("att_context_size[0] % (att_context_size[1] + 1) should be zero!")
                     self.chunk_size = self.att_context_size[1][0] + 1
                 else:

--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -242,7 +242,7 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable):
 
                 elif isinstance(self.att_context_size[1], list):
                     if self.att_context_size[0] % (self.att_context_size[1][0] + 1) > 0:
-                        raise ValueError("att_context_size[0] % (att_context_size[1] + 1) should be zero!")
+                        raise ValueError("att_context_size[0] % (att_context_size[1][0] + 1) should be zero!")
                     self.chunk_size = self.att_context_size[1][0] + 1
                 else:
                     raise ValueError(f"Not valid type for att_context_size: {att_context_size}")

--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -15,7 +15,7 @@
 import math
 import random
 from collections import OrderedDict
-from typing import List, Optional, Dict
+from typing import Dict, List, Optional
 
 import torch
 import torch.distributed
@@ -197,9 +197,13 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable):
             self.streaming = True
 
         if self.streaming is False and conv_dual_mode:
-            raise ValueError(f"conv_dual_mode should be enabled only when training streaming and non-streaming modes together!")
+            raise ValueError(
+                f"conv_dual_mode should be enabled only when training streaming and non-streaming modes together!"
+            )
         if self.streaming is False and streaming_layer_norm:
-            raise ValueError(f"streaming_layer_norm should be enabled only when training streaming and non-streaming modes together!")
+            raise ValueError(
+                f"streaming_layer_norm should be enabled only when training streaming and non-streaming modes together!"
+            )
 
         if isinstance(conv_context_size, ListConfig):
             conv_context_size = list(conv_context_size)
@@ -222,8 +226,10 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable):
             conv_context_size = [(conv_kernel_size - 1) // 2, (conv_kernel_size - 1) // 2]
         self.conv_context_size = conv_context_size
 
-        if conv_dual_mode and self.conv_context_size != [(conv_kernel_size - 1) // 2 , (conv_kernel_size - 1) // 2]:
-            raise ValueError(f"conv_dual_mode requires conv_context_size to be [(conv_kernel_size - 1) // 2, (conv_kernel_size - 1) // 2]")
+        if conv_dual_mode and self.conv_context_size != [(conv_kernel_size - 1) // 2, (conv_kernel_size - 1) // 2]:
+            raise ValueError(
+                f"conv_dual_mode requires conv_context_size to be [(conv_kernel_size - 1) // 2, (conv_kernel_size - 1) // 2]"
+            )
 
         if att_context_style == "chunked_limited":
             # the left context for self-attention in chunked_limited mode should be dividable by the right context
@@ -365,7 +371,6 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable):
             self.register_buffer('seq_range', seq_range, persistent=False)
         self.pos_enc.extend_pe(max_audio_length, device)
 
-
     @typecheck()
     def forward(self, audio_signal, length, cache_last_channel=None, cache_last_time=None):
         self.update_max_seq_length(seq_length=audio_signal.size(2), device=audio_signal.device)
@@ -383,7 +388,9 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable):
 
         att_mask = torch.ones(1, max_audio_length, max_audio_length, dtype=torch.bool, device=audio_signal.device)
         if self.training:
-            streaming = [self.streaming, "full" not in self.att_context_size][random.uniform(0, 1) < self.non_streaming_prob]
+            streaming = [self.streaming, "full" not in self.att_context_size][
+                random.uniform(0, 1) < self.non_streaming_prob
+            ]
         else:
             streaming = self.val_random_params['att_context_size_right'] != 'full'
 


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.
- Adds support to train and test models with adoptive lookahead

**Collection**: [ASR]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below
Need to add/modify following flags to train streaming conformer. `ATT_CONTEXT_STYLE` can be set to `regular`/`chunked_limited`. If `CONV_DUAL_MODE` is set to `true`, then `CONV_CONTEXT_SIZE` should be set to `null`, otherwise `CONV_CONTEXT_SIZE` can be set to `causal` to train streaming models. `ATT_CONTEXT_SIZE` can be set something like `[102,[16,33,50,0],full]` to train chunk-based streaming (middle four value) and non-streaming (last) modes together. Probability or fraction of updates for non-streaming mode can be controlled by setting `NON_STREAMING_PROB` in [0, 1] range. If both modes are trained together, separate layer norm can be instantiated by setting `STREAMING_LAYER_NORM` to `true`.

```python
model.preprocessor.normalize=NA \
model.encoder.att_context_size=$ATT_CONTEXT_SIZE \
model.encoder.att_context_style=$ATT_CONTEXT_STYLE \
model.encoder.causal_downsampling=true \
model.encoder.conv_context_size=$CONV_CONTEXT_SIZE \
model.encoder.conv_norm_type=layer_norm \
++model.encoder.non_streaming_prob=$NON_STREAMING_PROB \
++model.encoder.conv_dual_mode=$CONV_DUAL_MODE \
++model.streaming_layer_norm=$STREAMING_LAYER_NORM
```

To compute wer for different modes, use the following command
```
python ./examples/asr/transcribe_speech.py model_path=$MODEL_PATH \
       +val_random_params_enc.att_context_size_right=$ATT_CONTEXT_SIZE_RIGHT
```
where `ATT_CONTEXT_SIZE_RIGHT` can be set to any desired value from`{0, 16, 33, 50, 'full'}` if the model was trained with `ATT_CONTEXT_SIZE=[102,[16,33,50,0],full]`
```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
