### PR TITLE
Fixed bug where decoding strategy not being updated in transcribe speech

### DIFF
--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -33,7 +33,6 @@ from nemo.collections.common.tokenizers.aggregate_tokenizer import AggregateToke
 from nemo.core.config import hydra_runner
 from nemo.utils import logging, model_utils
 
-
 """
 Transcribe audio file on a single CPU/GPU. Useful for transcription of moderate amounts of audio data.
 
@@ -44,23 +43,23 @@ Transcribe audio file on a single CPU/GPU. Useful for transcription of moderate 
   dataset_manifest: path to dataset JSON manifest file (in NeMo format)
 
   compute_langs: Bool to request language ID information (if the model supports it)
-  
+
   output_filename: Output filename where the transcriptions will be written
   batch_size: batch size during inference
-  
+
   cuda: Optional int to enable or disable execution of model on certain CUDA device.
   amp: Bool to decide if Automatic Mixed Precision should be used during inference
   audio_type: Str filetype of the audio. Supported = wav, flac, mp3
-  
+
   overwrite_transcripts: Bool which when set allowes repeated transcriptions to overwrite previous results.
-  
+
   rnnt_decoding: Decoding sub-config for RNNT. Refer to documentation for specific values.
 
 # Usage
 ASR model can be specified by either "model_path" or "pretrained_name".
 Data for transcription can be defined with either "audio_dir" or "dataset_manifest".
 append_pred - optional. Allows you to add more than one prediction to an existing .json
-pred_name_postfix - optional. The name you want to be written for the current model 
+pred_name_postfix - optional. The name you want to be written for the current model
 Results are returned in a JSON manifest file.
 
 python transcribe_speech.py \
@@ -172,8 +171,9 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
     if hasattr(asr_model, 'change_decoding_strategy'):
         # Check if ctc or rnnt model
         if hasattr(asr_model, 'joint'):  # RNNT model
-            rnnt_decoding = RNNTDecodingConfig(fused_batch_size=-1, compute_langs=cfg.compute_langs)
-            asr_model.change_decoding_strategy(rnnt_decoding)
+            cfg.rnnt_decoding.fused_batch_size = -1
+            cfg.rnnt_decoding.compute_langs = cfg.compute_langs
+            asr_model.change_decoding_strategy(cfg.rnnt_decoding)
         else:
             asr_model.change_decoding_strategy(cfg.ctc_decoding)
 

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -33,6 +33,7 @@ from nemo.collections.common.tokenizers.aggregate_tokenizer import AggregateToke
 from nemo.core.config import hydra_runner
 from nemo.utils import logging, model_utils
 
+
 """
 Transcribe audio file on a single CPU/GPU. Useful for transcription of moderate amounts of audio data.
 


### PR DESCRIPTION
Signed-off-by: Shantanu Acharya <shantanua@nvidia.com>

# What does this PR do ?

In transcribe_speech.py, the `RNNTDecodingConfig` object was being created again thereby overriding the params specified by the user.

**Collection**: asr

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the asr team. 
