### PR TITLE
Fix bug where GPT always enabled distopt overlapped param sync

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import itertools
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, List, Optional, Union
 
 import numpy as np
 import torch

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -218,18 +218,6 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         else:
             self._optimizer_param_groups = get_params_for_weight_decay_optimization(self.model)
 
-    def setup_optimization(
-        self, optim_config: Optional[Union[DictConfig, Dict]] = None, optim_kwargs: Optional[Dict[str, Any]] = None,
-    ):
-        optim_kwargs = {} if optim_kwargs is None else optim_kwargs.copy()
-        if self.with_distributed_adam:
-
-            # Enable overlapped param sync by default
-            if 'overlap_param_sync' not in optim_kwargs:
-                optim_kwargs['overlap_param_sync'] = True
-
-        return super().setup_optimization(optim_config=optim_config, optim_kwargs=optim_kwargs)
-
     def configure_optimizers(self):
 
         if self.with_distributed_adam:


### PR DESCRIPTION
# What does this PR do ?

With the changes in https://github.com/NVIDIA/NeMo/pull/5684, I observe that GPT always sets `overlap_param_sync=True`. This PR allows the user to manually override that option, which now `False` by default.

**Collection**: NLP

# Changelog 
- Fix bug where GPT always enabled distopt overlapped param sync

# Usage

When using the `distributed_fused_adam` optimizer, set `overlap_param_sync: True` in the optimizer config.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to https://github.com/NVIDIA/NeMo/pull/5684
