### PR TITLE
Fix Unhashable type list for Numba Cuda spec augment kernel

### DIFF
--- a/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
+++ b/nemo/collections/asr/parts/numba/spec_augment/spec_aug_numba.py
@@ -154,7 +154,7 @@ def launch_spec_augment_kernel(
     if time_masks > 0 or freq_masks > 0:
         # Parallelize over freq and time axis, parallel threads over batch
         # Sequential over masks (adaptive in time).
-        blocks_per_grid = [sh[1], sh[2]]
+        blocks_per_grid = tuple([sh[1], sh[2]])
         # threads_per_block = min(MAX_THREAD_BUFFER, max(freq_masks, time_masks))
         threads_per_block = min(MAX_THREAD_BUFFER, x.shape[0])
 

--- a/nemo/core/utils/numba_utils.py
+++ b/nemo/core/utils/numba_utils.py
@@ -17,6 +17,8 @@ import logging as pylogger
 import operator
 import os
 
+import numba
+
 from nemo.utils import model_utils
 
 # Prevent Numba CUDA logs from showing at info level
@@ -159,4 +161,6 @@ def skip_numba_cuda_test_if_unsupported(min_version: str):
     if not numba_cuda_support:
         import pytest
 
-        pytest.skip(f"Numba cuda test is being skipped. Minimum version required : {min_version}")
+        pytest.skip(
+            f"Numba cuda test is being skipped. Minimum version required : {min_version}, found {numba.version_info}"
+        )


### PR DESCRIPTION
Signed-off-by: smajumdar <smajumdar@nvidia.com>

# What does this PR do ?

Fixes an issue where Numba Spec Augment kernel can no longer execute due to passing a list of values for `blocks_per_grid` on Numba > 0.56.0

**Collection**: [ASR]

# Changelog 
- Convert the list to tuple before passing to numba kernel launch

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

Closes #4863 
