### PR TITLE
Adjust stochastic depth dropout probability calculation

### DIFF
--- a/docs/source/asr/configs.rst
+++ b/docs/source/asr/configs.rst
@@ -592,7 +592,7 @@ use it, specify the following parameters in the encoder config file to reproduce
         # ...
         stochastic_depth_drop_prob: 0.3
         stochastic_depth_mode: linear  # linear or uniform
-        stochastic_depth_start_layer: 0
+        stochastic_depth_start_layer: 1
 
 See :ref:`documentation of ConformerEncoder <conformer-encoder-api>` for more details. Note that stochastic depth
 is supported for both CTC and Transducer model variations (or any other kind of model/loss that's using

--- a/examples/asr/conf/conformer/cache_aware_streaming/conformer_ctc_bpe_streaming.yaml
+++ b/examples/asr/conf/conformer/cache_aware_streaming/conformer_ctc_bpe_streaming.yaml
@@ -131,7 +131,7 @@ model:
     # set to non-zero to enable stochastic depth
     stochastic_depth_drop_prob: 0.0
     stochastic_depth_mode: linear  # linear or uniform
-    stochastic_depth_start_layer: 0
+    stochastic_depth_start_layer: 1
 
   decoder:
     _target_: nemo.collections.asr.modules.ConvASRDecoder

--- a/examples/asr/conf/conformer/cache_aware_streaming/conformer_transducer_bpe_streaming.yaml
+++ b/examples/asr/conf/conformer/cache_aware_streaming/conformer_transducer_bpe_streaming.yaml
@@ -141,7 +141,7 @@ model:
     # set to non-zero to enable stochastic depth
     stochastic_depth_drop_prob: 0.0
     stochastic_depth_mode: linear  # linear or uniform
-    stochastic_depth_start_layer: 0
+    stochastic_depth_start_layer: 1
 
   decoder:
     _target_: nemo.collections.asr.modules.RNNTDecoder

--- a/examples/asr/conf/conformer/conformer_ctc_bpe.yaml
+++ b/examples/asr/conf/conformer/conformer_ctc_bpe.yaml
@@ -140,7 +140,7 @@ model:
     # set to non-zero to enable stochastic depth
     stochastic_depth_drop_prob: 0.0
     stochastic_depth_mode: linear  # linear or uniform
-    stochastic_depth_start_layer: 0
+    stochastic_depth_start_layer: 1
 
   decoder:
     _target_: nemo.collections.asr.modules.ConvASRDecoder

--- a/examples/asr/conf/conformer/conformer_ctc_char.yaml
+++ b/examples/asr/conf/conformer/conformer_ctc_char.yaml
@@ -115,7 +115,7 @@ model:
     # set to non-zero to enable stochastic depth
     stochastic_depth_drop_prob: 0.0
     stochastic_depth_mode: linear  # linear or uniform
-    stochastic_depth_start_layer: 0
+    stochastic_depth_start_layer: 1
 
   decoder:
     _target_: nemo.collections.asr.modules.ConvASRDecoder

--- a/examples/asr/conf/conformer/conformer_transducer_bpe.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_bpe.yaml
@@ -144,7 +144,7 @@ model:
     # set to non-zero to enable stochastic depth
     stochastic_depth_drop_prob: 0.0
     stochastic_depth_mode: linear  # linear or uniform
-    stochastic_depth_start_layer: 0
+    stochastic_depth_start_layer: 1
 
   decoder:
     _target_: nemo.collections.asr.modules.RNNTDecoder

--- a/examples/asr/conf/conformer/conformer_transducer_char.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_char.yaml
@@ -139,7 +139,7 @@ model:
     # set to non-zero to enable stochastic depth
     stochastic_depth_drop_prob: 0.0
     stochastic_depth_mode: linear  # linear or uniform
-    stochastic_depth_start_layer: 0
+    stochastic_depth_start_layer: 1
 
   decoder:
     _target_: nemo.collections.asr.modules.RNNTDecoder

--- a/examples/asr/conf/fastconformer/fast-conformer_ctc_bpe.yaml
+++ b/examples/asr/conf/fastconformer/fast-conformer_ctc_bpe.yaml
@@ -122,7 +122,7 @@ model:
     # set to non-zero to enable stochastic depth
     stochastic_depth_drop_prob: 0.0
     stochastic_depth_mode: linear  # linear or uniform
-    stochastic_depth_start_layer: 0
+    stochastic_depth_start_layer: 1
 
   decoder:
     _target_: nemo.collections.asr.modules.ConvASRDecoder

--- a/examples/asr/conf/fastconformer/fast-conformer_transducer_bpe.yaml
+++ b/examples/asr/conf/fastconformer/fast-conformer_transducer_bpe.yaml
@@ -131,7 +131,7 @@ model:
     # set to non-zero to enable stochastic depth
     stochastic_depth_drop_prob: 0.0
     stochastic_depth_mode: linear  # linear or uniform
-    stochastic_depth_start_layer: 0
+    stochastic_depth_start_layer: 1
 
   decoder:
     _target_: nemo.collections.asr.modules.RNNTDecoder

--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -117,7 +117,7 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable, AccessMixin):
         stochastic_depth_start_layer (int): starting layer for stochastic depth.
             All layers before this will never be dropped. Note that drop
             probability will be adjusted accordingly if mode is "linear" when
-            start layer is > 0. Defaults to 0.
+            start layer is > 1. Defaults to 1.
     """
 
     def input_example(self, max_batch=1, max_dim=256):
@@ -207,7 +207,7 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable, AccessMixin):
         dropout_att=0.0,
         stochastic_depth_drop_prob: float = 0.0,
         stochastic_depth_mode: str = "linear",
-        stochastic_depth_start_layer: int = 0,
+        stochastic_depth_start_layer: int = 1,
     ):
         super().__init__()
         d_ff = d_model * ff_expansion_factor

--- a/tests/collections/asr/test_conformer_encoder.py
+++ b/tests/collections/asr/test_conformer_encoder.py
@@ -30,7 +30,7 @@ class TestStochasticDepth:
 
         # linear mode
         for drop_prob in [0.3, 0.5, 0.9]:
-            for start_layer in [0, 2]:
+            for start_layer in [1, 3]:
                 model = ConformerEncoder(
                     feat_in=10,
                     n_layers=n_layers,
@@ -40,7 +40,7 @@ class TestStochasticDepth:
                     stochastic_depth_start_layer=start_layer,
                 )
                 L = n_layers - start_layer
-                assert model.layer_drop_probs == [0.0] * start_layer + [drop_prob * l / (L - 1) for l in range(L)]
+                assert model.layer_drop_probs == [0.0] * start_layer + [drop_prob * l / L for l in range(1, L + 1)]
 
         # uniform mode
         for drop_prob in [0.3, 0.5, 0.9]:
@@ -71,7 +71,7 @@ class TestStochasticDepth:
         with pytest.raises(ValueError, match="stochastic_depth_mode has to be one of"):
             ConformerEncoder(feat_in=10, n_layers=n_layers, d_model=4, feat_out=8, stochastic_depth_mode="weird")
 
-        for start_layer in [-1, 5]:
+        for start_layer in [-1, 0, 5]:
             with pytest.raises(ValueError, match="stochastic_depth_start_layer has to be in"):
                 ConformerEncoder(
                     feat_in=10, n_layers=n_layers, d_model=4, feat_out=8, stochastic_depth_start_layer=start_layer,


### PR DESCRIPTION
# What does this PR do?

This PR adjusts calculation of stochastic depth dropout probability.
Currently, calculation fails for 1-layer ConformerEncoder with the default setup.

The culprit is calculation of the probability in `compute_stochastic_depth_drop_probs ` for `linear` mode:

```
layer_drop_probs += [l / (L - 1) * stochastic_depth_drop_prob for l in range(L)]
```

since in this case `L-1 == 0`.

## Proposed solution

Change calculation for the linear mode to the following
```
# we start with 1/L * drop_prob and and end with the desired drop probability.
layer_drop_probs += [l / L * stochastic_depth_drop_prob for l in range(1, L + 1)]
```

This can handle setup with a single layer and is consistent with the probability calculation for the `uniform` mode.

### Example
An example of calculated probabilities:

```
num_layers = 7
stochastic_depth_start_layer = 3
stochastic_depth_drop_prob = 0.5
```

| layer |  0  |  1  |  2  |  3  |  4  |  5  |  6  |
| ----- | --- | --- | --- | --- | --- | --- | --- |
| uniform         | 0.0 | 0.0 | 0.0 | 0.5   | 0.5   | 0.5   | 0.5 |
| linear original | 0.0 | 0.0 | 0.0 | 0.0   | 0.167 | 0.333 | 0.5 |
| linear proposed | 0.0 | 0.0 | 0.0 | 0.125 | 0.25  | 0.375 | 0.5 |



**Collection**: ASR

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
