### PR TITLE
[TTS] remove LinVocoder and apply Vocoder as parent class.

### DIFF
--- a/docs/source/tts/api.rst
+++ b/docs/source/tts/api.rst
@@ -71,10 +71,6 @@ Base Classes
 The classes below are the base of the TTS pipeline.
 To read more about them, see the `Base Classes <./intro.html#Base Classes>`__ section of the intro page.
 
-.. autoclass:: nemo.collections.tts.models.base.LinVocoder
-    :show-inheritance:
-    :members:
-
 .. autoclass:: nemo.collections.tts.models.base.MelToSpec
     :show-inheritance:
     :members:

--- a/nemo/collections/tts/models/base.py
+++ b/nemo/collections/tts/models/base.py
@@ -65,15 +65,18 @@ class SpectrogramGenerator(ModelPT, ABC):
 
 
 class Vocoder(ModelPT, ABC):
-    """ Base class for all TTS models that generate audio conditioned a on spectrogram """
+    """
+    A base class for models that convert spectrograms to audios. Note that this class takes as input either linear
+    or mel spectrograms.
+    """
 
     @abstractmethod
     def convert_spectrogram_to_audio(self, spec: 'torch.tensor', **kwargs) -> 'torch.tensor':
         """
-        Accepts a batch of spectrograms and returns a batch of audio
+        Accepts a batch of spectrograms and returns a batch of audio.
 
         Args:
-            spec: A torch tensor representing the spectrograms to be vocoded
+            spec:  ['B', 'n_freqs', 'T'], A torch tensor representing the spectrograms to be vocoded.
 
         Returns:
             audio
@@ -192,39 +195,6 @@ class GlowVocoder(Vocoder):
         audio_spect_denoised = torch.clamp(audio_spect_denoised, 0.0)
         audio_denoised = self.istft(audio_spect_denoised, audio_angles)
         return audio_denoised
-
-
-class LinVocoder(ModelPT, ABC):
-    """
-    A base class for models that convert from the linear (magnitude) spectrogram to audio. Note: The `Vocoder` class
-    differs from this class as the `Vocoder` class takes as input mel spectrograms.
-    """
-
-    @abstractmethod
-    def convert_linear_spectrogram_to_audio(self, spec: 'torch.tensor', **kwargs) -> 'torch.tensor':
-        """
-        Accepts a batch of linear spectrograms and returns a batch of audio
-
-        Args:
-            spec: A torch tensor representing the linear spectrograms to be vocoded ['B', 'n_freqs', 'T']
-
-        Returns:
-            audio
-        """
-
-    @classmethod
-    def list_available_models(cls) -> 'List[PretrainedModelInfo]':
-        """
-        This method returns a list of pre-trained model which can be instantiated directly from NVIDIA's NGC cloud.
-        Returns:
-            List of available pre-trained models.
-        """
-        list_of_models = []
-        for subclass in cls.__subclasses__():
-            subclass_models = subclass.list_available_models()
-            if subclass_models is not None and len(subclass_models) > 0:
-                list_of_models.extend(subclass_models)
-        return list_of_models
 
 
 class MelToSpec(ModelPT, ABC):

--- a/nemo/collections/tts/models/two_stages.py
+++ b/nemo/collections/tts/models/two_stages.py
@@ -21,7 +21,7 @@ from hydra.utils import instantiate
 from omegaconf import MISSING, DictConfig, OmegaConf
 
 from nemo.collections.tts.helpers.helpers import OperationMode, griffin_lim
-from nemo.collections.tts.models.base import LinVocoder, MelToSpec, Vocoder
+from nemo.collections.tts.models.base import MelToSpec, Vocoder
 from nemo.core.classes.common import PretrainedModelInfo
 from nemo.core.neural_types.elements import AudioSignal, MelSpectrogramType
 from nemo.core.neural_types.neural_type import NeuralType
@@ -59,7 +59,7 @@ class MelPsuedoInverseModel(MelToSpec):
         return self
 
 
-class GriffinLimModel(LinVocoder):
+class GriffinLimModel(Vocoder):
     def __init__(self, cfg: DictConfig):
         if isinstance(cfg, dict):
             cfg = OmegaConf.create(cfg)
@@ -70,7 +70,7 @@ class GriffinLimModel(LinVocoder):
         self.n_fft = self._cfg['n_fft']
         self.l_hop = self._cfg['l_hop']
 
-    def convert_linear_spectrogram_to_audio(self, spec, Ts=None):
+    def convert_spectrogram_to_audio(self, spec, Ts=None):
         batch_size = spec.shape[0]
 
         T_max = spec.shape[2]
@@ -135,7 +135,7 @@ class TwoStagesModel(Vocoder):
     def set_mel_to_spec_model(self, mel2spec: MelToSpec):
         self.mel2spec = mel2spec
 
-    def set_linear_vocoder(self, linvocoder: LinVocoder):
+    def set_linear_vocoder(self, linvocoder: Vocoder):
         self.linvocoder = linvocoder
 
     def cuda(self, *args, **kwargs):
@@ -172,7 +172,7 @@ class TwoStagesModel(Vocoder):
         with torch.no_grad():
             exp_spec = torch.exp(spec)
             linear_spec = self.mel2spec.convert_mel_spectrogram_to_linear(exp_spec)
-            audio = self.linvocoder.convert_linear_spectrogram_to_audio(linear_spec, **kwargs)
+            audio = self.linvocoder.convert_spectrogram_to_audio(linear_spec, **kwargs)
 
         return audio
 

--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -660,7 +660,7 @@ class Model(Typing, Serialization, FileIO):
     def list_available_models(cls) -> Optional[PretrainedModelInfo]:
         """
         Should list all pre-trained models available via NVIDIA NGC cloud.
-        Note: There is no check that requires model names and aliases to be unique. In the case of a collIsion, whatever
+        Note: There is no check that requires model names and aliases to be unique. In the case of a collision, whatever
         model (or alias) is listed first in the this returned list will be instantiated.
 
         Returns:


### PR DESCRIPTION
Signed-off-by: Xuesong Yang <1646669+XuesongYang@users.noreply.github.com>

# What does this PR do ?

`nemo.collections.tts.model.base.LinVocoder` is a redundant definition because `nemo.collections.tts.model.base.Vocoder` already defined all functions. The only difference is that `LinVocoder` calls `convert_linear_spectrogram_to_audio` while `Vocoder` calls `convert_spectrogram_to_audio`. So it is not necessary to duplicate the definition of Vocoder class.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
