### PR TITLE
removed uninstall nemo_cv and nemo_simple_gan and relax numba version…

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -3,7 +3,6 @@ set -e
 
 INSTALL_OPTION=${1:-"dev"}
 
-
 PIP=pip
 
 echo 'Uninstalling stuff'
@@ -14,21 +13,14 @@ ${PIP} uninstall -y sacrebleu
 ${PIP} uninstall -y nemo_asr
 ${PIP} uninstall -y nemo_nlp
 ${PIP} uninstall -y nemo_tts
-${PIP} uninstall -y nemo_simple_gan
-${PIP} uninstall -y nemo_cv
 
 ${PIP} install -U setuptools
 
-if [ ! -z "${NVIDIA_PYTORCH_VERSION}" ]
-
-then
+if [ ! -z "${NVIDIA_PYTORCH_VERSION}" ]; then
   echo 'Installing NeMo in NVIDIA PyTorch container:' ${NVIDIA_PYTORCH_VERSION} 'so will not install numba'
 else
-  if [ -n "${CONDA_PREFIX}" ]
-  then
-    NUMBA_VERSION=0.55
-    echo 'Installing numba=='${NUMBA_VERSION}
-    conda install -y -c conda-forge numba==${NUMBA_VERSION}
+  if [ -n "${CONDA_PREFIX}" ]; then
+    conda install -y -c conda-forge numba
   fi
 fi
 

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -20,7 +20,9 @@ if [ ! -z "${NVIDIA_PYTORCH_VERSION}" ]; then
   echo 'Installing NeMo in NVIDIA PyTorch container:' ${NVIDIA_PYTORCH_VERSION} 'so will not install numba'
 else
   if [ -n "${CONDA_PREFIX}" ]; then
-    conda install -y -c conda-forge numba
+    NUMBA_VERSION=0.55
+    echo 'Installing numba=='${NUMBA_VERSION}
+    conda install -y -c conda-forge numba==${NUMBA_VERSION}
   fi
 fi
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -6,6 +6,7 @@ python-dateutil
 ruamel.yaml
 scikit-learn
 setuptools==59.5.0
+tensorboard
 text-unidecode
 torch
 tqdm>=4.41.0


### PR DESCRIPTION
   
 * removed nemo_cv and nemo_simple_gan in reinstall.sh.
 * relaxed numba version limits.
 * added tensorboard requirement to avoid any incpmpatible issue.

not quite sure why we should enforce `numba==0.55`. When I run `./reinstall.sh`, I got incompatible env issue below for `tensorboard` and `numba`.

``` bash
(nemo) xueyang@LOCAL:~/workspace/NeMo:(main)$ ./reinstall.sh
Uninstalling stuff
Found existing installation: nemo-toolkit 1.12.0rc0
Uninstalling nemo-toolkit-1.12.0rc0:
  Successfully uninstalled nemo-toolkit-1.12.0rc0
Found existing installation: sacrebleu 2.2.1
Uninstalling sacrebleu-2.2.1:
  Successfully uninstalled sacrebleu-2.2.1
WARNING: Skipping nemo_asr as it is not installed.
WARNING: Skipping nemo_nlp as it is not installed.
WARNING: Skipping nemo_tts as it is not installed.
WARNING: Skipping nemo_simple_gan as it is not installed.
WARNING: Skipping nemo_cv as it is not installed.
Requirement already satisfied: setuptools in /Users/xueyang/miniconda3/envs/nemo/lib/python3.8/site-packages (65.5.0)
Collecting setuptools
  Downloading setuptools-65.5.1-py3-none-any.whl (1.2 MB)
     ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1.2/1.2 MB 12.1 MB/s eta 0:00:00
Installing collected packages: setuptools
  Attempting uninstall: setuptools
    Found existing installation: setuptools 65.5.0
    Uninstalling setuptools-65.5.0:
      Successfully uninstalled setuptools-65.5.0
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
tensorboard 2.10.0 requires protobuf<3.20,>=3.9.2, but you have protobuf 3.20.1 which is incompatible.
numba 0.55.0 requires numpy<1.22,>=1.18, but you have numpy 1.23.3 which is incompatible.
```


# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
