### PR TITLE
Fix EMA restart by allowing device to be set by the class init

### DIFF
--- a/nemo/collections/common/callbacks/ema.py
+++ b/nemo/collections/common/callbacks/ema.py
@@ -327,7 +327,6 @@ class EMAOptimizer(torch.optim.Optimizer):
             'current_step': self.current_step,
             'decay': self.decay,
             'every_n_steps': self.every_n_steps,
-            'device': self.device,
         }
         return state_dict
 
@@ -338,7 +337,6 @@ class EMAOptimizer(torch.optim.Optimizer):
         self.ema_params = tuple(param.to(self.device) for param in copy.deepcopy(state_dict['ema']))
         self.current_step = state_dict['current_step']
         self.decay = state_dict['decay']
-        self.device = state_dict['device']
         self.every_n_steps = state_dict['every_n_steps']
         self.rebuild_ema_params = False
 


### PR DESCRIPTION
# What does this PR do ?

Fixes a bug when restarting from a save checkpoint with multiple GPUs. We shouldn't override the device (or even store the device at all), relying on the LightningModule to provide the device.

**Collection**: Common

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
