### PR TITLE
Draft: Add support for modeling words in kenLM for subword models.

### DIFF
--- a/scripts/asr_language_modeling/ngram_lm/install_beamsearch_decoders.sh
+++ b/scripts/asr_language_modeling/ngram_lm/install_beamsearch_decoders.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # install Boost package
-sudo apt-get install build-essential libboost-all-dev cmake zlib1g-dev libbz2-dev liblzma-dev
+sudo apt-get install build-essential libboost-all-dev cmake zlib1g-dev libbz2-dev liblzma-dev swig
 git clone https://github.com/NVIDIA/OpenSeq2Seq
 cd OpenSeq2Seq
 git checkout ctc-decoders


### PR DESCRIPTION
# What does this PR do ?

Add support for modeling words in kenLM for subword models.

**Collection**: ASR

# Changelog 
- Add support for modeling words in kenLM for subword models.
- Add missing dependency to beam search installation.

# Usage
NA

**PR Type**:
- [X] New Feature
- [ ] Bugfix
- [ ] Documentation

## Who can review?

Finally, this is a draft. I am going to check with the effected party that these changes will work for them. Then maybe someone like @VahidooX can take a look.

# Additional Information
One commit message describes this in detail. Pasting here:

Previously, NeMo did not support beam search with a KenLM language
model trained on words when using a subword acoustic model. Rather, it
forces KenLM to model subpiece units instead. This caused problems for
a customer using https://github.com/nvidia-riva/riva-asrlib-decoder,
which does support this out of the box.

Adding --encoding_level_override=char enables this behavior. It is an
opt-in behavior.

There are very other additions here to make training KenLM models more
flexible:

- I add "--skip_symbols" to the "lmplz" call. Sometimes training data
can have "<s>" or "</s>" in it, which can cause a crash, unless you
trun this flag on. Always turning on the flag has no bad effects and
is backwards compatible.

- I add support for lmplz's "-T" option. This is useful if you are
working on a machine where "/tmp", the default directory, is small.

- I added "--limit_vocab_file". It speeds up training when you happen
to have a training file that has a lot of out of your vocabulary of interest
(e.g., scraped from webpages).

I disable forcibly deleting the arpa file created by lmplz. You need
to keep this if you are using a WFST decoder.
