### PR TITLE
Fix for incorrect computation of batched alignment in transducers

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -988,6 +988,22 @@ pipeline {
         }
       }
     }
+    stage('L2: Transducer alignment') {
+      when {
+        anyOf {
+          branch 'main'
+          changeRequest target: 'main'
+        }
+      }
+      failFast true
+      parallel {
+        stage('Running pytest') {
+          steps {
+            sh 'pytest tests/collections/asr/decoding/rnnt_alignments_check.py --durations=-1'
+          }
+        }
+      }
+    }
 
     stage('L2: Segmentation Tool') {
       when {

--- a/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
@@ -632,13 +632,13 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
             # Initialize Hidden state matrix (shared by entire batch)
             hidden = None
 
-            # If alignments need to be preserved, register a danling list to hold the values
+            # If alignments need to be preserved, register a dangling list to hold the values
             if self.preserve_alignments:
                 # alignments is a 3-dimensional dangling list representing B x T x U
                 for hyp in hypotheses:
                     hyp.alignments = [[]]
 
-            # If confidence scores need to be preserved, register a danling list to hold the values
+            # If confidence scores need to be preserved, register a dangling list to hold the values
             if self.preserve_frame_confidence:
                 # frame_confidence is a 3-dimensional dangling list representing B x T x U
                 for hyp in hypotheses:
@@ -787,6 +787,8 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
                                 hypotheses[kidx].y_sequence.append(ki)
                                 hypotheses[kidx].timestep.append(time_idx)
                                 hypotheses[kidx].score += float(v[kidx])
+                            elif self.preserve_alignments:  # creating new alignment list for samples that had blank
+                                hypotheses[kidx].alignments.append([])
 
                         symbols_added += 1
 
@@ -834,7 +836,7 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
         # Initialize Hidden state matrix (shared by entire batch)
         hidden = None
 
-        # If alignments need to be preserved, register a danling list to hold the values
+        # If alignments need to be preserved, register a dangling list to hold the values
         if self.preserve_alignments:
             # alignments is a 3-dimensional dangling list representing B x T x U
             for hyp in hypotheses:
@@ -842,7 +844,7 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
         else:
             alignments = None
 
-        # If confidence scores need to be preserved, register a danling list to hold the values
+        # If confidence scores need to be preserved, register a dangling list to hold the values
         if self.preserve_frame_confidence:
             # frame_confidence is a 3-dimensional dangling list representing B x T x U
             for hyp in hypotheses:
@@ -995,7 +997,6 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
                                 hypotheses[kidx].y_sequence.append(ki)
                                 hypotheses[kidx].timestep.append(time_idx)
                                 hypotheses[kidx].score += float(v[kidx])
-
                     symbols_added += 1
 
         # Remove trailing empty list of alignments at T_{am-len} x Uj

--- a/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
@@ -787,8 +787,11 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
                                 hypotheses[kidx].y_sequence.append(ki)
                                 hypotheses[kidx].timestep.append(time_idx)
                                 hypotheses[kidx].score += float(v[kidx])
-                            elif self.preserve_alignments:  # creating new alignment list for samples that had blank
-                                hypotheses[kidx].alignments.append([])
+                            else:
+                                if self.preserve_alignments:  # creating new alignment list for samples that had blank
+                                    hypotheses[kidx].alignments.append([])
+                                if self.preserve_frame_confidence:
+                                    hypotheses[kidx].frame_confidence.append([])
 
                         symbols_added += 1
 
@@ -997,8 +1000,11 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
                                 hypotheses[kidx].y_sequence.append(ki)
                                 hypotheses[kidx].timestep.append(time_idx)
                                 hypotheses[kidx].score += float(v[kidx])
-                            elif self.preserve_alignments:  # creating new alignment list for samples that had blank
-                                hypotheses[kidx].alignments.append([])
+                            else:
+                                if self.preserve_alignments:  # creating new alignment list for samples that had blank
+                                    hypotheses[kidx].alignments.append([])
+                                if self.preserve_frame_confidence:
+                                    hypotheses[kidx].frame_confidence.append([])
                     symbols_added += 1
 
         # Remove trailing empty list of alignments at T_{am-len} x Uj

--- a/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
@@ -556,6 +556,13 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
             confidence_method_cfg=confidence_method_cfg,
         )
 
+        # Depending on availability of `blank_as_pad` support
+        # switch between more efficient batch decoding technique
+        if self.decoder.blank_as_pad:
+            self._greedy_decode = self._greedy_decode_blank_as_pad
+        else:
+            self._greedy_decode = self._greedy_decode_masked
+
     @typecheck()
     def forward(
         self,
@@ -600,7 +607,7 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
 
         return (packed_result,)
 
-    def _greedy_decode(
+    def _greedy_decode_blank_as_pad(
         self,
         x: torch.Tensor,
         out_len: torch.Tensor,
@@ -642,8 +649,7 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
             # Last Label buffer + Last Label without blank buffer
             # batch level equivalent of the last_label
             last_label = torch.full([batchsize, 1], fill_value=self._blank_index, dtype=torch.long, device=device)
-            if not self.decoder.blank_as_pad:
-                last_label_without_blank = last_label.clone()
+
             # Mask buffers
             blank_mask = torch.full([batchsize], fill_value=0, dtype=torch.bool, device=device)
 
@@ -671,21 +677,8 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
                     if time_idx == 0 and symbols_added == 0 and hidden is None:
                         g, hidden_prime = self._pred_step(self._SOS, hidden, batch_size=batchsize)
                     else:
-                        if self.decoder.blank_as_pad:
-                            # Perform batch step prediction of decoder, getting new states and scores ("g")
-                            g, hidden_prime = self._pred_step(last_label, hidden, batch_size=batchsize)
-                        else:
-                            # Set a dummy label for the blank value
-                            # This value will be overwritten by "blank" again the last label update below
-                            # This is done as vocabulary of prediction network does not contain "blank" token of RNNT
-                            last_label_without_blank_mask = last_label == self._blank_index
-                            last_label_without_blank[last_label_without_blank_mask] = 0  # temp change of label
-                            last_label_without_blank[~last_label_without_blank_mask] = last_label[
-                                ~last_label_without_blank_mask
-                            ]
-
-                            # Perform batch step prediction of decoder, getting new states and scores ("g")
-                            g, hidden_prime = self._pred_step(last_label_without_blank, hidden, batch_size=batchsize)
+                        # Perform batch step prediction of decoder, getting new states and scores ("g")
+                        g, hidden_prime = self._pred_step(last_label, hidden, batch_size=batchsize)
 
                     # Batched joint step - Output = [B, V + 1]
                     # If preserving per-frame confidence, log_normalize must be true
@@ -812,6 +805,216 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
                         del hypotheses[batch_idx].y_3best[-1]
                         del hypotheses[batch_idx].frame_confidence_3best[-1]
                         del hypotheses[batch_idx].logp[-1]
+
+        # Preserve states
+        for batch_idx in range(batchsize):
+            hypotheses[batch_idx].dec_state = self.decoder.batch_select_state(hidden, batch_idx)
+
+        return hypotheses
+
+    def _greedy_decode_masked(
+        self,
+        x: torch.Tensor,
+        out_len: torch.Tensor,
+        device: torch.device,
+        partial_hypotheses: Optional[List[rnnt_utils.Hypothesis]] = None,
+    ):
+        if partial_hypotheses is not None:
+            raise NotImplementedError("`partial_hypotheses` support is not supported")
+
+        # x: [B, T, D]
+        # out_len: [B]
+        # device: torch.device
+
+        # Initialize state
+        batchsize = x.shape[0]
+        hypotheses = [
+            rnnt_utils.Hypothesis(score=0.0, y_sequence=[], timestep=[], dec_state=None) for _ in range(batchsize)
+        ]
+
+        # Initialize Hidden state matrix (shared by entire batch)
+        hidden = None
+
+        # If alignments need to be preserved, register a danling list to hold the values
+        if self.preserve_alignments:
+            # alignments is a 3-dimensional dangling list representing B x T x U
+            for hyp in hypotheses:
+                hyp.alignments = [[]]
+        else:
+            alignments = None
+
+        # If confidence scores need to be preserved, register a danling list to hold the values
+        if self.preserve_frame_confidence:
+            # frame_confidence is a 3-dimensional dangling list representing B x T x U
+            for hyp in hypotheses:
+                hyp.frame_confidence = [[]]
+
+        # Last Label buffer + Last Label without blank buffer
+        # batch level equivalent of the last_label
+        last_label = torch.full([batchsize, 1], fill_value=self._blank_index, dtype=torch.long, device=device)
+        last_label_without_blank = last_label.clone()
+
+        # Mask buffers
+        blank_mask = torch.full([batchsize], fill_value=0, dtype=torch.bool, device=device)
+
+        # Get max sequence length
+        max_out_len = out_len.max()
+
+        with torch.inference_mode():
+            for time_idx in range(max_out_len):
+                f = x.narrow(dim=1, start=time_idx, length=1)  # [B, 1, D]
+
+                # Prepare t timestamp batch variables
+                not_blank = True
+                symbols_added = 0
+
+                # Reset blank mask
+                blank_mask.mul_(False)
+
+                # Update blank mask with time mask
+                # Batch: [B, T, D], but Bi may have seq len < max(seq_lens_in_batch)
+                # Forcibly mask with "blank" tokens, for all sample where current time step T > seq_len
+                blank_mask = time_idx >= out_len
+
+                # Start inner loop
+                while not_blank and (self.max_symbols is None or symbols_added < self.max_symbols):
+                    # Batch prediction and joint network steps
+                    # If very first prediction step, submit SOS tag (blank) to pred_step.
+                    # This feeds a zero tensor as input to AbstractRNNTDecoder to prime the state
+                    if time_idx == 0 and symbols_added == 0 and hidden is None:
+                        g, hidden_prime = self._pred_step(self._SOS, hidden, batch_size=batchsize)
+                    else:
+                        # Set a dummy label for the blank value
+                        # This value will be overwritten by "blank" again the last label update below
+                        # This is done as vocabulary of prediction network does not contain "blank" token of RNNT
+                        last_label_without_blank_mask = last_label == self._blank_index
+                        last_label_without_blank[last_label_without_blank_mask] = 0  # temp change of label
+                        last_label_without_blank[~last_label_without_blank_mask] = last_label[
+                            ~last_label_without_blank_mask
+                        ]
+
+                        # Perform batch step prediction of decoder, getting new states and scores ("g")
+                        g, hidden_prime = self._pred_step(last_label_without_blank, hidden, batch_size=batchsize)
+
+                    # Batched joint step - Output = [B, V + 1]
+                    # If preserving per-frame confidence, log_normalize must be true
+                    logp = self._joint_step(f, g, log_normalize=True if self.preserve_frame_confidence else None)[
+                        :, 0, 0, :
+                    ]
+
+                    if logp.dtype != torch.float32:
+                        logp = logp.float()
+
+                    # Get index k, of max prob for batch
+                    v, k = logp.max(1)
+                    del g
+
+                    # Update blank mask with current predicted blanks
+                    # This is accumulating blanks over all time steps T and all target steps min(max_symbols, U)
+                    k_is_blank = k == self._blank_index
+                    blank_mask.bitwise_or_(k_is_blank)
+                    all_blanks = torch.all(blank_mask)
+
+                    # If preserving alignments, check if sequence length of sample has been reached
+                    # before adding alignment
+                    if self.preserve_alignments:
+                        # Insert logprobs into last timestep per sample
+                        logp_vals = logp.to('cpu')
+                        logp_ids = logp_vals.max(1)[1]
+                        for batch_idx, is_blank in enumerate(blank_mask):
+                            # we only want to update non-blanks, unless we are at the last step in the loop where
+                            # all elements produced blanks, otherwise there will be duplicate predictions
+                            # saved in alignments
+                            if time_idx < out_len[batch_idx] and (all_blanks or not is_blank):
+                                hypotheses[batch_idx].alignments[-1].append(
+                                    (logp_vals[batch_idx], logp_ids[batch_idx])
+                                )
+
+                        del logp_vals
+
+                    # If preserving per-frame confidence, check if sequence length of sample has been reached
+                    # before adding confidence scores
+                    if self.preserve_frame_confidence:
+                        # Insert probabilities into last timestep per sample
+                        confidence = self._get_confidence(logp)
+                        for batch_idx, is_blank in enumerate(blank_mask):
+                            if time_idx < out_len[batch_idx] and (all_blanks or not is_blank):
+                                hypotheses[batch_idx].frame_confidence[-1].append(confidence[batch_idx])
+                    del logp
+
+                    # If all samples predict / have predicted prior blanks, exit loop early
+                    # This is equivalent to if single sample predicted k
+                    if blank_mask.all():
+                        not_blank = False
+
+                        # If preserving alignments, convert the current Uj alignments into a torch.Tensor
+                        # Then preserve U at current timestep Ti
+                        # Finally, forward the timestep history to Ti+1 for that sample
+                        # All of this should only be done iff the current time index <= sample-level AM length.
+                        # Otherwise ignore and move to next sample / next timestep.
+                        if self.preserve_alignments:
+
+                            # convert Ti-th logits into a torch array
+                            for batch_idx in range(batchsize):
+
+                                # this checks if current timestep <= sample-level AM length
+                                # If current timestep > sample-level AM length, no alignments will be added
+                                # Therefore the list of Uj alignments is empty here.
+                                if len(hypotheses[batch_idx].alignments[-1]) > 0:
+                                    hypotheses[batch_idx].alignments.append([])  # blank buffer for next timestep
+
+                        # Do the same if preserving per-frame confidence
+                        if self.preserve_frame_confidence:
+
+                            for batch_idx in range(batchsize):
+                                if len(hypotheses[batch_idx].frame_confidence[-1]) > 0:
+                                    hypotheses[batch_idx].frame_confidence.append([])  # blank buffer for next timestep
+                    else:
+                        # Collect batch indices where blanks occurred now/past
+                        blank_indices = (blank_mask == 1).nonzero(as_tuple=False)
+
+                        # Recover prior state for all samples which predicted blank now/past
+                        if hidden is not None:
+                            # LSTM has 2 states
+                            hidden_prime = self.decoder.batch_copy_states(hidden_prime, hidden, blank_indices)
+
+                        elif len(blank_indices) > 0 and hidden is None:
+                            # Reset state if there were some blank and other non-blank predictions in batch
+                            # Original state is filled with zeros so we just multiply
+                            # LSTM has 2 states
+                            hidden_prime = self.decoder.batch_copy_states(hidden_prime, None, blank_indices, value=0.0)
+
+                        # Recover prior predicted label for all samples which predicted blank now/past
+                        k[blank_indices] = last_label[blank_indices, 0]
+
+                        # Update new label and hidden state for next iteration
+                        last_label = k.view(-1, 1)
+                        hidden = hidden_prime
+
+                        # Update predicted labels, accounting for time mask
+                        # If blank was predicted even once, now or in the past,
+                        # Force the current predicted label to also be blank
+                        # This ensures that blanks propogate across all timesteps
+                        # once they have occured (normally stopping condition of sample level loop).
+                        for kidx, ki in enumerate(k):
+                            if blank_mask[kidx] == 0:
+                                hypotheses[kidx].y_sequence.append(ki)
+                                hypotheses[kidx].timestep.append(time_idx)
+                                hypotheses[kidx].score += float(v[kidx])
+
+                    symbols_added += 1
+
+        # Remove trailing empty list of alignments at T_{am-len} x Uj
+        if self.preserve_alignments:
+            for batch_idx in range(batchsize):
+                if len(hypotheses[batch_idx].alignments[-1]) == 0:
+                    del hypotheses[batch_idx].alignments[-1]
+
+        # Remove trailing empty list of confidence scores at T_{am-len} x Uj
+        if self.preserve_frame_confidence:
+            for batch_idx in range(batchsize):
+                if len(hypotheses[batch_idx].frame_confidence[-1]) == 0:
+                    del hypotheses[batch_idx].frame_confidence[-1]
 
         # Preserve states
         for batch_idx in range(batchsize):

--- a/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
@@ -997,6 +997,8 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer):
                                 hypotheses[kidx].y_sequence.append(ki)
                                 hypotheses[kidx].timestep.append(time_idx)
                                 hypotheses[kidx].score += float(v[kidx])
+                            elif self.preserve_alignments:  # creating new alignment list for samples that had blank
+                                hypotheses[kidx].alignments.append([])
                     symbols_added += 1
 
         # Remove trailing empty list of alignments at T_{am-len} x Uj

--- a/tests/collections/asr/decoding/rnnt_alignments_check.py
+++ b/tests/collections/asr/decoding/rnnt_alignments_check.py
@@ -23,7 +23,7 @@ from omegaconf import OmegaConf
 
 from nemo.collections.asr.parts.utils.transcribe_utils import prepare_audio_data, setup_model
 
-TEST_DATA_PATH = "/mnt/datadrive/data/TestData/an4_dataset/an4_val.json"
+TEST_DATA_PATH = "/home/TestData/an4_dataset/an4_val.json"
 PRETRAINED_MODEL_NAME = "stt_en_conformer_transducer_small"
 
 

--- a/tests/collections/asr/decoding/rnnt_alignments_check.py
+++ b/tests/collections/asr/decoding/rnnt_alignments_check.py
@@ -67,6 +67,7 @@ def cleanup_local_folder():
     return
 
 
+# TODO: add the same tests for multi-blank RNNT decoding
 def test_rnnt_alignments():
     # using greedy as baseline and comparing all other configurations to it
     ref_transcriptions = get_rnnt_alignments("greedy")

--- a/tests/collections/asr/decoding/rnnt_alignments_check.py
+++ b/tests/collections/asr/decoding/rnnt_alignments_check.py
@@ -17,6 +17,7 @@
 #       these tests outside of the CI machines environment, where test data is
 #       stored
 
+import pytest
 from examples.asr.transcribe_speech import TranscriptionConfig
 from omegaconf import OmegaConf
 
@@ -36,6 +37,7 @@ def get_rnnt_alignments(strategy: str):
 
     model = setup_model(cfg, map_location="cuda")[0]
     model.change_decoding_strategy(cfg.rnnt_decoding)
+
     transcriptions = model.transcribe(
         paths2audio_files=filepaths,
         batch_size=cfg.batch_size,
@@ -54,6 +56,15 @@ def get_rnnt_alignments(strategy: str):
                 else:
                     assert pred[1].item() == model.decoder.blank_idx  # last one has to be blank
     return transcriptions
+
+
+@pytest.fixture(autouse=True)
+def cleanup_local_folder():
+    """Overriding global fixture to make sure it's not applied for this test.
+
+    Otherwise, there will be errors in the CI in github.
+    """
+    return
 
 
 def test_rnnt_alignments():

--- a/tests/collections/asr/decoding/rnnt_alignments_check.py
+++ b/tests/collections/asr/decoding/rnnt_alignments_check.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 
-# NOTE: the file name does not start with "test_" on purpose to avoid executing
+# NOTE: the file name does not contain "test" on purpose to avoid executing
 #       these tests outside of the CI machines environment, where test data is
 #       stored
 

--- a/tests/collections/asr/decoding/rnnt_alignments_test.py
+++ b/tests/collections/asr/decoding/rnnt_alignments_test.py
@@ -1,0 +1,51 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# NOTE: the file name does not start with "test_" on purpose to avoid executing
+#       these tests outside of the CI machines environment, where test data is
+#       stored
+import pytest
+from examples.asr.transcribe_speech import TranscriptionConfig
+from omegaconf import OmegaConf
+
+from nemo.collections.asr.parts.utils.transcribe_utils import prepare_audio_data, setup_model
+
+TEST_DATA_PATH = "/mnt/datadrive/data/TestData/an4_dataset/an4_val.json"
+PRETRAINED_MODEL_NAME = "stt_en_conformer_transducer_small"
+
+
+def test_rnnt_alignments():
+    cfg = OmegaConf.structured(TranscriptionConfig(pretrained_name=PRETRAINED_MODEL_NAME))
+    cfg.rnnt_decoding.preserve_alignments = True
+    cfg.dataset_manifest = TEST_DATA_PATH
+    filepaths = prepare_audio_data(cfg)[0][:10]  # selecting 10 files only
+
+    model = setup_model(cfg, map_location="cuda")[0]
+    model.change_decoding_strategy(cfg.rnnt_decoding)
+    transcriptions = model.transcribe(
+        paths2audio_files=filepaths,
+        batch_size=cfg.batch_size,
+        num_workers=cfg.num_workers,
+        return_hypotheses=True,
+        channel_selector=cfg.channel_selector,
+    )[0]
+
+    for transcription in transcriptions:
+        for align_elem in transcription.alignments:
+            for idx, pred in enumerate(align_elem):
+                if idx < len(align_elem) - 1:
+                    assert pred[1].item() != model.decoder.blank_idx  # all except last have to be non-blank
+                else:
+                    assert pred[1].item() == model.decoder.blank_idx  # last one has to be blank


### PR DESCRIPTION
# What does this PR do ?

The original code had a bug because of which whenever at least one batch element predicted non-blank symbol, all blank elements would duplicate the last prediction in their `.alignments` variable.

Additionally, I've unified `_greedy_decode_blank_as_pad` and `_greedy_decode_masked` into a single function with an if check. The two methods had 99% of the same code except 5 lines or so, so imo it does not make sense to have them as fully separate code paths. Please let me know if for some reason we don't want to have this change.

**Collection**: ASR

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
