### PR TITLE
Update Dockerfile to use numba==0.53.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -85,6 +85,10 @@ RUN python -c "import nemo.collections.nlp as nemo_nlp" && \
 # install pinned numba version
 # RUN conda install -c conda-forge numba==0.54.1
 
+# Pinned to numba==0.53.1 to avoid bug in training with num_workers > 0
+# The bug still exists with PTL 1.8.4, this is just a temporary workaround.
+RUN pip install numba==0.53.1
+
 # copy scripts/examples/tests into container for end user
 WORKDIR /workspace/nemo
 COPY scripts /workspace/nemo/scripts


### PR DESCRIPTION
Pinned to use `numba==0.53.1` to avoid crashing in training with `num_workers > 0`. This is just a temporary workaround, still need to fix it in the future.

Signed-off-by: He Huang (Steve) <105218074+stevehuang52@users.noreply.github.com>

