### PR TITLE
[TTS] bugfix for the script of generating mels from fastpitch.

### DIFF
--- a/scripts/dataset_processing/tts/generate_mels.py
+++ b/scripts/dataset_processing/tts/generate_mels.py
@@ -16,7 +16,7 @@
 This script is to generate mel spectrograms from a Fastpitch model checkpoint. Please see general usage below. It runs
 on GPUs by default, but you can add `--num-workers 5 --cpu` as an option to run on CPUs.
 
-$ python scripts/dataset_processing/tts/generate_mels_for_finetune_hifigan.py \
+$ python scripts/dataset_processing/tts/generate_mels.py \
     --fastpitch-model-ckpt ./models/fastpitch/multi_spk/FastPitch--val_loss\=1.4473-epoch\=209.ckpt \
     --input-json-manifests /home/xueyang/HUI-Audio-Corpus-German-clean/test_manifest_text_normed_phonemes.json
     --output-json-manifest-root /home/xueyang/experiments/multi_spk_tts_de
@@ -146,7 +146,7 @@ def main():
         spec_model.cuda()
     device = spec_model.device
 
-    use_beta_binomial_interpolator = spec_model.cfg.train_ds.dataset.use_beta_binomial_interpolator
+    use_beta_binomial_interpolator = spec_model.cfg.train_ds.dataset.get("use_beta_binomial_interpolator", False)
 
     for manifest in input_manifest_filepaths:
         logging.info(f"Processing {manifest}.")


### PR DESCRIPTION
Signed-off-by: Xuesong Yang <1646669+XuesongYang@users.noreply.github.com>

# What does this PR do ?

Some YAML config may not use `use_beta_binomial_interpolator` explicitly so that the script would raise errors like below,
``` bash
pyxis: importing docker image ...
OMP: Info #276: omp_set_nested routine deprecated, please use omp_set_max_active_levels instead.
Traceback (most recent call last):
  File "scripts/dataset_processing/tts/generate_mels_for_finetune_hifigan.py", line 177, in <module>
    main()
  File "scripts/dataset_processing/tts/generate_mels_for_finetune_hifigan.py", line 149, in main
    use_beta_binomial_interpolator = spec_model.cfg.train_ds.dataset.use_beta_binomial_interpolator
  File "/opt/conda/lib/python3.8/site-packages/omegaconf/dictconfig.py", line 357, in __getattr__
    self._format_and_raise(key=key, value=None, cause=e)
  File "/opt/conda/lib/python3.8/site-packages/omegaconf/base.py", line 190, in _format_and_raise
    format_and_raise(
  File "/opt/conda/lib/python3.8/site-packages/omegaconf/_utils.py", line 738, in format_and_raise
    _raise(ex, cause)
  File "/opt/conda/lib/python3.8/site-packages/omegaconf/_utils.py", line 716, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set end OC_CAUSE=1 for full backtrace
  File "/opt/conda/lib/python3.8/site-packages/omegaconf/dictconfig.py", line 351, in __getattr__
    return self._get_impl(key=key, default_value=_DEFAULT_MARKER_)
  File "/opt/conda/lib/python3.8/site-packages/omegaconf/dictconfig.py", line 438, in _get_impl
    node = self._get_node(key=key, throw_on_missing_key=True)
  File "/opt/conda/lib/python3.8/site-packages/omegaconf/dictconfig.py", line 465, in _get_node
    self._validate_get(key)
  File "/opt/conda/lib/python3.8/site-packages/omegaconf/dictconfig.py", line 166, in _validate_get
    self._format_and_raise(
  File "/opt/conda/lib/python3.8/site-packages/omegaconf/base.py", line 190, in _format_and_raise
    format_and_raise(
  File "/opt/conda/lib/python3.8/site-packages/omegaconf/_utils.py", line 818, in format_and_raise
    _raise(ex, cause)
  File "/opt/conda/lib/python3.8/site-packages/omegaconf/_utils.py", line 716, in _raise
    raise ex.with_traceback(sys.exc_info()[2])  # set end OC_CAUSE=1 for full backtrace
omegaconf.errors.ConfigAttributeError: Key 'use_beta_binomial_interpolator' is not in struct
    full_key: train_ds.dataset.use_beta_binomial_interpolator
    object_type=dict
```


**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
