### PR TITLE
T5 Decoding with PP > 2 fix

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -980,7 +980,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
             arg_names=arg_names, output_name="hiddens", output_enc_hidden_only=True
         )
 
-        # Counter-intuitively, we need to set decoder_sequence_length=encoder_seq_length because while running `.enocde()`, the last hidden states from encoder are passed through as identity through the pipeline. Setting it to anything else will cause hanging due to tensor shape mismatches.
+        # Counter intuitively, we need to set decoder_sequence_length=encoder_seq_length because while running `.enocde()`, the last hidden states from encoder are passed through as identity through the pipeline. Setting it to anything else will cause hanging due to tensor shape mismatches.
         if self.cfg.get('pipeline_model_parallel_size', 1) > 1:
             output_tensor = forward_backward_pipelining_without_interleaving(
                 forward_step_func=forward_step_func,

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -979,6 +979,8 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
         forward_step_func = self._get_forward_output_only_func(
             arg_names=arg_names, output_name="hiddens", output_enc_hidden_only=True
         )
+
+        # Counter-intuitively, we need to set decoder_sequence_length=encoder_seq_length because while running `.enocde()`, the last hidden states from encoder are passed through as identity through the pipeline. Setting it to anything else will cause hanging due to tensor shape mismatches.
         if self.cfg.get('pipeline_model_parallel_size', 1) > 1:
             output_tensor = forward_backward_pipelining_without_interleaving(
                 forward_step_func=forward_step_func,
@@ -986,7 +988,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
                 model=self.enc_dec_model,
                 forward_only=True,
                 tensor_shape=tensor_shape,
-                decoder_sequence_length=1,
+                decoder_sequence_length=encoder_seq_length,
                 dtype=self.autocast_dtype,
             )
         else:
@@ -996,12 +998,11 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
                 model=self.enc_dec_model,
                 forward_only=True,
                 tensor_shape=tensor_shape,
-                decoder_sequence_length=1,
+                decoder_sequence_length=encoder_seq_length,
                 dtype=self.autocast_dtype,
             )
 
-        # get output tensor of encoder [seq_len, batch, hidden]
-        if parallel_state.is_pipeline_last_stage():
+        if output_tensor:
             output_tensor = output_tensor[0]['hiddens']
         else:
             output_tensor = torch.zeros(tensor_shape, dtype=self.autocast_dtype).cuda()
@@ -1087,6 +1088,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
         # get encoder hiddens (output)
         if enc_output is None:
             # Encode returns a tensr of shape [batch, seq_len, hidden]
+            # All ranks will call `.encode()`, but only the last rank will have a non-empty output tensor.
             enc_output = self.encode(
                 tokens_enc=tokens_enc, enc_mask=enc_mask, encoder_input=encoder_input, reconfigure_microbatch=False
             )
@@ -1134,6 +1136,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
                         dim=-1, index=torch.tensor(ignore_ids, device=device), value=-float('Inf')
                     )
 
+                # TODO: do log_softmax in fp32?
                 log_probs, token_ids = torch.max(torch.nn.functional.log_softmax(output_tensor, dim=-1), dim=-1)
                 predicted_tokens_dec = torch.cat(
                     [predicted_tokens_dec.to(token_ids.device), token_ids[:, -1].unsqueeze(1)], dim=1


### PR DESCRIPTION
# What does this PR do ?

Fixes a bug that would cause decoding with an enc-dec model with PP > 2 to hang.

**Collection**: NLP

# Changelog 
- Set sequence lengths for the pipeline properly while decoding. 

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
