### PR TITLE
Add DLLogger support to exp_manager

### DIFF
--- a/docs/source/core/exp_manager.rst
+++ b/docs/source/core/exp_manager.rst
@@ -4,7 +4,7 @@
 Experiment Manager
 ==================
 
-NeMo's Experiment Manager leverages PyTorch Lightning for model checkpointing, TensorBoard Logging, Weights and Biases, and MLFlow logging. The
+NeMo's Experiment Manager leverages PyTorch Lightning for model checkpointing, TensorBoard Logging, Weights and Biases, DLLogger and MLFlow logging. The
 Experiment Manager is included by default in all NeMo example scripts.
 
 To use the experiment manager simply call :class:`~nemo.utils.exp_manager.exp_manager` and pass in the PyTorch Lightning ``Trainer``.

--- a/nemo/utils/dllogger.py
+++ b/nemo/utils/dllogger.py
@@ -52,8 +52,7 @@ class DLLogger(Logger):
 
         if not backends:
             logging.warning(
-                "Neither stdout nor json_file DLLogger parameters were specified."
-                "DLLogger will not log anything."
+                "Neither stdout nor json_file DLLogger parameters were specified." "DLLogger will not log anything."
             )
         dllogger.init(backends=backends)
 

--- a/nemo/utils/dllogger.py
+++ b/nemo/utils/dllogger.py
@@ -1,0 +1,70 @@
+# Copyright (c) 2020, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+
+from pytorch_lightning.loggers import Logger
+
+from nemo.utils import logging
+
+try:
+    import dllogger
+    from dllogger import Verbosity
+
+    HAVE_DLLOGGER = True
+except (ImportError, ModuleNotFoundError):
+    HAVE_DLLOGGER = False
+
+
+class DLLogger(Logger):
+    @property
+    def name(self):
+        return self.__class__.__name__
+
+    @property
+    def version(self):
+        return None
+
+    def __init__(self, stdout: bool, verbose: bool, json_file: str):
+        if not HAVE_DLLOGGER:
+            raise ImportError(
+                "DLLogger was not found. Please see the README for installation instructions: "
+                "https://github.com/NVIDIA/dllogger"
+            )
+        verbosity = Verbosity.VERBOSE if verbose else Verbosity.DEFAULT
+        backends = []
+        if json_file:
+            Path(json_file).parent.mkdir(parents=True, exist_ok=True)
+            backends.append(dllogger.JSONStreamBackend(verbosity, json_file))
+        if stdout:
+            backends.append(dllogger.StdOutBackend(verbosity))
+
+        if not backends:
+            logging.warning(
+                "Neither stdout nor json_file DLLogger parameters were specified."
+                "DLLogger will not log anything."
+            )
+        dllogger.init(backends=backends)
+
+    def log_hyperparams(self, params, *args, **kwargs):
+        dllogger.log(step="PARAMETER", data=params)
+
+    def log_metrics(self, metrics, step=None):
+        if step is None:
+            step = tuple()
+
+        dllogger.log(step=step, data=metrics)
+
+    def save(self):
+        dllogger.flush()

--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -33,7 +33,7 @@ from hydra.utils import get_original_cwd
 from omegaconf import DictConfig, OmegaConf, open_dict
 from pytorch_lightning.callbacks import Callback, ModelCheckpoint
 from pytorch_lightning.callbacks.timer import Interval, Timer
-from pytorch_lightning.loggers import MLFlowLogger, TensorBoardLogger, WandbLogger
+from pytorch_lightning.loggers import Logger, MLFlowLogger, TensorBoardLogger, WandbLogger
 from pytorch_lightning.loops import TrainingEpochLoop
 from pytorch_lightning.strategies.ddp import DDPStrategy
 from pytorch_lightning.utilities import rank_zero_info
@@ -66,6 +66,52 @@ class LoggerMisconfigurationError(NeMoBaseException):
 
 class CheckpointMisconfigurationError(NeMoBaseException):
     """ Raised when a mismatch between trainer.callbacks and exp_manager occurs"""
+
+
+try:
+    import dllogger
+    from dllogger import Verbosity
+
+    class DLLogger(Logger):
+        @property
+        def name(self):
+            return self.__class__.__name__
+
+        @property
+        def version(self):
+            return None
+
+        def __init__(self, stdout: bool, verbose: bool, json_file: str):
+            verbosity = Verbosity.VERBOSE if verbose else Verbosity.DEFAULT
+            backends = []
+            if json_file:
+                Path(json_file).parent.mkdir(parents=True, exist_ok=True)
+                backends.append(dllogger.JSONStreamBackend(verbosity, json_file))
+            if stdout:
+                backends.append(dllogger.StdOutBackend(verbosity))
+
+            if not backends:
+                logging.warning(
+                    "Neither stdout nor json_file DLLogger parameters were specified."
+                    "DLLogger will not log anything."
+                )
+            dllogger.init(backends=backends)
+
+        def log_hyperparams(self, params, *args, **kwargs):
+            dllogger.log(step="PARAMETER", data=params)
+
+        def log_metrics(self, metrics, step=None):
+            if step is None:
+                step = tuple()
+
+            dllogger.log(step=step, data=metrics)
+
+        def save(self):
+            dllogger.flush()
+
+
+except ModuleNotFoundError:
+    DLLogger = None
 
 
 @dataclass
@@ -104,6 +150,13 @@ class MLFlowParams:
 
 
 @dataclass
+class DLLoggerParams:
+    verbose: Optional[bool] = False
+    stdout: Optional[bool] = False
+    json_file: Optional[str] = "./dllogger.json"
+
+
+@dataclass
 class StepTimingParams:
     reduction: Optional[str] = "mean"
     # if True torch.cuda.synchronize() is called on start/stop
@@ -139,6 +192,8 @@ class ExpManagerConfig:
     wandb_logger_kwargs: Optional[Dict[Any, Any]] = None
     create_mlflow_logger: Optional[bool] = False
     mlflow_logger_kwargs: Optional[MLFlowParams] = MLFlowParams()
+    create_dllogger_logger: Optional[bool] = False
+    dllogger_logger_kwargs: Optional[DLLoggerParams] = DLLoggerParams()
     # Checkpointing parameters
     create_checkpoint_callback: Optional[bool] = True
     checkpoint_callback_params: Optional[CallbackParams] = CallbackParams()
@@ -207,7 +262,7 @@ def exp_manager(trainer: 'pytorch_lightning.Trainer', cfg: Optional[Union[DictCo
     directory. exp_manager also allows for explicit folder creation via explicit_log_dir.
 
     The version can be a datetime string or an integer. Datestime version can be disabled if use_datetime_version is set
-     to False. It optionally creates TensorBoardLogger, WandBLogger, MLFlowLogger, ModelCheckpoint objects from pytorch lightning.
+     to False. It optionally creates TensorBoardLogger, WandBLogger, DLLogger, MLFlowLogger, ModelCheckpoint objects from pytorch lightning.
     It copies sys.argv, and git information if available to the logging directory. It creates a log file for each
     process to log their output into.
 
@@ -251,6 +306,9 @@ def exp_manager(trainer: 'pytorch_lightning.Trainer', cfg: Optional[Union[DictCo
             - create_mlflow_logger (bool): Whether to create an MLFlow logger and attach it to the pytorch lightning
                 training. Defaults to False
             - mlflow_logger_kwargs (dict): optional parameters for the MLFlow logger
+            - create_dllogger_logger (bool): Whether to create an DLLogger logger and attach it to the pytorch lightning
+                training. Defaults to False
+            - dllogger_logger_kwargs (dict): optional parameters for the DLLogger logger
             - create_checkpoint_callback (bool): Whether to create a ModelCheckpoint callback and attach it to the
                 pytorch lightning trainer. The ModelCheckpoint saves the top 3 models with the best "val_loss", the most
                 recent checkpoint under ``*last.ckpt``, and the final checkpoint after training completes under ``*end.ckpt``.
@@ -366,7 +424,12 @@ def exp_manager(trainer: 'pytorch_lightning.Trainer', cfg: Optional[Union[DictCo
 
     # For some reason, LearningRateLogger requires trainer to have a logger. Safer to create logger on all ranks
     # not just global rank 0.
-    if cfg.create_tensorboard_logger or cfg.create_wandb_logger or cfg.create_mlflow_logger:
+    if (
+        cfg.create_tensorboard_logger
+        or cfg.create_wandb_logger
+        or cfg.create_mlflow_logger
+        or cfg.create_dllogger_logger
+    ):
         configure_loggers(
             trainer,
             exp_dir,
@@ -378,6 +441,8 @@ def exp_manager(trainer: 'pytorch_lightning.Trainer', cfg: Optional[Union[DictCo
             cfg.wandb_logger_kwargs,
             cfg.create_mlflow_logger,
             cfg.mlflow_logger_kwargs,
+            cfg.create_dllogger_logger,
+            cfg.dllogger_logger_kwargs,
         )
 
     # add loggers timing callbacks
@@ -433,7 +498,8 @@ def error_checks(trainer: 'pytorch_lightning.Trainer', cfg: Optional[Union[DictC
     """
     Checks that the passed trainer is compliant with NeMo and exp_manager's passed configuration. Checks that:
         - Throws error when hydra has changed the working directory. This causes issues with lightning's DDP
-        - Throws error when trainer has loggers defined but create_tensorboard_logger or create_WandB_logger  or create_mlflow_logger is True
+        - Throws error when trainer has loggers defined but create_tensorboard_logger or create_wandB_logger
+            or create_mlflow_logger or create_dllogger_logger is True
         - Prints error messages when 1) run on multi-node and not Slurm, and 2) run on multi-gpu without DDP
     """
     if HydraConfig.initialized() and get_original_cwd() != os.getcwd():
@@ -447,7 +513,8 @@ def error_checks(trainer: 'pytorch_lightning.Trainer', cfg: Optional[Union[DictC
         raise LoggerMisconfigurationError(
             "The pytorch lightning trainer that was passed to exp_manager contained a logger, and either "
             f"create_tensorboard_logger: {cfg.create_tensorboard_logger} or create_wandb_logger: "
-            f"{cfg.create_wandb_logger} or create_mlflow_logger: {cfg.create_mlflow_logger} was set to True. "
+            f"{cfg.create_wandb_logger} or create_mlflow_logger: {cfg.create_mlflow_logger}"
+            f"or create_dllogger_logger: {cfg.create_mlflow_logger} was set to True. "
             "These can only be used if trainer does not already have a logger."
         )
     if trainer.num_nodes > 1 and not check_slurm(trainer):
@@ -700,11 +767,14 @@ def configure_loggers(
     wandb_kwargs: dict,
     create_mlflow_logger: bool,
     mlflow_kwargs: dict,
+    create_dllogger_logger: bool,
+    dllogger_kwargs: dict,
 ):
-    """ Creates TensorboardLogger and/or WandBLogger / MLFlowLogger and attach them to trainer. Raises ValueError if
-    summary_writer_kwargs or wandb_kwargs are misconfigured.
     """
-    # Potentially create tensorboard logger and/or WandBLogger / MLFlowLogger
+    Creates TensorboardLogger and/or WandBLogger / MLFlowLogger / DLlogger and attach them to trainer.
+    Raises ValueError if summary_writer_kwargs or wandb_kwargs are misconfigured.
+    """
+    # Potentially create tensorboard logger and/or WandBLogger / MLFlowLogger / DLLogger
     logger_list = []
     if create_tensorboard_logger:
         if summary_writer_kwargs is None:
@@ -737,7 +807,19 @@ def configure_loggers(
         mlflow_logger = MLFlowLogger(run_name=version, **mlflow_kwargs)
 
         logger_list.append(mlflow_logger)
-        logging.info('MLFlowLogger has been set up')
+        logging.info("MLFlowLogger has been set up")
+
+    if create_dllogger_logger:
+        if DLLogger is not None:
+            dllogger_logger = DLLogger(**dllogger_kwargs)
+
+            logger_list.append(dllogger_logger)
+            logging.info("DLLogger has been set up")
+        else:
+            logging.error(
+                "Couldn't set up DLLogger. Is is installed? "
+                "pip install git+https://github.com/NVIDIA/dllogger#egg=dllogger"
+            )
 
     trainer._logger_connector.configure_logger(logger_list)
 

--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -33,7 +33,7 @@ from hydra.utils import get_original_cwd
 from omegaconf import DictConfig, OmegaConf, open_dict
 from pytorch_lightning.callbacks import Callback, ModelCheckpoint
 from pytorch_lightning.callbacks.timer import Interval, Timer
-from pytorch_lightning.loggers import Logger, MLFlowLogger, TensorBoardLogger, WandbLogger
+from pytorch_lightning.loggers import MLFlowLogger, TensorBoardLogger, WandbLogger
 from pytorch_lightning.loops import TrainingEpochLoop
 from pytorch_lightning.strategies.ddp import DDPStrategy
 from pytorch_lightning.utilities import rank_zero_info


### PR DESCRIPTION
# What does this PR do ?

Adds an option to log with DLLogger in the experiment manager.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Changed exp_manager.py to add a new logger
- Updated the exp_manager documentation

# Usage
In the exp_manager config:

```yaml
enable_dllogger_logger: True
dllogger_logger_kwargs:
    stdout: False
    verbose: False
    json_file: "./dllogger.json"
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
