### PR TITLE
[BugFix] decoder timestamp count has a mismatch when <unk> is decoded

### DIFF
--- a/nemo/collections/asr/parts/utils/decoder_timestamps_utils.py
+++ b/nemo/collections/asr/parts/utils/decoder_timestamps_utils.py
@@ -95,9 +95,9 @@ class WERBPE_TS(WERBPE):
 
             hypothesis = self.decode_tokens_to_str_with_ts(decoded_prediction)
             hypothesis = hypothesis.replace(unk, '')
-            word_ts = self.get_ts_from_decoded_prediction(decoded_prediction, hypothesis, char_ts)
+            word_ts, word_seq = self.get_ts_from_decoded_prediction(decoded_prediction, hypothesis, char_ts)
 
-            hypotheses.append(hypothesis)
+            hypotheses.append(" ".join(word_seq))
             timestamps.append(timestamp_list)
             word_timestamps.append(word_ts)
         return hypotheses, timestamps, word_timestamps
@@ -110,7 +110,7 @@ class WERBPE_TS(WERBPE):
         token_list = self.decoding.tokenizer.ids_to_tokens(tokens)
         return token_list
 
-    def get_ts_from_decoded_prediction(self, decoded_prediction: List[str], hypothesis: List[str], char_ts: List[str]):
+    def get_ts_from_decoded_prediction(self, decoded_prediction: List[str], hypothesis: str, char_ts: List[str]) -> Tuple[List[List[float]], List[str]]:
         decoded_char_list = self.decoding.tokenizer.ids_to_tokens(decoded_prediction)
         stt_idx, end_idx = 0, len(decoded_char_list) - 1
         stt_ch_idx, end_ch_idx = 0, 0
@@ -122,26 +122,29 @@ class WERBPE_TS(WERBPE):
             # If the symbol is space and not an end of the utterance, move on
             if idx != end_idx and (space == ch and space in decoded_char_list[idx + 1]):
                 continue
-            # If the symbol is unkown symbol such as '<unk>' symbol, move on
-            elif ch in ['<unk>']:
-                continue
 
+            # If the word does not containg space (the start of the word token), keep counting
             if (idx == stt_idx or space == decoded_char_list[idx - 1] or (space in ch and len(ch) > 1)) and (
                 ch != space
             ):
                 _stt = char_ts[idx]
                 stt_ch_idx = idx
                 word_open_flag = True
-
-            if word_open_flag and ch != space and (idx == end_idx or space in decoded_char_list[idx + 1]):
+            
+            # If this char has `word_open_flag=True` and meets any of one of the following condition:
+            # (1) last word (2) unknown word (3) start symbol in the following word,
+            # close the `word_open_flag` and add the word to the `word_seq` list.
+            close_cond = idx == end_idx or ch in ['<unk>'] or space in decoded_char_list[idx + 1]
+            if (word_open_flag and ch != space) and close_cond:
                 _end = round(char_ts[idx] + self.time_stride, 2)
                 end_ch_idx = idx
                 word_open_flag = False
                 word_ts.append([_stt, _end])
                 stitched_word = ''.join(decoded_char_list[stt_ch_idx : end_ch_idx + 1]).replace(space, '')
                 word_seq.append(stitched_word)
+
         assert len(word_ts) == len(hypothesis.split()), "Text hypothesis does not match word timestamps."
-        return word_ts
+        return word_ts, word_seq
 
 
 class WER_TS(WER):

--- a/nemo/collections/asr/parts/utils/decoder_timestamps_utils.py
+++ b/nemo/collections/asr/parts/utils/decoder_timestamps_utils.py
@@ -110,7 +110,9 @@ class WERBPE_TS(WERBPE):
         token_list = self.decoding.tokenizer.ids_to_tokens(tokens)
         return token_list
 
-    def get_ts_from_decoded_prediction(self, decoded_prediction: List[str], hypothesis: str, char_ts: List[str]) -> Tuple[List[List[float]], List[str]]:
+    def get_ts_from_decoded_prediction(
+        self, decoded_prediction: List[str], hypothesis: str, char_ts: List[str]
+    ) -> Tuple[List[List[float]], List[str]]:
         decoded_char_list = self.decoding.tokenizer.ids_to_tokens(decoded_prediction)
         stt_idx, end_idx = 0, len(decoded_char_list) - 1
         stt_ch_idx, end_ch_idx = 0, 0
@@ -130,7 +132,7 @@ class WERBPE_TS(WERBPE):
                 _stt = char_ts[idx]
                 stt_ch_idx = idx
                 word_open_flag = True
-            
+
             # If this char has `word_open_flag=True` and meets any of one of the following condition:
             # (1) last word (2) unknown word (3) start symbol in the following word,
             # close the `word_open_flag` and add the word to the `word_seq` list.


### PR DESCRIPTION
Signed-off-by: Taejin Park <tango4j@gmail.com>

# What does this PR do ?


decoder timestamp count has a mismatch when <unk> is decoded.
Instead of having a temporary solution to ignore <unk>, the script is changed to 
output <unk> as decoded output with a correct timestamps.

https://github.com/NVIDIA/NeMo/pull/5481/files

In this previous PR, the <unk> symbol is coded to be ignored, 
but it still causes mismatch errors when <unk> is in the middle of two isolated one-token words.

This PR fixes such errors.


**Collection**: [Note which collection this PR will affect]
ASR

# Changelog 

`ctc_decoder_predictions_tensor_with_ts()` in decoder_timestamps_utils.py
is changed to output the actual decoded text with the matching word timestamps.

# Usage

```python
python offline_diar_with_asr_infer.py \
    diarizer.manifest_filepath=<path to manifest file> \
    diarizer.out_dir='demo_asr_output' \
    diarizer.speaker_embeddings.model_path=<pretrained modelname or path to .nemo> \
    diarizer.asr.model_path=<pretrained modelname or path to .nemo> \
    diarizer.asr.parameters.asr_based_vad=True \
    diarizer.speaker_embeddings.parameters.save_embeddings=False
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation


## Who can review?

ASR contributors

# Additional Information
* Related to # (issue)
