### PR TITLE
Pin Transformers version to fix CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
         docker {
       //image 'gitlab-master.nvidia.com:5005/eharper/nemo_containers:nemo_ci_pytorch_22.07_apex_3c19f1061879394f28272a99a7ea26d58f72dace'
       image 'nvcr.io/nvidia/pytorch:22.08-py3'
-      args '--device=/dev/nvidia0 --gpus all -e TRANSFORMERS_OFFLINE=1 --user 0:128 -v /home/TestData:/home/TestData -v $HOME/.cache:/root/.cache --shm-size=8g'
+      args '--device=/dev/nvidia0 --gpus all -e TRANSFORMERS_OFFLINE=0 --user 0:128 -v /home/TestData:/home/TestData -v $HOME/.cache:/root/.cache --shm-size=8g'
         }
   }
   options {
@@ -32,11 +32,11 @@ pipeline {
       }
     }
 
-//     stage('Transformers Offline') {
-//       steps{
-//         sh 'echo "TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE}'
-//       }
-//     }
+    stage('Transformers Offline') {
+      steps{
+        sh 'echo "TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE}'
+      }
+    }
 
     stage('PyTorch version') {
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,11 +32,11 @@ pipeline {
       }
     }
 
-    stage('Transformers Offline') {
-      steps{
-        sh 'echo "TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE}'
-      }
-    }
+//     stage('Transformers Offline') {
+//       steps{
+//         sh 'echo "TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE}'
+//       }
+//     }
 
     stage('PyTorch version') {
       steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,12 @@ pipeline {
       }
     }
 
+    stage('Pin Transformers Version (Hotfix)') {
+      steps{
+        sh 'pip install transformers==4.21.3'
+      }
+    }
+
     stage('Transformers Offline') {
       steps{
         sh 'echo "TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE}'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
 
     stage('Pin Transformers Version (Hotfix)') {
       steps{
-        sh 'pip install transformers==4.21.3'
+        sh 'pip install transformers==4.21.2'
       }
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
         docker {
       //image 'gitlab-master.nvidia.com:5005/eharper/nemo_containers:nemo_ci_pytorch_22.07_apex_3c19f1061879394f28272a99a7ea26d58f72dace'
       image 'nvcr.io/nvidia/pytorch:22.08-py3'
-      args '--device=/dev/nvidia0 --gpus all -e TRANSFORMERS_OFFLINE=0 --user 0:128 -v /home/TestData:/home/TestData -v $HOME/.cache:/root/.cache --shm-size=8g'
+      args '--device=/dev/nvidia0 --gpus all -e TRANSFORMERS_OFFLINE=1 --user 0:128 -v /home/TestData:/home/TestData -v $HOME/.cache:/root/.cache --shm-size=8g'
         }
   }
   options {


### PR DESCRIPTION
# What does this PR do ?

We're seeing failures on main due to the the latest transformers version and our reliance on TRANSFORMERS_OFFLINE in the CI. Running the failed test locally reproduces the error:

```
HF_DATASETS_OFFLINE=1 TRANSFORMERS_OFFLINE=1 pytest tests/collections/nlp/test_prompt_learning.py::TestMegatronGPTPromptLearningDataset::test_init_prompt_learning_dataset
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

