### PR TITLE
[TTS] Spectrogram Enhancer: add option to zero out the initial tensor

### DIFF
--- a/examples/tts/conf/spectrogram-enhancer.yaml
+++ b/examples/tts/conf/spectrogram-enhancer.yaml
@@ -7,6 +7,7 @@ model:
   network_capacity: 16
   mixed_prob: 0.9
   fmap_max: 192
+  start_from_zero: true  # might give better results at downstream tasks 
 
   generator:
     _target_: "nemo.collections.tts.modules.spectrogram_enhancer.Generator"  

--- a/nemo/collections/tts/modules/spectrogram_enhancer.py
+++ b/nemo/collections/tts/modules/spectrogram_enhancer.py
@@ -230,7 +230,7 @@ class DiscriminatorBlock(torch.nn.Module):
 
 class Generator(torch.nn.Module):
     def __init__(
-        self, n_bands, latent_dim, style_depth, network_capacity=16, channels=1, fmap_max=512,
+        self, n_bands, latent_dim, style_depth, network_capacity=16, channels=1, fmap_max=512, start_from_zero=True
     ):
         super().__init__()
         self.image_size = n_bands
@@ -274,6 +274,8 @@ class Generator(torch.nn.Module):
         self.initial_block = torch.nn.Parameter(
             torch.randn((1, init_channels, *initial_block_size)), requires_grad=False
         )
+        if start_from_zero:
+            self.initial_block.data.zero_()
 
     def add_scaled_condition(self, target: torch.Tensor, condition: torch.Tensor, condition_lengths: torch.Tensor):
         *_, target_height, _ = target.shape


### PR DESCRIPTION
# What does this PR do ?

Enhancer is based on StyleGAN 2, which features a randomly-initialized "initial" tensor. Zeroing this tensor out helps a bit in a downstream ASR task (reported by @artbataev)

This PR adds this option and makes it the default behavior.

**Collection**: TTS

# Changelog 
- Add a `start_from_zero` option to enhancer

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
