### PR TITLE
Add cherry-pick action

### DIFF
--- a/.github/workflows/cherry-pick-release-commit.yml
+++ b/.github/workflows/cherry-pick-release-commit.yml
@@ -1,0 +1,27 @@
+name: Create PR to main with cherry-pick from release
+
+on: 
+  pull_request_target:
+    branches:
+      - 'r*.*.*'
+
+jobs:
+  cherry-pick-release-commit:
+    name: Cherry-pick release commit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: github-cherry-pick-action v1.0.3
+        uses: carloscastrojumo/github-cherry-pick-action@bb0869df47c27be4ae4c7a2d93d22827aa5a0054
+        with:
+          branch: main
+          labels: |
+            cherry-pick
+          reviewers: |
+            ${{ github.event.pull_request.user.login }}
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -26,6 +26,12 @@ pipeline {
       }
     }
 
+    stage('Pin Transformers Version (Hotfix)') {
+      steps{
+        sh 'pip install transformers==4.21.2'
+      }
+    }
+
     stage('Transformers Offline') {
       steps{
         sh 'echo "TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE}'


### PR DESCRIPTION
# What does this PR do ?

Automatically cherry-pick release commits to main when PR is merged.

**Collection**: Core

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
