### PR TITLE
Temporarily disable prompt learning CI tests

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3449,106 +3449,110 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
             trainer.num_nodes=1"
       }
     }
-    stage('L2: Megatron GPT Prompt Tuning') {
-      when {
-        anyOf {
-          branch 'main'
-          changeRequest target: 'main'
-        }
-      }
-      failFast true
-      parallel{
-        stage('GPT Prompt Learning TP=1 PP=1') {
-          steps {
-            sh "python examples/nlp/language_modeling/megatron_gpt_prompt_learning.py \
-                --config-name=megatron_gpt_prompt_learning_config \
-                name='/home/TestData/nlp/prompt_learning/prompt_tuning_test' \
-                trainer.devices=1 \
-                trainer.max_steps=6 \
-                trainer.max_epochs=null \
-                model.tensor_model_parallel_size=1 \
-                model.virtual_prompt_style='prompt-tuning' \
-                model.language_model_path='/home/TestData/nlp/megatron_gpt/tiny/megatron_14m_gpt_tp1_pp1.nemo' \
-                model.existing_tasks=[] \
-                model.new_tasks=['rte'] \
-                model.data.train_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl'] \
-                model.data.validation_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl'] \
-                model.global_batch_size=4"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/prompt_tuning_test"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/prompt_tuning_test.nemo"
-          }
-        }
-      }
-    }
-    stage('L2: Megatron GPT Prompt Learning') {
-      when {
-        anyOf {
-          branch 'main'
-          changeRequest target: 'main'
-        }
-      }
-      failFast true
-      parallel{
-        stage('GPT Prompt Learning TP=2 PP=1') {
-          steps {
-            sh "python examples/nlp/language_modeling/megatron_gpt_prompt_learning.py \
-                --config-name=megatron_gpt_prompt_learning_config \
-                name='/home/TestData/nlp/prompt_learning/p_tuning_test_tp' \
-                trainer.devices=2 \
-                trainer.max_steps=6 \
-                trainer.max_epochs=null \
-                model.tensor_model_parallel_size=2 \
-                model.language_model_path='/home/TestData/nlp/megatron_gpt/tiny/megatron_14m_gpt_tp2_pp1.nemo' \
-                model.existing_tasks=[] \
-                model.new_tasks=['rte'] \
-                model.data.train_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl'] \
-                model.data.validation_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl'] \
-                model.global_batch_size=4"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/p_tuning_test_tp"
-            sh "python examples/nlp/language_modeling/megatron_gpt_prompt_learning_eval.py \
-                virtual_prompt_model_file='/home/TestData/nlp/prompt_learning/p_tuning_test_tp.nemo' \
-                gpt_model_file='/home/TestData/nlp/megatron_gpt/tiny/megatron_14m_gpt_tp2_pp1.nemo' \
-                inference.greedy=True \
-                inference.add_BOS=False \
-                trainer.devices=2 \
-                tensor_model_parallel_size=2 \
-                pred_file_path=/home/TestData/nlp/prompt_learning/p_tuning_test_tp_preds.txt \
-                data_paths=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl']"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/p_tuning_test_tp.nemo"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/p_tuning_test_tp_preds.txt"
-          }
-        }
-        stage('GPT Prompt Learning TP=1 PP=2') {
-          steps {
-            sh "python examples/nlp/language_modeling/megatron_gpt_prompt_learning.py \
-                --config-name=megatron_gpt_prompt_learning_config \
-                name='/home/TestData/nlp/prompt_learning/p_tuning_test_pp' \
-                trainer.devices=2 \
-                trainer.max_steps=6 \
-                trainer.max_epochs=null \
-                model.pipeline_model_parallel_size=2 \
-                model.language_model_path='/home/TestData/nlp/megatron_gpt/tiny/megatron_14m_gpt_tp1_pp2.nemo' \
-                model.existing_tasks=[] \
-                model.new_tasks=['boolq'] \
-                model.data.train_ds=['/home/TestData/nlp/prompt_learning/boolq_CI_test.jsonl'] \
-                model.data.validation_ds=['/home/TestData/nlp/prompt_learning/boolq_CI_test.jsonl'] \
-                model.global_batch_size=4"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/p_tuning_test_pp"
-            sh "python examples/nlp/language_modeling/megatron_gpt_prompt_learning_eval.py \
-                virtual_prompt_model_file='/home/TestData/nlp/prompt_learning/p_tuning_test_pp.nemo' \
-                gpt_model_file='/home/TestData/nlp/megatron_gpt/tiny/megatron_14m_gpt_tp1_pp2.nemo' \
-                inference.greedy=True \
-                inference.add_BOS=False \
-                trainer.devices=2 \
-                pipeline_model_parallel_size=2 \
-                pred_file_path=/home/TestData/nlp/prompt_learning/p_tuning_test_pp_preds.txt \
-                data_paths=['/home/TestData/nlp/prompt_learning/boolq_CI_test.jsonl']"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/p_tuning_test_pp.nemo"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/p_tuning_test_pp_preds.txt"
-          }
-        }
-      }
-    }
+
+    // TODO: fix these tests! They are taking ~10 minutes to complete
+    // stage('L2: Megatron GPT Prompt Tuning') {
+    //   when {
+    //     anyOf {
+    //       branch 'main'
+    //       changeRequest target: 'main'
+    //     }
+    //   }
+    //   failFast true
+    //   parallel{
+    //     stage('GPT Prompt Learning TP=1 PP=1') {
+    //       steps {
+    //         sh "python examples/nlp/language_modeling/megatron_gpt_prompt_learning.py \
+    //             --config-name=megatron_gpt_prompt_learning_config \
+    //             name='/home/TestData/nlp/prompt_learning/prompt_tuning_test' \
+    //             trainer.devices=1 \
+    //             trainer.max_steps=6 \
+    //             trainer.max_epochs=null \
+    //             model.tensor_model_parallel_size=1 \
+    //             model.virtual_prompt_style='prompt-tuning' \
+    //             model.language_model_path='/home/TestData/nlp/megatron_gpt/tiny/megatron_14m_gpt_tp1_pp1.nemo' \
+    //             model.existing_tasks=[] \
+    //             model.new_tasks=['rte'] \
+    //             model.data.train_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl'] \
+    //             model.data.validation_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl'] \
+    //             model.global_batch_size=4"
+    //         sh "rm -rf /home/TestData/nlp/prompt_learning/prompt_tuning_test"
+    //         sh "rm -rf /home/TestData/nlp/prompt_learning/prompt_tuning_test.nemo"
+    //       }
+    //     }
+    //   }
+    // }
+
+    // TODO: fix these tests! They are taking ~10 minutes to complete
+    // stage('L2: Megatron GPT Prompt Learning') {
+    //   when {
+    //     anyOf {
+    //       branch 'main'
+    //       changeRequest target: 'main'
+    //     }
+    //   }
+    //   failFast true
+    //   parallel{
+    //     stage('GPT Prompt Learning TP=2 PP=1') {
+    //       steps {
+    //         sh "python examples/nlp/language_modeling/megatron_gpt_prompt_learning.py \
+    //             --config-name=megatron_gpt_prompt_learning_config \
+    //             name='/home/TestData/nlp/prompt_learning/p_tuning_test_tp' \
+    //             trainer.devices=2 \
+    //             trainer.max_steps=6 \
+    //             trainer.max_epochs=null \
+    //             model.tensor_model_parallel_size=2 \
+    //             model.language_model_path='/home/TestData/nlp/megatron_gpt/tiny/megatron_14m_gpt_tp2_pp1.nemo' \
+    //             model.existing_tasks=[] \
+    //             model.new_tasks=['rte'] \
+    //             model.data.train_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl'] \
+    //             model.data.validation_ds=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl'] \
+    //             model.global_batch_size=4"
+    //         sh "rm -rf /home/TestData/nlp/prompt_learning/p_tuning_test_tp"
+    //         sh "python examples/nlp/language_modeling/megatron_gpt_prompt_learning_eval.py \
+    //             virtual_prompt_model_file='/home/TestData/nlp/prompt_learning/p_tuning_test_tp.nemo' \
+    //             gpt_model_file='/home/TestData/nlp/megatron_gpt/tiny/megatron_14m_gpt_tp2_pp1.nemo' \
+    //             inference.greedy=True \
+    //             inference.add_BOS=False \
+    //             trainer.devices=2 \
+    //             tensor_model_parallel_size=2 \
+    //             pred_file_path=/home/TestData/nlp/prompt_learning/p_tuning_test_tp_preds.txt \
+    //             data_paths=['/home/TestData/nlp/prompt_learning/rte_CI_test.jsonl']"
+    //         sh "rm -rf /home/TestData/nlp/prompt_learning/p_tuning_test_tp.nemo"
+    //         sh "rm -rf /home/TestData/nlp/prompt_learning/p_tuning_test_tp_preds.txt"
+    //       }
+    //     }
+    //     stage('GPT Prompt Learning TP=1 PP=2') {
+    //       steps {
+    //         sh "python examples/nlp/language_modeling/megatron_gpt_prompt_learning.py \
+    //             --config-name=megatron_gpt_prompt_learning_config \
+    //             name='/home/TestData/nlp/prompt_learning/p_tuning_test_pp' \
+    //             trainer.devices=2 \
+    //             trainer.max_steps=6 \
+    //             trainer.max_epochs=null \
+    //             model.pipeline_model_parallel_size=2 \
+    //             model.language_model_path='/home/TestData/nlp/megatron_gpt/tiny/megatron_14m_gpt_tp1_pp2.nemo' \
+    //             model.existing_tasks=[] \
+    //             model.new_tasks=['boolq'] \
+    //             model.data.train_ds=['/home/TestData/nlp/prompt_learning/boolq_CI_test.jsonl'] \
+    //             model.data.validation_ds=['/home/TestData/nlp/prompt_learning/boolq_CI_test.jsonl'] \
+    //             model.global_batch_size=4"
+    //         sh "rm -rf /home/TestData/nlp/prompt_learning/p_tuning_test_pp"
+    //         sh "python examples/nlp/language_modeling/megatron_gpt_prompt_learning_eval.py \
+    //             virtual_prompt_model_file='/home/TestData/nlp/prompt_learning/p_tuning_test_pp.nemo' \
+    //             gpt_model_file='/home/TestData/nlp/megatron_gpt/tiny/megatron_14m_gpt_tp1_pp2.nemo' \
+    //             inference.greedy=True \
+    //             inference.add_BOS=False \
+    //             trainer.devices=2 \
+    //             pipeline_model_parallel_size=2 \
+    //             pred_file_path=/home/TestData/nlp/prompt_learning/p_tuning_test_pp_preds.txt \
+    //             data_paths=['/home/TestData/nlp/prompt_learning/boolq_CI_test.jsonl']"
+    //         sh "rm -rf /home/TestData/nlp/prompt_learning/p_tuning_test_pp.nemo"
+    //         sh "rm -rf /home/TestData/nlp/prompt_learning/p_tuning_test_pp_preds.txt"
+    //       }
+    //     }
+    //   }
+    // }
 
 
 
@@ -3866,66 +3870,67 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
             sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_preds.txt"
           }
         }
-        stage('T5 Prompt Learning TP=2 PP=1') {
-          steps {
-            sh "python examples/nlp/language_modeling/megatron_t5_prompt_learning.py \
-                --config-name=megatron_t5_prompt_learning \
-                name='/home/TestData/nlp/prompt_learning/t5_p_tuning_test_tp2' \
-                trainer.devices=2 \
-                trainer.max_steps=6 \
-                trainer.max_epochs=null \
-                model.tensor_model_parallel_size=2 \
-                model.language_model_path='/home/TestData/nlp/megatron_t5/8m/megatron_t5_8m_tp2.nemo' \
-                model.existing_tasks=[] \
-                model.new_tasks=['squad'] \
-                model.data.train_ds=['/home/TestData/nlp/prompt_learning/squad_CI_test.jsonl'] \
-                model.data.validation_ds=['/home/TestData/nlp/prompt_learning/squad_CI_test.jsonl'] \
-                model.global_batch_size=8 \
-                model.micro_batch_size=8"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_tp2"
-            sh "python examples/nlp/language_modeling/megatron_t5_prompt_learning_eval.py \
-                virtual_prompt_model_file='/home/TestData/nlp/prompt_learning/t5_p_tuning_test_tp2.nemo' \
-                language_model_path='/home/TestData/nlp/megatron_t5/8m/megatron_t5_8m_tp2.nemo' \
-                data.test_ds=['/home/TestData/nlp/prompt_learning/squad_CI_test.jsonl'] \
-                pred_file_path='/home/TestData/nlp/prompt_learning/t5_p_tuning_test_tp2_preds.txt' \
-                tensor_model_parallel_size=2 \
-                trainer.devices=2 \
-                data.global_batch_size=8 \
-                data.micro_batch_size=8"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_tp2.nemo"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_tp2_preds.txt"
-          }
-        }
-        stage('T5 Prompt Learning TP=1 PP=2') {
-          steps {
-            sh "python examples/nlp/language_modeling/megatron_t5_prompt_learning.py \
-                --config-name=megatron_t5_prompt_learning \
-                name='/home/TestData/nlp/prompt_learning/t5_p_tuning_test_pp2' \
-                trainer.devices=2 \
-                trainer.max_steps=6 \
-                trainer.max_epochs=null \
-                model.pipeline_model_parallel_size=2 \
-                model.language_model_path='/home/TestData/nlp/megatron_t5/8m/megatron_t5_8m_tp1_pp2.nemo' \
-                model.existing_tasks=[] \
-                model.new_tasks=['squad'] \
-                model.data.train_ds=['/home/TestData/nlp/prompt_learning/squad_CI_test.jsonl'] \
-                model.data.validation_ds=['/home/TestData/nlp/prompt_learning/squad_CI_test.jsonl'] \
-                model.global_batch_size=8 \
-                model.micro_batch_size=8"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_pp2"
-            sh "python examples/nlp/language_modeling/megatron_t5_prompt_learning_eval.py \
-                virtual_prompt_model_file='/home/TestData/nlp/prompt_learning/t5_p_tuning_test_pp2.nemo' \
-                language_model_path='/home/TestData/nlp/megatron_t5/8m/megatron_t5_8m_tp1_pp2.nemo' \
-                data.test_ds=['/home/TestData/nlp/prompt_learning/squad_CI_test.jsonl'] \
-                pred_file_path='/home/TestData/nlp/prompt_learning/t5_p_tuning_test_pp2_preds.txt' \
-                tensor_model_parallel_size=2 \
-                trainer.devices=2 \
-                data.global_batch_size=8 \
-                data.micro_batch_size=8"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_pp2.nemo"
-            sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_pp2_preds.txt"
-          }
-        }
+        // TODO: Fix these tests, they are taking ~10 minutes to complete
+        // stage('T5 Prompt Learning TP=2 PP=1') {
+        //   steps {
+        //     sh "python examples/nlp/language_modeling/megatron_t5_prompt_learning.py \
+        //         --config-name=megatron_t5_prompt_learning \
+        //         name='/home/TestData/nlp/prompt_learning/t5_p_tuning_test_tp2' \
+        //         trainer.devices=2 \
+        //         trainer.max_steps=6 \
+        //         trainer.max_epochs=null \
+        //         model.tensor_model_parallel_size=2 \
+        //         model.language_model_path='/home/TestData/nlp/megatron_t5/8m/megatron_t5_8m_tp2.nemo' \
+        //         model.existing_tasks=[] \
+        //         model.new_tasks=['squad'] \
+        //         model.data.train_ds=['/home/TestData/nlp/prompt_learning/squad_CI_test.jsonl'] \
+        //         model.data.validation_ds=['/home/TestData/nlp/prompt_learning/squad_CI_test.jsonl'] \
+        //         model.global_batch_size=8 \
+        //         model.micro_batch_size=8"
+        //     sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_tp2"
+        //     sh "python examples/nlp/language_modeling/megatron_t5_prompt_learning_eval.py \
+        //         virtual_prompt_model_file='/home/TestData/nlp/prompt_learning/t5_p_tuning_test_tp2.nemo' \
+        //         language_model_path='/home/TestData/nlp/megatron_t5/8m/megatron_t5_8m_tp2.nemo' \
+        //         data.test_ds=['/home/TestData/nlp/prompt_learning/squad_CI_test.jsonl'] \
+        //         pred_file_path='/home/TestData/nlp/prompt_learning/t5_p_tuning_test_tp2_preds.txt' \
+        //         tensor_model_parallel_size=2 \
+        //         trainer.devices=2 \
+        //         data.global_batch_size=8 \
+        //         data.micro_batch_size=8"
+        //     sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_tp2.nemo"
+        //     sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_tp2_preds.txt"
+        //   }
+        // }
+        // stage('T5 Prompt Learning TP=1 PP=2') {
+        //   steps {
+        //     sh "python examples/nlp/language_modeling/megatron_t5_prompt_learning.py \
+        //         --config-name=megatron_t5_prompt_learning \
+        //         name='/home/TestData/nlp/prompt_learning/t5_p_tuning_test_pp2' \
+        //         trainer.devices=2 \
+        //         trainer.max_steps=6 \
+        //         trainer.max_epochs=null \
+        //         model.pipeline_model_parallel_size=2 \
+        //         model.language_model_path='/home/TestData/nlp/megatron_t5/8m/megatron_t5_8m_tp1_pp2.nemo' \
+        //         model.existing_tasks=[] \
+        //         model.new_tasks=['squad'] \
+        //         model.data.train_ds=['/home/TestData/nlp/prompt_learning/squad_CI_test.jsonl'] \
+        //         model.data.validation_ds=['/home/TestData/nlp/prompt_learning/squad_CI_test.jsonl'] \
+        //         model.global_batch_size=8 \
+        //         model.micro_batch_size=8"
+        //     sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_pp2"
+        //     sh "python examples/nlp/language_modeling/megatron_t5_prompt_learning_eval.py \
+        //         virtual_prompt_model_file='/home/TestData/nlp/prompt_learning/t5_p_tuning_test_pp2.nemo' \
+        //         language_model_path='/home/TestData/nlp/megatron_t5/8m/megatron_t5_8m_tp1_pp2.nemo' \
+        //         data.test_ds=['/home/TestData/nlp/prompt_learning/squad_CI_test.jsonl'] \
+        //         pred_file_path='/home/TestData/nlp/prompt_learning/t5_p_tuning_test_pp2_preds.txt' \
+        //         tensor_model_parallel_size=2 \
+        //         trainer.devices=2 \
+        //         data.global_batch_size=8 \
+        //         data.micro_batch_size=8"
+        //     sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_pp2.nemo"
+        //     sh "rm -rf /home/TestData/nlp/prompt_learning/t5_p_tuning_test_pp2_preds.txt"
+        //   }
+        // }
       }
     }
     stage('L2: Megatron UL2 Pretraining and Resume Training TP=2') {


### PR DESCRIPTION
# What does this PR do ?

Prompt learning CI tests are taking ~10 minutes to complete. Temporarily disabling them until they can be fixed.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
