### PR TITLE
Tts fixed vocab

### DIFF
--- a/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
@@ -527,6 +527,7 @@ class IPATokenizer(BaseTokenizer):
                 Set only if overriding the default vocab generation process (reading from G2P dict).
                 If set, any dataset entries that have unincluded graphemes will be filtered out, and any words whose
                 pronunciations have unincluded phonemes will be treated as OOV.
+                Please make sure that the grapheme prefixes and cases are consistent with the G2P module's settings.
                 Defaults to None, which means default vocab generation is used.
             space: Space token as string.
             silence: Silence token as string (will be disabled if it is None).

--- a/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
@@ -555,7 +555,7 @@ class IPATokenizer(BaseTokenizer):
         # Build tokens list if fixed_vocab isn't set
         if fixed_vocab:
             tokens = set(fixed_vocab)
-            self.set_fixed_vocab = True     # Used to check whether dataset entries need filtering
+            self.set_fixed_vocab = True  # Used to check whether dataset entries need filtering
             g2p.replace_symbols(tokens)
         else:
             tokens = set(g2p.symbols)

--- a/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
@@ -598,7 +598,6 @@ class IPATokenizer(BaseTokenizer):
 
         self.g2p = g2p
 
-
     def encode(self, text: str) -> List[int]:
         """See base class for more information."""
         # normalize the input text with "NFC" form.

--- a/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
@@ -553,9 +553,14 @@ class IPATokenizer(BaseTokenizer):
         if hasattr(g2p, "phoneme_probability"):
             self.phoneme_probability = g2p.phoneme_probability
 
+        if locale == "en-US":
+            self.text_preprocessing_func = lambda text: english_text_preprocessing(text, lower=False)
+        else:
+            self.text_preprocessing_func = any_locale_text_preprocessing
+
         # Build tokens list if fixed_vocab isn't set
         if fixed_vocab:
-            tokens = set(fixed_vocab)
+            tokens = {self.text_preprocessing_func(c) for c in fixed_vocab}
             self.set_fixed_vocab = True  # Used to check whether dataset entries need filtering
             g2p.replace_symbols(tokens)
         else:
@@ -593,10 +598,6 @@ class IPATokenizer(BaseTokenizer):
 
         self.g2p = g2p
 
-        if locale == "en-US":
-            self.text_preprocessing_func = lambda text: english_text_preprocessing(text, lower=False)
-        else:
-            self.text_preprocessing_func = any_locale_text_preprocessing
 
     def encode(self, text: str) -> List[int]:
         """See base class for more information."""

--- a/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
@@ -562,6 +562,13 @@ class IPATokenizer(BaseTokenizer):
         if fixed_vocab:
             tokens = {self.text_preprocessing_func(c) for c in fixed_vocab}
             self.set_fixed_vocab = True  # Used to check whether dataset entries need filtering
+
+            if g2p.symbols == tokens:
+                logging.info(
+                    "Did not replace G2P valid symbol set since the given set is equivalent to the existing one."
+                )
+                self.set_fixed_vocab = False
+                break
             g2p.replace_symbols(tokens)
         else:
             tokens = set(g2p.symbols)

--- a/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
@@ -568,8 +568,8 @@ class IPATokenizer(BaseTokenizer):
                     "Did not replace G2P valid symbol set since the given set is equivalent to the existing one."
                 )
                 self.set_fixed_vocab = False
-                break
-            g2p.replace_symbols(tokens)
+            else:
+                g2p.replace_symbols(tokens)
         else:
             tokens = set(g2p.symbols)
             self.set_fixed_vocab = False

--- a/nemo/collections/tts/data/tts_dataset.py
+++ b/nemo/collections/tts/data/tts_dataset.py
@@ -25,6 +25,7 @@ import librosa
 import numpy as np
 import torch
 from einops import rearrange
+from nemo_text_processing.g2p.data.data_utils import set_grapheme_case
 from tqdm import tqdm
 
 from nemo.collections.asr.parts.preprocessing.features import WaveformFeaturizer
@@ -57,7 +58,6 @@ from nemo.collections.tts.torch.tts_data_types import (
 )
 from nemo.core.classes import Dataset
 from nemo.utils import logging
-from nemo_text_processing.g2p.data.data_utils import set_grapheme_case
 
 try:
     from nemo_text_processing.text_normalization.normalize import Normalizer
@@ -255,7 +255,9 @@ class TTSDataset(Dataset):
                         # Skip if set difference between graphemes in text and valid tokens set is nonempty
                         set_diff = text_set - self.text_tokenizer.tokens_set
                         if set_diff:
-                            logging.warning(f"Skipping entry, found illegal grapheme(s) [{set_diff}] in text: [{normalized_text}]")
+                            logging.warning(
+                                f"Skipping entry, found illegal grapheme(s) [{set_diff}] in text: [{normalized_text}]"
+                            )
                             continue
 
                     if self.cache_text:

--- a/nemo/collections/tts/data/tts_dataset.py
+++ b/nemo/collections/tts/data/tts_dataset.py
@@ -223,7 +223,7 @@ class TTSDataset(Dataset):
 
         # If filtering based on a user-set vocab and there's a grapheme prefix,
         # remove all prefixes for comparison with the normalized text
-        if self.text_tokenizer.set_fixed_vocab and self.text_tokenizer.g2p.grapheme_prefix:
+        if getattr(self.text_tokenizer, "set_fixed_vocab", False) and self.text_tokenizer.g2p.grapheme_prefix:
             prefix = self.text_tokenizer.g2p.grapheme_prefix
             # Have check for length of token in case the prefix is a valid symbol by itself
             tokens_set = {

--- a/nemo/collections/tts/data/tts_dataset.py
+++ b/nemo/collections/tts/data/tts_dataset.py
@@ -25,7 +25,6 @@ import librosa
 import numpy as np
 import torch
 from einops import rearrange
-from nemo_text_processing.g2p.data.data_utils import set_grapheme_case
 from tqdm import tqdm
 
 from nemo.collections.asr.parts.preprocessing.features import WaveformFeaturizer
@@ -35,6 +34,7 @@ from nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers import (
     EnglishCharsTokenizer,
     EnglishPhonemesTokenizer,
 )
+from nemo.collections.tts.parts.utils.g2p_utils import set_grapheme_case
 from nemo.collections.tts.parts.utils.tts_dataset_utils import (
     BetaBinomialInterpolator,
     beta_binomial_prior_distribution,

--- a/nemo/collections/tts/data/tts_dataset.py
+++ b/nemo/collections/tts/data/tts_dataset.py
@@ -57,6 +57,7 @@ from nemo.collections.tts.torch.tts_data_types import (
 )
 from nemo.core.classes import Dataset
 from nemo.utils import logging
+from nemo_text_processing.g2p.data.data_utils import set_grapheme_case
 
 try:
     from nemo_text_processing.text_normalization.normalize import Normalizer
@@ -250,7 +251,7 @@ class TTSDataset(Dataset):
                     # If so, entries with illegal graphemes should be filtered out
                     if self.text_tokenizer.set_fixed_vocab:
                         normalized_text = file_info["normalized_text"]
-                        text_set = set(normalized_text)
+                        text_set = set(set_grapheme_case(normalized_text, self.text_tokenizer.g2p.grapheme_case))
                         # Skip if set difference between graphemes in text and valid tokens set is nonempty
                         set_diff = text_set - self.text_tokenizer.tokens_set
                         if set_diff:

--- a/nemo/collections/tts/data/tts_dataset.py
+++ b/nemo/collections/tts/data/tts_dataset.py
@@ -223,6 +223,7 @@ class TTSDataset(Dataset):
 
         # If filtering based on a user-set vocab and there's a grapheme prefix,
         # remove all prefixes for comparison with the normalized text
+        tokens_set = set()  # Not used unless `set_fixed_vocab` is True
         if getattr(self.text_tokenizer, "set_fixed_vocab", False) and self.text_tokenizer.g2p.grapheme_prefix:
             prefix = self.text_tokenizer.g2p.grapheme_prefix
             # Have check for length of token in case the prefix is a valid symbol by itself
@@ -230,8 +231,6 @@ class TTSDataset(Dataset):
                 token if (token[0] != prefix or len(token) == 1) else token[1:]
                 for token in self.text_tokenizer.tokens_set
             }
-        else:
-            tokens_set = self.text_tokenizer.tokens_set
 
         data = []
         total_duration = 0
@@ -261,7 +260,7 @@ class TTSDataset(Dataset):
 
                     # Check whether the user passed in a fixed vocab
                     # If so, entries with illegal graphemes should be filtered out
-                    if self.text_tokenizer.set_fixed_vocab:
+                    if getattr(self.text_tokenizer, "set_fixed_vocab", False):
                         normalized_text = file_info["normalized_text"]
                         text_set = set(set_grapheme_case(normalized_text, self.text_tokenizer.g2p.grapheme_case))
                         # Skip if set difference between graphemes in text and valid tokens set is nonempty

--- a/nemo/collections/tts/g2p/modules.py
+++ b/nemo/collections/tts/g2p/modules.py
@@ -542,6 +542,59 @@ class IPAG2P(BaseG2p):
 
         return g2p_dict, symbols
 
+    def replace_symbols(self, symbols, keep_alternate=True):
+        """Replaces the vocabulary of symbols with the one given.
+        Also filters out any entries with illegal graphemes or phonemes according to the new vocab.
+
+        Args:
+            symbols (List, Set): User-provided set of valid symbols, both graphemes and phonemes
+            keep_alternate (bool): Whether to keep the other pronunciation(s) of a word if not all contain
+                illegal phonemes (and the word doesn't containi illegal graphemes).
+                Warning: this may change a word from being ambiguous to having only one valid pronunciation.
+                Defaults to True.
+        """
+        new_symbols = set(symbols)
+        if self.symbols == new_symbols:
+            logging.info("Did not replace G2P valid symbol set since the given set is equivalent to the existing one.")
+            return
+
+        # Keep track of what will need to be deleted or (if keep_alternate=True) replaced
+        deletion_words = []
+        replacement_dict = {}
+
+        for word, prons in self.phoneme_dict.items():
+            # Check for illegal grapheme in the word itself
+            word_diff = set(word) - new_symbols
+            if word_diff:
+                deletion_words.append(word)
+                continue
+
+            # Check for illegal phonemes in the pronunciation(s)
+            legal_prons = []
+            for pron in prons:
+                pron_diff = set(pron) - new_symbols
+                if not pron_diff:
+                    legal_prons.append(pron)
+
+            # Check if at least one pronunciation was illegal
+            if len(legal_prons) != len(prons):
+                if not keep_alternate:  # Remove the word and entry fully
+                    deletion_words.append(word)
+                else:   # Need to check if all prons were illegal
+                    if not legal_prons:
+                        deletion_words.append(word)
+                    else:
+                        replacement_dict[word] = legal_prons
+
+        # Update pronunciation dictionary as needed
+        for del_word in deletion_words:
+            del self.phoneme_dict[del_word]
+
+        if keep_alternate:
+            self.phoneme_dict.update(replacement_dict)
+
+        self.symbols = new_symbols
+
     def is_unique_in_phoneme_dict(self, word: str) -> bool:
         return len(self.phoneme_dict[word]) == 1
 

--- a/nemo/collections/tts/g2p/modules.py
+++ b/nemo/collections/tts/g2p/modules.py
@@ -564,7 +564,8 @@ class IPAG2P(BaseG2p):
 
         for word, prons in self.phoneme_dict.items():
             # Check for illegal grapheme in the word itself
-            word_diff = set(set_grapheme_case(word, self.grapheme_case)) - new_symbols
+            word_graphemes = set(self._prepend_prefix_for_one_word(set_grapheme_case(word, self.grapheme_case)))
+            word_diff = word_graphemes - new_symbols
             if word_diff:
                 deletion_words.append(word)
                 continue

--- a/nemo/collections/tts/g2p/modules.py
+++ b/nemo/collections/tts/g2p/modules.py
@@ -564,7 +564,7 @@ class IPAG2P(BaseG2p):
 
         for word, prons in self.phoneme_dict.items():
             # Check for illegal grapheme in the word itself
-            word_diff = set(word) - new_symbols
+            word_diff = set(set_grapheme_case(word, self.grapheme_case)) - new_symbols
             if word_diff:
                 deletion_words.append(word)
                 continue

--- a/nemo/collections/tts/g2p/modules.py
+++ b/nemo/collections/tts/g2p/modules.py
@@ -580,7 +580,7 @@ class IPAG2P(BaseG2p):
             if len(legal_prons) != len(prons):
                 if not keep_alternate:  # Remove the word and entry fully
                     deletion_words.append(word)
-                else:   # Need to check if all prons were illegal
+                else:  # Need to check if all prons were illegal
                     if not legal_prons:
                         deletion_words.append(word)
                     else:

--- a/nemo/collections/tts/g2p/modules.py
+++ b/nemo/collections/tts/g2p/modules.py
@@ -549,14 +549,11 @@ class IPAG2P(BaseG2p):
         Args:
             symbols (List, Set): User-provided set of valid symbols, both graphemes and phonemes
             keep_alternate (bool): Whether to keep the other pronunciation(s) of a word if not all contain
-                illegal phonemes (and the word doesn't containi illegal graphemes).
+                illegal phonemes (and the word doesn't contain illegal graphemes).
                 Warning: this may change a word from being ambiguous to having only one valid pronunciation.
                 Defaults to True.
         """
         new_symbols = set(symbols)
-        if self.symbols == new_symbols:
-            logging.info("Did not replace G2P valid symbol set since the given set is equivalent to the existing one.")
-            return
 
         # Keep track of what will need to be deleted or (if keep_alternate=True) replaced
         deletion_words = []

--- a/tests/collections/common/tokenizers/text_to_speech/test_tts_tokenizers.py
+++ b/tests/collections/common/tokenizers/text_to_speech/test_tts_tokenizers.py
@@ -157,3 +157,39 @@ class TestTTSTokenizers:
         chars, tokens = self._parse_text(tokenizer, input_text)
 
         assert chars == expected_output
+
+    # @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_ipa_tokenizer_fixed_vocab(self):
+        phoneme_dict = self.PHONEME_DICT_EN
+        phoneme_dict["WOUND"] = ["ˈwaʊnd", "ˈwund"]
+        g2p = IPAG2P(phoneme_dict=phoneme_dict)
+
+        assert "WOUND" in g2p.phoneme_dict
+
+        # fmt: off
+        symbol_vocab = {
+            'H', 'E', 'L', 'L', 'O',
+            'W', 'O', 'R', 'L', 'D',
+            'C', 'A', 'F', 'E',
+            'W', 'O', 'U', 'N', 'D',
+            'h', 'ə', 'ˈ', 'ɫ', 'o', 'ʊ',
+            'ˈ', 'w', 'ɝ', 'ɫ', 'd',
+            'k', 'ə', 'ˈ', 'f', 'e', 'ɪ',
+            'ˈ', 'w', 'a', 'ʊ', 'n', 'd',
+            'ˈ', 'w', 'u', 'n', 'd',
+        }
+        # fmt: on
+        fixed_vocab = symbol_vocab - {'ʊ', 'F'}
+        tokenizer = IPATokenizer(g2p=g2p, locale="en-US", fixed_vocab=fixed_vocab)
+
+        # Make sure phoneme_dict has been updated properly
+        assert "HELLO" not in tokenizer.g2p.phoneme_dict
+        assert "WORLD" in tokenizer.g2p.phoneme_dict
+        assert "CAFE" not in tokenizer.g2p.phoneme_dict
+        assert len(tokenizer.g2p.phoneme_dict["WOUND"]) == 1
+        assert tokenizer.g2p.phoneme_dict["WOUND"][0] == list("ˈwund")
+
+        chars, tokens = self._parse_text(tokenizer, "Hello, wound")
+        expected_output = "HELLO, ˈwund"
+        assert chars == expected_output

--- a/tests/collections/common/tokenizers/text_to_speech/test_tts_tokenizers.py
+++ b/tests/collections/common/tokenizers/text_to_speech/test_tts_tokenizers.py
@@ -158,7 +158,7 @@ class TestTTSTokenizers:
 
         assert chars == expected_output
 
-    # @pytest.mark.run_only_on('CPU')
+    @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
     def test_ipa_tokenizer_fixed_vocab(self):
         phoneme_dict = self.PHONEME_DICT_EN

--- a/tests/collections/tts/g2p/test_modules.py
+++ b/tests/collections/tts/g2p/test_modules.py
@@ -122,6 +122,67 @@ class TestIPAG2P:
         assert g2p.phoneme_dict["JONES"][0] == list("ˈdʒoʊnz")
         assert g2p.phoneme_dict["AIRPORT"][0] == list("ˈɛɹˌpɔɹt")
 
+    # @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_replace_symbols(self):
+        g2p = self._create_g2p(use_chars=True, grapheme_prefix=self.GRAPHEME_PREFIX)
+
+        # fmt: off
+        # Get full vocab without 'i' (phoneme) and 'J' (grapheme)
+        fixed_symbols = {
+            f"{self.GRAPHEME_PREFIX}{char}"
+            for char in {
+                'H', 'E', 'L', 'L', 'O',
+                'W', 'O', 'R', 'L', 'D',
+                'L', 'E', 'A', 'D',
+                'N', 'V', 'I', 'D', 'I', 'A',
+                'O', 'N', 'E', 'S',
+                'A', 'I', 'R', 'P', 'O', 'R', 'T',
+            }
+        }.union(
+                {
+                    'h', 'ə', 'ˈ', 'ɫ', 'o', 'ʊ',
+                    'ˈ', 'w', 'ɝ', 'ɫ', 'd',
+                    'ˈ', 'l', 'ɛ', 'd',
+                    'ˈ', 'l', 'd',
+                    'ɛ', 'n', 'ˈ', 'v', 'ɪ', 'd', 'ə',
+                    'ˈ', 'd', 'ʒ', 'o', 'ʊ', 'n', 'z',
+                    'ˈ', 'ɛ', 'ɹ', 'ˌ', 'p', 'ɔ', 'ɹ', 't',
+                }
+        )
+        # fmt: on
+
+        assert len(g2p.phoneme_dict["LEAD"]) == 2
+        assert len(g2p.phoneme_dict["JONES"]) == 1
+        assert len(g2p.phoneme_dict["NVIDIA"]) == 1
+
+        # Test with keep_alternate set to True (default)
+        g2p.replace_symbols(symbols=fixed_symbols, keep_alternate=True)
+
+        # Check that the alternate pron of "LEAD" was kept
+        assert len(g2p.phoneme_dict["LEAD"]) == 1
+        assert g2p.phoneme_dict["LEAD"][0] == list("ˈlɛd")
+        # Check that filtering was done for unique entries, both grapheme and phoneme
+        assert "JONES" not in g2p.phoneme_dict
+        assert "NVIDIA" not in g2p.phoneme_dict
+        # Check that other words weren't affected
+        assert g2p.phoneme_dict["HELLO"][0] == list("həˈɫoʊ")
+        assert g2p.phoneme_dict["WORLD"][0] == list("ˈwɝɫd")
+        assert g2p.phoneme_dict["AIRPORT"][0] == list("ˈɛɹˌpɔɹt")
+
+        # Test with keep_alternate set to False
+        g2p = self._create_g2p(use_chars=True, grapheme_prefix=self.GRAPHEME_PREFIX)
+        g2p.replace_symbols(symbols=fixed_symbols, keep_alternate=False)
+
+        # Check that both "LEAD" entries were removed
+        assert "LEAD" not in g2p.phoneme_dict
+        # Other checks remain the same
+        assert "JONES" not in g2p.phoneme_dict
+        assert "NVIDIA" not in g2p.phoneme_dict
+        assert g2p.phoneme_dict["HELLO"][0] == list("həˈɫoʊ")
+        assert g2p.phoneme_dict["WORLD"][0] == list("ˈwɝɫd")
+        assert g2p.phoneme_dict["AIRPORT"][0] == list("ˈɛɹˌpɔɹt")
+
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
     def test_forward_call(self):

--- a/tests/collections/tts/g2p/test_modules.py
+++ b/tests/collections/tts/g2p/test_modules.py
@@ -122,7 +122,7 @@ class TestIPAG2P:
         assert g2p.phoneme_dict["JONES"][0] == list("ˈdʒoʊnz")
         assert g2p.phoneme_dict["AIRPORT"][0] == list("ˈɛɹˌpɔɹt")
 
-    # @pytest.mark.run_only_on('CPU')
+    @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
     def test_replace_symbols(self):
         g2p = self._create_g2p(use_chars=True, grapheme_prefix=self.GRAPHEME_PREFIX)


### PR DESCRIPTION
# What does this PR do ?

Allows users to pass in a grapheme + phoneme list/set as an enforced symbol vocabulary when using the IPA classes. Other symbols, such as punctuation, OOV, etc. are still handled by other tokenizer arguments.

Once set, G2P dictionary entries will be filtered in the following way:
- Words with any illegal graphemes are removed entirely.
- Words with one unique pronunciation and any illegal phonemes are removed entirely.
- If a word has multiple pronunciations and all of them have at least one illegal phoneme, the word is removed entirely.
- If at least one pronunciation is valid, it is kept if `keep_alternate=True` (default), otherwise the word is removed entirely.

The `TTSDataset` will also filter out all manifest entries whose normalized forms have any illegal graphemes.

Note: Users should take care that the passed-in vocab is consistent with `grapheme_prefix` and `grapheme_case`, or else filtering may not work properly.

**Collection**: TTS

# Changelog 
- Added a `replace_symbols()` function to `IPAG2P` to enforce user-set vocab and filter existing G2P dict
- Modified `IPATokenizer` to support taking in a user-set vocab
- Modified `TTSDataset` to check for illegal graphemes if a fixed vocab is used
- Added unit tests for `replace_symbols()`
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
