### PR TITLE
Fix reinstall.sh dependencies

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -31,7 +31,7 @@ if [[ "$INSTALL_OPTION" == "dev" ]]; then
     ${PIP} install --editable ".[all]"
 else
     rm -rf dist/
-    ${PIP} install build
+    ${PIP} install build pytest-runner
     python -m build --no-isolation --wheel
     DIST_FILE=$(find ./dist -name "*.whl" | head -n 1)
     ${PIP} install "${DIST_FILE}[all]"


### PR DESCRIPTION
# What does this PR do ?

Adds missing dependency for using `build` to build the nemo pip wheel

**Collection**: [Core]

# Changelog 
- Add missing dependency `pytest-runner`


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
