### PR TITLE
[TTS] Make mel spectrogram norm configurable

### DIFF
--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -926,9 +926,10 @@ class AudioToMelSpectrogramPreprocessorConfig:
     nb_augmentation_prob: float = 0.0
     nb_max_freq: int = 4000
     use_torchaudio: bool = False
+    mel_norm: str = "slaney"
     stft_exact_pad: bool = False  # Deprecated argument, kept for compatibility with older checkpoints.
     stft_conv: bool = False  # Deprecated argument, kept for compatibility with older checkpoints.
-    mel_norm: str = 'slaney'
+
 
 
 @dataclass

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -162,10 +162,10 @@ class AudioToMelSpectrogramPreprocessor(AudioPreprocessor, Exportable):
             nb_max_freq (int) : Frequency above which all frequencies will be masked for narrowband augmentation.
                 Defaults to 4000
             use_torchaudio: Whether to use the `torchaudio` implementation.
+            mel_norm: Normalization used for mel filterbank weights.
+                Defaults to 'slaney' (area normalization)
             stft_exact_pad: Deprecated argument, kept for compatibility with older checkpoints.
             stft_conv: Deprecated argument, kept for compatibility with older checkpoints.
-            mel_norm: Normalization used for filterbanks in librosa.filters.mel.
-                Defaults to 'slaney' (area normalization)
         """
 
     def save_to(self, save_path: str):
@@ -229,9 +229,9 @@ class AudioToMelSpectrogramPreprocessor(AudioPreprocessor, Exportable):
         nb_augmentation_prob=0.0,
         nb_max_freq=4000,
         use_torchaudio: bool = False,
+        mel_norm="slaney",
         stft_exact_pad=False,  # Deprecated arguments; kept for config compatibility
         stft_conv=False,  # Deprecated arguments; kept for config compatibility
-        mel_norm='slaney',
     ):
         super().__init__(n_window_size, n_window_stride)
 
@@ -275,9 +275,9 @@ class AudioToMelSpectrogramPreprocessor(AudioPreprocessor, Exportable):
             rng=rng,
             nb_augmentation_prob=nb_augmentation_prob,
             nb_max_freq=nb_max_freq,
+            mel_norm=mel_norm,
             stft_exact_pad=stft_exact_pad,  # Deprecated arguments; kept for config compatibility
             stft_conv=stft_conv,  # Deprecated arguments; kept for config compatibility
-            mel_norm=mel_norm,
         )
 
     def input_example(self, max_batch: int = 8, max_dim: int = 32000, min_length: int = 200):

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -931,7 +931,6 @@ class AudioToMelSpectrogramPreprocessorConfig:
     stft_conv: bool = False  # Deprecated argument, kept for compatibility with older checkpoints.
 
 
-
 @dataclass
 class AudioToMFCCPreprocessorConfig:
     _target_: str = 'nemo.collections.asr.modules.AudioToMFCCPreprocessor'

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -164,6 +164,8 @@ class AudioToMelSpectrogramPreprocessor(AudioPreprocessor, Exportable):
             use_torchaudio: Whether to use the `torchaudio` implementation.
             stft_exact_pad: Deprecated argument, kept for compatibility with older checkpoints.
             stft_conv: Deprecated argument, kept for compatibility with older checkpoints.
+            mel_norm: Normalization used for filterbanks in librosa.filters.mel.
+                Defaults to 'slaney' (area normalization)
         """
 
     def save_to(self, save_path: str):
@@ -229,6 +231,7 @@ class AudioToMelSpectrogramPreprocessor(AudioPreprocessor, Exportable):
         use_torchaudio: bool = False,
         stft_exact_pad=False,  # Deprecated arguments; kept for config compatibility
         stft_conv=False,  # Deprecated arguments; kept for config compatibility
+        mel_norm='slaney',
     ):
         super().__init__(n_window_size, n_window_stride)
 
@@ -274,6 +277,7 @@ class AudioToMelSpectrogramPreprocessor(AudioPreprocessor, Exportable):
             nb_max_freq=nb_max_freq,
             stft_exact_pad=stft_exact_pad,  # Deprecated arguments; kept for config compatibility
             stft_conv=stft_conv,  # Deprecated arguments; kept for config compatibility
+            mel_norm=mel_norm,
         )
 
     def input_example(self, max_batch: int = 8, max_dim: int = 32000, min_length: int = 200):
@@ -924,6 +928,7 @@ class AudioToMelSpectrogramPreprocessorConfig:
     use_torchaudio: bool = False
     stft_exact_pad: bool = False  # Deprecated argument, kept for compatibility with older checkpoints.
     stft_conv: bool = False  # Deprecated argument, kept for compatibility with older checkpoints.
+    mel_norm: str = 'slaney'
 
 
 @dataclass

--- a/nemo/collections/asr/parts/preprocessing/features.py
+++ b/nemo/collections/asr/parts/preprocessing/features.py
@@ -255,9 +255,9 @@ class FilterbankFeatures(nn.Module):
         rng=None,
         nb_augmentation_prob=0.0,
         nb_max_freq=4000,
+        mel_norm="slaney",
         stft_exact_pad=False,  # Deprecated arguments; kept for config compatibility
         stft_conv=False,  # Deprecated arguments; kept for config compatibility
-        mel_norm='slaney',
     ):
         super().__init__()
         if stft_conv or stft_exact_pad:
@@ -495,6 +495,7 @@ class FilterbankFeaturesTA(nn.Module):
         window: str = "hann",
         pad_to: int = 0,
         pad_value: float = 0.0,
+        mel_norm="slaney",
         # Seems like no one uses these options anymore. Don't convolute the code by supporting thm.
         use_grads: bool = False,  # Deprecated arguments; kept for config compatibility
         max_duration: float = 16.7,  # Deprecated arguments; kept for config compatibility
@@ -551,7 +552,7 @@ class FilterbankFeaturesTA(nn.Module):
             n_mels=nfilt,
             window_fn=self.torch_windows[window],
             mel_scale="slaney",
-            norm="slaney",
+            norm=mel_norm,
             n_fft=n_fft,
             f_max=highfreq,
             f_min=lowfreq,

--- a/nemo/collections/asr/parts/preprocessing/features.py
+++ b/nemo/collections/asr/parts/preprocessing/features.py
@@ -257,6 +257,7 @@ class FilterbankFeatures(nn.Module):
         nb_max_freq=4000,
         stft_exact_pad=False,  # Deprecated arguments; kept for config compatibility
         stft_conv=False,  # Deprecated arguments; kept for config compatibility
+        mel_norm='slaney',
     ):
         super().__init__()
         if stft_conv or stft_exact_pad:
@@ -322,7 +323,9 @@ class FilterbankFeatures(nn.Module):
         highfreq = highfreq or sample_rate / 2
 
         filterbanks = torch.tensor(
-            librosa.filters.mel(sr=sample_rate, n_fft=self.n_fft, n_mels=nfilt, fmin=lowfreq, fmax=highfreq),
+            librosa.filters.mel(
+                sr=sample_rate, n_fft=self.n_fft, n_mels=nfilt, fmin=lowfreq, fmax=highfreq, norm=mel_norm
+            ),
             dtype=torch.float,
         ).unsqueeze(0)
         self.register_buffer("fb", filterbanks)


### PR DESCRIPTION
# What does this PR do ?

Add optional configuration to AudioToMelSpectrogramPreprocessor to allow disabling area normalization in the librosa mel filter.

Applying area normalization to the mel spectrogram reduces its range of values from approximately [0, 100] to [0, 1], which is detrimental when you take the log of the [0, 1] values producing a poor distribution of negative features.

The intention is to experiment with disabling the area normalization and replacing the current mel spectrogram used in TTS which is:

> log(max(1E-5, area_norm(mel))

With a more accurate representation like:

> log(1.0 + mel)

This will also enable us to compute energy features using the mel spectrogram instead of the linear spectrogram.

**Collection**: [TTS], [ASR]

# Changelog 
- Add an optional parameter to AudioToMelSpectrogramPreprocessor to configure the mel filter normalization, defaulting to the librosa default of 'slaney'

# Usage
.yaml config:

> preprocessor:
>     _target_: nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor
>     log: true
>     log_zero_guard_type: add
>     log_zero_guard_value: 1.0
>     mag_power: 1.0
>     mel_norm: null

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
