### PR TITLE
Add spe_split_by_unicode_script arg

### DIFF
--- a/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
+++ b/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
@@ -364,7 +364,7 @@ def create_spt_model(
 
     if not split_by_whitespace:
         cmd += " --split_by_whitespace=false"
-    
+
     if not split_by_unicode_script:
         cmd += " --split_by_unicode_script=false"
 

--- a/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
+++ b/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
@@ -272,6 +272,7 @@ def create_spt_model(
     byte_fallback: bool = False,
     split_digits: bool = False,
     split_by_whitespace: bool = True,
+    split_by_unicode_script: bool = True,
 ):
     """
     Creates sentence piece tokenizer model from data file.
@@ -297,6 +298,7 @@ def create_spt_model(
         byte_fallback: If <unk>, fallback to a byte sequence of the character.
         split_digits: If true, digits are split into individual tokens.
         split_by_whitespace: Whether to respect white space while creating subwords. If False, will learn merges across whitespace.
+        split_by_unicode_script: Whether to include multiple Unicode scripts. Ex. is Arabic diacritics which are considered part of the letter (عِدَّةُ)
     """
 
     if not data_file or not os.path.exists(data_file):
@@ -362,6 +364,9 @@ def create_spt_model(
 
     if not split_by_whitespace:
         cmd += " --split_by_whitespace=false"
+    
+    if not split_by_unicode_script:
+        cmd += " --split_by_unicode_script=false"
 
     sentencepiece.SentencePieceTrainer.Train(cmd)
 

--- a/scripts/tokenizers/process_asr_text_tokenizer.py
+++ b/scripts/tokenizers/process_asr_text_tokenizer.py
@@ -128,6 +128,12 @@ parser.add_argument(
     help='Limit the maximum number of tokens in each SentencePiece subword. '
     'Must be a positive integer > 0. By default places no limit on subword length.',
 )
+parser.add_argument(
+    '--spe_no_split_by_unicode_script', 
+    dest='spe_split_by_unicode_script', 
+    action='store_false', 
+    help="Don't use Unicode script to split sentence pieces."
+)
 parser.add_argument('--no_lower_case', dest='lower_case', action='store_false')
 parser.add_argument("--log", action='store_true')
 parser.set_defaults(log=False, lower_case=True, spe_train_extremely_large_corpus=False)
@@ -181,6 +187,7 @@ def __process_data(
     spe_train_extremely_large_corpus: bool,
     spe_sample_size: int,
     spe_max_sentencepiece_length: int,
+    spe_split_by_unicode_script: bool,
     spe_bos: bool,
     spe_eos: bool,
     spe_pad: bool,
@@ -246,6 +253,7 @@ def __process_data(
             character_coverage=spe_character_coverage,
             train_extremely_large_corpus=spe_train_extremely_large_corpus,
             max_sentencepiece_length=spe_max_sentencepiece_length,
+            split_by_unicode_script=spe_split_by_unicode_script,
             bos=spe_bos,
             eos=spe_eos,
             pad=spe_pad,
@@ -276,6 +284,7 @@ def main():
     spe_sample_size = args.spe_sample_size
     spe_train_extremely_large_corpus = args.spe_train_extremely_large_corpus
     spe_max_sentencepiece_length = args.spe_max_sentencepiece_length
+    spe_split_by_unicode_script = args.spe_split_by_unicode_script
     spe_bos, spe_eos, spe_pad = args.spe_bos, args.spe_eos, args.spe_pad
     lower_case = args.lower_case
 
@@ -300,6 +309,7 @@ def main():
         spe_sample_size=spe_sample_size,
         spe_train_extremely_large_corpus=spe_train_extremely_large_corpus,
         spe_max_sentencepiece_length=spe_max_sentencepiece_length,
+        spe_split_by_unicode_script=spe_split_by_unicode_script,
         spe_bos=spe_bos,
         spe_eos=spe_eos,
         spe_pad=spe_pad,

--- a/scripts/tokenizers/process_asr_text_tokenizer.py
+++ b/scripts/tokenizers/process_asr_text_tokenizer.py
@@ -129,10 +129,10 @@ parser.add_argument(
     'Must be a positive integer > 0. By default places no limit on subword length.',
 )
 parser.add_argument(
-    '--spe_no_split_by_unicode_script', 
-    dest='spe_split_by_unicode_script', 
-    action='store_false', 
-    help="Don't use Unicode script to split sentence pieces."
+    '--spe_no_split_by_unicode_script',
+    dest='spe_split_by_unicode_script',
+    action='store_false',
+    help="Don't use Unicode script to split sentence pieces.",
 )
 parser.add_argument('--no_lower_case', dest='lower_case', action='store_false')
 parser.add_argument("--log", action='store_true')


### PR DESCRIPTION
# What does this PR do ?

Expose the `spe_split_by_unicode_script` SentencePiece cmd line flag to the tokenizer generation script.

Arabic text contains diacritics that can influence the meaning of a word, therefore, they must be considered part of a character when generating a tokenizer vocabulary.
The `sentencepiece` library however does not consider diacritics as part of the word and generally considers it as a separate token altogether.
As a result, the diacritics are generally stripped as separate tokens from the word and the generated vocabulary does not properly represent the words in the dataset.

By adding this flag, we allow the SPE library to consider multiple unicode scripts as a single "piece".
See the comments on the flag [here](https://github.com/google/sentencepiece/blob/9f3ed99f5c68609fc94ac83a5c0aea9eb163f6d9/src/sentencepiece_model.proto#L135).

**Collection**: ASR

# Changelog 
- Expose the `spe_split_by_unicode_script` SentencePiece command line flag to the tokenizer generation script.

# Usage

```sh
python process_asr_text_tokenizer.py --manifest=/path/to/dataset_manifest.json \
        --data_root=tokenizers/datatset \
        --vocab_size=1024 \
        --tokenizer=spe \
        --spe_no_spe_split_by_unicode_script \
        --log
```

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [X] Did you add or update any necessary documentation?
- [X] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [X] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

