### PR TITLE
[TTS] fixed wrong val loss for epoch 0 and inconsistent metrics names

### DIFF
--- a/examples/tts/conf/de/fastpitch_align_22050.yaml
+++ b/examples/tts/conf/de/fastpitch_align_22050.yaml
@@ -234,6 +234,6 @@ exp_manager:
   create_tensorboard_logger: true
   create_checkpoint_callback: true
   checkpoint_callback_params:
-    monitor: v_loss
+    monitor: val_loss
   resume_if_exists: false
   resume_ignore_no_checkpoint: false

--- a/examples/tts/conf/de/fastpitch_align_44100.yaml
+++ b/examples/tts/conf/de/fastpitch_align_44100.yaml
@@ -236,6 +236,6 @@ exp_manager:
   create_tensorboard_logger: true
   create_checkpoint_callback: true
   checkpoint_callback_params:
-    monitor: v_loss
+    monitor: val_loss
   resume_if_exists: false
   resume_ignore_no_checkpoint: false

--- a/examples/tts/conf/fastpitch_align_44100.yaml
+++ b/examples/tts/conf/fastpitch_align_44100.yaml
@@ -244,7 +244,7 @@ exp_manager:
   create_tensorboard_logger: True
   create_checkpoint_callback: True
   checkpoint_callback_params:
-    monitor: v_loss
+    monitor: val_loss
   resume_if_exists: false
   resume_ignore_no_checkpoint: false
 

--- a/examples/tts/conf/fastpitch_align_ipa.yaml
+++ b/examples/tts/conf/fastpitch_align_ipa.yaml
@@ -243,6 +243,6 @@ exp_manager:
   create_tensorboard_logger: true
   create_checkpoint_callback: true
   checkpoint_callback_params:
-    monitor: v_loss
+    monitor: val_loss
   resume_if_exists: false
   resume_ignore_no_checkpoint: false

--- a/examples/tts/conf/fastpitch_align_v1.05.yaml
+++ b/examples/tts/conf/fastpitch_align_v1.05.yaml
@@ -244,6 +244,6 @@ exp_manager:
   create_tensorboard_logger: true
   create_checkpoint_callback: true
   checkpoint_callback_params:
-    monitor: v_loss
+    monitor: val_loss
   resume_if_exists: false
   resume_ignore_no_checkpoint: false

--- a/nemo/collections/tts/models/fastpitch.py
+++ b/nemo/collections/tts/models/fastpitch.py
@@ -446,10 +446,10 @@ class FastPitchModel(SpectrogramGenerator, Exportable):
         mel_loss = collect("mel_loss")
         dur_loss = collect("dur_loss")
         pitch_loss = collect("pitch_loss")
-        self.log("v_loss", val_loss)
-        self.log("v_mel_loss", mel_loss)
-        self.log("v_dur_loss", dur_loss)
-        self.log("v_pitch_loss", pitch_loss)
+        self.log("val_loss", val_loss)
+        self.log("val_mel_loss", mel_loss)
+        self.log("val_dur_loss", dur_loss)
+        self.log("val_pitch_loss", pitch_loss)
 
         _, _, _, _, spec_target, spec_predict = outputs[0].values()
 

--- a/nemo/core/utils/numba_utils.py
+++ b/nemo/core/utils/numba_utils.py
@@ -159,6 +159,4 @@ def skip_numba_cuda_test_if_unsupported(min_version: str):
     if not numba_cuda_support:
         import pytest
 
-        pytest.skip(
-            f"Numba cuda test is being skipped. Minimum version required : {min_version}"
-        )
+        pytest.skip(f"Numba cuda test is being skipped. Minimum version required : {min_version}")

--- a/scripts/dataset_processing/tts/generate_mels_for_finetune_hifigan.py
+++ b/scripts/dataset_processing/tts/generate_mels_for_finetune_hifigan.py
@@ -17,7 +17,7 @@ This script is to generate mel spectrograms from a Fastpitch model checkpoint. P
 on GPUs by default, but you can add `--num-workers 5 --cpu` as an option to run on CPUs.
 
 $ python scripts/dataset_processing/tts/generate_mels_for_finetune_hifigan.py \
-    --fastpitch-model-ckpt ./models/fastpitch/multi_spk/FastPitch--v_loss\=1.4473-epoch\=209.ckpt \
+    --fastpitch-model-ckpt ./models/fastpitch/multi_spk/FastPitch--val_loss\=1.4473-epoch\=209.ckpt \
     --input-json-manifests /home/xueyang/HUI-Audio-Corpus-German-clean/test_manifest_text_normed_phonemes.json
     --output-json-manifest-root /home/xueyang/experiments/multi_spk_tts_de
 """

--- a/tutorials/tts/FastPitch_GermanTTS_Training.ipynb
+++ b/tutorials/tts/FastPitch_GermanTTS_Training.ipynb
@@ -669,6 +669,7 @@
     "    whitelist_path=./whitelist.tsv \\\n",
     "    exp_manager.exp_dir=resultGermanTTS \\\n",
     "    trainer.max_epochs=1 \\\n",
+    "    trainer.check_val_every_n_epoch=1 \\\n",
     "    pitch_mean=#paste_pitch_mean_here \\\n",
     "    pitch_std=#paste_pitch_std_here \\\n",
     "    +exp_manager.create_wandb_logger=true \\\n",

--- a/tutorials/tts/FastPitch_GermanTTS_Training.ipynb
+++ b/tutorials/tts/FastPitch_GermanTTS_Training.ipynb
@@ -1193,6 +1193,8 @@
     "    exp_manager.exp_dir=resultGermanTTS \\\n",
     "    +init_from_nemo_model=DataGermanTTS/tts_hifigan.nemo \\\n",
     "    trainer.devices=-1 \\\n",
+    "    +trainer.val_check_interval=5 \\\n",
+    "    trainer.check_val_every_n_epoch=null \\\n",
     "    model/train_ds=train_ds_finetune \\\n",
     "    model/validation_ds=val_ds_finetune \\\n",
     "    exp_manager.create_wandb_logger=true \\\n",


### PR DESCRIPTION
Signed-off-by: Xuesong Yang <1646669+XuesongYang@users.noreply.github.com>

# What does this PR do ?
This PR fixed two issues below,
1. initial checkpoint got wrong `val_loss` so the name was not correct. The root-cause is that `trainer.max_epochs=1` is less than `train.check_val_every_n_epoch=5`. So specify `train.check_val_every_n_epoch=1` would fix the issue for FastPitch. Similar fix for HiFiGAN. See results comparison below,
```
# before fix:
$ ls resultGermanTTS/FastPitch/2022-10-05_12-35-50/checkpoints/
 FastPitch.nemo  'FastPitch--val_loss=0.0000-epoch=1-last.ckpt 
$ ls resultGermanTTS/HifiGan/2022-10-05_19-29-39/checkpoints/
 HifiGan.nemo  'HifiGan--val_loss=0.0000-epoch=1-last.ckpt'

# after fix:
$ ls resultGermanTTS/FastPitch/2022-10-05_14-18-25/checkpoints/
 FastPitch.nemo  'FastPitch--val_loss=4.0512-epoch=0.ckpt'  'FastPitch--val_loss=4.0512-epoch=1-last.ckpt'
$ ls resultGermanTTS/HifiGan/2022-10-05_20-10-50/checkpoints/
 HifiGan.nemo  'HifiGan--val_loss=0.5253-epoch=0.ckpt'  'HifiGan--val_loss=0.5253-epoch=0-last.ckpt'
```
2. TTS loss metrics used `v_loss` rather than `val_loss` as the keyword for validation loss. So this check (https://github.com/NVIDIA/NeMo/blob/r1.12.0/nemo/utils/exp_manager.py#L906) was never succeeded. Rename to `val_loss` helps to make the check valid.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
