### PR TITLE
[TTS] Add SpanishCharsTokenizer

### DIFF
--- a/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
@@ -19,8 +19,13 @@ import string
 from contextlib import contextmanager
 from typing import List, Optional
 
-from nemo_text_processing.g2p.data.data_utils import english_text_preprocessing, german_text_preprocessing
+from nemo_text_processing.g2p.data.data_utils import (
+    english_text_preprocessing,
+    german_text_preprocessing,
+    spanish_text_preprocessing,
+)
 
+from nemo.collections.common.tokenizers.text_to_speech.ipa_lexicon import get_ipa_punctuation_list
 from nemo.utils import logging
 from nemo.utils.decorators import experimental
 
@@ -230,6 +235,35 @@ class GermanCharsTokenizer(BaseCharsTokenizer):
             pad_with_space=pad_with_space,
             non_default_punct_list=non_default_punct_list,
             text_preprocessing_func=text_preprocessing_func,
+        )
+
+
+class SpanishCharsTokenizer(BaseCharsTokenizer):
+
+    PUNCT_LIST = get_ipa_punctuation_list("es-ES")
+
+    def __init__(
+        self, punct=True, apostrophe=True, add_blank_at=None, pad_with_space=False, non_default_punct_list=None,
+    ):
+        """Spanish grapheme tokenizer.
+        Args:
+            punct: Whether to reserve grapheme for basic punctuation or not.
+            apostrophe: Whether to use apostrophe or not.
+            add_blank_at: Add blank to labels in the specified order ("last") or after tokens (any non None),
+             if None then no blank in labels.
+            pad_with_space: Whether to pad text with spaces at the beginning and at the end or not.
+            non_default_punct_list: List of punctuation marks which will be used instead default.
+        """
+
+        es_alphabet = "abcdefghijklmnopqrstuvwxyzáéíñóúü"
+        super().__init__(
+            chars=es_alphabet,
+            punct=punct,
+            apostrophe=apostrophe,
+            add_blank_at=add_blank_at,
+            pad_with_space=pad_with_space,
+            non_default_punct_list=non_default_punct_list,
+            text_preprocessing_func=spanish_text_preprocessing,
         )
 
 

--- a/nemo_text_processing/g2p/data/data_utils.py
+++ b/nemo_text_processing/g2p/data/data_utils.py
@@ -148,3 +148,7 @@ def ipa_word_tokenize(text):
 
 def german_text_preprocessing(text):
     return text.lower()
+
+
+def spanish_text_preprocessing(text):
+    return text.lower()

--- a/tests/collections/common/tokenizers/text_to_speech/test_tts_tokenizers.py
+++ b/tests/collections/common/tokenizers/text_to_speech/test_tts_tokenizers.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tests/collections/common/tokenizers/text_to_speech/test_tts_tokenizers.py
+++ b/tests/collections/common/tokenizers/text_to_speech/test_tts_tokenizers.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers import (
+    EnglishCharsTokenizer,
+    GermanCharsTokenizer,
+    SpanishCharsTokenizer,
+)
+
+
+class TestTTSTokenizers:
+    @staticmethod
+    def _parse_text(tokenizer, text):
+        tokens = tokenizer.encode(text)
+        chars = tokenizer.decode(tokens)
+        chars = chars.replace('|', '')
+        return chars, tokens
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_english_chars_tokenizer(self):
+        input_text = "Hello world!"
+        expected_output = "hello world!"
+
+        tokenizer = EnglishCharsTokenizer()
+        chars, tokens = self._parse_text(tokenizer, input_text)
+
+        assert chars == expected_output
+        assert len(tokens) == len(input_text)
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_english_chars_tokenizer_unknown_token(self):
+        input_text = "Hey 🙂 there"
+        expected_output = "hey there"
+
+        tokenizer = EnglishCharsTokenizer()
+        chars, tokens = self._parse_text(tokenizer, input_text)
+
+        assert chars == expected_output
+        assert len(tokens) == len(expected_output)
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_english_chars_tokenizer_accented_character(self):
+        input_text = "Let's drink at the café."
+        expected_output = "let's drink at the cafe."
+
+        tokenizer = EnglishCharsTokenizer()
+        chars, tokens = self._parse_text(tokenizer, input_text)
+
+        assert chars == expected_output
+        assert len(tokens) == len(input_text)
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_german_chars_tokenizer(self):
+        input_text = "Was ist dein Lieblingsgetränk?"
+        expected_output = "was ist dein lieblingsgetränk?"
+
+        tokenizer = GermanCharsTokenizer()
+        chars, tokens = self._parse_text(tokenizer, input_text)
+
+        assert chars == expected_output
+        assert len(tokens) == len(input_text)
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_spanish_chars_tokenizer(self):
+        input_text = "¿Cuál es su nombre?"
+        expected_output = "¿cuál es su nombre?"
+
+        tokenizer = SpanishCharsTokenizer()
+        chars, tokens = self._parse_text(tokenizer, input_text)
+
+        assert chars == expected_output
+        assert len(tokens) == len(input_text)


### PR DESCRIPTION
Signed-off-by: Ryan <rlangman@nvidia.com>

# What does this PR do ?

Add a Spanish language tokenizer for doing grapheme-only TTS training.

**Collection**: [TTS]

# Changelog 
- Add SpanishCharsTokenizer
- Add unit tests for English, German, and Spanish grapheme tokenizers.

# Usage

```python
from nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers import SpanishCharsTokenizer

text = "¿Cuál es su nombre?"

tokenizer = SpanishCharsTokenizer(
    pad_with_space=True,
)

tokens = tokenizer(text)
graphemes = tokenizer.decode(tokens)
graphemes = graphemes.replace('|', '')

# [0, 54, 3, 21, 27, 12, 0, 5, 19, 0, 19, 21, 0, 14, 15, 13, 2, 18, 5, 38, 0]
print(tokens)
# ¿cuál es su nombre? 
print(graphemes)
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation