### PR TITLE
[ASR] Use a subset of manifest when using `scatter` shard strategy

### DIFF
--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -133,6 +133,9 @@ class ASRManifestProcessor:
         eos_id: Optional[int] = None,
         pad_id: int = 0,
         index_by_file_id: bool = False,
+        shard_strategy: Optional[str] = None,
+        global_rank: Optional[int] = None,
+        world_size: Optional[int] = None,
     ):
         self.parser = parser
 
@@ -143,6 +146,9 @@ class ASRManifestProcessor:
             max_duration=max_duration,
             max_number=max_utts,
             index_by_file_id=index_by_file_id,
+            shard_strategy=shard_strategy,
+            global_rank=global_rank,
+            world_size=world_size,
         )
 
         self.eos_id = eos_id
@@ -786,6 +792,9 @@ class _TarredAudioToTextDataset(IterableDataset):
             eos_id=eos_id,
             pad_id=pad_id,
             index_by_file_id=True,  # Must set this so the manifest lines can be indexed by file ID
+            shard_strategy=shard_strategy,
+            global_rank=global_rank,
+            world_size=world_size,
         )
 
         self.featurizer = WaveformFeaturizer(sample_rate=sample_rate, int_values=int_values, augmentor=augmentor)

--- a/nemo/collections/common/parts/utils.py
+++ b/nemo/collections/common/parts/utils.py
@@ -96,3 +96,28 @@ def flatten(list_in: List) -> List:
         A flat list of values.
     """
     return list(flatten_iterable(list_in))
+
+
+def get_num_lines(filepath: str, buffer_size: int = 2 ** 16) -> int:
+    """Get number of lines in a text file by reading buffers
+    and counting `'\n'`.
+
+    Args:
+        filepath: path to a text file
+        buffer_size: size of the buffer
+
+    Returns:
+        Number of lines in the input file.
+    """
+
+    def buffer_generator(read, buffer_size):
+        """Generate buffers using read.
+        """
+        b = read(buffer_size)
+        while b:
+            yield b
+            b = read(buffer_size)
+
+    with open(filepath, 'rb') as f:
+        num_lines = sum(b.count(b'\n') for b in buffer_generator(read=f.raw.read, buffer_size=buffer_size))
+    return num_lines

--- a/tests/collections/common/test_utils.py
+++ b/tests/collections/common/test_utils.py
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import tempfile
+
 import pytest
 
-from nemo.collections.common.parts.utils import flatten
+from nemo.collections.common.parts.utils import flatten, get_num_lines
 
 
 class TestListUtils:
@@ -31,3 +34,22 @@ class TestListUtils:
 
         for n, test_case in enumerate(test_cases):
             assert flatten(test_case['input']) == test_case['golden'], f'Test case {n} failed!'
+
+
+class TestTextUtils:
+    @pytest.mark.unit
+    def test_get_num_lines(self):
+        """Test getting the number of lines from a text file.
+        """
+        test_cases = [0, 1, 10, 42, 97]
+
+        for num_lines in test_cases:
+
+            lines = [f'line {n}\n' for n in range(num_lines)]
+
+            with tempfile.TemporaryDirectory() as tmp_dir:
+                tmp_file = os.path.join(tmp_dir, 'file.txt')
+                with open(tmp_file, 'w') as f:
+                    f.writelines(lines)
+
+                assert get_num_lines(tmp_file) == num_lines, f'Failed for num_lines {num_lines}'


### PR DESCRIPTION
# What does this PR do ?

When using `shard_strategy='scatter'` this PR loads only a subset of lines from the manifest file.
This may reduce the time to process a manifest file by an order of magnitude.

Opening as a draft to get feedback if there are any underlying assumptions which may be broken by this change.

**Collection**: ASR

# Changelog 
| File                      | Change |
| ---------------- | -------- |
| `manifest.py::item_iter` | Load only a subset of lines if `shard_strategy == 'scatter'` |
| `collections.py:: ASRAudioText ` | forward `shard_strategy`, `global_rank` and `world_size` to `manifest.item_iter`  |
| `collections.py:: AudioText ` | Use rank and world size to restore the original data list length for `shard_strategy='scatter'` |
|  `audio_to_text.py` | forward `shard_strategy`, `global_rank` and `world_size` to `collections.ASRAudioText` |
| `utils,py` | Added a function to get number of lines from a text file |
| `test_utils.py` | Added unit test for the utility function added above |


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
