### PR TITLE
Fix for prompt table restore error

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
@@ -435,9 +435,9 @@ class MegatronBasePromptLearningModel(MegatronBaseModel, TextGeneration):
         # Set values back to their training state to continue training
         self.virtual_prompt_style = current_virtual_prompt_style
         self.virtual_prompt_source = current_virtual_prompt_source
-        
+
         # Revert prompt table back to previous state
-        if self.virtual_prompt_style ==  VirtualPromptStyle.P_TUNING and self.first_stage_of_pipeline():
+        if self.virtual_prompt_style == VirtualPromptStyle.P_TUNING and self.first_stage_of_pipeline():
             for taskname in current_new_tasks:
                 if taskname in self.prompt_table.prompt_table:
                     del self.prompt_table.prompt_table[taskname]

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
@@ -435,6 +435,12 @@ class MegatronBasePromptLearningModel(MegatronBaseModel, TextGeneration):
         # Set values back to their training state to continue training
         self.virtual_prompt_style = current_virtual_prompt_style
         self.virtual_prompt_source = current_virtual_prompt_source
+        
+        # Revert prompt table back to previous state
+        if self.virtual_prompt_style ==  VirtualPromptStyle.P_TUNING and self.first_stage_of_pipeline():
+            for taskname in current_new_tasks:
+                if taskname in self.prompt_table.prompt_table:
+                    del self.prompt_table.prompt_table[taskname]
 
         with open_dict(self.cfg):
             self.cfg.existing_tasks = current_existing_tasks

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -706,9 +706,9 @@ class MegatronGPTPromptLearningModel(MegatronBaseModel, TextGeneration):
         # Set values back to their training state to continue training
         self.virtual_prompt_style = current_virtual_prompt_style
         self.virtual_prompt_source = current_virtual_prompt_source
-        
+
         # Revert prompt table back to previous state
-        if self.virtual_prompt_style ==  VirtualPromptStyle.P_TUNING and self.frozen_model.model.pre_process:
+        if self.virtual_prompt_style == VirtualPromptStyle.P_TUNING and self.frozen_model.model.pre_process:
             for taskname in current_new_tasks:
                 if taskname in self.prompt_table.prompt_table:
                     del self.prompt_table.prompt_table[taskname]

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -706,6 +706,10 @@ class MegatronGPTPromptLearningModel(MegatronBaseModel, TextGeneration):
         # Set values back to their training state to continue training
         self.virtual_prompt_style = current_virtual_prompt_style
         self.virtual_prompt_source = current_virtual_prompt_source
+        
+        # Set revert prompt table back to previous state
+        for taskname in current_new_tasks:
+            del self.prompt_table.prompt_table[taskname]
 
         with open_dict(self.cfg):
             self.cfg.existing_tasks = current_existing_tasks

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -707,8 +707,8 @@ class MegatronGPTPromptLearningModel(MegatronBaseModel, TextGeneration):
         self.virtual_prompt_style = current_virtual_prompt_style
         self.virtual_prompt_source = current_virtual_prompt_source
         
-        # Set revert prompt table back to previous state
-        if self.virtual_prompt_style ==  VirtualPromptStyle.P_TUNING:
+        # Revert prompt table back to previous state
+        if self.virtual_prompt_style ==  VirtualPromptStyle.P_TUNING and self.frozen_model.model.pre_process:
             for taskname in current_new_tasks:
                 if taskname in self.prompt_table.prompt_table:
                     del self.prompt_table.prompt_table[taskname]

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -708,8 +708,10 @@ class MegatronGPTPromptLearningModel(MegatronBaseModel, TextGeneration):
         self.virtual_prompt_source = current_virtual_prompt_source
         
         # Set revert prompt table back to previous state
-        for taskname in current_new_tasks:
-            del self.prompt_table.prompt_table[taskname]
+        if self.virtual_prompt_style ==  VirtualPromptStyle.P_TUNING:
+            for taskname in current_new_tasks:
+                if taskname in self.prompt_table.prompt_table:
+                    del self.prompt_table.prompt_table[taskname]
 
         with open_dict(self.cfg):
             self.cfg.existing_tasks = current_existing_tasks

--- a/tutorials/tools/Multispeaker_Simulator.ipynb
+++ b/tutorials/tools/Multispeaker_Simulator.ipynb
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -90,18 +90,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The LibriSpeech forced word alignments are from [this repository.](https://github.com/CorentinJ/librispeech-alignments). You can access to the whole LibriSpeech splits at this google drive link [link](https://drive.google.com/file/d/1WYfgr31T-PPwMcxuAq09XZfHQO5Mw8fE/view?usp=sharing). We will download the dev-clean part for demo purpose."
+    "The LibriSpeech forced word alignments are from [this repository](https://github.com/CorentinJ/librispeech-alignments). You can access to the whole LibriSpeech splits at this google drive [link](https://drive.google.com/file/d/1WYfgr31T-PPwMcxuAq09XZfHQO5Mw8fE/view?usp=sharing). We will download the dev-clean part for demo purpose."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget https://dldata-public.s3.us-east-2.amazonaws.com/LibriSpeech_Alignments.tar.gz\n",
-    "!tar -xvzf LibriSpeech_Alignments.tar.gz\n",
-    "!rm LibriSpeech-Alignments.zip"
+    "!wget -nc https://dldata-public.s3.us-east-2.amazonaws.com/LibriSpeech_Alignments.tar.gz\n",
+    "!tar -xzf LibriSpeech_Alignments.tar.gz\n",
+    "!rm -f LibriSpeech_Alignments.tar.gz"
    ]
   },
   {
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,8 +144,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!wget https://www.openslr.org/resources/28/rirs_noises.zip\n",
-    "!unzip -o rirs_noises.zip"
+    "!wget -nc https://www.openslr.org/resources/28/rirs_noises.zip\n",
+    "!unzip -o rirs_noises.zip\n",
+    "!rm -f rirs_noises.zip"
    ]
   },
   {


### PR DESCRIPTION
Signed-off-by: Virginia Adams <vadams@nvidia.com>

Every time a new low val loss is reached, the virtual tokens from the prompt encoder are moved to the prompt table in order to save a .nemo file for that checkpoint. This PR removes the premature virtual prompt tokens from the prompt table so that restoring from a .ckpt doesn't error. The error was:

```
Traceback (most recent call last):
  File "scripts/convert_prompt_learning_ckpt_to_nemo.py", line 85, in main
    model: MegatronGPTPromptLearningModel = MegatronGPTPromptLearningModel.load_from_checkpoint(
  File "/home/vadams/NeMo/nemo/collections/nlp/models/nlp_model.py", line 355, in load_from_checkpoint
    model = ptl_load_state(cls, checkpoint, strict=strict, cfg=cfg, **kwargs)
  File "/home/vadams/miniconda3/envs/dev/lib/python3.8/site-packages/pytorch_lightning/core/saving.py", line 259, in _load_state
    keys = obj.load_state_dict(checkpoint["state_dict"], strict=strict)
  File "/home/vadams/NeMo/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py", line 382, in load_state_dict
    self.prompt_table.load_state_dict(state_dict_, strict)
  File "/home/vadams/miniconda3/envs/dev/lib/python3.8/site-packages/torch/nn/modules/module.py", line 1667, in load_state_dict
    raise RuntimeError('Error(s) in loading state_dict for {}:\n\t{}'.format(
RuntimeError: Error(s) in loading state_dict for PromptTable:
	Unexpected key(s) in state_dict: "prompt_table.squad.indices", "prompt_table.squad.prompt_embeddings.weight"
```

**Collection**: NLP

# Changelog 
- Updated GPT and T5 Prompt learning

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
- [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
