### PR TITLE
Fix wrong label mapping in batch_inference for label_model

### DIFF
--- a/nemo/collections/asr/models/label_models.py
+++ b/nemo/collections/asr/models/label_models.py
@@ -545,7 +545,9 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
             mapped_labels = list(mapped_labels)
 
         featurizer = WaveformFeaturizer(sample_rate=sample_rate)
-        dataset = AudioToSpeechLabelDataset(manifest_filepath=manifest_filepath, labels=None, featurizer=featurizer)
+        dataset = AudioToSpeechLabelDataset(
+            manifest_filepath=manifest_filepath, labels=mapped_labels, featurizer=featurizer
+        )
 
         dataloader = torch.utils.data.DataLoader(
             dataset=dataset, batch_size=batch_size, collate_fn=dataset.fixed_seq_collate_fn,

--- a/tests/collections/asr/test_speaker_label_models.py
+++ b/tests/collections/asr/test_speaker_label_models.py
@@ -18,6 +18,7 @@ import tempfile
 from unittest import TestCase
 
 import pytest
+import torch
 from omegaconf import DictConfig
 
 from nemo.collections.asr.models import EncDecSpeakerLabelModel
@@ -179,6 +180,7 @@ class TestEncDecSpeechLabelModel:
         lang_model = EncDecSpeakerLabelModel.from_pretrained(model_name)
         relative_filepath = "an4_speaker/an4/wav/an4_clstk/fash/an255-fash-b.wav"
         filename = os.path.join(test_data_dir, relative_filepath)
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
 
         with tempfile.TemporaryDirectory() as tmpdir:
             temp_manifest = os.path.join(tmpdir, 'manifest.json')
@@ -186,7 +188,7 @@ class TestEncDecSpeechLabelModel:
                 entry = {"audio_filepath": filename, "duration": 4.5, "label": 'en'}
                 fp.write(json.dumps(entry) + '\n')
 
-            embs, logits, gt_labels, mapped_labels = lang_model.batch_inference(temp_manifest)
+            embs, logits, gt_labels, mapped_labels = lang_model.batch_inference(temp_manifest, device=device)
             pred_label = mapped_labels[logits.argmax(axis=-1)[0]]
             true_label = mapped_labels[gt_labels[0]]
             assert pred_label == true_label

--- a/tests/collections/asr/test_speaker_label_models.py
+++ b/tests/collections/asr/test_speaker_label_models.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
+import tempfile
 from unittest import TestCase
 
 import pytest
@@ -170,3 +172,21 @@ class TestEncDecSpeechLabelModel:
         label = lang_model.get_label(filename)
 
         assert label == "en"
+
+    @pytest.mark.unit
+    def test_pretrained_ambernet_logits_batched(self, test_data_dir):
+        model_name = 'langid_ambernet'
+        lang_model = EncDecSpeakerLabelModel.from_pretrained(model_name)
+        relative_filepath = "an4_speaker/an4/wav/an4_clstk/fash/an255-fash-b.wav"
+        filename = os.path.join(test_data_dir, relative_filepath)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_manifest = os.path.join(tmpdir, 'manifest.json')
+            with open(temp_manifest, 'w', encoding='utf-8') as fp:
+                entry = {"audio_filepath": filename, "duration": 4.5, "label": 'en'}
+                fp.write(json.dumps(entry) + '\n')
+
+            embs, logits, gt_labels, mapped_labels = lang_model.batch_inference(temp_manifest)
+            pred_label = mapped_labels[logits.argmax(axis=-1)[0]]
+            true_label = mapped_labels[gt_labels[0]]
+            assert pred_label == true_label


### PR DESCRIPTION
# What does this PR do ?

Fix groundtruth label mapping in `batch_inference` in `label_models.py` and add test. 

**Collection**: ASR

# Changelog 
-  The groundtruth label `batch_inference` was mapped wrongly. Fixed it
-  Add test for `batch_inference`

# Usage
* You can potentially add a usage example below

```python
from nemo.collections.asr.models import EncDecSpeakerLabelModel 
model = EncDecSpeakerLabelModel.from_pretrained('langid_ambernet')
embs, logits, gt_labels, mapped_labels = model.batch_inference(<path_to_manifest>)
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to https://github.com/NVIDIA/NeMo/pull/5278
