### PR TITLE
Conformer local attention

### DIFF
--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -15,7 +15,7 @@
 import contextlib
 import os
 from dataclasses import dataclass, is_dataclass
-from typing import Optional
+from typing import Any, Optional
 
 import pytorch_lightning as pl
 import torch
@@ -115,6 +115,8 @@ class TranscriptionConfig:
 
     # Decoding strategy for RNNT models
     rnnt_decoding: RNNTDecodingConfig = RNNTDecodingConfig(fused_batch_size=-1)
+
+    merge_into_model_config: Optional[Any] = None
 
 
 @hydra_runner(config_name="TranscriptionConfig", schema=TranscriptionConfig)

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -116,6 +116,7 @@ class TranscriptionConfig:
     # Decoding strategy for RNNT models
     rnnt_decoding: RNNTDecodingConfig = RNNTDecodingConfig(fused_batch_size=-1)
 
+    # This will be merged with the model config, overriding existing parameters.
     merge_into_model_config: Optional[Any] = None
 
 

--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -75,12 +75,17 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable):
             Defaults to 4.
         self_attention_model (str): type of the attention layer and positional encoding
             'rel_pos': relative positional embedding and Transformer-XL
+            'rel_pos_local_attn': relative positional embedding and Transformer-XL with local attention using
+                overlapping windows. Attention context is determined by att_context_size parameter.
             'abs_pos': absolute positional embedding and Transformer
-            default is rel_pos.
+            Default is rel_pos.
         pos_emb_max_len (int): the maximum length of positional embeddings
-            Defaulst to 5000
+            Defaults to 5000
         n_heads (int): number of heads in multi-headed attention layers
             Defaults to 4.
+        att_context_size (List[int]): List of 2 ints corresponding to left and right attention context sizes,
+            or None for full context.
+            Defaults to None.
         xscaling (bool): enables scaling the inputs to the multi-headed attention layers by sqrt(d_model)
             Defaults to True.
         untie_biases (bool): whether to not share (untie) the bias weights between layers of Transformer-XL

--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -492,6 +492,8 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable):
             padding_length.size(0), -1
         ) < padding_length.unsqueeze(-1)
 
+        pad_mask = ~pad_mask
+
         if self.use_att_mask:
             # pad_mask_for_att_mask is the mask which helps to ignore paddings
             pad_mask_for_att_mask = pad_mask.unsqueeze(1).repeat([1, max_audio_length, 1])
@@ -501,7 +503,6 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable):
             # paddings should also get ignored, so pad_mask_for_att_mask is used to ignore their corresponding scores
             att_mask = torch.logical_and(pad_mask_for_att_mask, att_mask.to(pad_mask_for_att_mask.device))
 
-            pad_mask = ~pad_mask
             att_mask = ~att_mask
         else:
             att_mask = None

--- a/nemo/collections/asr/parts/submodules/multi_head_attention.py
+++ b/nemo/collections/asr/parts/submodules/multi_head_attention.py
@@ -268,6 +268,7 @@ class RelPositionMultiHeadAttentionLocal(RelPositionMultiHeadAttention):
         dropout_rate (float): dropout rate
         pos_bias_u (Tensor): the positional bias matrix U
         pos_bias_v (Tensor): the positional bias matrix V
+        att_context_size (
         max_cache_len (int): the maximum size of cache
     """
 
@@ -331,7 +332,6 @@ class RelPositionMultiHeadAttentionLocal(RelPositionMultiHeadAttention):
             mask = self._get_invalid_locations_mask_fixed_dilation(affected_seq_len, w, d)
             mask = mask[None, None, :, :]
         else:
-            # TODO not verified
             affected_seq_len = w * d.max()
             head_masks = []
             d_list = d.cpu().numpy().tolist()
@@ -491,7 +491,6 @@ class RelPositionMultiHeadAttentionLocal(RelPositionMultiHeadAttention):
             float_mask = mask.type_as(scores).masked_fill(mask, -10000.0)
             ones = float_mask.new_ones(size=float_mask.size())  # tensor of ones
             # diagonal mask with zeros everywhere and -inf inplace of padding
-            # TODO what pad value to use?
             d_mask = self.sliding_chunks_matmul_qk(ones, float_mask, w, padding_value=0.0)
 
             scores += d_mask

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -184,13 +184,15 @@ def setup_model(cfg: DictConfig, map_location: torch.device) -> Tuple[ASRModel, 
         imported_class = model_utils.import_class_by_path(classpath)  # type: ASRModel
         logging.info(f"Restoring model : {imported_class.__name__}")
         asr_model = imported_class.restore_from(
-            restore_path=cfg.model_path, map_location=map_location
+            restore_path=cfg.model_path, map_location=map_location, merge_into_model_config=cfg.merge_into_model_config
         )  # type: ASRModel
         model_name = os.path.splitext(os.path.basename(cfg.model_path))[0]
     else:
         # restore model by name
         asr_model = ASRModel.from_pretrained(
-            model_name=cfg.pretrained_name, map_location=map_location
+            model_name=cfg.pretrained_name,
+            map_location=map_location,
+            merge_into_model_config=cfg.merge_into_model_config,
         )  # type: ASRModel
         model_name = cfg.pretrained_name
 

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -271,6 +271,7 @@ class ModelPT(LightningModule, Model):
         return_config: bool = False,
         save_restore_connector: SaveRestoreConnector = None,
         trainer: Optional[Trainer] = None,
+        merge_into_model_config: OmegaConf = None,
     ):
         """
         Restores model instance (weights and configuration) from .nemo file.
@@ -314,7 +315,14 @@ class ModelPT(LightningModule, Model):
 
         cls.update_save_restore_connector(save_restore_connector)
         instance = cls._save_restore_connector.restore_from(
-            cls, restore_path, override_config_path, map_location, strict, return_config, trainer
+            cls,
+            restore_path,
+            override_config_path,
+            map_location,
+            strict,
+            return_config,
+            trainer,
+            merge_into_model_config,
         )
         if isinstance(instance, ModelPT):
             instance._save_restore_connector = save_restore_connector

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -288,7 +288,8 @@ class ModelPT(LightningModule, Model):
             trainer: Optional, a pytorch lightning Trainer object that will be forwarded to the
                 instantiated model's constructor.
             save_restore_connector (SaveRestoreConnector): Can be overridden to add custom save and restore logic.
-
+            merge_into_model_config (OmegaConf): This will be merged with the model config,
+                overriding existing parameters.
             Example:
                 ```
                 model = nemo.collections.asr.models.EncDecCTCModel.restore_from('asr.nemo')

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -88,7 +88,8 @@ class SaveRestoreConnector:
             strict: Passed to load_state_dict. By default True
             return_config: If set to true, will return just the underlying config of the restored
                 model as an OmegaConf DictConfig object without instantiating the model.
-
+            merge_into_model_config (OmegaConf): This will be merged with the model config,
+                overriding existing parameters.
         Example:
             ```
             model = nemo.collections.asr.models.EncDecCTCModel.restore_from('asr.nemo')
@@ -225,7 +226,7 @@ class SaveRestoreConnector:
             return_config: If set to true, will return just the underlying config of the restored
                 model as an OmegaConf DictConfig object without instantiating the model.
             trainer: An optional Trainer object, passed to the model constructor.
-
+            merge_into_model_config (OmegaConf): This will be merged with the model config, overriding existing parameters.
         Example:
             ```
             model = nemo.collections.asr.models.EncDecCTCModel.restore_from('asr.nemo')

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -74,6 +74,7 @@ class SaveRestoreConnector:
         strict: bool = True,
         return_config: bool = False,
         trainer: Trainer = None,
+        merge_into_model_config: OmegaConf = None,
     ):
         """
         Restores model instance (weights and configuration) into .nemo file
@@ -143,6 +144,9 @@ class SaveRestoreConnector:
                 if 'model' in conf:
                     conf = conf.model
 
+                if isinstance(merge_into_model_config, (OmegaConf, DictConfig)):
+                    conf = OmegaConf.merge(conf, merge_into_model_config)
+
                 if return_config:
                     instance = conf
                     return instance
@@ -206,6 +210,7 @@ class SaveRestoreConnector:
         strict: bool = True,
         return_config: bool = False,
         trainer: Trainer = None,
+        merge_into_model_config: OmegaConf = None,
     ):
         """
         Restores model instance (weights and configuration) into .nemo file
@@ -233,7 +238,14 @@ class SaveRestoreConnector:
         # Get path where the command is executed - the artifacts will be "retrieved" there
         # (original .nemo behavior)
         loaded_params = self.load_config_and_state_dict(
-            calling_cls, restore_path, override_config_path, map_location, strict, return_config, trainer,
+            calling_cls,
+            restore_path,
+            override_config_path,
+            map_location,
+            strict,
+            return_config,
+            trainer,
+            merge_into_model_config,
         )
         if not isinstance(loaded_params, tuple):
             return loaded_params


### PR DESCRIPTION
# What does this PR do ?

Sliding window local attention for Conformer.

**Collection**: ASR

# Changelog 
- adds option to use local attention for Conformer
- adds option for overriding/merging parameters into model config when using transcribe/eval scripts or loading model

# Usage

With an eval script can be used like this to switch to local attention with any Conformer checkpoint

```
python speech_to_text_eval.py \
  (...other params...)  \
  ++merge_into_model_config.encoder.att_context_size=[64,64] \
  ++merge_into_model_config.encoder.self_attention_model="rel_pos_local_attn"
```

Or when loading model 

```python
merge_into_model_config = {
  'encoder': dict({
    'self_attention_model': "rel_pos_local_attn",
    'att_context_size': [64, 64]
    }),
}
merge_into_model_config = DictConfig(merge_into_model_config)
asr_model = ASRModel.from_pretrained('stt_en_conformer_ctc_large', map_location='cuda',
  merge_into_model_config=merge_into_model_config)
```

**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
