### PR TITLE
Update data_prep.py

### DIFF
--- a/tools/nemo_forced_aligner/utils/data_prep.py
+++ b/tools/nemo_forced_aligner/utils/data_prep.py
@@ -73,7 +73,6 @@ def get_manifest_lines_batch(manifest_filepath, start, end):
         for line_i, line in enumerate(f):
             if line_i >= start and line_i <= end:
                 manifest_lines_batch.append(json.loads(line))
-                break
 
             if line_i == end:
                 break

--- a/tools/nemo_forced_aligner/utils/data_prep.py
+++ b/tools/nemo_forced_aligner/utils/data_prep.py
@@ -71,14 +71,12 @@ def get_manifest_lines_batch(manifest_filepath, start, end):
     manifest_lines_batch = []
     with open(manifest_filepath, "r") as f:
         for line_i, line in enumerate(f):
-            if line_i == start and line_i == end:
+            if line_i >= start and line_i <= end:
                 manifest_lines_batch.append(json.loads(line))
                 break
 
             if line_i == end:
                 break
-            if line_i >= start:
-                manifest_lines_batch.append(json.loads(line))
     return manifest_lines_batch
 
 


### PR DESCRIPTION
When batch_size >= 2, the align.py doesn't work on the batch_size examples. This function should return [start, end] (inclusive) examples.

# What does this PR do ?

Fix a function logic:  https://github.com/NVIDIA/NeMo/blob/main/tools/nemo_forced_aligner/utils/data_prep.py#L78

**Collection**: [Note which collection this PR will affect]
nemo neural aligner
no collections will be affected

# Changelog 
- 

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
python NeMo/tools/nemo_forced_aligner/align.py \
         pretrained_name="stt_en_citrinet_1024_gamma_0_25" \
       model_downsample_factor=8 \
       manifest_filepath=./test_manifest.json \
      output_dir=./ctm_test_manifest
      batch_size=2
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?
Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
