### PR TITLE
Changed the URL for the Mozilla S3 bucket

### DIFF
--- a/scripts/dataset_processing/get_commonvoice_data.py
+++ b/scripts/dataset_processing/get_commonvoice_data.py
@@ -64,7 +64,7 @@ parser.add_argument(
 )
 parser.add_argument(
     '--version',
-    default='cv-corpus-5.1-2020-06-22',
+    default='cv-corpus-11.0-2022-09-21',
     type=str,
     help='Version of the dataset (obtainable via https://commonvoice.mozilla.org/en/datasets',
 )
@@ -77,8 +77,8 @@ parser.add_argument(
 )
 args = parser.parse_args()
 COMMON_VOICE_URL = (
-    f"https://voice-prod-bundler-ee1969a6ce8178826482b88e843c335139bd3fb4.s3.amazonaws.com/"
-    "{}/{}.tar.gz".format(args.version, args.language)
+    f"https://mozilla-common-voice-datasets.s3.dualstack.us-west-2.amazonaws.com/"
+    f"{args.version}/{args.version}-{args.language}.tar.gz"
 )
 
 


### PR DESCRIPTION
Signed-off-by: Maicon Domingues [dominguesm@outlook.com](mailto:dominguesm@outlook.com)

# What does this PR do ?

Changes the URL used to download Common Voice datasets, thus allowing the latest versions to be downloaded in any language.

**Collection**: asr

# Changelog 

The change allows any version and language of the Common Voice dataset to be downloaded. Directly pointing to the Bucket S3 made available by Mozilla.

It is worth mentioning that I have been following and using this URL for at least 4 months, so I believe the change is safe.

As the contract for using the `get_commonvoice_data.py` file has remained the same, no impact is expected on examples using this script.

# Usage
* You can potentially add a usage example below

```sh
!python scripts/dataset_processing/get_commonvoice_data.py \
    --data_root "datasets/$LANGUAGE/" \
    --manifest_dir=$manifest_dir \
    --sample_rate=16000 \
    --n_channels=1 \
    --version="cv-corpus-11.0-2022-09-21" \
    --language="pt" \
    --log \
    --files_to_process 'train.tsv' 'dev.tsv' 'test.tsv'
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
