### PR TITLE
Add duration padding support for RADTTS inference

### DIFF
--- a/nemo/collections/tts/helpers/helpers.py
+++ b/nemo/collections/tts/helpers/helpers.py
@@ -478,7 +478,8 @@ def remove(conv_list):
     return new_conv_list
 
 
-def regulate_len(durations, enc_out, pace=1.0, mel_max_len=None):
+def regulate_len(durations, enc_out, pace=1.0, mel_max_len=None, replicate_to_nearest_multiple=False,
+                 group_size=2, in_lens: torch.tensor=None):
     """A function that takes predicted durations per encoded token, and repeats enc_out according to the duration.
     NOTE: durations.shape[1] == enc_out.shape[1]
 
@@ -486,15 +487,25 @@ def regulate_len(durations, enc_out, pace=1.0, mel_max_len=None):
         durations (torch.tensor): A tensor of shape (batch x enc_length) that represents how many times to repeat each
             token in enc_out.
         enc_out (torch.tensor): A tensor of shape (batch x enc_length x enc_hidden) that represents the encoded tokens.
-        pace (float): The pace of speaker. Higher values result in faster speaking pace. Defaults to 1.0.
-        max_mel_len (int): The maximum length above which the output will be removed. If sum(durations, dim=1) >
+        pace (float): The pace of speaker. Higher values result in faster speaking pace. Defaults to 1.0.        max_mel_len (int): The maximum length above which the output will be removed. If sum(durations, dim=1) >
             max_mel_len, the values after max_mel_len will be removed. Defaults to None, which has no max length.
+        replicate_to_nearest_multiple (bool): replicate the last element specified by durations[i, in_lens[i] - 1] until the
+            full length of the sequence is the next nearest multiple of group_size
+        group_size (int): factor used by replicate_to_nearest_multiple
+        in_lens (torch.tensor): input sequence length specifying valid values in the durations input tensor
     """
 
     dtype = enc_out.dtype
     reps = durations.float() / pace
     reps = (reps + 0.5).floor().long()
     dec_lens = reps.sum(dim=1)
+
+    if replicate_to_nearest_multiple:
+        to_pad = group_size * (torch.div(dec_lens, group_size, rounding_mode='floor') + 1) - dec_lens
+        to_pad = to_pad.unsqueeze(-1).repeat(1, reps.shape[1])
+        to_pad_expanded = torch.zeros_like(reps).scatter_(1, in_lens.unsqueeze(-1).long()-1, to_pad)
+        reps = reps + to_pad_expanded
+        dec_lens = reps.sum(dim=1)
 
     max_len = dec_lens.max()
     reps_cumsum = torch.cumsum(torch.nn.functional.pad(reps, (1, 0, 0, 0), value=0.0), dim=1)[:, None, :]

--- a/nemo/collections/tts/helpers/helpers.py
+++ b/nemo/collections/tts/helpers/helpers.py
@@ -478,8 +478,15 @@ def remove(conv_list):
     return new_conv_list
 
 
-def regulate_len(durations, enc_out, pace=1.0, mel_max_len=None, replicate_to_nearest_multiple=False,
-                 group_size=2, in_lens: torch.tensor=None):
+def regulate_len(
+    durations,
+    enc_out,
+    pace=1.0,
+    mel_max_len=None,
+    replicate_to_nearest_multiple=False,
+    group_size=2,
+    in_lens: torch.tensor = None,
+):
     """A function that takes predicted durations per encoded token, and repeats enc_out according to the duration.
     NOTE: durations.shape[1] == enc_out.shape[1]
 
@@ -503,7 +510,7 @@ def regulate_len(durations, enc_out, pace=1.0, mel_max_len=None, replicate_to_ne
     if replicate_to_nearest_multiple:
         to_pad = group_size * (torch.div(dec_lens, group_size, rounding_mode='floor') + 1) - dec_lens
         to_pad = to_pad.unsqueeze(-1).repeat(1, reps.shape[1])
-        to_pad_expanded = torch.zeros_like(reps).scatter_(1, in_lens.unsqueeze(-1).long()-1, to_pad)
+        to_pad_expanded = torch.zeros_like(reps).scatter_(1, in_lens.unsqueeze(-1).long() - 1, to_pad)
         reps = reps + to_pad_expanded
         dec_lens = reps.sum(dim=1)
 

--- a/nemo/collections/tts/modules/radtts.py
+++ b/nemo/collections/tts/modules/radtts.py
@@ -107,17 +107,17 @@ class FlowStep(nn.Module):
 
 class RadTTSModule(NeuralModule, Exportable):
     """
-    Takes model parameters (modelConfig) from config file to intialize radtts module. 
-    Specifiy the type of training in the include_modules parameter. "decatnvpred" for decoder training. and "decatnunvbiasdpmvpredapm" for feature training 
-    n_speakers (int): Number of speakers 
+    Takes model parameters (modelConfig) from config file to intialize radtts module.
+    Specifiy the type of training in the include_modules parameter. "decatnvpred" for decoder training. and "decatnunvbiasdpmvpredapm" for feature training
+    n_speakers (int): Number of speakers
     n_speaker_dim (int): number of speakers dimention
     n_text (int): Symbols embedding size
     n_text_dim (int):
     n_flows (int):
-    n_conv_layers_per_step (int): number of convultion layers per step 
-    dummy_speaker_embedding (bool): 
-    include_modules (string): A string that describes what to train. "decatnvpred" for decoder training. and "decatnunvbiasdpmvpredapm" for feature training. 
-    scaling_fn (string): scaling function 
+    n_conv_layers_per_step (int): number of convultion layers per step
+    dummy_speaker_embedding (bool):
+    include_modules (string): A string that describes what to train. "decatnvpred" for decoder training. and "decatnunvbiasdpmvpredapm" for feature training.
+    scaling_fn (string): scaling function
     decoder_use_partial_padding (Bool): Set this to True to add partial padding
     learn_alignments (Bool): set this to true to learn alignments
     attn_use_CTC (Bool): set True to use CTC
@@ -360,7 +360,7 @@ class RadTTSModule(NeuralModule, Exportable):
     def fold(self, mel):
         """Inverse of the self.unfold(mel.unsqueeze(-1)) operation used for the
          grouping or "squeeze" operation on input
-        
+
          Args:
              mel: B x C x T tensor of temporal data
          """
@@ -608,7 +608,11 @@ class RadTTSModule(NeuralModule, Exportable):
             dur = dur[:, 0]
             dur = dur.clamp(0, token_duration_max)
 
-        txt_enc_time_expanded, out_lens = regulate_len(dur, txt_enc.transpose(1, 2), pace)
+        txt_enc_time_expanded, out_lens = regulate_len(dur, txt_enc.transpose(1, 2), pace,
+                                                       replicate_to_nearest_multiple=True,
+                                                       group_size=self.n_group_size,
+                                                       in_lens=in_lens
+                                                       )
         n_groups = torch.div(out_lens, self.n_group_size, rounding_mode='floor')
         max_out_len = torch.max(out_lens)
 
@@ -771,7 +775,9 @@ class RadTTSModule(NeuralModule, Exportable):
         par = next(self.parameters())
         sz = (max_batch, max_dim)
         inp = torch.randint(16, 32, sz, device=par.device, dtype=torch.int64)
-        lens = torch.randint(max_dim // 2, max_dim, (max_batch,), device=par.device, dtype=torch.int)
+        lens = torch.randint(max_dim // 8, max_dim // 4, (max_batch,), device=par.device, dtype=torch.int)
+        zeros_src = torch.zeros_like(inp)
+        inp.scatter_(1, lens.long().unsqueeze(-1)-1, zeros_src) # set the inp[i, lens[i]-1] elt to zero
         speaker = torch.randint(0, 1, (max_batch,), device=par.device, dtype=torch.int64)
         inputs = {
             'text': inp,

--- a/nemo/collections/tts/modules/radtts.py
+++ b/nemo/collections/tts/modules/radtts.py
@@ -608,11 +608,14 @@ class RadTTSModule(NeuralModule, Exportable):
             dur = dur[:, 0]
             dur = dur.clamp(0, token_duration_max)
 
-        txt_enc_time_expanded, out_lens = regulate_len(dur, txt_enc.transpose(1, 2), pace,
-                                                       replicate_to_nearest_multiple=True,
-                                                       group_size=self.n_group_size,
-                                                       in_lens=in_lens
-                                                       )
+        txt_enc_time_expanded, out_lens = regulate_len(
+            dur,
+            txt_enc.transpose(1, 2),
+            pace,
+            replicate_to_nearest_multiple=True,
+            group_size=self.n_group_size,
+            in_lens=in_lens,
+        )
         n_groups = torch.div(out_lens, self.n_group_size, rounding_mode='floor')
         max_out_len = torch.max(out_lens)
 
@@ -777,7 +780,7 @@ class RadTTSModule(NeuralModule, Exportable):
         inp = torch.randint(16, 32, sz, device=par.device, dtype=torch.int64)
         lens = torch.randint(max_dim // 8, max_dim // 4, (max_batch,), device=par.device, dtype=torch.int)
         zeros_src = torch.zeros_like(inp)
-        inp.scatter_(1, lens.long().unsqueeze(-1)-1, zeros_src) # set the inp[i, lens[i]-1] elt to zero
+        inp.scatter_(1, lens.long().unsqueeze(-1) - 1, zeros_src)  # set the inp[i, lens[i]-1] elt to zero
         speaker = torch.randint(0, 1, (max_batch,), device=par.device, dtype=torch.int64)
         inputs = {
             'text': inp,


### PR DESCRIPTION
# What does this PR do ?
During inference, radtts++ duration predictions tend to be close to zero when given random inputs. This can be an issue as a sequence with length less than the grouping size in the radtts flow operation will result in a crash. 

The solution is to set the last input token to correspond to a blank space, and stretch out the duration for said token until the the total duration of the sequence reaches the next multiple of group_size.

**Collection**: [Note which collection this PR will affect]
TTS

# Changelog 
- sets the last element of the generated text token sequences in RadTTSModule.input_example() to zero (represents blank space). Note that this still needs to be done separately during inference with raw text, otherwise a non-space token may be replicated.
- helpers.regulate_len is extended to support last-valid-token replication until the next nearest multiple of group_size
- RadTTSModule.infer() now calls regulate_len with additional parameters for the replication behavior

# Usage
* Radtts should now pass the tests in:

```python
pytest tests/collections/tts/test_tts_exportables.py
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)

