### PR TITLE
Add simple pre-commit file

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,3 +34,4 @@ repos:
       - id: isort
         name: Format imports
         args: [ --multi-line=3, --trailing-comma, --force-grid-wrap=0, --use-parentheses, --line-width=119, -rc, -ws ]
+        exclude: docs/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,36 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+default_language_version:
+  python: python3
+
+ci:
+  autofix_prs: true
+  autoupdate_commit_msg: '[pre-commit.ci] pre-commit suggestions'
+  autoupdate_schedule: quarterly
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.3.0
+    hooks:
+      - id: check-yaml
+      - id: check-case-conflict
+      - id: detect-private-key
+
+  - repo: https://github.com/PyCQA/isort
+    rev: 4.3.21
+    hooks:
+      - id: isort
+        name: Format imports
+        args: [ --multi-line=3, --trailing-comma, --force-grid-wrap=0, --use-parentheses, --line-width=119, -rc, -ws ]

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,13 +15,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import glob
 import os
 import re
 import sys
+import glob
 
 import sphinx_book_theme
-from package_info import __version__
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -31,6 +30,7 @@ sys.path.insert(0, os.path.abspath("../.."))
 sys.path.insert(0, os.path.abspath("../../nemo"))
 sys.path.insert(0, os.path.abspath("../../nemo_text_processing"))
 
+from package_info import __version__
 
 templates_path = ["_templates"]
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,12 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import glob
 import os
 import re
 import sys
-import glob
 
 import sphinx_book_theme
+from package_info import __version__
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -30,7 +31,6 @@ sys.path.insert(0, os.path.abspath("../.."))
 sys.path.insert(0, os.path.abspath("../../nemo"))
 sys.path.insert(0, os.path.abspath("../../nemo_text_processing"))
 
-from package_info import __version__
 
 templates_path = ["_templates"]
 

--- a/setup.py
+++ b/setup.py
@@ -18,15 +18,14 @@
 """Setup for pip package."""
 
 import codecs
+import importlib.util
 import os
 import subprocess
 from distutils import cmd as distutils_cmd
 from distutils import log as distutils_log
 from itertools import chain
-import importlib.util
 
 import setuptools
-
 
 spec = importlib.util.spec_from_file_location('package_info', 'nemo/package_info.py')
 package_info = importlib.util.module_from_spec(spec)

--- a/setup.py
+++ b/setup.py
@@ -18,14 +18,15 @@
 """Setup for pip package."""
 
 import codecs
-import importlib.util
 import os
 import subprocess
 from distutils import cmd as distutils_cmd
 from distutils import log as distutils_log
 from itertools import chain
+import importlib.util
 
 import setuptools
+
 
 spec = importlib.util.spec_from_file_location('package_info', 'nemo/package_info.py')
 package_info = importlib.util.module_from_spec(spec)


### PR DESCRIPTION
# What does this PR do ?

Related #4972 

We add a file to stop the failing CI run, but do not include Black until we find a way to resolve the difference in formatting.

# Changelog 
- Add pre-commit ci file.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
