### PR TITLE
Switch order of args in optimizer_step override

### DIFF
--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -590,8 +590,8 @@ class MegatronHalfPrecisionPlugin(NativeMixedPrecisionPlugin):
 
     def optimizer_step(
         self,
-        model: Union["pl.LightningModule", torch.nn.Module],
         optimizer: torch.optim.Optimizer,
+        model: Union["pl.LightningModule", torch.nn.Module],
         optimizer_idx: int,
         closure: Callable[[], Any],
         **kwargs: Any,


### PR DESCRIPTION
# What does this PR do ?

PTL 1.8 swapped the order of the positional args for the optimizer_step method that we are overriding.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
