### PR TITLE
Use module-based k2 import guard

### DIFF
--- a/nemo/collections/asr/losses/lattice_losses.py
+++ b/nemo/collections/asr/losses/lattice_losses.py
@@ -102,11 +102,6 @@ class LatticeLoss(Loss):
 
         # we assume that self._blank + 1 == num_classes
         if backend == "k2":
-            # use k2 import guard
-            from nemo.core.utils.k2_utils import k2_import_guard
-
-            k2_import_guard()
-
             if criterion_type == "ml":
                 from nemo.collections.asr.parts.k2.ml_loss import MLLoss as K2Loss
             elif criterion_type == "map":

--- a/nemo/collections/asr/modules/graph_decoder.py
+++ b/nemo/collections/asr/modules/graph_decoder.py
@@ -112,11 +112,6 @@ class ViterbiDecoderWithGraph(NeuralModule):
 
         # we assume that self._blank + 1 == num_classes
         if backend == "k2":
-            # use k2 import guard
-            from nemo.core.utils.k2_utils import k2_import_guard
-
-            k2_import_guard()
-
             if self.dec_type == "topo":
                 from nemo.collections.asr.parts.k2.graph_decoders import BaseDecoder as Decoder
             elif self.dec_type == "token_lm":

--- a/nemo/collections/asr/parts/k2/classes.py
+++ b/nemo/collections/asr/parts/k2/classes.py
@@ -65,11 +65,6 @@ class ASRK2Mixin(ABC):
         This method is expected to run after the __init__ which sets self._cfg
         self._cfg is expected to have the attribute graph_module_cfg
         """
-        # use k2 import guard
-        from nemo.core.utils.k2_utils import k2_import_guard
-
-        k2_import_guard()
-
         if not hasattr(self, "_cfg"):
             raise ValueError("self._cfg must be set before calling _init_k2().")
         if not hasattr(self._cfg, "graph_module_cfg") or self._cfg.graph_module_cfg is None:

--- a/nemo/collections/asr/parts/k2/graph_compilers.py
+++ b/nemo/collections/asr/parts/k2/graph_compilers.py
@@ -33,12 +33,7 @@ import torch
 from nemo.collections.asr.parts.k2.topologies import build_topo
 from nemo.collections.asr.parts.k2.utils import compose_with_self_loops, intersect_with_self_loops
 
-# use k2 import guard
-# fmt: off
-from nemo.core.utils.k2_utils import k2_import_guard # isort:skip
-k2_import_guard()
-import k2 # isort:skip
-# fmt: on
+from nemo.core.utils.k2_guard import k2  # import k2 from guard module
 
 
 class CtcTopologyCompiler(object):
@@ -55,9 +50,6 @@ class CtcTopologyCompiler(object):
         topo_with_self_loops: bool = True,
         device: torch.device = torch.device("cpu"),
     ):
-        # use k2 import guard
-        k2_import_guard()
-
         self.topo_type = topo_type
         self.device = device
         self.base_graph = k2.arc_sort(build_topo(topo_type, list(range(num_classes)), topo_with_self_loops)).to(

--- a/nemo/collections/asr/parts/k2/graph_decoders.py
+++ b/nemo/collections/asr/parts/k2/graph_decoders.py
@@ -28,14 +28,8 @@ from nemo.collections.asr.parts.k2.utils import (
     prep_padded_densefsavec,
     shift_labels_inpl,
 )
+from nemo.core.utils.k2_guard import k2  # import k2 from guard module
 from nemo.utils import logging
-
-# use k2 import guard
-# fmt: off
-from nemo.core.utils.k2_utils import k2_import_guard # isort:skip
-k2_import_guard()
-import k2 # isort:skip
-# fmt: on
 
 
 class BaseDecoder(object):
@@ -57,8 +51,6 @@ class BaseDecoder(object):
         topo_with_self_loops: bool = True,
         device: torch.device = torch.device("cpu"),
     ):
-        # use k2 import guard
-        k2_import_guard()
 
         if cfg is not None:
             intersect_pruned = cfg.get("intersect_pruned", intersect_pruned)

--- a/nemo/collections/asr/parts/k2/map_loss.py
+++ b/nemo/collections/asr/parts/k2/map_loss.py
@@ -42,14 +42,8 @@ from nemo.collections.asr.parts.k2.utils import (
     prep_padded_densefsavec,
     shift_labels_inpl,
 )
+from nemo.core.utils.k2_guard import k2  # import k2 from guard module
 from nemo.utils import logging
-
-# use k2 import guard
-# fmt: off
-from nemo.core.utils.k2_utils import k2_import_guard # isort:skip
-k2_import_guard()
-import k2 # isort:skip
-# fmt: on
 
 
 class MAPLoss(torch.nn.Module):
@@ -78,9 +72,6 @@ class MAPLoss(torch.nn.Module):
         intersect_conf: GraphIntersectDenseConfig = GraphIntersectDenseConfig(),
         boost_coeff: float = 0.0,
     ):
-        # use k2 import guard
-        k2_import_guard()
-
         super().__init__()
         if cfg is not None:
             topo_type = cfg.get("topo_type", topo_type)

--- a/nemo/collections/asr/parts/k2/ml_loss.py
+++ b/nemo/collections/asr/parts/k2/ml_loss.py
@@ -40,12 +40,7 @@ from nemo.collections.asr.parts.k2.utils import (
     prep_padded_densefsavec,
 )
 
-# use k2 import guard
-# fmt: off
-from nemo.core.utils.k2_utils import k2_import_guard # isort:skip
-k2_import_guard()
-import k2 # isort:skip
-# fmt: on
+from nemo.core.utils.k2_guard import k2  # import k2 from guard module
 
 
 class MLLoss(torch.nn.Module):
@@ -71,9 +66,6 @@ class MLLoss(torch.nn.Module):
         graph_type: str = "topo",
         token_lm: Optional[Union['k2.Fsa', str]] = None,
     ):
-        # use k2 import guard
-        k2_import_guard()
-
         super().__init__()
         if cfg is not None:
             topo_type = cfg.get("topo_type", topo_type)

--- a/nemo/collections/asr/parts/k2/topologies.py
+++ b/nemo/collections/asr/parts/k2/topologies.py
@@ -14,12 +14,7 @@
 
 from typing import List
 
-# use k2 import guard
-# fmt: off
-from nemo.core.utils.k2_utils import k2_import_guard # isort:skip
-k2_import_guard()
-import k2 # isort:skip
-# fmt: on
+from nemo.core.utils.k2_guard import k2  # import k2 from guard module
 
 
 def build_topo(name: str, tokens: List[int], with_self_loops: bool = True) -> 'k2.Fsa':

--- a/nemo/collections/asr/parts/k2/utils.py
+++ b/nemo/collections/asr/parts/k2/utils.py
@@ -33,14 +33,8 @@ from typing import List, Optional, Tuple, Union
 
 import torch
 
+from nemo.core.utils.k2_guard import k2  # import k2 from guard module
 from nemo.utils import logging
-
-# use k2 import guard
-# fmt: off
-from nemo.core.utils.k2_utils import k2_import_guard # isort:skip
-k2_import_guard()
-import k2 # isort:skip
-# fmt: on
 
 
 def create_supervision(input_lengths: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:

--- a/nemo/core/utils/__init__.py
+++ b/nemo/core/utils/__init__.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nemo.core.utils import k2_utils, numba_utils, process_launcher
+from nemo.core.utils import numba_utils, process_launcher

--- a/nemo/core/utils/k2_guard.py
+++ b/nemo/core/utils/k2_guard.py
@@ -12,7 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Tuple
+"""
+Guard for importing optional NeMo dependency k2.
+Contains checks for k2 availability and version.
+Use `from nemo.core.utils.k2_guard import k2` to import k2 instead of direct import.
+If there is an error, the module will raise an exception with a helpful message.
+"""
+
+import textwrap
 
 __K2_MINIMUM_MAJOR_VERSION__ = 1
 __K2_MINIMUM_MINOR_VERSION__ = 11
@@ -26,39 +33,24 @@ K2_INSTALLATION_MESSAGE = (
     "It is advised to always install k2 using setup.sh only, "
     "as different versions of k2 may not interact with the NeMo code as expected."
 )
-K2_IMPORT_SUCCESS = "Successfully imported k2."
 
-
-def k2_is_available() -> Tuple[bool, str]:
-    try:
-        import k2
-
-        return True, K2_IMPORT_SUCCESS
-    except (ImportError, ModuleNotFoundError):
-        pass
-    return False, K2_INSTALLATION_MESSAGE
-
-
-def k2_satisfies_minimum_version() -> Tuple[bool, str]:
+try:
     import k2
 
-    k2_major_version, k2_minor_version = k2.__dev_version__.split(".")[:2]
-    ver_satisfies = (
-        int(k2_major_version) >= __K2_MINIMUM_MAJOR_VERSION__ and int(k2_minor_version) >= __K2_MINIMUM_MINOR_VERSION__
+    k2_major_version, k2_minor_version = map(int, k2.__dev_version__.split(".")[:2])
+    k2_version = (k2_major_version, k2_minor_version)
+    k2_minimum_required_version = (
+        __K2_MINIMUM_MAJOR_VERSION__,
+        __K2_MINIMUM_MINOR_VERSION__,
     )
-    return (
-        ver_satisfies,
-        (
-            f"Minimum required k2 version: {__K2_MINIMUM_MAJOR_VERSION__}.{__K2_MINIMUM_MINOR_VERSION__};\n"
-            f"Installed k2 version: {k2_major_version}.{k2_minor_version}"
-        ),
-    )
-
-
-def k2_import_guard():
-    avail, msg = k2_is_available()
-    if not avail:
-        raise ModuleNotFoundError(msg)
-    ver_ge, msg = k2_satisfies_minimum_version()
-    if not ver_ge:
-        raise ImportError(msg)
+    if k2_version < k2_minimum_required_version:
+        raise ImportError(
+            textwrap.dedent(
+                f"""
+                Minimum required k2 version: {__K2_MINIMUM_MAJOR_VERSION__}.{__K2_MINIMUM_MINOR_VERSION__};
+                Installed k2 version: {k2_major_version}.{k2_minor_version}
+                """
+            )
+        )
+except ModuleNotFoundError:
+    raise ModuleNotFoundError(K2_INSTALLATION_MESSAGE)

--- a/nemo/core/utils/k2_guard.py
+++ b/nemo/core/utils/k2_guard.py
@@ -21,8 +21,13 @@ If there is an error, the module will raise an exception with a helpful message.
 
 import textwrap
 
-__K2_MINIMUM_MAJOR_VERSION__ = 1
-__K2_MINIMUM_MINOR_VERSION__ = 11
+from packaging.version import Version
+from pytorch_lightning.utilities.imports import package_available
+
+__K2_MINIMUM_MAJOR_VERSION = 1
+__K2_MINIMUM_MINOR_VERSION = 111
+
+__K2_MINIMUM_VERSION = Version(f"{__K2_MINIMUM_MAJOR_VERSION}.{__K2_MINIMUM_MINOR_VERSION}")
 
 K2_INSTALLATION_MESSAGE = (
     "Could not import `k2`.\n"
@@ -34,23 +39,19 @@ K2_INSTALLATION_MESSAGE = (
     "as different versions of k2 may not interact with the NeMo code as expected."
 )
 
-try:
-    import k2
-
-    k2_major_version, k2_minor_version = map(int, k2.__dev_version__.split(".")[:2])
-    k2_version = (k2_major_version, k2_minor_version)
-    k2_minimum_required_version = (
-        __K2_MINIMUM_MAJOR_VERSION__,
-        __K2_MINIMUM_MINOR_VERSION__,
-    )
-    if k2_version < k2_minimum_required_version:
-        raise ImportError(
-            textwrap.dedent(
-                f"""
-                Minimum required k2 version: {__K2_MINIMUM_MAJOR_VERSION__}.{__K2_MINIMUM_MINOR_VERSION__};
-                Installed k2 version: {k2_major_version}.{k2_minor_version}
-                """
-            )
-        )
-except ModuleNotFoundError:
+if not package_available("k2"):
     raise ModuleNotFoundError(K2_INSTALLATION_MESSAGE)
+
+import k2  # noqa: E402
+
+__k2_version = Version(k2.__dev_version__)
+
+if __k2_version < __K2_MINIMUM_VERSION:
+    raise ImportError(
+        textwrap.dedent(
+            f"""
+            Minimum required k2 version: {__K2_MINIMUM_VERSION};
+            Installed k2 version: {__k2_version}
+            """
+        )
+    )

--- a/nemo/core/utils/k2_guard.py
+++ b/nemo/core/utils/k2_guard.py
@@ -25,7 +25,7 @@ from packaging.version import Version
 from pytorch_lightning.utilities.imports import package_available
 
 __K2_MINIMUM_MAJOR_VERSION = 1
-__K2_MINIMUM_MINOR_VERSION = 111
+__K2_MINIMUM_MINOR_VERSION = 11
 
 __K2_MINIMUM_VERSION = Version(f"{__K2_MINIMUM_MAJOR_VERSION}.{__K2_MINIMUM_MINOR_VERSION}")
 


### PR DESCRIPTION
Signed-off-by: Vladimir Bataev <vbataev@nvidia.com>

# What does this PR do ?

Simplify `k2` library import guard: use module-based approach.

**Advantages:**
- less code is required for using guard
- no need to suppress linters (isort, etc.)

**Collection**: [ASR]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage

```python
from nemo.core.utils.k2_guard import k2  # import k2 with performing all required checks
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
