### PR TITLE
[ASR][Test] Enable test for cache audio with a single worker

### DIFF
--- a/tests/collections/asr/test_asr_datasets.py
+++ b/tests/collections/asr/test_asr_datasets.py
@@ -1725,8 +1725,7 @@ class TestAudioDatasets:
 
 class TestUtilityFunctions:
     @pytest.mark.unit
-    # TEMP WORKAROUND: Skip `True`, multiprocessing failing in CI (#5607)
-    @pytest.mark.parametrize('cache_audio', [False])
+    @pytest.mark.parametrize('cache_audio', [False, True])
     def test_cache_datastore_manifests(self, cache_audio: bool):
         """Test caching of manifest and audio files.
         """
@@ -1794,7 +1793,8 @@ class TestUtilityFunctions:
             with mock.patch(
                 'nemo.collections.asr.data.audio_to_text.is_datastore_path', lambda x: True
             ), mock.patch.object(DataStoreObject, 'get', fake_get):
-                cache_datastore_manifests(manifest_filepaths, cache_audio=cache_audio)
+                # Use a single worker for this test to avoid failure with mock & multiprocessing (#5607)
+                cache_datastore_manifests(manifest_filepaths, cache_audio=cache_audio, num_workers=1)
 
             # Manifests need to be compared
             store_files_to_compare = manifest_filepaths


### PR DESCRIPTION
Signed-off-by: Ante Jukić <ajukic@nvidia.com>

# What does this PR do ?

Enable a test which was disabled in #5615.

**Collection**: ASR tests

# Changelog 
- Enabled the test using a single worker

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #5607 and #5615
