### PR TITLE
Add support for skipping validation on resume + extend saving last ckpt test

### DIFF
--- a/examples/nlp/machine_translation/enc_dec_nmt_finetune.py
+++ b/examples/nlp/machine_translation/enc_dec_nmt_finetune.py
@@ -29,6 +29,7 @@ from nemo.utils import logging
 from nemo.utils.config_utils import update_model_config
 from nemo.utils.exp_manager import ExpManagerConfig, exp_manager
 
+
 """
 Usage:
  python enc_dec_nmt_finetune.py \

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -172,8 +172,6 @@ class MegatronBertModel(MegatronBaseModel):
         return reduced_loss
 
     def validation_epoch_end(self, outputs):
-        if not outputs:
-            return
         averaged_loss = torch.stack(outputs).mean()
         self.log('val_loss', averaged_loss, prog_bar=True)
         self.log('consumed_samples', self.compute_consumed_samples(self.trainer.global_step - self.init_global_step))

--- a/nemo/collections/nlp/models/language_modeling/megatron_finetune_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_finetune_model.py
@@ -354,8 +354,6 @@ class MegatronT5FinetuneModel(MegatronT5Model):
 
     def inference_epoch_end(self, outputs, mode, data_cfg):
         # Parent class will handle logging of the loss.
-        if not outputs:
-            return
         if isinstance(outputs[0], dict):
             outputs = [outputs]
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -462,8 +462,6 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         return loss_mean
 
     def validation_epoch_end(self, outputs):
-        if not outputs:
-            return
         if parallel_state.is_pipeline_last_stage():
             # only the last pipeline parallel stages return loss
             averaged_loss = torch.stack(outputs).mean()

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -632,8 +632,6 @@ class MegatronGPTPromptLearningModel(MegatronBaseModel, TextGeneration):
         return loss_mean
 
     def validation_epoch_end(self, outputs):
-        if not outputs:
-            return
         if parallel_state.is_pipeline_last_stage():
             # only the last pipeline parallel stages return loss
             averaged_loss = torch.stack(outputs).mean()

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -643,8 +643,6 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
         return loss_mean
 
     def validation_epoch_end(self, outputs):
-        if not outputs:
-            return
         if parallel_state.is_pipeline_last_stage():
             # only the last pipeline parallel stages return loss
             averaged_loss = torch.stack(outputs).mean()
@@ -667,8 +665,6 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
         return self.validation_step(batch, batch_idx)
 
     def test_epoch_end(self, outputs):
-        if not outputs:
-            return
         if parallel_state.is_pipeline_last_stage():
             # only the last pipeline parallel stages return loss
             averaged_loss = torch.stack(outputs).mean()

--- a/nemo/collections/nlp/models/language_modeling/megatron_retrieval_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_retrieval_model.py
@@ -330,8 +330,6 @@ class MegatronRetrievalModel(MegatronBaseModel):
         return reduced_loss
 
     def validation_epoch_end(self, outputs):
-        if not outputs:
-            return
         averaged_loss = torch.stack(outputs).mean()
         self.log('val_loss', averaged_loss, prog_bar=True)
         # formula to compute the perplexity

--- a/nemo/collections/nlp/models/machine_translation/megatron_nmt_model.py
+++ b/nemo/collections/nlp/models/machine_translation/megatron_nmt_model.py
@@ -327,8 +327,6 @@ class MegatronNMTModel(MegatronLMEncoderDecoderModel):
         return self.eval_epoch_end(outputs, 'test')
 
     def eval_epoch_end(self, outputs, mode):
-        if not outputs:
-            return
         if isinstance(outputs[0], dict):
             outputs = [outputs]
 

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_model.py
@@ -407,9 +407,6 @@ class MTEncDecModel(EncDecNLPModel, Exportable):
 
     def eval_epoch_end(self, outputs, mode, global_rank):
         # if user specifies one validation dataloader, then PTL reverts to giving a list of dictionary instead of a list of list of dictionary
-        if not outputs:
-            return
-
         if isinstance(outputs[0], dict):
             outputs = [outputs]
 

--- a/nemo/collections/nlp/models/text_classification/text_classification_model.py
+++ b/nemo/collections/nlp/models/text_classification/text_classification_model.py
@@ -129,8 +129,6 @@ class TextClassificationModel(NLPModel, Exportable):
         Called at the end of validation to aggregate outputs.
         :param outputs: list of individual outputs of each validation step.
         """
-        if not outputs:
-            return {}
         if self.trainer.testing:
             prefix = 'test'
         else:

--- a/tests/core/test_exp_manager.py
+++ b/tests/core/test_exp_manager.py
@@ -15,12 +15,15 @@ import math
 import os
 import re
 from pathlib import Path
+from typing import Any
 
 import pytest
 import pytorch_lightning as pl
 import torch
 from omegaconf import OmegaConf
 from omegaconf.errors import OmegaConfBaseException
+from pytorch_lightning import Callback
+from pytorch_lightning.loops import TrainingEpochLoop
 
 from nemo.constants import NEMO_ENV_VARNAME_VERSION
 from nemo.core.classes import ModelPT
@@ -443,22 +446,120 @@ class TestExpManager:
         assert math.fabs(float(model(torch.tensor([1.0, 1.0], device=model.device))) - 0.03) < 1e-5
 
     @pytest.mark.unit
-    def test_nemo_checkpoint_make_checkpoint_dir(self, tmp_path):
+    def test_last_checkpoint_saved(self, tmp_path):
         max_steps = 64
+        tmp_path = tmp_path / "test_1"
 
         class TestModel(ExampleModel):
             def train_dataloader(self):
                 dataset = OnesDataset(64)
                 return torch.utils.data.DataLoader(dataset, batch_size=1)
 
-        test_trainer = pl.Trainer(
+        trainer = pl.Trainer(
             accelerator='cpu', enable_checkpointing=False, logger=False, max_steps=max_steps, val_check_interval=0.33
         )
-        exp_manager(test_trainer, {"explicit_log_dir": str(tmp_path / "test")})
+        exp_manager(
+            trainer,
+            {
+                "explicit_log_dir": tmp_path,
+                "checkpoint_callback_params": {"filename": f"{{val_loss:.4f}}-{{epoch}}-{{step}}"},
+            },
+        )
         model = TestModel()
-        test_trainer.fit(model)
+        trainer.fit(model)
 
-        checkpoint_dir = Path(str(tmp_path / "test" / "checkpoints"))
-        model_path = checkpoint_dir / "default--val_loss=0.0300-epoch=1-last.ckpt"
+        checkpoint_dir = Path(str(tmp_path / "checkpoints"))
+        model_path = checkpoint_dir / "val_loss=0.0300-epoch=1-step=64-last.ckpt"
         last_saved_checkpoint = torch.load(model_path)
         assert max_steps == last_saved_checkpoint['global_step']
+        # restart training, ensure global step starts correctly
+        class AssertCallback(Callback):
+            def on_train_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
+                assert trainer.global_step == max_steps
+
+            def on_train_batch_end(
+                self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", outputs, batch: Any, batch_idx: int
+            ) -> None:
+                # we should only be running for one more step.
+                assert trainer.global_step == max_steps + 1
+
+        trainer = pl.Trainer(
+            accelerator='cpu',
+            enable_checkpointing=False,
+            logger=False,
+            max_steps=65,
+            val_check_interval=0.33,
+            callbacks=AssertCallback(),
+        )
+        exp_manager(
+            trainer,
+            {
+                "explicit_log_dir": tmp_path,
+                "checkpoint_callback_params": {"filename": f"{{val_loss:.4f}}-{{epoch}}-{{step}}"},
+            },
+        )
+        model = TestModel()
+        trainer.fit(model, ckpt_path=model_path)
+
+    @pytest.mark.unit
+    def test_resume_checkpoint_skip_validation(self, tmp_path):
+        """Test to ensure that when we resume from a checkpoint, we do not re-run validation unnecessarily."""
+        tmp_path = tmp_path / "test_2"
+
+        def run_training(resume_path=None):
+            class TestModel(ExampleModel):
+                def train_dataloader(self):
+                    dataset = OnesDataset(10)
+                    return torch.utils.data.DataLoader(dataset, batch_size=1)
+
+            class AssertCallback(Callback):
+                recorded_validations = 0
+
+                def on_validation_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
+                    self.recorded_validations += 1
+
+                def on_train_end(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
+                    if resume_path is not None:
+                        # we should only run validation at the end of training.
+                        assert self.recorded_validations == 1
+                    else:
+                        # we've run validation within the middle of training and at the end of training.
+                        assert self.recorded_validations == 2
+
+            model = TestModel()
+            trainer = pl.Trainer(
+                accelerator='cpu',
+                enable_checkpointing=False,
+                logger=False,
+                callbacks=[AssertCallback()],
+                val_check_interval=0.5,
+                num_sanity_val_steps=0,
+                max_epochs=1,
+            )
+            exp_manager(
+                trainer,
+                {"explicit_log_dir": str(tmp_path), "checkpoint_callback_params": {"filename": f"{{epoch}}-{{step}}"}},
+            )
+            trainer.fit(model, ckpt_path=resume_path)
+
+        run_training()
+        resume_path = tmp_path / 'checkpoints/epoch=0-step=5.ckpt'
+        run_training(resume_path)
+
+    def test_warning_validation_skipping_when_custom_epoch_loop(self, tmp_path):
+        """When using validation skipping on restart with a custom epoch loop, we warn the user that we skip
+        support to not interfere with their custom logic.
+        """
+        tmp_path = tmp_path / "test_3"
+
+        class CustomLoop(TrainingEpochLoop):
+            ...
+
+        trainer = pl.Trainer(
+            accelerator='cpu', enable_checkpointing=False, logger=False, max_epochs=1, val_check_interval=0.33
+        )
+        loop = CustomLoop()
+        loop.trainer = trainer
+        trainer.fit_loop.epoch_loop = loop
+        with pytest.warns(UserWarning, match="Detected custom epoch loop"):
+            exp_manager(trainer, {"explicit_log_dir": str(tmp_path)})

--- a/tests/core/test_exp_manager.py
+++ b/tests/core/test_exp_manager.py
@@ -461,7 +461,7 @@ class TestExpManager:
         exp_manager(
             trainer,
             {
-                "explicit_log_dir": tmp_path,
+                "explicit_log_dir": str(tmp_path),
                 "checkpoint_callback_params": {"filename": f"{{val_loss:.4f}}-{{epoch}}-{{step}}"},
             },
         )
@@ -494,7 +494,7 @@ class TestExpManager:
         exp_manager(
             trainer,
             {
-                "explicit_log_dir": tmp_path,
+                "explicit_log_dir": str(tmp_path),
                 "checkpoint_callback_params": {"filename": f"{{val_loss:.4f}}-{{epoch}}-{{step}}"},
             },
         )


### PR DESCRIPTION
# What does this PR do ?

When restarting training from a saved checkpoint during validation, validation is re-run as a first step (as the checkpoint was saved just before validation). This PR introduces a new loop injected via the `exp_manager` that skips validation if we're restarting.

There was also a mistake with the test definition from #4905 and I extended the test further to check @yaoyu-33s' case.

cc @MaximumEntropy @ericharper @titu1994 

# Changelog 
- Skip initial validation by default when resuming from checkpoint which saved after a validation pass has occurred.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.
