### PR TITLE
Fix k2 and torchaudio installation (Docker, macOS). Cherry-pick (#6094)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,15 +21,23 @@ ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:23.01-py3
 # image (by specifying build target as `nemo-deps`)
 FROM ${BASE_IMAGE} as nemo-deps
 
+# dependency flags; should be declared after FROM
+# torchaudio: not required by default
+ARG REQUIRE_TORCHAUDIO=false
+# k2: not required by default
+ARG REQUIRE_K2=false
+
 # Ensure apt-get won't prompt for selecting options
 ENV DEBIAN_FRONTEND=noninteractive
+# libavdevice-dev rerquired for latest torchaudio
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y \
     libsndfile1 sox \
     libfreetype6 \
     swig \
-    ffmpeg && \
+    ffmpeg \
+    libavdevice-dev && \
     rm -rf /var/lib/apt/lists/*
 
 WORKDIR /tmp/
@@ -47,7 +55,14 @@ RUN pip3 uninstall -y sacrebleu torchtext
 # build torchaudio
 WORKDIR /tmp/torchaudio_build
 COPY scripts/installers /tmp/torchaudio_build/scripts/installers/
-RUN /bin/bash /tmp/torchaudio_build/scripts/installers/install_torchaudio_latest.sh
+RUN INSTALL_MSG=$(/bin/bash /tmp/torchaudio_build/scripts/installers/install_torchaudio_latest.sh); INSTALL_CODE=$?; \
+    echo ${INSTALL_MSG}; \
+    if [ ${INSTALL_CODE} -ne 0 ]; then \
+      echo "torchaudio installation failed";  \
+      if [ "${REQUIRE_TORCHAUDIO}" = true ]; then \
+        exit ${INSTALL_CODE};  \
+      else echo "Skipping failed torchaudio installation"; fi \
+    else echo "torchaudio installed successfully"; fi
 
 # install nemo dependencies
 WORKDIR /tmp/nemo
@@ -60,7 +75,14 @@ RUN /bin/bash /tmp/nemo/install_pynini.sh
 
 # install k2, skip if installation fails
 COPY scripts /tmp/nemo/scripts/
-RUN /bin/bash /tmp/nemo/scripts/speech_recognition/k2/setup.sh || exit 0
+RUN INSTALL_MSG=$(/bin/bash /tmp/nemo/scripts/speech_recognition/k2/setup.sh); INSTALL_CODE=$?; \
+    echo ${INSTALL_MSG}; \
+    if [ ${INSTALL_CODE} -ne 0 ]; then \
+      echo "k2 installation failed";  \
+      if [ "${REQUIRE_K2}" = true ]; then \
+        exit ${INSTALL_CODE};  \
+      else echo "Skipping failed k2 installation"; fi \
+    else echo "k2 installed successfully"; fi
 
 # copy nemo source into a scratch image
 FROM scratch as nemo-src

--- a/scripts/speech_recognition/k2/setup.sh
+++ b/scripts/speech_recognition/k2/setup.sh
@@ -18,7 +18,9 @@ K2_REPO=https://github.com/k2-fsa/k2
 LATEST_RELEASE=$(git -c 'versionsort.suffix=-' \
     ls-remote --exit-code --refs --sort='version:refname' --tags ${K2_REPO} '*.*' \
     | tail --lines=1 \
-    | cut --delimiter='/' --fields=3)
+    | cut -d '/' -f 3)
+# "cut --delimiter '/' --fields 3" doesn't work on macOS, use "-d ... -f ..." instead
 
-K2_MAKE_ARGS="-j" pip install -v git+${K2_REPO}@${LATEST_RELEASE}#egg=k2 || (echo "k2 could not be installed!"; exit 1)
-python3 -m k2.version > /dev/null || (echo "k2 installed with errors! Please check installation manually."; exit 1) && echo "k2 installed successfully!"
+K2_MAKE_ARGS="-j" pip install -v "git+${K2_REPO}@${LATEST_RELEASE}#egg=k2" || { echo "k2 could not be installed!"; exit 1; }
+python3 -m k2.version > /dev/null || { echo "k2 installed with errors! Please check installation manually."; exit 1; }
+echo "k2 installed successfully!"


### PR DESCRIPTION
# What does this PR do ?

Cherry-pick from #6094

Fix `torchaudio` installation, fix `k2` installation in some cases. Make `torchaudio` and `k2` not required by default.

**Collection**: [CI]

# Changelog 
- add build arguments `REQUIRE_TORCHAUDIO` and `REQUIRE_K2` for `torchaudio` and `k2` in Dockerfile
  - `false` (by default): library will be installed if possible, errors ignored
  - `true`: if library not installed correctly, end build with error
- fix `k2` installation script on macOS
- fix `k2` installation in Docker (`k2` depends on `torchaudio`)
- fix `torchaudio` installation for latest PyTorch versions
- also fixes bug https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=3940510&cmtNo= (`apt update && apt install -y libavdevice-dev` should be also used before executing install script)

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
