### PR TITLE
[TTS] replace obsolete torch_tts unit test marker with run_only_on('CPU')

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -51,25 +51,6 @@ pipeline {
       }
     }
 
-    // Removed `torch_tts` install option from NeMo>=1.7.0
-    // Will add test back if/when we decide to support it again
-    // stage('Torch TTS unit tests') {
-    //   when {
-    //     anyOf {
-    //       branch 'main'
-    //       changeRequest target: 'main'
-    //     }
-    //   }
-    //   steps {
-    //     sh 'pip install ".[torch_tts]"'
-    //     sh 'pip list'
-    //     sh 'test $(pip list | grep -c lightning) -eq 0'
-    //     sh 'test $(pip list | grep -c omegaconf) -eq 0'
-    //     sh 'test $(pip list | grep -c hydra) -eq 0'
-    //     sh 'pytest -m "torch_tts" --cpu tests/collections/tts/test_torch_tts.py --relax_numba_compat'
-    //   }
-    // }
-
     stage('NeMo Installation') {
       steps {
         sh './reinstall.sh release'
@@ -105,7 +86,7 @@ pipeline {
     }
     stage('L0: Unit Tests GPU') {
       steps {
-        sh 'NEMO_NUMBA_MINVER=0.53 pytest -m "not pleasefixme and not torch_tts" --with_downloads'
+        sh 'NEMO_NUMBA_MINVER=0.53 pytest -m "not pleasefixme" --with_downloads'
       }
     }
 

--- a/ci.groovy
+++ b/ci.groovy
@@ -71,7 +71,7 @@ spec:
                 }
 
                 stage('L0: GPU unit tests') {
-                            sh "NEMO_NUMBA_MINVER=0.53 pytest -m 'not pleasefixme and not torch_tts'"         
+                            sh "NEMO_NUMBA_MINVER=0.53 pytest -m 'not pleasefixme'"
                 }
 
                 parallel( //USE CUDA_VISIBLE_DEVICES to execute 2 single GPU tests in parallel here

--- a/nemo/collections/tts/torch/README.md
+++ b/nemo/collections/tts/torch/README.md
@@ -1,9 +1,8 @@
 # Torch TTS Collection
 
-This section of code can be used by installing the requirements inside our *requirements.txt* and *requirements_torch_tts.txt*.
+This section of code can be used by installing the requirements inside our *requirements.txt* and *requirements_tts.txt*.
 
-Note: As of NeMo 1.8.0, we have removed the ability to install the `torch_tts` collection by itself. Please install
-NeMo using the TTS option:
+Please install NeMo using the TTS option:
 
  - `pip install nemo_toolkit[tts]`
  - `pip install git+https://github.com/nvidia/NeMo.git#egg=nemo_toolkit[tts]`

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,6 @@ markers =
     docs: mark tests related to documentation (deselect with '-m "not docs"')
     skipduringci: marks tests that are skipped ci as they are addressed by Jenkins jobs but should be run to test user setups
     pleasefixme: marks tests that are broken and need fixing
-    torch_tts: marks tests that are to be run when "torch_tts" is installed but not all nemo packages
 
 [isort]
 known_localfolder = nemo,tests

--- a/tests/collections/tts/test_torch_tts.py
+++ b/tests/collections/tts/test_torch_tts.py
@@ -28,7 +28,7 @@ from nemo.collections.tts.torch.helpers import get_base_dir
 
 class TestTTSDataset:
     @pytest.mark.unit
-    @pytest.mark.torch_tts
+    @pytest.mark.run_only_on('CPU')
     def test_dataset(self, test_data_dir):
         manifest_path = os.path.join(test_data_dir, 'tts/mini_ljspeech/manifest.json')
         sup_path = os.path.join(test_data_dir, 'tts/mini_ljspeech/sup')
@@ -53,7 +53,7 @@ class TestTTSDataset:
         data, _, _, _, _, _ = next(iter(dataloader))
 
     @pytest.mark.unit
-    @pytest.mark.torch_tts
+    @pytest.mark.run_only_on('CPU')
     def test_raise_exception_on_not_supported_sup_data_types(self, test_data_dir):
         manifest_path = os.path.join(test_data_dir, 'tts/mini_ljspeech/manifest.json')
         sup_path = os.path.join(test_data_dir, 'tts/mini_ljspeech/sup')
@@ -75,7 +75,7 @@ class TestTTSDataset:
             )
 
     @pytest.mark.unit
-    @pytest.mark.torch_tts
+    @pytest.mark.run_only_on('CPU')
     def test_raise_exception_on_not_supported_window(self, test_data_dir):
         manifest_path = os.path.join(test_data_dir, 'tts/mini_ljspeech/manifest.json')
         sup_path = os.path.join(test_data_dir, 'tts/mini_ljspeech/sup')
@@ -98,7 +98,7 @@ class TestTTSDataset:
             )
 
     @pytest.mark.unit
-    @pytest.mark.torch_tts
+    @pytest.mark.run_only_on('CPU')
     @pytest.mark.parametrize("sup_data_type", ["voiced_mask", "p_voiced"])
     def test_raise_exception_on_missing_pitch_sup_data_type_if_use_voiced(self, test_data_dir, sup_data_type):
         manifest_path = os.path.join(test_data_dir, 'tts/mini_ljspeech/manifest.json')
@@ -122,7 +122,7 @@ class TestTTSDataset:
             )
 
     @pytest.mark.unit
-    @pytest.mark.torch_tts
+    @pytest.mark.run_only_on('CPU')
     @pytest.mark.parametrize(
         "sup_data_types, output_indices",
         [


### PR DESCRIPTION

Signed-off-by: Xuesong Yang <1646669+XuesongYang@users.noreply.github.com>

# What does this PR do ?
* we should remove the legacy unit test marker `torch_tts` and use the common `run_only_on('CPU')` marker. `torch_tts` marker was only used for testing `TTSDataset` on CPU.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
