### PR TITLE
[ASR] Transcribe for multi-channel signals

### DIFF
--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -87,6 +87,8 @@ class TranscriptionConfig:
     pretrained_name: Optional[str] = None  # Name of a pretrained model
     audio_dir: Optional[str] = None  # Path to a directory which contains audio files
     dataset_manifest: Optional[str] = None  # Path to dataset's JSON manifest
+    channel_selector: Optional[int] = None  # Used to select a single channel from multi-channel files
+    audio_key: str = 'audio_filepath'  # Used to override the default audio key in dataset_manifest
 
     # General configs
     output_filename: Optional[str] = None
@@ -198,6 +200,7 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
                         batch_size=cfg.batch_size,
                         num_workers=cfg.num_workers,
                         return_hypotheses=return_hypotheses,
+                        channel_selector=cfg.channel_selector,
                     )
                 else:
                     logging.warning(
@@ -208,6 +211,7 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
                         batch_size=cfg.batch_size,
                         num_workers=cfg.num_workers,
                         return_hypotheses=return_hypotheses,
+                        channel_selector=cfg.channel_selector,
                     )
             else:
                 transcriptions = asr_model.transcribe(
@@ -215,6 +219,7 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
                     batch_size=cfg.batch_size,
                     num_workers=cfg.num_workers,
                     return_hypotheses=return_hypotheses,
+                    channel_selector=cfg.channel_selector,
                 )
 
     logging.info(f"Finished transcribing {len(filepaths)} files !")

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -725,6 +725,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin):
             'shuffle': False,
             'num_workers': config.get('num_workers', min(batch_size, os.cpu_count() - 1)),
             'pin_memory': True,
+            'channel_selector': config.get('channel_selector', None),
         }
 
         temporary_datalayer = self._setup_dataloader_from_config(config=DictConfig(dl_config))

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -15,7 +15,7 @@ import glob
 import json
 import os
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import torch
 from omegaconf import DictConfig
@@ -220,7 +220,8 @@ def prepare_audio_data(cfg: DictConfig) -> Tuple[List[str], bool]:
                     has_two_fields.append(True)
                 else:
                     has_two_fields.append(False)
-                audio_file = Path(item['audio_filepath'])
+                audio_key = cfg.get('audio_key', 'audio_filepath')
+                audio_file = Path(item[audio_key])
                 if not audio_file.is_file() and not audio_file.is_absolute():
                     audio_file = manifest_dir / audio_file
                 filepaths.append(str(audio_file.absolute()))
@@ -290,6 +291,7 @@ def transcribe_partial_audio(
     logprobs: bool = False,
     return_hypotheses: bool = False,
     num_workers: int = 0,
+    channel_selector: Optional[int] = None,
 ) -> List[str]:
 
     assert isinstance(asr_model, EncDecCTCModel), "Currently support CTC model only."
@@ -325,6 +327,7 @@ def transcribe_partial_audio(
             'manifest_filepath': path2manifest,
             'batch_size': batch_size,
             'num_workers': num_workers,
+            'channel_selector': channel_selector,
         }
 
         temporary_datalayer = asr_model._setup_transcribe_dataloader(config)


### PR DESCRIPTION

# What does this PR do ?

This PR adds the following optional parameters to ASR transcription:
- select a single channel from multi-channel input
- override the default audio key (`"audio_filepath"`) when loading paths from a manifest

**Collection**: ASR

# Changelog 
- Added optional `channel_selector` parameter to `TranscriptionConfig`
- Added optional `audio_key` parameter to `TranscriptionConfig`
- Propagated the two parameters to `transcribe` and `transcribe_utils`

# Usage

Transcription config can be updated, for example as

```python
cfg.channel_selector = 0 # Evaluate on the first channel
cfg.audio_key = 'alternative_audio_filepath' # Load audio from an alternative filepath provided in the manifest
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
