### PR TITLE
[CI] Set readthedocs python version to 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -26,6 +26,6 @@ sphinx:
 
 # Set the version of Python and requirements required to build your docs
 python:
-  version: 3.7
+  version: 3.8
   install:
     - requirements: requirements/requirements_docs.txt


### PR DESCRIPTION
# What does this PR do ?

Offline it was mentioned that API docs were failing due to some syntax available in Python 3.8. This can be seen here: https://readthedocs.com/projects/nvidia-nemo/builds/1305908/

Setting the build python version to 3.8 for readthedocs.

**Collection**: Common

# Changelog 
- Increment readthedocs build python version to 3.8.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation