### PR TITLE
Fix setting up of `ReduceLROnPlateau` learning rate scheduler

### DIFF
--- a/nemo/core/config/schedulers.py
+++ b/nemo/core/config/schedulers.py
@@ -284,4 +284,5 @@ AVAILABLE_SCHEDULER_PARAMS = {
     'WarmupAnnealingParams': WarmupAnnealingParams,
     'PolynomialDecayAnnealingParams': PolynomialDecayAnnealingParams,
     'PolynomialHoldDecayAnnealingParams': PolynomialHoldDecayAnnealingParams,
+    'ReduceLROnPlateauParams': ReduceLROnPlateauParams,
 }

--- a/tests/core/test_optimizers_schedulers.py
+++ b/tests/core/test_optimizers_schedulers.py
@@ -310,6 +310,51 @@ class TestOptimizersSchedulers:
         assert isinstance(scheduler_setup['scheduler'], optim.lr_scheduler.CosineAnnealing)
 
     @pytest.mark.unit
+    def test_sched_config_parse_reduce_on_plateau(self):
+        model = TempModel()
+        opt_cls = optim.get_optimizer('novograd')
+        opt = opt_cls(model.parameters(), lr=self.INITIAL_LR)
+        reduce_on_plateau_parameters = {
+            'mode': 'min',
+            'factor': 0.5,
+            'patience': 1,
+            'threshold': 1e-4,
+            'threshold_mode': 'rel',
+            'min_lr': 1e-6,
+            'eps': 1e-7,
+            'verbose': True,
+            'cooldown': 1,
+        }
+        basic_sched_config = {
+            'name': 'ReduceLROnPlateau',
+            'monitor': 'val_loss',
+            'reduce_on_plateau': True,
+            'max_steps': self.MAX_STEPS,
+        }
+        basic_sched_config.update(reduce_on_plateau_parameters)
+        scheduler_setup = optim.lr_scheduler.prepare_lr_scheduler(opt, basic_sched_config)
+        assert isinstance(scheduler_setup['scheduler'], torch.optim.lr_scheduler.ReduceLROnPlateau)
+        for k, v in reduce_on_plateau_parameters.items():
+            if k == 'min_lr':
+                k += 's'
+                v = [v]
+            found_v = getattr(scheduler_setup['scheduler'], k)
+            assert (
+                found_v == v
+            ), f"Wrong value `{repr(found_v)}` for `ReduceLROnPlateau` parameter `{k}`. Expected `{repr(v)}`."
+        dict_config = omegaconf.OmegaConf.create(basic_sched_config)
+        scheduler_setup = optim.lr_scheduler.prepare_lr_scheduler(opt, dict_config)
+        assert isinstance(scheduler_setup['scheduler'], torch.optim.lr_scheduler.ReduceLROnPlateau)
+        for k, v in reduce_on_plateau_parameters.items():
+            if k == 'min_lr':
+                k += 's'
+                v = [v]
+            found_v = getattr(scheduler_setup['scheduler'], k)
+            assert (
+                found_v == v
+            ), f"Wrong value `{repr(found_v)}` for `ReduceLROnPlateau` parameter `{k}`. Expected `{repr(v)}`."
+
+    @pytest.mark.unit
     def test_WarmupPolicy(self):
         model = TempModel()
         opt_cls = optim.get_optimizer('novograd')


### PR DESCRIPTION
# What does this PR do ?

Fix setting up of `ReduceLROnPlateau` learning rate scheduler.

**Collection**: core

Steps to reproduce
```bash
git clone https://github.com/NVIDIA/NeMo.git
cd NeMo
git checkout fix/reduce_on_plateau_r1.11.0
git checkout r1.11.0 -- nemo/core/optim/lr_scheduler.py nemo/core/config/schedulers.py
pytest tests/core/test_optimizers_schedulers.py
```


# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
