### PR TITLE
[TTS] Spectrogram Enhancer: correct dim for length when loading data

### DIFF
--- a/nemo/collections/tts/torch/data.py
+++ b/nemo/collections/tts/torch/data.py
@@ -1134,7 +1134,7 @@ class PairedRealFakeSpectrogramsDataset(Dataset):
 
     def _collate_fn(self, batch):
         pred_specs, true_specs = zip(*batch)
-        lengths = [spec.shape[-1] for spec in true_specs]
+        lengths = [spec.shape[0] for spec in true_specs]
 
         pred_specs = torch.nn.utils.rnn.pad_sequence(pred_specs, batch_first=True)
         true_specs = torch.nn.utils.rnn.pad_sequence(true_specs, batch_first=True)


### PR DESCRIPTION
# What does this PR do ?

Makes DataLoader for Spectrogram enhancer (#5565) use correct dimension to determine length of the spectrogram.

Currently it uses number of mel bands as length, so in practice enhancer trains on 80x80 patches, which is obviously suboptimal and a **bug**.

**Collection**: TTS

# Changelog 
- Fixes just one single dimension index

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #6007 but there's more work to do