### PR TITLE
[TTS] Replace IPA lambda arguments with locale string

### DIFF
--- a/nemo/collections/common/tokenizers/text_to_speech/__init__.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/__init__.py
@@ -11,5 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-from nemo.collections.common.tokenizers.text_to_speech.tokenizer_wrapper import TextToSpeechTokenizer

--- a/nemo/collections/common/tokenizers/text_to_speech/ipa_lexicon.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/ipa_lexicon.py
@@ -71,8 +71,7 @@ IPA_CHARACTER_SETS = {
 
 def validate_locale(locale):
     if locale not in SUPPORTED_LOCALES:
-        raise ValueError(f"Unsupported locale '{locale}'. "
-                         f"Supported locales {SUPPORTED_LOCALES}")
+        raise ValueError(f"Unsupported locale '{locale}'. " f"Supported locales {SUPPORTED_LOCALES}")
 
 
 def get_grapheme_character_set(locale):
@@ -88,8 +87,7 @@ def get_grapheme_character_set(locale):
 def get_ipa_character_set(locale):
     if locale not in IPA_CHARACTER_SETS:
         raise ValueError(
-            f"IPA character set not found for locale '{locale}'. "
-            f"Supported locales {IPA_CHARACTER_SETS.keys()}"
+            f"IPA character set not found for locale '{locale}'. " f"Supported locales {IPA_CHARACTER_SETS.keys()}"
         )
     char_set = set(IPA_CHARACTER_SETS[locale])
     return char_set

--- a/nemo/collections/common/tokenizers/text_to_speech/ipa_lexicon.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/ipa_lexicon.py
@@ -14,6 +14,9 @@
 
 
 # fmt: off
+
+SUPPORTED_LOCALES = ["en-US", "de-DE", "es-ES"]
+
 DEFAULT_PUNCTUATION = (
     ',', '.', '!', '?', '-',
     ':', ';', '/', '"', '(',
@@ -62,31 +65,47 @@ IPA_CHARACTER_SETS = {
         'ʊ', 'ʌ', 'ʒ', '̃', 'θ'
     )
 }
+
 # fmt: on
+
+
+def validate_locale(locale):
+    if locale not in SUPPORTED_LOCALES:
+        raise ValueError(f"Unsupported locale '{locale}'. " f"Supported locales {SUPPORTED_LOCALES}")
 
 
 def get_grapheme_character_set(locale):
     if locale not in GRAPHEME_CHARACTER_SETS:
-        raise ValueError(f"Grapheme character set not found for locale {locale}")
+        raise ValueError(
+            f"Grapheme character set not found for locale '{locale}'. "
+            f"Supported locales {GRAPHEME_CHARACTER_SETS.keys()}"
+        )
     char_set = set(GRAPHEME_CHARACTER_SETS[locale])
     return char_set
 
 
 def get_ipa_character_set(locale):
     if locale not in IPA_CHARACTER_SETS:
-        raise ValueError(f"IPA character set not found for locale {locale}")
+        raise ValueError(
+            f"IPA character set not found for locale '{locale}'. " f"Supported locales {IPA_CHARACTER_SETS.keys()}"
+        )
     char_set = set(IPA_CHARACTER_SETS[locale])
     return char_set
 
 
-def get_ipa_punctuation_list(locale):
-    punct_list = list(DEFAULT_PUNCTUATION)
+def get_ipa_punctuation_set(locale):
+    if locale is None:
+        return set(DEFAULT_PUNCTUATION)
+
+    validate_locale(locale)
+
+    punct_set = set(DEFAULT_PUNCTUATION)
     if locale in ["de-DE", "es-ES"]:
         # https://en.wikipedia.org/wiki/Guillemet#Uses
-        punct_list.extend(['«', '»', '‹', '›'])
+        punct_set.update(['«', '»', '‹', '›'])
     if locale == "de-DE":
-        punct_list.extend(['„', '“'])
+        punct_set.update(['„', '“'])
     elif locale == "es-ES":
-        punct_list.extend(['¿', '¡'])
+        punct_set.update(['¿', '¡'])
 
-    return punct_list
+    return punct_set

--- a/nemo/collections/common/tokenizers/text_to_speech/ipa_lexicon.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/ipa_lexicon.py
@@ -93,9 +93,9 @@ def get_ipa_character_set(locale):
     return char_set
 
 
-def get_ipa_punctuation_set(locale):
+def get_ipa_punctuation_list(locale):
     if locale is None:
-        return set(DEFAULT_PUNCTUATION)
+        return sorted(list(DEFAULT_PUNCTUATION))
 
     validate_locale(locale)
 
@@ -108,4 +108,5 @@ def get_ipa_punctuation_set(locale):
     elif locale == "es-ES":
         punct_set.update(['¿', '¡'])
 
-    return punct_set
+    punct_list = sorted(list(punct_set))
+    return punct_list

--- a/nemo/collections/common/tokenizers/text_to_speech/ipa_lexicon.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/ipa_lexicon.py
@@ -71,7 +71,8 @@ IPA_CHARACTER_SETS = {
 
 def validate_locale(locale):
     if locale not in SUPPORTED_LOCALES:
-        raise ValueError(f"Unsupported locale '{locale}'. " f"Supported locales {SUPPORTED_LOCALES}")
+        raise ValueError(f"Unsupported locale '{locale}'. "
+                         f"Supported locales {SUPPORTED_LOCALES}")
 
 
 def get_grapheme_character_set(locale):
@@ -87,7 +88,8 @@ def get_grapheme_character_set(locale):
 def get_ipa_character_set(locale):
     if locale not in IPA_CHARACTER_SETS:
         raise ValueError(
-            f"IPA character set not found for locale '{locale}'. " f"Supported locales {IPA_CHARACTER_SETS.keys()}"
+            f"IPA character set not found for locale '{locale}'. "
+            f"Supported locales {IPA_CHARACTER_SETS.keys()}"
         )
     char_set = set(IPA_CHARACTER_SETS[locale])
     return char_set

--- a/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
@@ -27,7 +27,7 @@ from nemo_text_processing.g2p.data.data_utils import (
     spanish_text_preprocessing,
 )
 
-from nemo.collections.common.tokenizers.text_to_speech.ipa_lexicon import get_ipa_punctuation_set, validate_locale
+from nemo.collections.common.tokenizers.text_to_speech.ipa_lexicon import get_ipa_punctuation_list, validate_locale
 from nemo.utils import logging
 from nemo.utils.decorators import experimental
 
@@ -242,7 +242,7 @@ class GermanCharsTokenizer(BaseCharsTokenizer):
 
 class SpanishCharsTokenizer(BaseCharsTokenizer):
 
-    PUNCT_LIST = get_ipa_punctuation_set("es-ES")
+    PUNCT_LIST = get_ipa_punctuation_list("es-ES")
 
     def __init__(
         self, punct=True, apostrophe=True, add_blank_at=None, pad_with_space=False, non_default_punct_list=None,
@@ -558,7 +558,7 @@ class IPATokenizer(BaseTokenizer):
             if non_default_punct_list is not None:
                 self.punct_list = non_default_punct_list
             else:
-                self.punct_list = get_ipa_punctuation_set(locale)
+                self.punct_list = get_ipa_punctuation_list(locale)
 
             tokens.update(self.punct_list)
 

--- a/nemo_text_processing/g2p/data/data_utils.py
+++ b/nemo_text_processing/g2p/data/data_utils.py
@@ -146,6 +146,10 @@ def ipa_word_tokenize(text):
     return _word_tokenize(words)
 
 
+def ipa_text_preprocessing(text):
+    return text.lower()
+
+
 def german_text_preprocessing(text):
     return text.lower()
 

--- a/nemo_text_processing/g2p/data/data_utils.py
+++ b/nemo_text_processing/g2p/data/data_utils.py
@@ -115,7 +115,8 @@ def english_text_preprocessing(text, lower=True):
 
 def _word_tokenize(words):
     """
-    Convert text (str) to List[Tuple[Union[str, List[str]], bool]] where every tuple denotes word representation and flag whether to leave unchanged or not.
+    Convert text (str) to List[Tuple[Union[str, List[str]], bool]] where every tuple denotes word representation and
+    flag whether to leave unchanged or not.
     Word can be one of: valid english word, any substring starts from | to | (unchangeable word) or punctuation marks.
     This function expects that unchangeable word is carefully divided by spaces (e.g. HH AH L OW).
     Unchangeable word will be splitted by space and represented as List[str], other cases are represented as str.

--- a/nemo_text_processing/g2p/modules.py
+++ b/nemo_text_processing/g2p/modules.py
@@ -25,6 +25,7 @@ import nltk
 import torch
 from nemo_text_processing.g2p.data.data_utils import english_word_tokenize, ipa_word_tokenize
 
+from nemo.collections.common.tokenizers.text_to_speech.ipa_lexicon import validate_locale
 from nemo.utils import logging
 from nemo.utils.decorators import experimental
 from nemo.utils.get_rank import is_global_rank_zero
@@ -281,14 +282,9 @@ class IPAG2P(BaseG2p):
             phoneme_dict (str, Path, Dict): Path to file in CMUdict format or a IPA dict object with CMUdict-like entries.
                 a dictionary file example: scripts/tts_dataset_files/ipa_cmudict-0.7b_nv22.06.txt;
                 a dictionary object example: {..., "WIRE": [["ˈ", "w", "a", "ɪ", "ɚ"], ["ˈ", "w", "a", "ɪ", "ɹ"]], ...}
-            word_tokenize_func: Function for tokenizing text to words.
-                It has to return List[Tuple[Union[str, List[str]], bool]] where every tuple denotes word
-                representation and flag whether to leave unchanged or not.
-                It is expected that unchangeable word representation will be represented as List[str], other
-                cases are represented as str.
-                It is useful to mark word as unchangeable which is already in phoneme representation.
-                Defaults to the English word tokenizer.
-            locale: Locale used to determine tokenization logic.
+            locale: Locale used to determine default tokenization logic.
+                Supports ["en-US", "de-DE", "es-ES"]. Defaults to "en-US".
+                Specify None if implementing custom logic for a new locale.
             apply_to_oov_word: Function that will be applied to out of phoneme_dict word.
             ignore_ambiguous_words: Whether to not handle word via phoneme_dict with ambiguous phoneme sequences.
                 Defaults to True.
@@ -307,6 +303,9 @@ class IPAG2P(BaseG2p):
         self.set_graphemes_upper = set_graphemes_upper
         self.phoneme_probability = phoneme_probability
         self._rng = random.Random()
+
+        if locale is not None:
+            validate_locale(locale)
 
         if not use_chars and self.phoneme_probability is not None:
             self.use_chars = True
@@ -349,6 +348,9 @@ class IPAG2P(BaseG2p):
                 "you may see unexpected deletions in your input."
             )
 
+        # word_tokenize_func returns a List[Tuple[Union[str, List[str]], bool]] where every tuple denotes
+        # a word representation (word or list tokens) and a flag indicating whether to process the output or
+        # leave it unchanged.
         if locale == "en-US":
             word_tokenize_func = english_word_tokenize
         else:

--- a/nemo_text_processing/g2p/modules.py
+++ b/nemo_text_processing/g2p/modules.py
@@ -349,7 +349,7 @@ class IPAG2P(BaseG2p):
             )
 
         # word_tokenize_func returns a List[Tuple[Union[str, List[str]], bool]] where every tuple denotes
-        # a word representation (word or list tokens) and a flag indicating whether to process the output or
+        # a word representation (word or list tokens) and a flag indicating whether to process the word or
         # leave it unchanged.
         if locale == "en-US":
             word_tokenize_func = english_word_tokenize

--- a/nemo_text_processing/g2p/modules.py
+++ b/nemo_text_processing/g2p/modules.py
@@ -23,7 +23,7 @@ from typing import Callable, DefaultDict, List, Optional, Set, Tuple, Union
 
 import nltk
 import torch
-from nemo_text_processing.g2p.data.data_utils import english_word_tokenize
+from nemo_text_processing.g2p.data.data_utils import english_word_tokenize, ipa_word_tokenize
 
 from nemo.utils import logging
 from nemo.utils.decorators import experimental
@@ -263,7 +263,7 @@ class IPAG2P(BaseG2p):
     def __init__(
         self,
         phoneme_dict: Union[str, pathlib.Path, dict],
-        word_tokenize_func: Callable[[str], List[Tuple[Union[str, List[str]], bool]]] = english_word_tokenize,
+        locale: str = "en-US",
         apply_to_oov_word: Optional[Callable[[str], str]] = None,
         ignore_ambiguous_words: bool = True,
         heteronyms: Optional[Union[str, pathlib.Path, List[str]]] = None,
@@ -288,6 +288,7 @@ class IPAG2P(BaseG2p):
                 cases are represented as str.
                 It is useful to mark word as unchangeable which is already in phoneme representation.
                 Defaults to the English word tokenizer.
+            locale: Locale used to determine tokenization logic.
             apply_to_oov_word: Function that will be applied to out of phoneme_dict word.
             ignore_ambiguous_words: Whether to not handle word via phoneme_dict with ambiguous phoneme sequences.
                 Defaults to True.
@@ -347,6 +348,11 @@ class IPAG2P(BaseG2p):
                 "This may be intended if phonemes and chars are both valid inputs, otherwise, "
                 "you may see unexpected deletions in your input."
             )
+
+        if locale == "en-US":
+            word_tokenize_func = english_word_tokenize
+        else:
+            word_tokenize_func = ipa_word_tokenize
 
         super().__init__(
             phoneme_dict=self.phoneme_dict,

--- a/tests/collections/common/tokenizers/text_to_speech/test_tts_tokenizers.py
+++ b/tests/collections/common/tokenizers/text_to_speech/test_tts_tokenizers.py
@@ -13,15 +13,27 @@
 # limitations under the License.
 
 import pytest
+from nemo_text_processing.g2p.modules import IPAG2P
 
 from nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers import (
     EnglishCharsTokenizer,
     GermanCharsTokenizer,
+    IPATokenizer,
     SpanishCharsTokenizer,
 )
 
 
 class TestTTSTokenizers:
+    PHONEME_DICT_DE = {
+        "HALLO": ["hˈaloː"],
+        "WELT": ["vˈɛlt"],
+    }
+    PHONEME_DICT_EN = {"HELLO": ["həˈɫoʊ"], "WORLD": ["ˈwɝɫd"], "CAFE": ["kəˈfeɪ"]}
+    PHONEME_DICT_ES = {
+        "BUENOS": ["bwˈenos"],
+        "DÍAS": ["dˈias"],
+    }
+
     @staticmethod
     def _parse_text(tokenizer, text):
         tokens = tokenizer.encode(text)
@@ -88,3 +100,60 @@ class TestTTSTokenizers:
 
         assert chars == expected_output
         assert len(tokens) == len(input_text)
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_tokenizer(self):
+        input_text = "Hello world!"
+        expected_output = " həˈɫoʊ ˈwɝɫd! "
+
+        g2p = IPAG2P(phoneme_dict=self.PHONEME_DICT_EN)
+
+        tokenizer = IPATokenizer(g2p=g2p, locale=None, pad_with_space=True)
+        chars, tokens = self._parse_text(tokenizer, input_text)
+
+        assert chars == expected_output
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_tokenizer_unsupported_locale(self):
+        g2p = IPAG2P(phoneme_dict=self.PHONEME_DICT_EN)
+        with pytest.raises(ValueError, match="Unsupported locale"):
+            IPATokenizer(g2p=g2p, locale="asdf")
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_tokenizer_de_de(self):
+        input_text = "Hallo welt"
+        expected_output = "hˈaloː vˈɛlt"
+
+        g2p = IPAG2P(phoneme_dict=self.PHONEME_DICT_DE, locale="de-DE")
+        tokenizer = IPATokenizer(g2p=g2p, locale="de-DE")
+        chars, tokens = self._parse_text(tokenizer, input_text)
+
+        assert chars == expected_output
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_tokenizer_en_us(self):
+        input_text = "Hello café."
+        expected_output = "həˈɫoʊ kəˈfeɪ."
+        g2p = IPAG2P(phoneme_dict=self.PHONEME_DICT_EN)
+
+        tokenizer = IPATokenizer(g2p=g2p, locale="en-US")
+        tokenizer.tokens.extend("CAFE")
+        chars, tokens = self._parse_text(tokenizer, input_text)
+
+        assert chars == expected_output
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_tokenizer_es_es(self):
+        input_text = "¡Buenos días!"
+        expected_output = "¡bwˈenos dˈias!"
+
+        g2p = IPAG2P(phoneme_dict=self.PHONEME_DICT_ES, locale="es-ES")
+        tokenizer = IPATokenizer(g2p=g2p, locale="es-ES")
+        chars, tokens = self._parse_text(tokenizer, input_text)
+
+        assert chars == expected_output

--- a/tests/nemo_text_processing/g2p/phoneme_dict/test_dict_de.txt
+++ b/tests/nemo_text_processing/g2p/phoneme_dict/test_dict_de.txt
@@ -1,0 +1,2 @@
+HALLO  hˈaloː
+WELT  vˈɛlt

--- a/tests/nemo_text_processing/g2p/phoneme_dict/test_dict_es.txt
+++ b/tests/nemo_text_processing/g2p/phoneme_dict/test_dict_es.txt
@@ -1,0 +1,2 @@
+HOLA  ˈola
+MUNDO  mˈundo

--- a/tests/nemo_text_processing/g2p/test_modules.py
+++ b/tests/nemo_text_processing/g2p/test_modules.py
@@ -20,11 +20,15 @@ from nemo_text_processing.g2p.modules import IPAG2P
 
 class TestModules:
 
-    PHONEME_DICT_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), "phoneme_dict", "test_dict.txt")
+    PHONEME_DICT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "phoneme_dict")
+    PHONEME_DICT_PATH_EN = os.path.join(PHONEME_DICT_DIR, "test_dict.txt")
+    PHONEME_DICT_PATH_ES = os.path.join(PHONEME_DICT_DIR, "test_dict_es.txt")
+    PHONEME_DICT_PATH_DE = os.path.join(PHONEME_DICT_DIR, "test_dict_de.txt")
 
     @staticmethod
     def _create_g2p(
-        phoneme_dict=PHONEME_DICT_PATH,
+        phoneme_dict=PHONEME_DICT_PATH_EN,
+        locale="en-US",
         apply_to_oov_word=lambda x: x,
         use_chars=False,
         phoneme_probability=None,
@@ -32,6 +36,7 @@ class TestModules:
     ):
         return IPAG2P(
             phoneme_dict,
+            locale=locale,
             apply_to_oov_word=apply_to_oov_word,
             use_chars=use_chars,
             phoneme_probability=phoneme_probability,
@@ -120,6 +125,26 @@ class TestModules:
         input_text = "Hello world."
         expected_output = [char for char in input_text.lower()]
         g2p = self._create_g2p(use_chars=True, phoneme_probability=0.0, set_graphemes_upper=False)
+
+        phonemes = g2p(input_text)
+        assert phonemes == expected_output
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_g2p_es_ES(self):
+        input_text = "¿Hola mundo, amigo?"
+        expected_output = [char for char in "¿ˈola mˈundo, AMIGO?"]
+        g2p = self._create_g2p(phoneme_dict=self.PHONEME_DICT_PATH_ES, locale="es-ES")
+
+        phonemes = g2p(input_text)
+        assert phonemes == expected_output
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_g2p_de_DE(self):
+        input_text = "Hallo „welt“!"
+        expected_output = [char for char in "hˈaloː „vˈɛlt“!"]
+        g2p = self._create_g2p(phoneme_dict=self.PHONEME_DICT_PATH_DE, locale="de-DE")
 
         phonemes = g2p(input_text)
         assert phonemes == expected_output

--- a/tests/nemo_text_processing/g2p/test_modules.py
+++ b/tests/nemo_text_processing/g2p/test_modules.py
@@ -157,7 +157,7 @@ class TestModules:
 
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
-    def test_ipa_g2p_ensupported_locale(self):
+    def test_ipa_g2p_unsupported_locale(self):
         with pytest.raises(ValueError, match="Unsupported locale"):
             self._create_g2p(locale="en-USA")
 

--- a/tests/nemo_text_processing/g2p/test_modules.py
+++ b/tests/nemo_text_processing/g2p/test_modules.py
@@ -21,14 +21,14 @@ from nemo_text_processing.g2p.modules import IPAG2P
 class TestModules:
 
     PHONEME_DICT_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "phoneme_dict")
+    PHONEME_DICT_PATH_DE = os.path.join(PHONEME_DICT_DIR, "test_dict_de.txt")
     PHONEME_DICT_PATH_EN = os.path.join(PHONEME_DICT_DIR, "test_dict.txt")
     PHONEME_DICT_PATH_ES = os.path.join(PHONEME_DICT_DIR, "test_dict_es.txt")
-    PHONEME_DICT_PATH_DE = os.path.join(PHONEME_DICT_DIR, "test_dict_de.txt")
 
     @staticmethod
     def _create_g2p(
         phoneme_dict=PHONEME_DICT_PATH_EN,
-        locale="en-US",
+        locale=None,
         apply_to_oov_word=lambda x: x,
         use_chars=False,
         phoneme_probability=None,
@@ -91,6 +91,22 @@ class TestModules:
 
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
+    def test_ipa_g2p_with_dict_input(self):
+        input_text = "Hello world."
+        expected_output = [char for char in "həˈɫoʊ ˈwɝɫd."]
+
+        phoneme_dict = {"HELLO": ["həˈɫoʊ"], "WORLD": ["ˈwɝɫd"]}
+
+        g2p_file = self._create_g2p()
+        g2p_dict = self._create_g2p(phoneme_dict=phoneme_dict)
+
+        phonemes_file = g2p_file(input_text)
+        phonemes_dict = g2p_dict(input_text)
+        assert phonemes_dict == expected_output
+        assert phonemes_file == phonemes_dict
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
     def test_ipa_g2p_with_oov(self):
         input_text = "Hello Kitty!"
         expected_output = [char for char in "həˈɫoʊ KITTY!"]
@@ -131,20 +147,46 @@ class TestModules:
 
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
-    def test_ipa_g2p_es_ES(self):
-        input_text = "¿Hola mundo, amigo?"
-        expected_output = [char for char in "¿ˈola mˈundo, AMIGO?"]
-        g2p = self._create_g2p(phoneme_dict=self.PHONEME_DICT_PATH_ES, locale="es-ES")
+    def test_ipa_g2p_with_escaped_characters(self):
+        input_text = "Hello |wo rld|."
+        expected_output = ["h", "ə", "ˈ", "ɫ", "o", "ʊ", " ", "wo", "rld", "."]
+        g2p = self._create_g2p()
 
         phonemes = g2p(input_text)
         assert phonemes == expected_output
 
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
-    def test_ipa_g2p_de_DE(self):
+    def test_ipa_g2p_ensupported_locale(self):
+        with pytest.raises(ValueError, match="Unsupported locale"):
+            self._create_g2p(locale="en-USA")
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_g2p_de_de(self):
         input_text = "Hallo „welt“!"
         expected_output = [char for char in "hˈaloː „vˈɛlt“!"]
         g2p = self._create_g2p(phoneme_dict=self.PHONEME_DICT_PATH_DE, locale="de-DE")
+
+        phonemes = g2p(input_text)
+        assert phonemes == expected_output
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_g2p_en_us(self):
+        input_text = "Hello Kitty!"
+        expected_output = [char for char in "həˈɫoʊ KITTY!"]
+        g2p = self._create_g2p(locale="en-US")
+
+        phonemes = g2p(input_text)
+        assert phonemes == expected_output
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_g2p_es_es(self):
+        input_text = "¿Hola mundo, amigo?"
+        expected_output = [char for char in "¿ˈola mˈundo, AMIGO?"]
+        g2p = self._create_g2p(phoneme_dict=self.PHONEME_DICT_PATH_ES, locale="es-ES")
 
         phonemes = g2p(input_text)
         assert phonemes == expected_output


### PR DESCRIPTION
# What does this PR do ?

Currently you cannot configure the IPATokenizer in .yaml config because there is no way to modify the lambda arguments. This PR replaces the lambda arguments with a locale string that maps to the correct behavior, which now just maps to English vs Non-English.

An alternative approach would be to replace the lambda arguments with a new class/interface, but we thought that was too complicated for now. And that having default configurations available that someone can control with just a language/locale string would be nice to have regardless.

**Collection**: [TTS]

# Changelog 
- Replace IPA tokenizer lambda arguments with locale string that maps to English vs non-English IPA functions.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation