### PR TITLE
Suggest users to add GitHub labels to PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,8 +2,6 @@
 
 Add a one line overview of what this PR aims to accomplish.
 
-**Collection**: [Note which collection this PR will affect]
-
 # Changelog 
 - Add specific line by line info of high level changes in this PR.
 
@@ -20,12 +18,9 @@ Add a one line overview of what this PR aims to accomplish.
 - [ ] Did you write any new necessary tests?
 - [ ] Did you add or update any necessary documentation?
 - [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
-  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
-  
-**PR Type**:
-- [ ] New Feature
-- [ ] Bugfix
-- [ ] Documentation
+- [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
+- [ ] Did you add GitHub tags on the right? e.g Add `ASR`, `bug` for an ASR bugfix
+
 
 If you haven't finished some of the above items you can still open "Draft" PR.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -19,7 +19,7 @@ Add a one line overview of what this PR aims to accomplish.
 - [ ] Did you add or update any necessary documentation?
 - [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
 - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
-- [ ] Did you add GitHub tags on the right? e.g Add `ASR`, `bug` for an ASR bugfix
+- [ ] Did you add GitHub labels on the right? e.g Add `ASR`, `bug` for an ASR bugfix
 
 
 If you haven't finished some of the above items you can still open "Draft" PR.


### PR DESCRIPTION
# What does this PR do ?

Suggests users to add labels to their PR. This helps classify for maintainers.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
