### PR TITLE
Update numpy requirements from 1.21 to 1.22

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,6 +1,6 @@
 huggingface_hub
 numba
-numpy>=1.21
+numpy>=1.22
 onnx>=1.7.0
 python-dateutil
 ruamel.yaml


### PR DESCRIPTION
Seeking to overcome this issue  UserWarning: Failed to initialize NumPy: module compiled against API version 0xf but this version of numpy is 0xe based on https://iq.opengenus.org/module-compiled-against-api-version-0x10-but-this-version-of-numpy-is-0xe/

Note: this warning actually causes a crash later one when trying to import things from numpy typing

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: NLP, ASR

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
