### PR TITLE
CommonVoice support for `convert_hf_dataset_to_nemo` script

### DIFF
--- a/scripts/speech_recognition/convert_hf_dataset_to_nemo.py
+++ b/scripts/speech_recognition/convert_hf_dataset_to_nemo.py
@@ -255,8 +255,10 @@ def convert_offline_dataset_to_nemo(
             del sample['audio']
             if 'file' in sample:
                 del sample['file']
-
-            manifest_f.write(f"{json.dumps(sample, ensure_ascii=cfg.ensure_ascii)}\n")
+            if cfg.ensure_ascii:
+                manifest_f.write(f"{json.dumps(sample, ensure_ascii=cfg.ensure_ascii)}\n")
+            else:
+                manifest_f.write(f"{json.dumps(sample, ensure_ascii=cfg.ensure_ascii)}")
 
 
 def convert_streaming_dataset_to_nemo(
@@ -302,7 +304,10 @@ def convert_streaming_dataset_to_nemo(
 
             manifest_line.update(sample)
 
-            manifest_f.write(f"{json.dumps(manifest_line, ensure_ascii=cfg.ensure_ascii)}\n")
+            if cfg.ensure_ascii:
+                manifest_f.write(f"{json.dumps(sample, ensure_ascii=cfg.ensure_ascii)}\n")
+            else:
+                manifest_f.write(f"{json.dumps(sample, ensure_ascii=cfg.ensure_ascii)}")
 
 
 def process_dataset(dataset: IterableDataset, cfg: HFDatasetConversionConfig):

--- a/scripts/speech_recognition/convert_hf_dataset_to_nemo.py
+++ b/scripts/speech_recognition/convert_hf_dataset_to_nemo.py
@@ -255,10 +255,7 @@ def convert_offline_dataset_to_nemo(
             del sample['audio']
             if 'file' in sample:
                 del sample['file']
-            if cfg.ensure_ascii:
-                manifest_f.write(f"{json.dumps(sample, ensure_ascii=cfg.ensure_ascii)}\n")
-            else:
-                manifest_f.write(f"{json.dumps(sample, ensure_ascii=cfg.ensure_ascii)}")
+            manifest_f.write(f"{json.dumps(sample, ensure_ascii=cfg.ensure_ascii)}\n")
 
 
 def convert_streaming_dataset_to_nemo(
@@ -304,10 +301,7 @@ def convert_streaming_dataset_to_nemo(
 
             manifest_line.update(sample)
 
-            if cfg.ensure_ascii:
-                manifest_f.write(f"{json.dumps(sample, ensure_ascii=cfg.ensure_ascii)}\n")
-            else:
-                manifest_f.write(f"{json.dumps(sample, ensure_ascii=cfg.ensure_ascii)}")
+            manifest_f.write(f"{json.dumps(sample, ensure_ascii=cfg.ensure_ascii)}\n")
 
 
 def process_dataset(dataset: IterableDataset, cfg: HFDatasetConversionConfig):

--- a/scripts/speech_recognition/convert_hf_dataset_to_nemo.py
+++ b/scripts/speech_recognition/convert_hf_dataset_to_nemo.py
@@ -98,7 +98,7 @@ from omegaconf import OmegaConf
 
 
 @dataclass
-class HFDatasetConvertionConfig:
+class HFDatasetConversionConfig:
     # Nemo Dataset info
     output_dir: str  # path to output directory where the files will be saved
 
@@ -112,6 +112,7 @@ class HFDatasetConvertionConfig:
     sampling_rate: int = 16000
     streaming: bool = False  # Whether to use Streaming dataset API. [NOT RECOMMENDED]
     num_proc: int = -1
+    ensure_ascii: bool = True  # When saving the JSON entry, whether to ensure ascii.
 
     # Placeholders. Generated internally.
     resolved_output_dir: str = ''
@@ -120,7 +121,7 @@ class HFDatasetConvertionConfig:
     hydra: HydraConf = HydraConf(run=RunDir(dir="."))
 
 
-def prepare_output_dirs(cfg: HFDatasetConvertionConfig):
+def prepare_output_dirs(cfg: HFDatasetConversionConfig):
     """
     Prepare output directories and subfolders as needed.
     Also prepare the arguments of the config with these directories.
@@ -191,7 +192,7 @@ def prepare_audio_filepath(audio_filepath):
     return audio_filepath
 
 
-def build_map_dataset_to_nemo_func(cfg: HFDatasetConvertionConfig, basedir):
+def build_map_dataset_to_nemo_func(cfg: HFDatasetConversionConfig, basedir):
     """
     Helper method to run in batch mode over a mapped Dataset.
 
@@ -225,7 +226,7 @@ def build_map_dataset_to_nemo_func(cfg: HFDatasetConvertionConfig, basedir):
 
 
 def convert_offline_dataset_to_nemo(
-    dataset: Dataset, cfg: HFDatasetConvertionConfig, basedir: str, manifest_filepath: str
+    dataset: Dataset, cfg: HFDatasetConversionConfig, basedir: str, manifest_filepath: str,
 ):
     """
     Converts a HF dataset to a audio-preprocessed Nemo dataset in Offline mode.
@@ -255,11 +256,11 @@ def convert_offline_dataset_to_nemo(
             if 'file' in sample:
                 del sample['file']
 
-            manifest_f.write(f"{json.dumps(sample)}\n")
+            manifest_f.write(f"{json.dumps(sample, ensure_ascii=cfg.ensure_ascii)}\n")
 
 
 def convert_streaming_dataset_to_nemo(
-    dataset: IterableDataset, cfg: HFDatasetConvertionConfig, basedir: str, manifest_filepath: str
+    dataset: IterableDataset, cfg: HFDatasetConversionConfig, basedir: str, manifest_filepath: str
 ):
     """
     Converts a HF dataset to a audio-preprocessed Nemo dataset in Streaming mode.
@@ -301,10 +302,10 @@ def convert_streaming_dataset_to_nemo(
 
             manifest_line.update(sample)
 
-            manifest_f.write(f"{json.dumps(manifest_line)}\n")
+            manifest_f.write(f"{json.dumps(manifest_line, ensure_ascii=cfg.ensure_ascii)}\n")
 
 
-def process_dataset(dataset: IterableDataset, cfg: HFDatasetConvertionConfig):
+def process_dataset(dataset: IterableDataset, cfg: HFDatasetConversionConfig):
     """
     Top level method that processes a given IterableDataset to Nemo compatible dataset.
     It also writes out a nemo compatible manifest file.
@@ -314,6 +315,10 @@ def process_dataset(dataset: IterableDataset, cfg: HFDatasetConvertionConfig):
         cfg: HFDatasetConvertionConfig
     """
     dataset = dataset.cast_column("audio", Audio(cfg.sampling_rate, mono=True))
+
+    # for Common Voice, "sentence" is used instead of "text" to store the transcript.
+    if 'sentence' in dataset.features:
+        dataset = dataset.rename_column("sentence", "text")
 
     if cfg.split_output_dir is None:
         basedir = cfg.resolved_output_dir
@@ -340,7 +345,7 @@ def process_dataset(dataset: IterableDataset, cfg: HFDatasetConvertionConfig):
 
 
 @hydra.main(config_name='hfds_config', config_path=None)
-def main(cfg: HFDatasetConvertionConfig):
+def main(cfg: HFDatasetConversionConfig):
     # Convert dataclass to omegaconf
     if is_dataclass(cfg):
         cfg = OmegaConf.structured(cfg)
@@ -399,7 +404,16 @@ def main(cfg: HFDatasetConvertionConfig):
 
 
 # Register the dataclass as a valid config
-ConfigStore.instance().store(name='hfds_config', node=HFDatasetConvertionConfig)
+ConfigStore.instance().store(name='hfds_config', node=HFDatasetConversionConfig)
 
 if __name__ == '__main__':
     main()
+
+"""
+python scripts/speech_recognition/convert_hf_dataset_to_nemo.py \
+        output_dir=/data/commonvoice/ \
+        path="mozilla-foundation/common_voice_11_0" \
+        name="eo" \
+        split="dev" \
+        use_auth_token=True
+"""

--- a/scripts/speech_recognition/convert_hf_dataset_to_nemo.py
+++ b/scripts/speech_recognition/convert_hf_dataset_to_nemo.py
@@ -408,12 +408,3 @@ ConfigStore.instance().store(name='hfds_config', node=HFDatasetConversionConfig)
 
 if __name__ == '__main__':
     main()
-
-"""
-python scripts/speech_recognition/convert_hf_dataset_to_nemo.py \
-        output_dir=/data/commonvoice/ \
-        path="mozilla-foundation/common_voice_11_0" \
-        name="eo" \
-        split="dev" \
-        use_auth_token=True
-"""


### PR DESCRIPTION
# What does this PR do ?

Related #5638 #5772  

Renames `sentence` column to `text` before creating manifest. Exposes `ensure_ascii` for saving the transcripts + fix naming of config class.

**Collection**: ASR

# Changelog 
- CommonVoice support for `convert_hf_dataset_to_nemo` script.

# Usage
* You can potentially add a usage example below

```bash
python scripts/speech_recognition/convert_hf_dataset_to_nemo.py \
        output_dir=/data/commonvoice/ \
        path="mozilla-foundation/common_voice_11_0" \
        name="eo" \ # esperanto
        split="validation" \
        ensure_ascii=False \
        use_auth_token=True
```

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation