### PR TITLE
[Fix] ConformerEncoder forward when length is None

### DIFF
--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -414,7 +414,7 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable):
 
         if length is None:
             length = audio_signal.new_full(
-                audio_signal.size(0), max_audio_length, dtype=torch.int32, device=audio_signal.device
+                (audio_signal.size(0),), max_audio_length, dtype=torch.int32, device=audio_signal.device
             )
 
         if cache_last_time is not None:


### PR DESCRIPTION
Signed-off-by: Ante Jukić <ajukic@nvidia.com>

# What does this PR do ?

This PR fixes a bug in `forward` of `ConformerEncoder` when `length is None`

**Collection**: ASR

# Changelog 
- Fixed initialization of `length` with `new_full`

# Usage

Currently, the following
```
import torch
from nemo.collections.asr.modules.conformer_encoder import ConformerEncoder

# create layer
conformer_encoder = ConformerEncoder(feat_in=10, n_layers=1, d_model=16)

# run
out, out_length = conformer_encoder(audio_signal=torch.rand(10, 9, 32), length=None)
```

results in a `TypeError`:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "${PATH}/miniforge3/envs/nemo_env/lib/python3.9/site-packages/torch/nn/modules/module.py", line 1482, in _call_impl
    return forward_call(*args, **kwargs)
  File "${NEMO}/nemo/core/classes/common.py", line 1087, in __call__
    outputs = wrapped(*args, **kwargs)
  File "${NEMO}/nemo/collections/asr/modules/conformer_encoder.py", line 416, in forward
    length = audio_signal.new_full(
TypeError: new_full(): argument 'size' (position 1) must be tuple of ints, not int
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
