### PR TITLE
NFA samples fix

### DIFF
--- a/tools/nemo_forced_aligner/README.md
+++ b/tools/nemo_forced_aligner/README.md
@@ -63,7 +63,7 @@ For each utterance specified in a line of `manifest_filepath`, several CTM files
 * a CTM file containing word-level alignments at `<output_dir>/words/<utt_id>.ctm`,
 * if `additional_ctm_grouping_separator` is specified, there will also be a CTM file containing those segments at `output_dir/additional_segments`.
 Each CTM file will contain lines of the format:
-`<utt_id> 1 <start time in samples> <duration in samples> <text, ie token/word/segment>`.
+`<utt_id> 1 <start time in seconds> <duration in seconds> <text, ie token/word/segment>`.
 Note the second item in the line (the 'channel ID', which is required by the CTM file format) is always 1, as NFA operates on single channel audio.
 
 # Output JSON manifest file format

--- a/tools/nemo_forced_aligner/align.py
+++ b/tools/nemo_forced_aligner/align.py
@@ -19,7 +19,6 @@ from typing import Optional
 import torch
 from omegaconf import OmegaConf
 from utils.data_prep import (
-    get_audio_sr,
     get_batch_starts_ends,
     get_batch_tensors_and_boundary_info,
     get_manifest_lines_batch,
@@ -188,13 +187,6 @@ def main(cfg: AlignmentConfig):
             " Currently only instances of EncDecCTCModels are supported"
         )
 
-    audio_sr = get_audio_sr(cfg.manifest_filepath)
-    logging.info(
-        f"Detected audio sampling rate {audio_sr}Hz in first audio in manifest at {cfg.manifest_filepath}. "
-        "Will assume all audios in manifest have this sampling rate. Sampling rate will be used to determine "
-        "timestamps in output CTM."
-    )
-
     if cfg.minimum_timestamp_duration > 0:
         logging.warning(
             f"cfg.minimum_timestamp_duration has been set to {cfg.minimum_timestamp_duration} seconds. "
@@ -242,7 +234,6 @@ def main(cfg: AlignmentConfig):
             cfg.remove_blank_tokens_from_ctm,
             cfg.audio_filepath_parts_in_utt_id,
             cfg.minimum_timestamp_duration,
-            audio_sr,
         )
 
         make_ctm(
@@ -255,7 +246,6 @@ def main(cfg: AlignmentConfig):
             False,  # dont try to remove blank tokens because we dont expect them to be there anyway
             cfg.audio_filepath_parts_in_utt_id,
             cfg.minimum_timestamp_duration,
-            audio_sr,
         )
 
         if cfg.additional_ctm_grouping_separator:
@@ -269,7 +259,6 @@ def main(cfg: AlignmentConfig):
                 False,  # dont try to remove blank tokens because we dont expect them to be there anyway
                 cfg.audio_filepath_parts_in_utt_id,
                 cfg.minimum_timestamp_duration,
-                audio_sr,
             )
 
     make_new_manifest(

--- a/tools/nemo_forced_aligner/utils/data_prep.py
+++ b/tools/nemo_forced_aligner/utils/data_prep.py
@@ -67,22 +67,6 @@ def is_entry_in_all_lines(manifest_filepath, entry):
     return True
 
 
-def get_audio_sr(manifest_filepath):
-    """
-    Measure the sampling rate of the audio file in the first line
-    of the manifest at manifest_filepath
-    """
-    with open(manifest_filepath, "r") as f_manifest:
-        first_line = json.loads(f_manifest.readline())
-
-    audio_file = first_line["audio_filepath"]
-    if not os.path.exists(audio_file):
-        raise RuntimeError(f"Did not find filepath {audio_file} which was specified in manifest {manifest_filepath}.")
-
-    with sf.SoundFile(audio_file, "r") as f_audio:
-        return f_audio.samplerate
-
-
 def get_manifest_lines_batch(manifest_filepath, start, end):
     manifest_lines_batch = []
     with open(manifest_filepath, "r") as f:

--- a/tools/nemo_forced_aligner/utils/make_output_files.py
+++ b/tools/nemo_forced_aligner/utils/make_output_files.py
@@ -108,7 +108,6 @@ def make_ctm(
     remove_blank_tokens_from_ctm,
     audio_filepath_parts_in_utt_id,
     minimum_timestamp_duration,
-    audio_sr,
 ):
     """
     Function to save CTM files for all the utterances in the incoming batch.
@@ -145,8 +144,8 @@ def make_ctm(
                 start_sample = boundary_info_["t_start"] * timestep_to_sample_ratio
                 end_sample = (boundary_info_["t_end"] + 1) * timestep_to_sample_ratio - 1
 
-                start_time = start_sample / audio_sr
-                end_time = end_sample / audio_sr
+                start_time = start_sample / model.cfg.sample_rate
+                end_time = end_sample / model.cfg.sample_rate
 
                 if minimum_timestamp_duration > 0 and minimum_timestamp_duration > end_time - start_time:
                     # make the predicted duration of the token/word/segment longer, growing it outwards equal


### PR DESCRIPTION
# What does this PR do ?

Correct NFA README typo and fix an NFA error that would give incorrect timestamps when the input audio had a different sampling rate to that of the ASR model.

**Collection**: tools/nemo_forced_aligner

# Changelog 
- Correct NFA README typo: 'samples' -> 'seconds'
- Fix timestamps bug: change variable 'audio_sr' -> 'model.cfg.sample_rate'

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ N/A ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ N/A ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ N/A ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Addressing question raised in https://github.com/NVIDIA/NeMo/discussions/5848. 
