### PR TITLE
Makes filename extraction os independent in vad_utils.py

### DIFF
--- a/nemo/collections/asr/parts/utils/vad_utils.py
+++ b/nemo/collections/asr/parts/utils/vad_utils.py
@@ -17,6 +17,7 @@ import math
 import multiprocessing
 import os
 import shutil
+from pathlib import Path
 from itertools import repeat
 from typing import Dict, Tuple
 
@@ -218,7 +219,7 @@ def load_tensor_from_file(filepath: str) -> Tuple[torch.Tensor, str]:
         for line in f.readlines():
             frame.append(float(line))
 
-    name = filepath.split("/")[-1].rsplit(".", 1)[0]
+    name = Path(filepath).stem
     return torch.tensor(frame), name
 
 

--- a/nemo/collections/asr/parts/utils/vad_utils.py
+++ b/nemo/collections/asr/parts/utils/vad_utils.py
@@ -17,8 +17,8 @@ import math
 import multiprocessing
 import os
 import shutil
-from pathlib import Path
 from itertools import repeat
+from pathlib import Path
 from typing import Dict, Tuple
 
 import IPython.display as ipd


### PR DESCRIPTION
# What does this PR do ?

- Makes filename extraction os independent in vad_utils.py
- Old behavior makes vad_infer script unfunctional on windows since it assumed path separator is always "/"

**Collection**: [Note which collection this PR will affect]
- nemo.collections.asr.parts.utils.vad_utils 


# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
- [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [X] Bugfix


If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
