### PR TITLE
Fix link to inference notebook

### DIFF
--- a/tutorials/tts/NeMo_TTS_Primer.ipynb
+++ b/tutorials/tts/NeMo_TTS_Primer.ipynb
@@ -1991,7 +1991,7 @@
     "\n",
     "To get more hands on experience with NeMo TTS, look through some of our other [tutorials](https://github.com/NVIDIA/NeMo/tree/main/tutorials/tts).\n",
     "\n",
-    "*   Running pretrained models: [Inference_ModelSelect](https://github.com/NVIDIA/NeMo/blob/main)\n",
+    "*   Running pretrained models: [Inference_ModelSelect](https://github.com/NVIDIA/NeMo/blob/main/tutorials/tts/Inference_ModelSelect.ipynb)\n",
     "*   FastPitch [training](https://github.com/NVIDIA/NeMo/blob/main/tutorials/tts/FastPitch_MixerTTS_Training.ipynb) and [fine-tuning](https://github.com/NVIDIA/NeMo/blob/main/tutorials/tts/FastPitch_Finetuning.ipynb)\n",
     "\n",
     "To learn how to deploy and serve your TTS models, visit [Riva](https://docs.nvidia.com/deeplearning/riva/index.html)."


### PR DESCRIPTION
Signed-off-by: Jocelyn Huang <jocelynh@nvidia.com>

# What does this PR do ?

Fixes the Inference_ModelSelect notebook link in the NeMo TTS Primer notebook.

**Collection**: TTS

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation