### PR TITLE
Add support for Sampled Softmax for RNNT Joint

### DIFF
--- a/docs/source/asr/api.rst
+++ b/docs/source/asr/api.rst
@@ -72,6 +72,27 @@ Modules
     :show-inheritance:
     :members:
 
+.. _rnnt-decoder-api:
+
+.. autoclass:: nemo.collections.asr.modules.RNNTDecoder
+    :show-inheritance:
+    :members:
+
+.. autoclass:: nemo.collections.asr.modules.StatelessTransducerDecoder
+    :show-inheritance:
+    :members:
+
+.. _rnnt-joint-api:
+
+.. autoclass:: nemo.collections.asr.modules.RNNTJoint
+    :show-inheritance:
+    :members:
+
+.. autoclass:: nemo.collections.asr.modules.SampledRNNTJoint
+    :show-inheritance:
+    :members:
+
+
 
 Parts
 -----

--- a/docs/source/asr/configs.rst
+++ b/docs/source/asr/configs.rst
@@ -632,6 +632,31 @@ The Joint model config has several essential components which we discuss below :
       activation: "relu"
       dropout: 0.0
 
+Sampled Softmax Joint Model
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There are some situations where a large vocabulary with a Transducer model - such as for multilingual models with a large
+number of languages. In this setting, we need to consider the cost of memory of training Transducer networks which does
+not allow large vocabulary.
+
+For such cases, one can instead utilize the ``SampledRNNTJoint`` module instead of the usual ``RNNTJoint`` module, in order
+to compute the loss using a sampled subset of the vocabulary rather than the full vocabulary file.
+
+It adds only one additional parameter :
+
+* ``n_samples``: Specifies the minimum number of tokens to sample from the vocabulary space,
+  excluding the RNNT blank token. If a given value is larger than the entire vocabulary size,
+  then the full vocabulary will be used.
+
+The only difference in config required is to replace ``nemo.collections.asr.modules.RNNTJoint`` with ``nemo.collections.asr.modules.SampledRNNTJoint``
+
+.. code-block:: yaml
+
+  joint:
+    _target_: nemo.collections.asr.modules.SampledRNNTJoint
+    n_samples: 500
+    ...  # All other arguments from RNNTJoint can be used after this.
+
 
 Effect of Batch Splitting / Fused Batch step
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/asr/conf/conformer/multilang/conformer_transducer_bpe_multilang.yaml
+++ b/examples/asr/conf/conformer/multilang/conformer_transducer_bpe_multilang.yaml
@@ -155,6 +155,10 @@ model:
       dropout: 0.1
 
   joint:
+    # If the vocabulary size is large, replace below _target_ with following lines
+    # _target_: nemo.collections.asr.modules.SampledRNNTJoint
+    # n_samples: 500
+
     _target_: nemo.collections.asr.modules.RNNTJoint
     log_softmax: null  # 'null' would set it automatically according to CPU/GPU device
     preserve_memory: false  # dramatically slows down training, but might preserve some memory

--- a/nemo/collections/asr/modules/__init__.py
+++ b/nemo/collections/asr/modules/__init__.py
@@ -39,7 +39,7 @@ from nemo.collections.asr.modules.rnnt import (
     RNNTDecoder,
     RNNTDecoderJointSSL,
     RNNTJoint,
-    StatelessTransducerDecoder,
     SampledRNNTJoint,
+    StatelessTransducerDecoder,
 )
 from nemo.collections.asr.modules.squeezeformer_encoder import SqueezeformerEncoder, SqueezeformerEncoderAdapter

--- a/nemo/collections/asr/modules/__init__.py
+++ b/nemo/collections/asr/modules/__init__.py
@@ -35,5 +35,11 @@ from nemo.collections.asr.modules.graph_decoder import ViterbiDecoderWithGraph
 from nemo.collections.asr.modules.lstm_decoder import LSTMDecoder
 from nemo.collections.asr.modules.msdd_diarizer import MSDD_module
 from nemo.collections.asr.modules.rnn_encoder import RNNEncoder
-from nemo.collections.asr.modules.rnnt import RNNTDecoder, RNNTDecoderJointSSL, RNNTJoint, StatelessTransducerDecoder
+from nemo.collections.asr.modules.rnnt import (
+    RNNTDecoder,
+    RNNTDecoderJointSSL,
+    RNNTJoint,
+    StatelessTransducerDecoder,
+    SampledRNNTJoint,
+)
 from nemo.collections.asr.modules.squeezeformer_encoder import SqueezeformerEncoder, SqueezeformerEncoderAdapter

--- a/nemo/collections/asr/modules/rnnt.py
+++ b/nemo/collections/asr/modules/rnnt.py
@@ -1685,9 +1685,6 @@ class SampledRNNTJoint(RNNTJoint):
         )
         self.n_samples = n_samples
         self.register_buffer('blank_id', torch.tensor([self.num_classes_with_blank - 1]), persistent=False)
-        self.register_buffer(
-            'adjustment_val', torch.log(torch.tensor(self.num_classes_with_blank) - 1), persistent=False
-        )
 
     @typecheck()
     def forward(

--- a/nemo/collections/asr/modules/rnnt.py
+++ b/nemo/collections/asr/modules/rnnt.py
@@ -1858,8 +1858,12 @@ class SampledRNNTJoint(RNNTJoint):
             # print("Vocab", [(idx, v) for idx, v in enumerate(transcript_vocab_ids.cpu().numpy())])
             # print("Transcript original IDS:", transcript[0])
 
+            # Remap the transcript label ids to new positions of label ids (in the transcript_vocab_ids)
+            # This is necessary cause the RNNT loss doesnt care about the value, only the position of the ids
+            # of the transcript tokens. We can skip this step for noise samples cause those are only used for softmax
+            # not for computing actual label.
             t_ids = torch.arange(transcript_vocab_ids.size(0), device='cpu')
-            mapping = {k.item(): v.item() for k, v in zip(transcript_vocab_ids.to('cpu'), t_ids)}
+            mapping = {k: v for k, v in zip(transcript_vocab_ids.to('cpu'), t_ids)}
             mapping[0] = 0
 
             # From `https://stackoverflow.com/questions/13572448`.

--- a/tests/collections/asr/test_asr_rnnt_encdec_model.py
+++ b/tests/collections/asr/test_asr_rnnt_encdec_model.py
@@ -18,7 +18,7 @@ import torch
 from omegaconf import DictConfig, ListConfig
 
 from nemo.collections.asr.models import EncDecRNNTModel
-from nemo.collections.asr.modules import RNNTDecoder, RNNTJoint, StatelessTransducerDecoder
+from nemo.collections.asr.modules import RNNTDecoder, RNNTJoint, SampledRNNTJoint, StatelessTransducerDecoder
 from nemo.collections.asr.parts.submodules import rnnt_beam_decoding as beam_decode
 from nemo.collections.asr.parts.submodules import rnnt_greedy_decoding as greedy_decode
 from nemo.collections.asr.parts.utils import rnnt_utils
@@ -563,3 +563,82 @@ class TestEncDecRNNTModel:
                     logp, label = hyp.alignments[t][u]
                     assert torch.is_tensor(logp)
                     assert torch.is_tensor(label)
+
+    @pytest.mark.skipif(
+        not NUMBA_RNNT_LOSS_AVAILABLE, reason='RNNTLoss has not been compiled with appropriate numba version.',
+    )
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "greedy_class", [greedy_decode.GreedyRNNTInfer, greedy_decode.GreedyBatchedRNNTInfer],
+    )
+    def test_greedy_decoding_SampledRNNTJoint(self, greedy_class):
+        token_list = [" ", "a", "b", "c"]
+        vocab_size = len(token_list)
+
+        encoder_output_size = 4
+        decoder_output_size = 4
+        joint_output_shape = 4
+
+        prednet_cfg = {'pred_hidden': decoder_output_size, 'pred_rnn_layers': 1}
+        jointnet_cfg = {
+            'encoder_hidden': encoder_output_size,
+            'pred_hidden': decoder_output_size,
+            'joint_hidden': joint_output_shape,
+            'activation': 'relu',
+        }
+
+        decoder = RNNTDecoder(prednet_cfg, vocab_size)
+        joint_net = SampledRNNTJoint(jointnet_cfg, vocab_size, n_samples=2, vocabulary=token_list)
+
+        greedy = greedy_class(decoder, joint_net, blank_index=len(token_list) - 1, max_symbols_per_step=5)
+
+        # (B, D, T)
+        enc_out = torch.randn(1, encoder_output_size, 30)
+        enc_len = torch.tensor([30], dtype=torch.int32)
+
+        with torch.no_grad():
+            _ = greedy(encoder_output=enc_out, encoded_lengths=enc_len)
+
+    @pytest.mark.skipif(
+        not NUMBA_RNNT_LOSS_AVAILABLE, reason='RNNTLoss has not been compiled with appropriate numba version.',
+    )
+    @pytest.mark.unit
+    @pytest.mark.parametrize(
+        "beam_config",
+        [
+            {"search_type": "greedy"},
+            {"search_type": "default", "score_norm": False, "return_best_hypothesis": False},
+            {"search_type": "alsd", "alsd_max_target_len": 20, "return_best_hypothesis": False},
+            {"search_type": "tsd", "tsd_max_sym_exp_per_step": 3, "return_best_hypothesis": False},
+            {"search_type": "maes", "maes_num_steps": 2, "maes_expansion_beta": 2, "return_best_hypothesis": False},
+            {"search_type": "maes", "maes_num_steps": 3, "maes_expansion_beta": 1, "return_best_hypothesis": False},
+        ],
+    )
+    def test_beam_decoding_SampledRNNTJoint(self, beam_config):
+        token_list = [" ", "a", "b", "c"]
+        vocab_size = len(token_list)
+        beam_size = 1 if beam_config["search_type"] == "greedy" else 2
+
+        encoder_output_size = 4
+        decoder_output_size = 4
+        joint_output_shape = 4
+
+        prednet_cfg = {'pred_hidden': decoder_output_size, 'pred_rnn_layers': 1}
+        jointnet_cfg = {
+            'encoder_hidden': encoder_output_size,
+            'pred_hidden': decoder_output_size,
+            'joint_hidden': joint_output_shape,
+            'activation': 'relu',
+        }
+
+        decoder = RNNTDecoder(prednet_cfg, vocab_size)
+        joint_net = SampledRNNTJoint(jointnet_cfg, vocab_size, n_samples=2, vocabulary=token_list)
+
+        beam = beam_decode.BeamRNNTInfer(decoder, joint_net, beam_size=beam_size, **beam_config,)
+
+        # (B, D, T)
+        enc_out = torch.randn(1, encoder_output_size, 30)
+        enc_len = torch.tensor([30], dtype=torch.int32)
+
+        with torch.no_grad():
+            _ = beam(encoder_output=enc_out, encoded_lengths=enc_len)


### PR DESCRIPTION
# What does this PR do ?

Adds support for Sampled Softmax for RNNT Joint networks via subclass `SampledRNNTJoint`.
Implements the paper [Memory-Efficient Training of RNN-Transducer with Sampled Softmax](https://arxiv.org/abs/2203.16868).

**Collection**: [ASR]

# Changelog 
- Add support for Sampled Softmax in RNNT Joint - allowing huge vocabulary networks at near constant memory cost.
- Add docs for the RNNT decoder and joint modules
- Add tests for Sampled RNNT Joint

# Usage


``` yaml

# Replace the target for model.joint and add new value for `n_samples`
model:
  ...
  joint:
    #  _target_: nemo.collections.asr.modules.RNNTJoint
    _target_: nemo.collections.asr.modules.SampledRNNTJoint
    n_samples: 500
  
  ...

```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
