### PR TITLE
Set the stream position to 0 for pydub

### DIFF
--- a/nemo/collections/asr/parts/preprocessing/segment.py
+++ b/nemo/collections/asr/parts/preprocessing/segment.py
@@ -219,6 +219,9 @@ class AudioSegment(object):
                     f"NeMo will fallback to loading via pydub."
                 )
 
+                if hasattr(audio_file, "seek"):
+                    audio_file.seek(0)
+
         if HAVE_PYDUB and samples is None:
             try:
                 samples = Audio.from_file(audio_file)


### PR DESCRIPTION
# What does this PR do ?

This PR sets the stream position to 0 to use pydub as fallback if SoundFile fails to read an audio file. 

When using tarred datasets, `audio_file` is a file-like object, not a path-like object. In this situation, to use pydub as fallback, we need to set the stream position of `audio_file` to 0 since SoundFile have advanced the position while reading it.

**Collection**: ASR

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
