### PR TITLE
Update torch.stft() calls due to deprecation of return_complex=False

### DIFF
--- a/nemo/collections/tts/losses/stftlosses.py
+++ b/nemo/collections/tts/losses/stftlosses.py
@@ -61,7 +61,7 @@ def stft(x, fft_size, hop_size, win_length, window):
     Returns:
         Tensor: Magnitude spectrogram (B, #frames, fft_size // 2 + 1).
     """
-    x_stft = torch.stft(x, fft_size, hop_size, win_length, window, return_complex=False)
+    x_stft = torch.view_as_real(torch.stft(x, fft_size, hop_size, win_length, window, return_complex=True))
     real = x_stft[..., 0]
     imag = x_stft[..., 1]
 

--- a/nemo/collections/tts/models/base.py
+++ b/nemo/collections/tts/models/base.py
@@ -146,9 +146,15 @@ class GlowVocoder(Vocoder):
                 ) from e
 
             def yet_another_patch(audio, n_fft, hop_length, win_length, window):
-                spec = torch.stft(audio, n_fft=n_fft, hop_length=hop_length, win_length=win_length, window=window)
-                if spec.dtype in [torch.cfloat, torch.cdouble]:
-                    spec = torch.view_as_real(spec)
+                spec = torch.stft(
+                    audio,
+                    n_fft=n_fft,
+                    hop_length=hop_length,
+                    win_length=win_length,
+                    window=window,
+                    return_complex=True,
+                )
+                spec = torch.view_as_real(spec)
                 return torch.sqrt(spec.pow(2).sum(-1)), torch.atan2(spec[..., -1], spec[..., 0])
 
             self.stft = lambda x: yet_another_patch(

--- a/nemo/collections/tts/models/hifigan.py
+++ b/nemo/collections/tts/models/hifigan.py
@@ -286,7 +286,8 @@ class HifiGanModel(Vocoder, Exportable):
 
     def _bias_denoise(self, audio, mel):
         def stft(x):
-            comp = torch.stft(x.squeeze(1), n_fft=1024, hop_length=256, win_length=1024)
+            comp = torch.stft(x.squeeze(1), n_fft=1024, hop_length=256, win_length=1024, return_complex=True)
+            comp = torch.view_as_real(comp)
             real, imag = comp[..., 0], comp[..., 1]
             mags = torch.sqrt(real ** 2 + imag ** 2)
             phase = torch.atan2(imag, real)
@@ -294,7 +295,7 @@ class HifiGanModel(Vocoder, Exportable):
 
         def istft(mags, phase):
             comp = torch.stack([mags * torch.cos(phase), mags * torch.sin(phase)], dim=-1)
-            x = torch.istft(comp, n_fft=1024, hop_length=256, win_length=1024)
+            x = torch.istft(torch.view_as_complex(comp), n_fft=1024, hop_length=256, win_length=1024)
             return x
 
         # Create bias tensor

--- a/nemo/collections/tts/models/univnet.py
+++ b/nemo/collections/tts/models/univnet.py
@@ -237,7 +237,8 @@ class UnivNetModel(Vocoder, Exportable):
 
     def _bias_denoise(self, audio, mel):
         def stft(x):
-            comp = torch.stft(x.squeeze(1), n_fft=1024, hop_length=256, win_length=1024)
+            comp = torch.stft(x.squeeze(1), n_fft=1024, hop_length=256, win_length=1024, return_complex=True)
+            comp = torch.view_as_real(comp)
             real, imag = comp[..., 0], comp[..., 1]
             mags = torch.sqrt(real ** 2 + imag ** 2)
             phase = torch.atan2(imag, real)
@@ -245,7 +246,7 @@ class UnivNetModel(Vocoder, Exportable):
 
         def istft(mags, phase):
             comp = torch.stack([mags * torch.cos(phase), mags * torch.sin(phase)], dim=-1)
-            x = torch.istft(comp, n_fft=1024, hop_length=256, win_length=1024)
+            x = torch.istft(torch.view_as_complex(comp), n_fft=1024, hop_length=256, win_length=1024)
             return x
 
         # Create bias tensor

--- a/nemo/collections/tts/modules/univnet_modules.py
+++ b/nemo/collections/tts/modules/univnet_modules.py
@@ -574,7 +574,9 @@ class DiscriminatorR(NeuralModule):
         n_fft, hop_length, win_length = self.resolution
         x = F.pad(x, (int((n_fft - hop_length) / 2), int((n_fft - hop_length) / 2)), mode='reflect')
         x = x.squeeze(1)
-        x = torch.stft(x, n_fft=n_fft, hop_length=hop_length, win_length=win_length, center=False)  # [B, F, TT, 2]
+        x = torch.view_as_real(
+            torch.stft(x, n_fft=n_fft, hop_length=hop_length, win_length=win_length, center=False, return_complex=True)
+        )  # [B, F, TT, 2] (Note: torch.stft() returns complex tensor [B, F, TT]; converted via view_as_real)
         mag = torch.norm(x, p=2, dim=-1)  # [B, F, TT]
 
         return mag


### PR DESCRIPTION
Signed-off-by: Jocelyn Huang <jocelynh@nvidia.com>

# What does this PR do ?

Fixes errors due to deprecation of `return_complex=False` in `torch.stft()` in version 1.14.

Most of our calls implicitly use `return_complex=False` (was the default), which returns a tensor of shape [B, N, T, 2] where the last dimension captures the real and imaginary parts of the tensor. However, moving forward, pytorch is deprecating this in favor of the behavior of `return_complex=True`, which returns a complex tensor of shape [B, N, T].

This bugfix explicitly sets `return_complex=True` as required by v1.14, and then converts the output of `torch.stft()` back to [B, N, T, 2] using `torch.view_as_real()`.

Similarly, `torch.istft()` now wants a complex tensor input; this is fixed by calling `torch.view_as_complex()` on our original input.

**Collection**: TTS

# Changelog 
- `torch.stft()` calls explicitly set `return_complex=True` and then convert output where necessary
- Added `torch.view_as_complex()` to input of `torch.istft()`

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
