### PR TITLE
[TTS][ZH] bugfix import jieba errors.

### DIFF
--- a/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
@@ -661,7 +661,6 @@ class ChinesePhonemesTokenizer(BaseTokenizer):
         g2p,
         punct=True,
         non_default_punct_list=None,
-        chars=False,
         *,
         space=' ',
         silence=None,
@@ -676,7 +675,6 @@ class ChinesePhonemesTokenizer(BaseTokenizer):
             g2p: Grapheme to phoneme module.
             punct: Whether to reserve grapheme for basic punctuation or not.
             non_default_punct_list: List of punctuation marks which will be used instead default.
-            chars: Whether to additionally use chars together with phonemes. It is useful if g2p module can return chars too.
             space: Space token as string.
             silence: Silence token as string (will be disabled if it is None).
             apostrophe: Whether to use apostrophe or not.


### PR DESCRIPTION
There was a bug which hits errors below. This PR fixed the error by importing `jieba` correctly.

```
 21 Error executing job with overrides: ['++dataloader_params.num_workers=48', 'manifest_filepath=/manifest/train_manifest.json', 'sup_data_path=/sup_data']
 22 Traceback (most recent call last):
 23   File "/usr/local/lib/python3.8/dist-packages/hydra/_internal/instantiate/_instantiate2.py", line 92, in _call_target
 24     return _target_(*args, **kwargs)
 25   File "/code/nemo/collections/tts/torch/data.py", line 241, in __init__
 26     file_info["text_tokens"] = self.text_tokenizer(file_info["normalized_text"])
 27   File "/code/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py", line 74, in __call__
 28     return self.encode(text)
 29   File "/code/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py", line 723, in encode
 30     g2p_text = self.g2p(text)  # TODO: handle infer
 31   File "/code/nemo_text_processing/g2p/modules.py", line 617, in __call__
 32     words_list = list(jieba.cut(text))
 33 NameError: name 'jieba' is not defined
 34
 35 The above exception was the direct cause of the following exception:
 36
 37 Traceback (most recent call last):
 38   File "scripts/dataset_processing/tts/extract_sup_data.py", line 83, in <module>
 39     main()  # noqa pylint: disable=no-value-for-parameter
 40   File "/code/nemo/core/config/hydra_runner.py", line 105, in wrapper
 41     _run_hydra(
 42   File "/usr/local/lib/python3.8/dist-packages/hydra/_internal/utils.py", line 389, in _run_hydra
 43     _run_app(
 44   File "/usr/local/lib/python3.8/dist-packages/hydra/_internal/utils.py", line 452, in _run_app
 45     run_and_report(
 46   File "/usr/local/lib/python3.8/dist-packages/hydra/_internal/utils.py", line 216, in run_and_report
 47     raise ex
 48   File "/usr/local/lib/python3.8/dist-packages/hydra/_internal/utils.py", line 213, in run_and_report
 49     return func()
 50   File "/usr/local/lib/python3.8/dist-packages/hydra/_internal/utils.py", line 453, in <lambda>
 51     lambda: hydra.run(
 52   File "/usr/local/lib/python3.8/dist-packages/hydra/_internal/hydra.py", line 132, in run
 53     _ = ret.return_value
 54   File "/usr/local/lib/python3.8/dist-packages/hydra/core/utils.py", line 260, in return_value
 55     raise self._return_value
 56   File "/usr/local/lib/python3.8/dist-packages/hydra/core/utils.py", line 186, in run_job
 57     ret.return_value = task_function(task_cfg)
 58   File "scripts/dataset_processing/tts/extract_sup_data.py", line 70, in main
 59     dataset = instantiate(cfg.dataset)
 60   File "/usr/local/lib/python3.8/dist-packages/hydra/_internal/instantiate/_instantiate2.py", line 222, in instantiate
 61     return instantiate_node(
 62   File "/usr/local/lib/python3.8/dist-packages/hydra/_internal/instantiate/_instantiate2.py", line 339, in instantiate_node
 63     return _call_target(_target_, partial, args, kwargs, full_key)
 64   File "/usr/local/lib/python3.8/dist-packages/hydra/_internal/instantiate/_instantiate2.py", line 97, in _call_target
 65     raise InstantiationException(msg) from e
 66 hydra.errors.InstantiationException: Error in call to target 'nemo.collections.tts.torch.data.TTSDataset':
 67 NameError("name 'jieba' is not defined")
 68 full_key: dataset
```

Signed-off-by: Xuesong Yang <1646669+XuesongYang@users.noreply.github.com>

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
