### PR TITLE
fix to t5 adapter and ia3 eval scripts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -701,7 +701,8 @@ pipeline {
                 pipeline_model_parallel_size=2 \
                 data.global_batch_size=2 \
                 data.micro_batch_size=2 \
-                data.test_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl']"
+                data.test_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl'] \
+                pred_file_path='examples/adapter_tuning/test_tp1_pp2/preds.txt'"
             sh "rm -rf examples/adapter_tuning/test_tp1_pp2.nemo"
             sh "rm -rf examples/adapter_tuning/test_tp1_pp2"
           }
@@ -742,7 +743,8 @@ pipeline {
                 tensor_model_parallel_size=2 \
                 data.global_batch_size=2 \
                 data.micro_batch_size=2 \
-                data.test_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl']"
+                data.test_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl'] \
+                pred_file_path='examples/adapter_tuning/test_tp2_pp1/preds.txt'"
             sh "rm -rf examples/adapter_tuning/test_tp2_pp1.nemo"
             sh "rm -rf examples/adapter_tuning/test_tp2_pp1"
           }
@@ -785,7 +787,8 @@ pipeline {
                 pipeline_model_parallel_size=2 \
                 data.global_batch_size=2 \
                 data.micro_batch_size=2 \
-                data.test_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl']"
+                data.test_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl'] \
+                pred_file_path='examples/ia3_tuning/test_tp1_pp2/preds.txt'"
             sh "rm -rf examples/ia3_tuning/test_tp1_pp2.nemo"
             sh "rm -rf examples/ia3_tuning/test_tp1_pp2"
           }
@@ -826,7 +829,8 @@ pipeline {
                 tensor_model_parallel_size=2 \
                 data.global_batch_size=2 \
                 data.micro_batch_size=2 \
-                data.test_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl']"
+                data.test_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl'] \
+                pred_file_path='examples/ia3_tuning/test_tp2_pp1/preds.txt'"
             sh "rm -rf examples/ia3_tuning/test_tp2_pp1.nemo"
             sh "rm -rf examples/ia3_tuning/test_tp2_pp1"
           }

--- a/examples/nlp/language_modeling/tuning/megatron_t5_adapter_eval.py
+++ b/examples/nlp/language_modeling/tuning/megatron_t5_adapter_eval.py
@@ -129,7 +129,7 @@ def main(cfg) -> None:
     if cfg.pred_file_path is not None:
         with open(cfg.pred_file_path, "w", encoding="utf-8") as f:
             for batch in response:
-                for inp, pred in zip(batch['enc_input'], batch['predicted_token_ids']):
+                for inp, pred in zip(batch['input_text'], batch['preds_text']):
                     inp = ' '.join(inp.split('\n'))
                     pred = ' '.join(pred.split('\n'))
                     f.write(f'{inp} {pred}\n')

--- a/examples/nlp/language_modeling/tuning/megatron_t5_ia3_eval.py
+++ b/examples/nlp/language_modeling/tuning/megatron_t5_ia3_eval.py
@@ -129,7 +129,7 @@ def main(cfg) -> None:
     if cfg.pred_file_path is not None:
         with open(cfg.pred_file_path, "w", encoding="utf-8") as f:
             for batch in response:
-                for inp, pred in zip(batch['enc_input'], batch['predicted_token_ids']):
+                for inp, pred in zip(batch['input_text'], batch['preds_text']):
                     inp = ' '.join(inp.split('\n'))
                     pred = ' '.join(pred.split('\n'))
                     f.write(f'{inp} {pred}\n')


### PR DESCRIPTION
Signed-off-by: arendu <adithya.r@gmail.com>

# What does this PR do ?
The `predict_step` for T5 adapters and IA3 returns a dictionary with different keys (#4746)  . This PR updates to the eval scripts to use the new keys.

**Collection**: [NLP]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
