### PR TITLE
Propagate LayerNorm1P to TE

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -780,7 +780,7 @@ class AutocastTransformerLayer(TransformerLayer):
         drop_path_rate: float = 0,
         use_emha: bool = False,
         autocast_dtype: Any = 16,
-        zero_centered_gamma: bool = False
+        zero_centered_gamma: bool = False,
     ) -> None:
         super().__init__(
             hidden_size=hidden_size,

--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -780,6 +780,7 @@ class AutocastTransformerLayer(TransformerLayer):
         drop_path_rate: float = 0,
         use_emha: bool = False,
         autocast_dtype: Any = 16,
+        zero_centered_gamma: bool = False
     ) -> None:
         super().__init__(
             hidden_size=hidden_size,
@@ -809,6 +810,7 @@ class AutocastTransformerLayer(TransformerLayer):
             drop_path_rate=drop_path_rate,
             set_parallel_mode=tp_size > 1,
             fuse_qkv_params=True,
+            zero_centered_gamma=zero_centered_gamma,
         )
         # use_emha=use_emha,
 
@@ -1048,6 +1050,7 @@ class ParallelTransformer(MegatronModule):
                     apply_residual_connection_post_layernorm=False,
                     autocast_dtype=precision,
                     use_emha=use_emha,
+                    zero_centered_gamma=normalization == 'layernorm1p',
                 )
             else:
                 return ParallelTransformerLayer(


### PR DESCRIPTION
# What does this PR do ?
Enables using LayerNorm1P implementation with TransformerEngine.
So far, only non-TE path allowed using LayerNorm1P.

NOTE: this PR requires TE version >=0.6!

**Collection**: NLP

# Changelog 
- enable LayerNorm1P for TransformerEngine

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
