### PR TITLE
Avoid multiple warnings for loss mask

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_dataset.py
@@ -396,7 +396,7 @@ class GPTDataset(Dataset):
         # Negative index comes when we pad the last batch in MegatronPretrainingBatchSampler
         # We make the loss_mask zero to mask out loss from these samples
         if idx == -1:
-            logging.info('WARNING: Got -1 as item index. Masking loss from this sample')
+            logging.debug('Got -1 as item index. Masking loss from this sample')
             loss_mask = torch.zeros_like(loss_mask)
 
         return {


### PR DESCRIPTION
# What does this PR do ?

Currently loss masking for GPT (used when `model.data.pad_samples_to_global_batch_size=True`) issues a warning for every masked sample. In typical workflows there might be hundreds of masked samples in 1 batch, which spawns hundreds of warnings every validation. This PR fixes that

**Collection**: NLP

# Changelog 
- Turn loss mask warning into a debug log

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
