### PR TITLE
fix label models restoring issue from weighted cross entropy

### DIFF
--- a/nemo/collections/asr/models/label_models.py
+++ b/nemo/collections/asr/models/label_models.py
@@ -89,9 +89,15 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
         self.cal_labels_occurrence_train = False
         self.labels_occurrence = None
 
+        if 'num_classes' in cfg.decoder:
+            num_classes = cfg.decoder.num_classes
+        else:
+            num_classes = cfg.decoder.params.num_classes  # to pass test
+
         if 'loss' in cfg:
             if 'weight' in cfg.loss:
                 if cfg.loss.weight == 'auto':
+                    weight = num_classes * [1]
                     self.cal_labels_occurrence_train = True
                 else:
                     weight = cfg.loss.weight
@@ -142,16 +148,11 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
             tmp_loss_cfg = OmegaConf.create(
                 {"_target_": "nemo.collections.common.losses.cross_entropy.CrossEntropyLoss"}
             )
+
             self.loss = instantiate(tmp_loss_cfg)
             self.eval_loss = instantiate(tmp_loss_cfg)
 
-        self.task = None
         self._accuracy = TopKClassificationAccuracy(top_k=[1])
-
-        if 'num_classes' in cfg.decoder:
-            num_classes = cfg.decoder.num_classes
-        else:
-            num_classes = cfg.decoder.params.num_classes  # to pass test
 
         self.preprocessor = EncDecSpeakerLabelModel.from_config_dict(cfg.preprocessor)
         self.encoder = EncDecSpeakerLabelModel.from_config_dict(cfg.encoder)


### PR DESCRIPTION
Signed-off-by: nithinraok <nithinrao.koluguri@gmail.com>

# What does this PR do ?

torch creates state dict of weight in weighted cross entropy and while restoring if weight is None, then it throws error. 
Fixes by introducing weight with all ones. 

**Collection**: ASR

# Changelog 
- Fixes by introducing weight with all ones. 

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

