### PR TITLE
[Fix] setup_multiple validation/test data

### DIFF
--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -721,7 +721,7 @@ class ModelPT(LightningModule, Model):
                 and self._cfg.validation_ds.get('defer_setup', False)
             )
             if self.val_dataloader() is None and val_deferred_setup:
-                self.setup_validation_data(self._cfg.validation_ds)
+                self.setup_multiple_validation_data(val_data_config=self._cfg.validation_ds)
 
         if stage == 'test':
             test_deferred_setup = (
@@ -730,7 +730,7 @@ class ModelPT(LightningModule, Model):
                 and self._cfg.test_ds.get('defer_setup', False)
             )
             if self.test_dataloader() is None and test_deferred_setup:
-                self.setup_test_data(self._cfg.test_ds)
+                self.setup_multiple_test_data(test_data_config=self._cfg.test_ds)
 
     def train_dataloader(self):
         if self._train_dl is not None:


### PR DESCRIPTION
Signed-off-by: Ante Jukić <ajukic@nvidia.com>

# What does this PR do ?

We missed a c/p mistake in just-merged PR #5569.
This bug does not affect default functionality, just the new param added in #5569.

Fix:
When setting up validation and test data, we need to use `setup_multiple_*`.

**Collection**: Core

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage

n/a

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #5437 5569
