### PR TITLE
Default RNNT loss to int64 targets

### DIFF
--- a/nemo/collections/asr/losses/rnnt.py
+++ b/nemo/collections/asr/losses/rnnt.py
@@ -322,10 +322,10 @@ class RNNTLoss(Loss):
 
     @typecheck()
     def forward(self, log_probs, targets, input_lengths, target_lengths):
-        # Cast to int 32
-        targets = targets.int()
-        input_lengths = input_lengths.int()
-        target_lengths = target_lengths.int()
+        # Cast to int 64
+        targets = targets.long()
+        input_lengths = input_lengths.long()
+        target_lengths = target_lengths.long()
 
         max_logit_len = input_lengths.max()
         max_targets_len = target_lengths.max()

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_numpy.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_numpy.py
@@ -50,9 +50,9 @@ def check_dim(var, dim, name):
 
 def certify_inputs(log_probs, labels, lengths, label_lengths):
     # check_type(log_probs, torch.float32, "log_probs")
-    check_type(labels, torch.int32, "labels")
-    check_type(label_lengths, torch.int32, "label_lengths")
-    check_type(lengths, torch.int32, "lengths")
+    check_type(labels, torch.int64, "labels")
+    check_type(label_lengths, torch.int64, "label_lengths")
+    check_type(lengths, torch.int64, "lengths")
     check_contiguous(log_probs, "log_probs")
     check_contiguous(labels, "labels")
     check_contiguous(label_lengths, "label_lengths")
@@ -357,8 +357,8 @@ if __name__ == '__main__':
     torch.manual_seed(0)
 
     acts = torch.randn(1, 2, 5, 3)
-    labels = torch.tensor([[0, 2, 1, 2]], dtype=torch.int32)
-    act_lens = torch.tensor([2], dtype=torch.int32)
-    label_lens = torch.tensor([len(labels[0])], dtype=torch.int32)
+    labels = torch.tensor([[0, 2, 1, 2]], dtype=torch.int64)
+    act_lens = torch.tensor([2], dtype=torch.int64)
+    label_lens = torch.tensor([len(labels[0])], dtype=torch.int64)
 
     loss_val = loss(acts, labels, act_lens, label_lens)

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
@@ -371,9 +371,9 @@ def check_dim(var, dim, name):
 
 def certify_inputs(log_probs, labels, lengths, label_lengths):
     # check_type(log_probs, torch.float32, "log_probs")
-    check_type(labels, torch.int32, "labels")
-    check_type(label_lengths, torch.int32, "label_lengths")
-    check_type(lengths, torch.int32, "lengths")
+    check_type(labels, torch.int64, "labels")
+    check_type(label_lengths, torch.int64, "label_lengths")
+    check_type(lengths, torch.int64, "lengths")
     check_contiguous(log_probs, "log_probs")
     check_contiguous(labels, "labels")
     check_contiguous(label_lengths, "label_lengths")

--- a/tests/collections/asr/numba/rnnt_loss/test_rnnt_pytorch.py
+++ b/tests/collections/asr/numba/rnnt_loss/test_rnnt_pytorch.py
@@ -42,9 +42,9 @@ def wrap_and_call(fn, acts, labels, device):
 
     lengths = [acts.shape[1]] * acts.shape[0]
     label_lengths = [len(l) for l in labels]
-    labels = torch.IntTensor(labels)
-    lengths = torch.IntTensor(lengths)
-    label_lengths = torch.IntTensor(label_lengths)
+    labels = torch.LongTensor(labels)
+    lengths = torch.LongTensor(lengths)
+    label_lengths = torch.LongTensor(label_lengths)
     if 'cuda' in device:
         labels = labels.cuda()
         lengths = lengths.cuda()
@@ -422,13 +422,13 @@ class TestRNNTLossPytorch:
         # run 1
         acts1 = torch.matmul(mid1, base_layer)  # [1, 4, 3, 5]
         pt_cost1, _ = wrap_and_call(fn_pt, acts1, labels1, device)
-        pt_grads1 = base_layer.grad.clone().cpu().numpy()
+        pt_grads1 = base_layer.grad.detach().cpu().numpy()
 
         zero_grad()
 
         acts1 = torch.matmul(mid1, base_layer)  # [1, 4, 3, 5]
         np_cost1, _ = wrap_and_call(fn_np, acts1, labels1, device)
-        np_grads1 = base_layer.grad.clone().cpu().numpy()
+        np_grads1 = base_layer.grad.detach().cpu().numpy()
 
         zero_grad()
 

--- a/tests/collections/asr/numba/rnnt_loss/utils/test_gpu_rnnt_kernel.py
+++ b/tests/collections/asr/numba/rnnt_loss/utils/test_gpu_rnnt_kernel.py
@@ -67,14 +67,14 @@ class TestRNNTCUDAKernels:
             stream = cuda.default_stream()
 
         x_c = torch.tensor(x, device=device, dtype=torch.float32)
-        labels_c = torch.tensor(labels, device=device, dtype=torch.int32)
+        labels_c = torch.tensor(labels, device=device, dtype=torch.int64)
 
         # Allocate workspace memory
         denom = torch.zeros(B * T * U, device=device, dtype=x_c.dtype)
         alphas = torch.zeros(B * T * U, device=device, dtype=x_c.dtype)
         llForward = torch.zeros(B, device=device, dtype=x_c.dtype)
-        input_lengths = torch.tensor([T], dtype=torch.int32, device=device)
-        label_lengths = torch.tensor([len(labels[0])], dtype=torch.int32, device=device)
+        input_lengths = torch.tensor([T], dtype=torch.int64, device=device)
+        label_lengths = torch.tensor([len(labels[0])], dtype=torch.int64, device=device)
 
         # certify input data
         certify_inputs(x_c, labels_c, input_lengths, label_lengths)
@@ -135,14 +135,14 @@ class TestRNNTCUDAKernels:
             stream = cuda.default_stream()
 
         x_c = torch.tensor(x, device=device, dtype=torch.float32)
-        labels_c = torch.tensor(labels, device=device, dtype=torch.int32)
+        labels_c = torch.tensor(labels, device=device, dtype=torch.int64)
 
         # Allocate workspace memory
         denom = torch.zeros(B * T * U, device=device, dtype=x_c.dtype)
         betas = torch.zeros(B * T * U, device=device, dtype=x_c.dtype)
         llBackward = torch.zeros(B, device=device, dtype=x_c.dtype)
-        input_lengths = torch.tensor([T], dtype=torch.int32, device=device)
-        label_lengths = torch.tensor([len(labels[0])], dtype=torch.int32, device=device)
+        input_lengths = torch.tensor([T], dtype=torch.int64, device=device)
+        label_lengths = torch.tensor([len(labels[0])], dtype=torch.int64, device=device)
 
         # certify input data
         certify_inputs(x_c, labels_c, input_lengths, label_lengths)
@@ -189,9 +189,9 @@ class TestRNNTCUDAKernels:
 
         # Numpy kernel
         x = random.randn(*original_shape)
-        labels = torch.from_numpy(np.array([[1, 1, 1, 2, 2, 2, 1, 2, 2, 1]], dtype=np.int32))  # [1, 10]
-        audio_len = torch.from_numpy(np.array([T], dtype=np.int32))
-        label_len = torch.from_numpy(np.array([U - 1], dtype=np.int32))
+        labels = torch.from_numpy(np.array([[1, 1, 1, 2, 2, 2, 1, 2, 2, 1]], dtype=np.int64))  # [1, 10]
+        audio_len = torch.from_numpy(np.array([T], dtype=np.int64))
+        label_len = torch.from_numpy(np.array([U - 1], dtype=np.int64))
         blank_idx = 0
 
         x_np = torch.from_numpy(x)
@@ -220,7 +220,7 @@ class TestRNNTCUDAKernels:
             stream = cuda.default_stream()
 
         x_c = torch.tensor(x, device=device, dtype=torch.float32)
-        labels_c = torch.tensor(labels, device=device, dtype=torch.int32)
+        labels_c = labels.clone().to(device=device, dtype=torch.int64)
 
         # Allocate workspace memory
         denom = torch.zeros(B * T * U, device=device, dtype=x_c.dtype)
@@ -228,8 +228,8 @@ class TestRNNTCUDAKernels:
         betas = torch.zeros(B * T * U, device=device, dtype=x_c.dtype)
         llForward = torch.zeros(B, device=device, dtype=x_c.dtype)
         llBackward = torch.zeros(B, device=device, dtype=x_c.dtype)
-        input_lengths = torch.tensor([T], dtype=torch.int32, device=device)
-        label_lengths = torch.tensor([len(labels[0])], dtype=torch.int32, device=device)
+        input_lengths = torch.tensor([T], dtype=torch.int64, device=device)
+        label_lengths = torch.tensor([len(labels[0])], dtype=torch.int64, device=device)
 
         # certify input data
         certify_inputs(x_c, labels_c, input_lengths, label_lengths)
@@ -299,9 +299,9 @@ class TestRNNTCUDAKernels:
 
         # Numpy kernel
         x = random.randn(*original_shape)
-        labels = torch.from_numpy(np.array([[1, 1, 1, 2, 2, 2, 1, 2, 2, 1]], dtype=np.int32))  # [1, 10]
-        audio_len = torch.from_numpy(np.array([T], dtype=np.int32))
-        label_len = torch.from_numpy(np.array([U - 1], dtype=np.int32))
+        labels = torch.from_numpy(np.array([[1, 1, 1, 2, 2, 2, 1, 2, 2, 1]], dtype=np.int64))  # [1, 10]
+        audio_len = torch.from_numpy(np.array([T], dtype=np.int64))
+        label_len = torch.from_numpy(np.array([U - 1], dtype=np.int64))
         blank_idx = 0
 
         x_np = torch.from_numpy(x)
@@ -330,7 +330,7 @@ class TestRNNTCUDAKernels:
             stream = cuda.default_stream()
 
         x_c = torch.tensor(x, device=device, dtype=torch.float32)
-        labels_c = torch.tensor(labels, device=device, dtype=torch.int32)
+        labels_c = labels.clone().to(device=device, dtype=torch.int64)
 
         # Allocate workspace memory
         denom = torch.zeros(B * T * U, device=device, dtype=x_c.dtype)
@@ -338,8 +338,8 @@ class TestRNNTCUDAKernels:
         betas = torch.zeros(B * T * U, device=device, dtype=x_c.dtype)
         llForward = torch.zeros(B, device=device, dtype=x_c.dtype)
         llBackward = torch.zeros(B, device=device, dtype=x_c.dtype)
-        input_lengths = torch.tensor([T], dtype=torch.int32, device=device)
-        label_lengths = torch.tensor([len(labels[0])], dtype=torch.int32, device=device)
+        input_lengths = torch.tensor([T], dtype=torch.int64, device=device)
+        label_lengths = torch.tensor([len(labels[0])], dtype=torch.int64, device=device)
 
         # certify input data
         certify_inputs(x_c, labels_c, input_lengths, label_lengths)
@@ -409,9 +409,9 @@ class TestRNNTCUDAKernels:
 
         # Numpy kernel
         x = random.randn(*original_shape)
-        labels = torch.from_numpy(np.array([[1, 1, 1, 2, 2, 2, 1, 2, 2, 1]], dtype=np.int32))  # [1, 10]
-        audio_len = torch.from_numpy(np.array([T], dtype=np.int32))
-        label_len = torch.from_numpy(np.array([U - 1], dtype=np.int32))
+        labels = torch.from_numpy(np.array([[1, 1, 1, 2, 2, 2, 1, 2, 2, 1]], dtype=np.int64))  # [1, 10]
+        audio_len = torch.from_numpy(np.array([T], dtype=np.int64))
+        label_len = torch.from_numpy(np.array([U - 1], dtype=np.int64))
         blank_idx = 0
 
         x_np = torch.from_numpy(x)
@@ -440,7 +440,7 @@ class TestRNNTCUDAKernels:
             stream = cuda.default_stream()
 
         x_c = torch.tensor(x, device=device, dtype=torch.float32)
-        labels_c = torch.tensor(labels, device=device, dtype=torch.int32)
+        labels_c = labels.clone().to(device=device, dtype=torch.int64)
 
         # Allocate workspace memory
         denom = torch.zeros(B * T * U, device=device, dtype=x_c.dtype)
@@ -448,8 +448,8 @@ class TestRNNTCUDAKernels:
         betas = torch.zeros(B * T * U, device=device, dtype=x_c.dtype)
         llForward = torch.zeros(B, device=device, dtype=x_c.dtype)
         llBackward = torch.zeros(B, device=device, dtype=x_c.dtype)
-        input_lengths = torch.tensor([T], dtype=torch.int32, device=device)
-        label_lengths = torch.tensor([len(labels[0])], dtype=torch.int32, device=device)
+        input_lengths = torch.tensor([T], dtype=torch.int64, device=device)
+        label_lengths = torch.tensor([len(labels[0])], dtype=torch.int64, device=device)
 
         # certify input data
         certify_inputs(x_c, labels_c, input_lengths, label_lengths)


### PR DESCRIPTION
Signed-off-by: smajumdar <titu1994@gmail.com>

# What does this PR do ?

Defaults the targets of RNNT to int64 to match CTC loss. Should mostly be a cosmetic change, since it is near impossible to train an RNNT with target vocabulary of > 2B tokens, or with seq length > 2B.

**Collection**: [ASR]

# Changelog 
- Update internal casts to int64
- Update tests to force int64 targets

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

