### PR TITLE
[TTS] expand to support flexible dictionary entry formats in IPAG2P.

### DIFF
--- a/nemo/collections/tts/modules/common.py
+++ b/nemo/collections/tts/modules/common.py
@@ -14,8 +14,7 @@
 
 ###############################################################################
 
-import ast
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 import numpy as np
 import torch

--- a/nemo/collections/tts/modules/radtts.py
+++ b/nemo/collections/tts/modules/radtts.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pdb
 
 ###############################################################################
 import torch
@@ -32,7 +31,6 @@ from nemo.collections.tts.modules.common import (
     LinearNorm,
     get_mask_from_lengths,
     getRadTTSEncoder,
-    sort_tensor,
 )
 from nemo.collections.tts.modules.submodules import PartialConv1d
 from nemo.core.classes import Exportable, NeuralModule

--- a/nemo/collections/tts/modules/submodules.py
+++ b/nemo/collections/tts/modules/submodules.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 import torch
 from torch.autograd import Variable

--- a/nemo_text_processing/g2p/modules.py
+++ b/nemo_text_processing/g2p/modules.py
@@ -321,14 +321,14 @@ class IPAG2P(BaseG2p):
             # load the dictionary file where there may exist a digit suffix after a word, which
             # represents the pronunciation variant of that word.
             phoneme_dict_obj = defaultdict(list)
-            _alt_re = re.compile(r'\([0-9]+\)')
+            _alt_re = re.compile(r"\([0-9]+\)")
             with open(phoneme_dict, "r") as fdict:
                 for line in fdict:
                     if len(line) and ('A' <= line[0] <= 'Z' or line[0] == "'"):
-                        parts = line.strip().split("  ")
-                        assert len(parts) == 2, f"Wrong format for the entry: {line.strip()}."
-                        word = re.sub(_alt_re, '', parts[0])
-                        phoneme_dict_obj[word].append(list(parts[1]))
+                        parts = line.strip().split(maxsplit=1)
+                        word = re.sub(_alt_re, "", parts[0])
+                        prons = re.sub(r"\s+", "", parts[1])
+                        phoneme_dict_obj[word].append(list(prons))
         else:
             # Load phoneme_dict as dictionary object
             logging.info("Loading phoneme_dict as a Dict object.")

--- a/nemo_text_processing/text_normalization/zh/taggers/tokenize_and_classify.py
+++ b/nemo_text_processing/text_normalization/zh/taggers/tokenize_and_classify.py
@@ -14,7 +14,7 @@
 import os
 
 import pynini
-from nemo_text_processing.text_normalization.zh.graph_utils import NEMO_SIGMA, GraphFst
+from nemo_text_processing.text_normalization.zh.graph_utils import GraphFst
 from nemo_text_processing.text_normalization.zh.taggers.cardinal import Cardinal
 from nemo_text_processing.text_normalization.zh.taggers.char import Char
 from nemo_text_processing.text_normalization.zh.taggers.date import Date

--- a/tests/collections/tts/test_torch_tts.py
+++ b/tests/collections/tts/test_torch_tts.py
@@ -16,7 +16,6 @@ import json
 import os
 from pathlib import Path
 
-import numpy as np
 import pytest
 import torch
 from nemo_text_processing.g2p.modules import EnglishG2p

--- a/tests/collections/tts/test_waveglow.py
+++ b/tests/collections/tts/test_waveglow.py
@@ -14,15 +14,12 @@
 
 import os
 import tempfile
-from unittest import TestCase
 
-import onnx
 import pytest
 import torch
 from omegaconf import DictConfig
 
 from nemo.collections.tts.models import WaveGlowModel
-from nemo.collections.tts.modules import WaveGlowModule
 from nemo.core.classes import typecheck
 
 mcfg = DictConfig(

--- a/tests/nemo_text_processing/g2p/phoneme_dict/test_dict.txt
+++ b/tests/nemo_text_processing/g2p/phoneme_dict/test_dict.txt
@@ -1,2 +1,5 @@
 HELLO  həˈɫoʊ
 WORLD  ˈwɝɫd
+LEAD  ˈlɛd
+LEAD(1)  ˈlid
+NVIDIA    ɛ n ˈ v ɪ d i ə

--- a/tests/nemo_text_processing/g2p/phoneme_dict/test_dict.txt
+++ b/tests/nemo_text_processing/g2p/phoneme_dict/test_dict.txt
@@ -1,5 +1,5 @@
 HELLO  həˈɫoʊ
-WORLD  ˈwɝɫd
+WORLD ˈwɝɫd
 LEAD  ˈlɛd
-LEAD(1)  ˈlid
+LEAD(1) ˈ l i d
 NVIDIA    ɛ n ˈ v ɪ d i ə


### PR DESCRIPTION
* expand to support flexible dictionary entry formats in IPAG2P.
* removed unused imports in test.collections.tts
* removed unused imports in nemo.collections.tts.modules
* removed unused imports in nemo_text_processing.text_normalization.zh
* updated unit tests with new cases
* renamed test function names because we only test IPAG2P rather than all classes in the `modules.py`.

Signed-off-by: Xuesong Yang <1646669+XuesongYang@users.noreply.github.com>

```bash
$ pytest --cpu tests/nemo_text_processing/g2p/test_modules.py
A valid `test_data.tar.gz` test archive (10445891B) found in the `/Users/xueyang/workspace/NeMo/tests/.data` folder.
/Users/xueyang/miniconda3/envs/nemo/lib/python3.8/site-packages/torch/utils/tensorboard/__init__.py:4: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  if not hasattr(tensorboard, "__version__") or LooseVersion(
/Users/xueyang/miniconda3/envs/nemo/lib/python3.8/site-packages/torch/utils/tensorboard/__init__.py:6: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  ) < LooseVersion("1.15"):
[NeMo W 2022-11-03 19:03:03 optimizers:55] Apex was not found. Using the lamb or fused_adam optimizer will error out.
Setting numba compat : True
==================================================================== test session starts =====================================================================
platform darwin -- Python 3.8.13, pytest-7.1.2, pluggy-1.0.0 -- /Users/xueyang/miniconda3/envs/nemo/bin/python
cachedir: .pytest_cache
rootdir: /Users/xueyang/workspace/NeMo, configfile: setup.cfg
plugins: anyio-3.5.0, hydra-core-1.1.2
collected 13 items

tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_normalize_dict_with_phonemes PASSED                                                   [  7%]
tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_normalize_dict_with_graphemes_and_phonemes PASSED                                     [ 15%]
tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_forward_call PASSED                                                                   [ 23%]
tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_forward_call_with_file_or_object_dict_type PASSED                                     [ 30%]
tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_forward_call_with_oov_word PASSED                                                     [ 38%]
tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_forward_call_with_oov_func PASSED                                                     [ 46%]
tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_forward_call_with_graphemes_uppercase PASSED                                          [ 53%]
tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_forward_call_with_graphemes_lowercase PASSED                                          [ 61%]
tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_forward_call_with_escaped_characters PASSED                                           [ 69%]
tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_instantiate_unsupported_locale PASSED                                                 [ 76%]
tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_forward_call_de_de PASSED                                                             [ 84%]
tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_forward_call_en_us PASSED                                                             [ 92%]
tests/nemo_text_processing/g2p/test_modules.py::TestIPAG2P::test_forward_call_es_es PASSED                                                             [100%]

===================================================================== slowest durations ======================================================================

(39 durations < 0.005s hidden.  Use -vv to show these durations.)
===================================================================== 13 passed in 0.43s =====================================================================
```


# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below



# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
