### PR TITLE
Fixing masking in RadTTS bottleneck layer

### DIFF
--- a/nemo/collections/tts/models/radtts.py
+++ b/nemo/collections/tts/models/radtts.py
@@ -395,6 +395,15 @@ class RadTTSModel(SpectrogramGenerator, Exportable):
             self._tb_logger = tb_logger
         return self._tb_logger
 
+    def load_state_dict(self, state_dict, strict=True):
+        # Override load_state_dict to be backward-compatible with old checkpoints
+        new_state_dict = {}
+        for k, v in state_dict.items():
+            k = k.replace("projection_fn.weight", "projection_fn.conv.weight")
+            k = k.replace("projection_fn.bias", "projection_fn.conv.bias")
+            new_state_dict[k] = v
+        super().load_state_dict(new_state_dict, strict=strict)
+
     @property
     def input_module(self):
         return self.model

--- a/nemo/collections/tts/modules/attribute_prediction_model.py
+++ b/nemo/collections/tts/modules/attribute_prediction_model.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 import torch
-from torch import nn
-from torch.nn import functional as F
+import torch.nn as nn
+import torch.nn.functional as F
 
 from nemo.collections.tts.helpers.helpers import get_mask_from_lengths
 from nemo.collections.tts.modules.common import ConvLSTMLinear
@@ -60,6 +60,8 @@ class BottleneckLayerLayer(nn.Module):
                 norm_args = {"use_weight_norm": True}
             elif norm == 'instancenorm':
                 norm_args = {"norm_fn": MaskedInstanceNorm1d}
+            else:
+                norm_args = {}
             fn = ConvNorm(in_dim, reduced_dim, kernel_size=3, **norm_args)
             self.projection_fn = fn
             self.non_linearity = non_linearity

--- a/nemo/collections/tts/modules/attribute_prediction_model.py
+++ b/nemo/collections/tts/modules/attribute_prediction_model.py
@@ -16,7 +16,9 @@ import torch
 from torch import nn
 from torch.nn import functional as F
 
-from nemo.collections.tts.modules.common import ConvLSTMLinear, ConvNorm
+from nemo.collections.tts.helpers.helpers import get_mask_from_lengths
+from nemo.collections.tts.modules.common import ConvLSTMLinear
+from nemo.collections.tts.modules.submodules import ConvNorm, MaskedInstanceNorm1d
 
 
 def get_attribute_prediction_model(config):
@@ -54,18 +56,18 @@ class BottleneckLayerLayer(nn.Module):
         reduced_dim = int(in_dim / reduction_factor)
         self.out_dim = reduced_dim
         if self.reduction_factor > 1:
-            fn = ConvNorm(in_dim, reduced_dim, kernel_size=3)
             if norm == 'weightnorm':
-                fn = torch.nn.utils.weight_norm(fn.conv, name='weight')
+                norm_args = {"use_weight_norm": True}
             elif norm == 'instancenorm':
-                fn = nn.Sequential(fn, nn.InstanceNorm1d(reduced_dim, affine=True))
-
+                norm_args = {"norm_fn": MaskedInstanceNorm1d}
+            fn = ConvNorm(in_dim, reduced_dim, kernel_size=3, **norm_args)
             self.projection_fn = fn
             self.non_linearity = non_linearity
 
-    def forward(self, x):
+    def forward(self, x, lens):
         if self.reduction_factor > 1:
-            x = self.projection_fn(x)
+            mask = get_mask_from_lengths(lens, x).unsqueeze(1)
+            x = self.projection_fn(x, mask)
             if self.non_linearity == 'relu':
                 x = F.relu(x)
             elif self.non_linearity == 'leakyrelu':
@@ -77,7 +79,6 @@ class DAP(AttributeProcessing):
     def __init__(self, n_speaker_dim, bottleneck_hparams, take_log_of_input, arch_hparams):
         super(DAP, self).__init__(take_log_of_input)
         self.bottleneck_layer = BottleneckLayerLayer(**bottleneck_hparams)
-
         arch_hparams['in_dim'] = self.bottleneck_layer.out_dim + n_speaker_dim
         self.feat_pred_fn = ConvLSTMLinear(**arch_hparams)
 
@@ -85,7 +86,7 @@ class DAP(AttributeProcessing):
         if x is not None:
             x = self.normalize(x)
 
-        txt_enc = self.bottleneck_layer(txt_enc)
+        txt_enc = self.bottleneck_layer(txt_enc, lens)
         spk_emb_expanded = spk_emb[..., None].expand(-1, -1, txt_enc.shape[2])
         context = torch.cat((txt_enc, spk_emb_expanded), 1)
         x_hat = self.feat_pred_fn(context, lens)


### PR DESCRIPTION
Signed-off-by: Boris Fomitchev <bfomitchev@nvidia.com>

Mask/length vector was ignored in bottleneck layer before.

**Collection**: [Note which collection this PR will affect]
TTS 

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
