### PR TITLE
Set providers for onnxruntime inference session

### DIFF
--- a/tutorials/asr/ASR_with_NeMo.ipynb
+++ b/tutorials/asr/ASR_with_NeMo.ipynb
@@ -1077,7 +1077,7 @@
                 "\n",
                 "quartznet.export('qn.onnx')\n",
                 "\n",
-                "ort_session = onnxruntime.InferenceSession('qn.onnx')\n",
+                "ort_session = onnxruntime.InferenceSession('qn.onnx', providers=['TensorrtExecutionProvider', 'CUDAExecutionProvider', 'CPUExecutionProvider'])\n",
                 "\n",
                 "with tempfile.TemporaryDirectory() as tmpdir:\n",
                 "    with open(os.path.join(tmpdir, 'manifest.json'), 'w') as fp:\n",


### PR DESCRIPTION
Signed-off-by: athitten <abhishreetm@gmail.com>

# What does this PR do ?

Explicitly sets the providers parameter when instantiating InferenceSession with onnxruntime.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
