### PR TITLE
add suffix [add]?[digit] to thousand graph

### DIFF
--- a/nemo_text_processing/inverse_text_normalization/en/taggers/date.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/date.py
@@ -85,7 +85,11 @@ def _get_year_graph():
             + delete_space
             + graph_hundred_component
             + delete_space
-            + (graph_teen | graph_ties | pynini.closure(pynutil.delete("and") + delete_space) + pynutil.insert("0") + graph_digit)
+            + (
+                graph_teen
+                | graph_ties
+                | pynini.closure(pynutil.delete("and") + delete_space) + pynutil.insert("0") + graph_digit
+            )
         )
         return graph
 

--- a/nemo_text_processing/inverse_text_normalization/en/taggers/date.py
+++ b/nemo_text_processing/inverse_text_normalization/en/taggers/date.py
@@ -85,7 +85,7 @@ def _get_year_graph():
             + delete_space
             + graph_hundred_component
             + delete_space
-            + (graph_teen | graph_ties)
+            + (graph_teen | graph_ties | pynini.closure(pynutil.delete("and") + delete_space) + pynutil.insert("0") + graph_digit)
         )
         return graph
 


### PR DESCRIPTION
Signed-off-by: Cuong Nguyen Dang <nndcuong@gmail.com>

# What does this PR do ?

Fix issue \(https://github.com/NVIDIA/NeMo/issues/5367)

**Collection**: ITN

# Changelog 
- add suffix ```[and]?[digit]``` to thousand graph

# Usage
```python
from nemo_text_processing.inverse_text_normalization.en.taggers.cardinal import CardinalFst
from nemo_text_processing.inverse_text_normalization.en.taggers.ordinal import OrdinalFst
from nemo_text_processing.inverse_text_normalization.en.taggers.date import DateFst

cardinal = CardinalFst()
ordinal = OrdinalFst(cardinal)
date_fst = DateFst(ordinal).fst

text = "two thousand and nine"
print(pynini.shortestpath(text @ date_fst).string())
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (5367)
