### PR TITLE
[TTS] fix ranges of char set for accented letters.

### DIFF
--- a/nemo_text_processing/g2p/data/data_utils.py
+++ b/nemo_text_processing/g2p/data/data_utils.py
@@ -37,9 +37,17 @@ SYNOGLYPH2ASCII = {g: asc for asc, glyphs in _synoglyphs.items() for g in glyphs
 # 3rd group -- punctuation marks.
 # Text (first line) and mask of groups for every char (second line).
 # config file must contain |EY1 EY1|, B, C, D, E, F, and G.
-# 111111311113111131111111322222222233133133133133133111313
-_WORDS_RE = re.compile(r"([a-zA-Z]+(?:[a-zA-Z-']*[a-zA-Z]+)*)|(\|[^|]*\|)|([^a-zA-Z|]+)")
-_WORDS_RE_IPA = re.compile(r"([a-zA-ZÀ-ÿ\d]+(?:[a-zA-ZÀ-ÿ\d\-']*[a-zA-ZÀ-ÿ\d]+)*)|(\|[^|]*\|)|([^a-zA-ZÀ-ÿ\d|]+)")
+
+# define char set based on https://en.wikipedia.org/wiki/List_of_Unicode_characters
+LATIN_ALPHABET_BASIC = "A-Za-z"
+ACCENTED_CHARS = "À-ÖØ-öø-ÿ"
+LATIN_CHARS_ALL = f"{LATIN_ALPHABET_BASIC}{ACCENTED_CHARS}"
+_WORDS_RE = re.compile(
+    fr"([{LATIN_ALPHABET_BASIC}]+(?:[{LATIN_ALPHABET_BASIC}\-']*[{LATIN_ALPHABET_BASIC}]+)*)|(\|[^|]*\|)|([^{LATIN_ALPHABET_BASIC}|]+)"
+)
+_WORDS_RE_IPA = re.compile(
+    fr"([{LATIN_CHARS_ALL}\d]+(?:[{LATIN_CHARS_ALL}\d\-']*[{LATIN_CHARS_ALL}\d]+)*)|(\|[^|]*\|)|([^{LATIN_CHARS_ALL}\d|]+)"
+)
 
 # -
 
@@ -77,7 +85,7 @@ def read_wordids(wordid_map: str):
 
 def get_wordid_to_nemo(wordid_to_nemo_cmu_file: str = "../../../scripts/tts_dataset_files/wordid_to_nemo_cmu.tsv"):
     """
-    WikiHomograph and NeMo use slightly differene phoneme sets, this funtion reads WikiHomograph word_ids to NeMo
+    WikiHomograph and NeMo use slightly different phoneme sets, this function reads WikiHomograph word_ids to NeMo
     IPA heteronyms mapping
     """
     wordid_to_nemo_cmu = {}


### PR DESCRIPTION
Signed-off-by: Xuesong Yang <1646669+XuesongYang@users.noreply.github.com>

# What does this PR do ?

Previously, the char set pattern `[À-ÿ]` includes math operators, such as `÷` and `×`. Revise the pattern to exclude these. 
```
ord("À")
Out[5]: 192
ord("ÿ")
Out[6]: 255

chr(247)
Out[8]: '÷'
chr(215)
Out[9]: '×'
```

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
