### PR TITLE
Add support for Time Stamp calculation using transcribe_speech.py

### DIFF
--- a/examples/asr/asr_chunked_inference/ctc/speech_to_text_buffered_infer_ctc.py
+++ b/examples/asr/asr_chunked_inference/ctc/speech_to_text_buffered_infer_ctc.py
@@ -183,7 +183,9 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
         manifest,
         filepaths,
     )
-    output_filename = write_transcription(hyps, cfg, model_name, filepaths=filepaths, compute_langs=False)
+    output_filename = write_transcription(
+        hyps, cfg, model_name, filepaths=filepaths, compute_langs=False, compute_timestamps=False
+    )
     logging.info(f"Finished writing predictions to {output_filename}!")
 
     return cfg

--- a/examples/asr/asr_chunked_inference/rnnt/speech_to_text_buffered_infer_rnnt.py
+++ b/examples/asr/asr_chunked_inference/rnnt/speech_to_text_buffered_infer_rnnt.py
@@ -237,7 +237,9 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
         filepaths=filepaths,
     )
 
-    output_filename = write_transcription(hyps, cfg, model_name, filepaths=filepaths, compute_langs=False)
+    output_filename = write_transcription(
+        hyps, cfg, model_name, filepaths=filepaths, compute_langs=False, compute_timestamps=False
+    )
     logging.info(f"Finished writing predictions to {output_filename}!")
 
     return cfg

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -44,8 +44,13 @@ Transcribe audio file on a single CPU/GPU. Useful for transcription of moderate 
   pretrained_name: name of pretrained ASR model (from NGC registry)
   audio_dir: path to directory with audio files
   dataset_manifest: path to dataset JSON manifest file (in NeMo format)
-
+    
+  compute_timestamps: Bool to request greedy time stamp information (if the model supports it)
   compute_langs: Bool to request language ID information (if the model supports it)
+  
+  (Optionally: You can limit the type of timestamp computations using below overrides)
+  ctc_decoding.ctc_timestamp_type="all"  # (default all, can be [all, char, word])
+  rnnt_decoding.rnnt_timestamp_type="all"  # (default all, can be [all, char, word])
 
   output_filename: Output filename where the transcriptions will be written
   batch_size: batch size during inference
@@ -72,6 +77,7 @@ python transcribe_speech.py \
     dataset_manifest="<remove or path to manifest>" \
     output_filename="<remove or specify output filename>" \
     batch_size=32 \
+    compute_timestamps=False \
     compute_langs=False \
     cuda=0 \
     amp=True \
@@ -96,6 +102,9 @@ class TranscriptionConfig:
     num_workers: int = 0
     append_pred: bool = False  # Sets mode of work, if True it will add new field transcriptions.
     pred_name_postfix: Optional[str] = None  # If you need to use another model name, rather than standard one.
+
+    # Set to True to output greedy timestamp information (only supported models)
+    compute_timestamps: bool = False
 
     # Set to True to output language ID information
     compute_langs: bool = False
@@ -156,20 +165,40 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
     return_hypotheses = True
 
     # we will adjust this flag is the model does not support it
+    compute_timestamps = cfg.compute_timestamps
     compute_langs = cfg.compute_langs
 
     # Setup decoding strategy
     if hasattr(asr_model, 'change_decoding_strategy'):
         if cfg.decoder_type is not None:
-            asr_model.change_decoding_strategy(
-                cfg.rnnt_decoding if cfg.decoder_type == 'rnnt' else cfg.ctc_decoding, decoder_type=cfg.decoder_type
-            )
+            # TODO: Support compute_langs in CTC eventually
+            if cfg.compute_langs and cfg.decoder_type == 'ctc':
+                raise ValueError("CTC models do not support `compute_langs` at the moment")
+
+            decoding_cfg = cfg.rnnt_decoding if cfg.decoder_type == 'rnnt' else cfg.ctc_decoding
+            decoding_cfg.compute_timestamps = cfg.compute_timestamps  # both ctc and rnnt support it
+            if 'preserve_alignments' in decoding_cfg:
+                decoding_cfg.preserve_alignments = cfg.compute_timestamps
+            if 'compute_langs' in decoding_cfg:
+                decoding_cfg.compute_langs = cfg.compute_langs
+
+            asr_model.change_decoding_strategy(decoding_cfg, decoder_type=cfg.decoder_type)
+
         # Check if ctc or rnnt model
         elif hasattr(asr_model, 'joint'):  # RNNT model
             cfg.rnnt_decoding.fused_batch_size = -1
+            cfg.rnnt_decoding.compute_timestamps = cfg.compute_timestamps
             cfg.rnnt_decoding.compute_langs = cfg.compute_langs
+
+            if 'preserve_alignments' in cfg.rnnt_decoding:
+                cfg.rnnt_decoding.preserve_alignments = cfg.compute_timestamps
+
             asr_model.change_decoding_strategy(cfg.rnnt_decoding)
         else:
+            if cfg.compute_langs:
+                raise ValueError("CTC models do not support `compute_langs` at the moment.")
+            cfg.ctc_decoding.compute_timestamps = cfg.compute_timestamps
+
             asr_model.change_decoding_strategy(cfg.ctc_decoding)
 
     # prepare audio filepaths and decide wether it's partical audio
@@ -237,7 +266,14 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
         transcriptions = transcriptions[0]
 
     # write audio transcriptions
-    output_filename = write_transcription(transcriptions, cfg, model_name, filepaths, compute_langs)
+    output_filename = write_transcription(
+        transcriptions,
+        cfg,
+        model_name,
+        filepaths=filepaths,
+        compute_langs=compute_langs,
+        compute_timestamps=compute_timestamps,
+    )
     logging.info(f"Finished writing predictions to {output_filename}!")
 
     return cfg


### PR DESCRIPTION
Signed-off-by: smajumdar <titu1994@gmail.com>

# What does this PR do ?

Adds flag to compute word and char level timestamp using the transcribe speech script.

**Collection**: [ASR]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage

```python

python transcribe_speech.py \
    model_path=null \
    pretrained_name=null \
    audio_dir="<remove or path to folder of audio files>" \
    dataset_manifest="<remove or path to manifest>" \
    output_filename="<remove or specify output filename>" \
    batch_size=32 \
    compute_timestamps=True \
    compute_langs=False \
    cuda=0 \
    amp=True

(Optionally)
    ctc_decoding.ctc_timestamp_type="all"  # (default all, can be [all, char, word])
    rnnt_decoding.rnnt_timestamp_type="all"  # (default all, can be [all, char, word])

```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?
