### PR TITLE
Add an option to defer data setup from ``__init__`` to ``setup``

### DIFF
--- a/docs/source/asr/configs.rst
+++ b/docs/source/asr/configs.rst
@@ -61,6 +61,20 @@ An example ASR train and validation configuration should look similar to the fol
       num_workers: 8
       pin_memory: true
 
+By default, dataloaders are set up when the model is instantiated. However, dataloader setup can be deferred to
+model's `setup()` method by setting ``defer_setup`` in the configuration.
+
+For example, training data setup can be deferred as follows:
+
+.. code-block:: yaml
+
+  model:
+    train_ds:
+      # Configure training data as usual
+      ...
+      # Defer train dataloader setup from `__init__` to `setup`
+      defer_setup: true
+
 
 Preprocessor Configuration
 --------------------------

--- a/docs/source/asr/speaker_recognition/configs.rst
+++ b/docs/source/asr/speaker_recognition/configs.rst
@@ -1,11 +1,11 @@
-NeMo ASR Configuration Files
-============================
+NeMo Speaker Recognition Configuration Files
+============================================
 
 This page covers NeMo configuration file setup that is specific to speaker recognition models.
 For general information about how to set up and run experiments that is common to all NeMo models (e.g.
 experiment manager and PyTorch Lightning trainer parameters), see the :doc:`../../core/core` page.
 
-The model section of NeMo ASR configuration files will generally require information about the dataset(s) being
+The model section of NeMo speaker recognition configuration files will generally require information about the dataset(s) being
 used, the preprocessor for audio files, parameters for any augmentation being performed, as well as the
 model architecture specification.
 The sections on this page cover each of these in more detail.

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -128,13 +128,27 @@ class ModelPT(LightningModule, Model):
             app_state.device_id = torch.cuda.current_device()
 
         if self._cfg is not None and not self._is_model_being_restored():
-            if 'train_ds' in self._cfg and self._cfg.train_ds is not None:
+            # Setup data loaders now (default) or defer setup to `self.setup()`
+            # if `defer_setup` is set in the config of the corresponding dataloader.
+            if (
+                'train_ds' in self._cfg
+                and self._cfg.train_ds is not None
+                and not self._cfg.train_ds.get('defer_setup', False)
+            ):
                 self.setup_training_data(self._cfg.train_ds)
 
-            if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
+            if (
+                'validation_ds' in self._cfg
+                and self._cfg.validation_ds is not None
+                and not self._cfg.validation_ds.get('defer_setup', False)
+            ):
                 self.setup_multiple_validation_data(val_data_config=cfg.validation_ds)
 
-            if 'test_ds' in self._cfg and self._cfg.test_ds is not None:
+            if (
+                'test_ds' in self._cfg
+                and self._cfg.test_ds is not None
+                and not self._cfg.test_ds.get('defer_setup', False)
+            ):
                 self.setup_multiple_test_data(test_data_config=cfg.test_ds)
 
         else:
@@ -683,6 +697,40 @@ class ModelPT(LightningModule, Model):
             return self._optimizer
         else:
             return [self._optimizer], [self._scheduler]
+
+    def setup(self, stage: Optional[str] = None):
+        """Called at the beginning of fit, validate, test, or predict.
+        This is called on every process when using DDP.
+
+        Args:
+            stage: fit, validate, test or predict
+        """
+        if stage == 'fit':
+            train_deferred_setup = (
+                'train_ds' in self._cfg
+                and self._cfg.train_ds is not None
+                and self._cfg.train_ds.get('defer_setup', False)
+            )
+            if self.train_dataloader() is None and train_deferred_setup:
+                self.setup_training_data(self._cfg.train_ds)
+
+        if stage in ('fit', 'validate'):
+            val_deferred_setup = (
+                'validation_ds' in self._cfg
+                and self._cfg.validation_ds is not None
+                and self._cfg.validation_ds.get('defer_setup', False)
+            )
+            if self.val_dataloader() is None and val_deferred_setup:
+                self.setup_validation_data(self._cfg.validation_ds)
+
+        if stage == 'test':
+            test_deferred_setup = (
+                'test_ds' in self._cfg
+                and self._cfg.test_ds is not None
+                and self._cfg.test_ds.get('defer_setup', False)
+            )
+            if self.test_dataloader() is None and test_deferred_setup:
+                self.setup_test_data(self._cfg.test_ds)
 
     def train_dataloader(self):
         if self._train_dl is not None:


### PR DESCRIPTION
Signed-off-by: Ante Jukić <ajukic@nvidia.com>

# What does this PR do ?

This PR adds an option to defer dataloader setup in `ModelPT` from `__init__` to `setup`.
Default behavior remains unchanged.

**Collection**: Core

# Changelog 
- In `ModelPT::__init__()`
  - Nothing is changed if `self._cfg.train_ds.defer_setup` is not set or is set to `False` (default)
  - If `self._cfg.train_ds.defer_setup` is set to `True`, `self.setup_training_data` will be skipped
  - Analogous behavior for validation and test data

- In `ModelPT::setup()`
  - If dataloader is not initialized and `defer_setup==True`, run data setup

# Usage

To use deferred setup, set the following

```python
  cfg.model.train_ds.defer_setup = True
  cfg.model.validation_ds.defer_setup = True
  cfg.model.test_ds.defer_setup = True
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
