### PR TITLE
Updated data simulator config part in Speaker_Diarization_Training.ipynb

### DIFF
--- a/tutorials/speaker_tasks/Speaker_Diarization_Training.ipynb
+++ b/tutorials/speaker_tasks/Speaker_Diarization_Training.ipynb
@@ -925,11 +925,6 @@
     },
     "source": []
    }
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "d7c2e67a9e46a97df6de4205d6538bb411bb2318a62191f8b5ef6dbe7b00623c"
-   }
   }
  },
  "nbformat": 4,

--- a/tutorials/speaker_tasks/Speaker_Diarization_Training.ipynb
+++ b/tutorials/speaker_tasks/Speaker_Diarization_Training.ipynb
@@ -901,7 +901,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "t01",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -915,7 +915,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.0"
+   "version": "3.9.7"
   },
   "pycharm": {
    "stem_cell": {

--- a/tutorials/speaker_tasks/Speaker_Diarization_Training.ipynb
+++ b/tutorials/speaker_tasks/Speaker_Diarization_Training.ipynb
@@ -301,8 +301,8 @@
     "  --input_manifest_filepath LibriSpeech/dev_clean.json \\\n",
     "  --base_alignment_path LibriSpeech_Alignments \\\n",
     "  --output_manifest_filepath ./dev-clean-align.json \\\n",
-    "  --ctm_directory ./ctm_out \\\n",
-    "  --dataset dev-clean"
+    "  --ctm_output_directory ./ctm_out \\\n",
+    "  --libri_dataset_split dev-clean"
    ]
   },
   {
@@ -901,7 +901,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "t01",
    "language": "python",
    "name": "python3"
   },
@@ -915,7 +915,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.8.0"
   },
   "pycharm": {
    "stem_cell": {
@@ -924,6 +924,11 @@
      "collapsed": false
     },
     "source": []
+   }
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "d7c2e67a9e46a97df6de4205d6538bb411bb2318a62191f8b5ef6dbe7b00623c"
    }
   }
  },


### PR DESCRIPTION
# What does this PR do ?

This PR fixes the deprecated configuration in speaker diarization training notebook.


**Collection**: [Note which collection this PR will affect]
ASR

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage

Now, create alignment script for libri speech should follow the following commands 
```python
!python NeMo/scripts/speaker_tasks/create_alignment_manifest.py \
  --input_manifest_filepath LibriSpeech/dev_clean.json \
  --base_alignment_path LibriSpeech_Alignments \
  --output_manifest_filepath ./dev-clean-align.json \
  --ctm_output_directory ./ctm_out \
  --libri_dataset_split dev-clean
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
