### PR TITLE
Moved eval notebook data to aws

### DIFF
--- a/tutorials/tts/Evaluation_MelCepstralDistortion.ipynb
+++ b/tutorials/tts/Evaluation_MelCepstralDistortion.ipynb
@@ -188,23 +188,7 @@
    "id": "6efac554",
    "metadata": {},
    "source": [
-    "For this tutorial, we have already generated mels from trained [FastPitch](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nemo/models/tts_en_fastpitch) and [RAD-TTS](https://github.com/NVIDIA/radtts) models, and we have the ground truth sample that they correspond to. We'll untar them from `.../NeMo/tutorials/tts/audio_samples/MCD_DTW_examples.tar`.\n",
-    "\n",
-    "(Note: If you are using Google Colab, you will need to uncomment and run the following cell to download them, first.)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b4847fbc",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Uncomment and run if using Colab\n",
-    "\n",
-    "# !wget https://raw.githubusercontent.com/nvidia/NeMo/$BRANCH/tutorials/tts/audio_samples/MCD_DTW_examples.tar\n",
-    "# !mkdir audio_samples/\n",
-    "# !mv MCD_DTW_examples.tar audio_samples/"
+    "For this tutorial, we have already generated mels from trained [FastPitch](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nemo/models/tts_en_fastpitch) and [RAD-TTS](https://github.com/NVIDIA/radtts) models, and we have the ground truth sample that they correspond to. Let's first download the tarball with the data and expand it."
    ]
   },
   {
@@ -215,7 +199,8 @@
    "outputs": [],
    "source": [
     "# Untar the example files.\n",
-    "! cd audio_samples/ && tar -xvf MCD_DTW_examples.tar && cd .."
+    "!wget https://tts-tutorial-data.s3.us-east-2.amazonaws.com/MCD_DTW_examples.tar\n",
+    "!tar -xvf MCD_DTW_examples.tar"
    ]
   },
   {
@@ -236,8 +221,8 @@
    "outputs": [],
    "source": [
     "## Generate spectrograms\n",
-    "gt_mels = wav2mel(\"audio_samples/MCD_DTW/gt/sample_0.wav\")\n",
-    "synt_mels = np.load(\"audio_samples/MCD_DTW/fastpitch/mels/mels_0.npy\")\n",
+    "gt_mels = wav2mel(\"MCD_DTW/gt/sample_0.wav\")\n",
+    "synt_mels = np.load(\"MCD_DTW/fastpitch/mels/mels_0.npy\")\n",
     "\n",
     "## Generate MFCCs\n",
     "gt_mfcc = mel2mfcc(gt_mels)\n",
@@ -262,11 +247,11 @@
    "outputs": [],
    "source": [
     "print(\"Ground truth audio:\")\n",
-    "audio_gt, sr_gt = librosa.load(\"audio_samples/MCD_DTW/gt/sample_0.wav\")\n",
+    "audio_gt, sr_gt = librosa.load(\"MCD_DTW/gt/sample_0.wav\")\n",
     "ipd.display(ipd.Audio(audio_gt, rate=sr_gt))\n",
     "\n",
     "print(\"Synthesized audio:\")\n",
-    "audio_fp, sr_fp = librosa.load(\"audio_samples/MCD_DTW/fastpitch/audio/sample_0.wav\")\n",
+    "audio_fp, sr_fp = librosa.load(\"MCD_DTW/fastpitch/audio/sample_0.wav\")\n",
     "ipd.display(ipd.Audio(audio_fp, rate=sr_fp))"
    ]
   },
@@ -537,9 +522,9 @@
    "outputs": [],
    "source": [
     "%%capture --no-display\n",
-    "mels_dir_m1 = \"audio_samples/MCD_DTW/fastpitch/mels/\"\n",
-    "mels_dir_m2 = \"audio_samples/MCD_DTW/radtts/mels/\"\n",
-    "mels_dir_gt = \"audio_samples/MCD_DTW/gt/\"\n",
+    "mels_dir_m1 = \"MCD_DTW/fastpitch/mels/\"\n",
+    "mels_dir_m2 = \"MCD_DTW/radtts/mels/\"\n",
+    "mels_dir_gt = \"MCD_DTW/gt/\"\n",
     "\n",
     "mcds_m1 = cal_mcd_dir(mels_dir_m1, mels_dir_gt)  # FastPitch\n",
     "mcds_m2 = cal_mcd_dir(mels_dir_m2, mels_dir_gt)  # RAD-TTS"


### PR DESCRIPTION
Signed-off-by: Jocelyn Huang <jocelynh@nvidia.com>

# What does this PR do ?

Moves the MCD DTW data tarball to AWS instead of storing it in NeMo.
Paths tested locally again.

**Collection**: TTS