### PR TITLE
Add keep_initializers_as_inputs to _export method

### DIFF
--- a/nemo/core/classes/exportable.py
+++ b/nemo/core/classes/exportable.py
@@ -79,6 +79,7 @@ class Exportable(ABC):
                 dynamic_axes=dynamic_axes,
                 check_tolerance=check_tolerance,
                 export_modules_as_functions=export_modules_as_functions,
+                keep_initializers_as_inputs=keep_initializers_as_inputs,
             )
             # Propagate input example (default scenario, may need to be overriden)
             if input_example is not None:


### PR DESCRIPTION
Signed-off-by: Patrick Simianer <patrick@lilt.com>

# What does this PR do ?

In https://github.com/NVIDIA/NeMo/pull/5052 I forgot to add the `keep_initializers_as_inputs` arg to the `_export` method.

**Collection**: core

# Changelog 
- Simple fix.

# Usage
* See https://github.com/NVIDIA/NeMo/pull/5052

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #5052 