### PR TITLE
[EMA] Change success message to reduce confusion

### DIFF
--- a/nemo/collections/common/callbacks/ema.py
+++ b/nemo/collections/common/callbacks/ema.py
@@ -135,7 +135,7 @@ class EMA(Callback):
                 # we could enforce that if you trained with EMA and want to continue training
                 checkpoint['optimizer_states'] = ema_state_dict['optimizer_states']
                 del ema_state_dict
-                logging.info("EMA weights have been loaded successfully. Continuing training with saved EMA weights.")
+                logging.info("EMA state has been restored.")
             else:
                 raise MisconfigurationException(
                     "Unable to find the associated EMA weights when re-loading, "


### PR DESCRIPTION
# What does this PR do ?

Suggestion in slack to reduce confusion. The current message made it seem like the EMA weights are loaded into the main weights which is incorrect.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
