### PR TITLE
Cache aware streaming nfa

### DIFF
--- a/nemo/collections/asr/parts/mixins/mixins.py
+++ b/nemo/collections/asr/parts/mixins/mixins.py
@@ -610,7 +610,9 @@ class ASRModuleMixin(ASRAdapterModelMixin):
         for streaming_buffer in data_loader:
             streaming_buffer_iter = iter(streaming_buffer)
             batch_size = len(streaming_buffer.streams_length)
-            cache_last_channel, cache_last_time, cache_last_channel_len = self.encoder.get_initial_cache_state(batch_size=batch_size)
+            cache_last_channel, cache_last_time, cache_last_channel_len = self.encoder.get_initial_cache_state(
+                batch_size=batch_size
+            )
             previous_hypotheses = None
             pred_out_stream = None
             encoded_len = None

--- a/nemo/collections/asr/parts/mixins/mixins.py
+++ b/nemo/collections/asr/parts/mixins/mixins.py
@@ -558,6 +558,7 @@ class ASRModuleMixin(ASRAdapterModelMixin):
             all_hyp_or_transcribed_texts,
             cache_last_channel_next,
             cache_last_time_next,
+            cache_last_channel_next_len,
             best_hyp,
         ]
         if return_log_probs:
@@ -641,6 +642,7 @@ class ASRModuleMixin(ASRAdapterModelMixin):
                             transcribed_texts,
                             cache_last_channel,
                             cache_last_time,
+                            cache_last_channel_len,
                             previous_hypotheses,
                             cur_chunk_log_probs,
                             encoded_len,
@@ -652,6 +654,7 @@ class ASRModuleMixin(ASRAdapterModelMixin):
                             transcribed_texts,
                             cache_last_channel,
                             cache_last_time,
+                            cache_last_channel_len,
                             previous_hypotheses,
                         ) = result
 
@@ -717,3 +720,4 @@ class DiarizationMixin(ABC):
             Speaker labels
         """
         pass
+

--- a/nemo/collections/asr/parts/mixins/mixins.py
+++ b/nemo/collections/asr/parts/mixins/mixins.py
@@ -480,6 +480,9 @@ class ASRModuleMixin(ASRAdapterModelMixin):
                 "return_transcription can not be False for Transducer models as decoder returns the transcriptions too."
             )
 
+        if not isinstance(self, asr_models.EncDecCTCModel) and return_log_probs is True:
+            logging.info("return_log_probs can only be True for CTC models.")
+
         (
             encoded,
             encoded_len,
@@ -580,7 +583,7 @@ class ASRModuleMixin(ASRAdapterModelMixin):
             logprobs: (bool) pass True to get log probabilities instead of transcripts.
             return_hypotheses: (bool) Either return hypotheses or text
                 With hypotheses can do some postprocessing like getting timestamp or rescoring
-            online_normalization: (bool)
+            online_normalization: (bool) Perform normalization on the run per chunk.
         Returns:
             A list of transcriptions (or raw log probabilities if logprobs is True) in the same order as paths2audio_files
         """
@@ -639,7 +642,7 @@ class ASRModuleMixin(ASRAdapterModelMixin):
                             cur_chunk_log_probs,
                             encoded_len,
                         ) = result
-                        batch_log_probs.append(cur_chunk_log_probs)
+                        batch_log_probs.append(cur_chunk_log_probs.cpu())
                     else:
                         (
                             pred_out_stream,

--- a/nemo/collections/asr/parts/mixins/mixins.py
+++ b/nemo/collections/asr/parts/mixins/mixins.py
@@ -720,4 +720,3 @@ class DiarizationMixin(ABC):
             Speaker labels
         """
         pass
-

--- a/nemo/collections/asr/parts/mixins/mixins.py
+++ b/nemo/collections/asr/parts/mixins/mixins.py
@@ -440,6 +440,7 @@ class ASRModuleMixin(ASRAdapterModelMixin):
         previous_pred_out: torch.Tensor = None,
         drop_extra_pre_encoded: int = None,
         return_transcription: bool = True,
+        return_log_probs: bool = False
     ):
         """
         It simulates a forward step with caching for streaming purposes.
@@ -455,6 +456,7 @@ class ASRModuleMixin(ASRAdapterModelMixin):
             previous_pred_out: the predicted outputs from the previous step for CTC models
             drop_extra_pre_encoded: number of steps to drop from the beginning of the outputs after the downsampling module. This can be used if extra paddings are added on the left side of the input.
             return_transcription: whether to decode and return the transcriptions. It can not get disabled for Transducer models.
+            return_log_probs: whether to return the log probs, only valid for ctc model
 
         Returns:
             greedy_predictions: the greedy predictions from the decoder
@@ -463,6 +465,9 @@ class ASRModuleMixin(ASRAdapterModelMixin):
             cache_last_time_next: the updated tensor cache for last time layers to be used for next streaming step
             cache_last_channel_next_len: the updated lengths for cache_last_channel
             best_hyp: the best hypotheses for the Transducer models
+
+            log_probs: the logits tensor of current streaming chunk, only returned when return_log_probs=True
+            encoded_len: the length of the output log_probs + history chunk log_probs, only returned when return_log_probs=True
         """
         if not isinstance(self, asr_models.EncDecRNNTModel) and not isinstance(self, asr_models.EncDecCTCModel):
             raise NotImplementedError(f"stream_step does not support {type(self)}!")
@@ -545,14 +550,144 @@ class ASRModuleMixin(ASRAdapterModelMixin):
             if all_hyp_or_transcribed_texts is None:
                 all_hyp_or_transcribed_texts = best_hyp
 
-        return (
-            greedy_predictions,
-            all_hyp_or_transcribed_texts,
-            cache_last_channel_next,
-            cache_last_time_next,
-            cache_last_channel_next_len,
-            best_hyp,
-        )
+        result = [
+                greedy_predictions,
+                all_hyp_or_transcribed_texts,
+                cache_last_channel_next,
+                cache_last_time_next,
+                best_hyp,]
+        if return_log_probs:
+            result.append(log_probs)
+            result.append(encoded_len)
+
+        return tuple(result)
+
+    @torch.no_grad()
+    def transcribe_simulate_cache_aware_streaming(
+        self,
+        paths2audio_files: List[str],
+        batch_size: int = 4,
+        logprobs: bool = False,
+        return_hypotheses: bool = False,
+        online_normalization: bool = False
+    ):
+        """
+        Args:
+            paths2audio_files: (a list) of paths to audio files.
+            batch_size: (int) batch size to use during inference.
+                Bigger will result in better throughput performance but would use more memory.
+            logprobs: (bool) pass True to get log probabilities instead of transcripts.
+            return_hypotheses: (bool) Either return hypotheses or text
+                With hypotheses can do some postprocessing like getting timestamp or rescoring
+            online_normalization: (bool)
+        Returns:
+            A list of transcriptions (or raw log probabilities if logprobs is True) in the same order as paths2audio_files
+        """
+        if paths2audio_files is None or len(paths2audio_files) == 0:
+            return {}
+
+        if return_hypotheses and logprobs:
+            raise ValueError(
+                "Either `return_hypotheses` or `logprobs` can be True at any given time."
+                "Returned hypotheses will contain the logprobs."
+            )
+
+        if not isinstance(self, asr_models.EncDecCTCModel):
+            raise NotImplementedError(f"simulate streaming does not support {type(self)}!")
+
+        if not isinstance(self.encoder, StreamingEncoder):
+            raise NotImplementedError(f"Encoder of this model does not support streaming!")
+
+        data_loader = self._setup_streaming_transcribe_dataloader(
+            paths2audio_files, batch_size, online_normalization)
+
+        total_log_probs = []
+        total_texts = []
+
+        for streaming_buffer in data_loader:
+            streaming_buffer_iter = iter(streaming_buffer)
+            batch_size = len(streaming_buffer.streams_length)
+            cache_last_channel, cache_last_time = \
+                    self.encoder.get_initial_cache_state(batch_size=batch_size)
+            previous_hypotheses = None
+            pred_out_stream = None
+            encoded_len = None
+            transcribed_texts = None
+            batch_log_probs = []
+
+            for step_num, (chunk_audio, chunk_lengths) in enumerate(streaming_buffer_iter):
+                drop_extra_pre_encoded = self.encoder.streaming_cfg.drop_extra_pre_encoded if step_num != 0 else 0
+                with torch.inference_mode():
+                    result = self.conformer_stream_step(
+                        processed_signal=chunk_audio,
+                        processed_signal_length=chunk_lengths,
+                        cache_last_channel=cache_last_channel,
+                        cache_last_time=cache_last_time,
+                        keep_all_outputs=streaming_buffer.is_buffer_empty(),
+                        previous_hypotheses=previous_hypotheses,
+                        previous_pred_out=pred_out_stream,
+                        drop_extra_pre_encoded=drop_extra_pre_encoded,
+                        return_transcription=True,
+                        return_log_probs=logprobs or return_hypotheses
+                    )
+                    if logprobs or return_hypotheses:
+                        pred_out_stream, transcribed_texts, cache_last_channel, \
+                        cache_last_time, previous_hypotheses, cur_chunk_log_probs, \
+                        encoded_len = result
+                        batch_log_probs.append(cur_chunk_log_probs)
+                    else:
+                        pred_out_stream, transcribed_texts, cache_last_channel, \
+                        cache_last_time, previous_hypotheses = result
+
+            if logprobs or return_hypotheses:
+                # concatenate chunk log probs on T dim
+                batch_log_probs = torch.cat(batch_log_probs, axis=1)
+                for log_probs, log_prob_len in zip(batch_log_probs, encoded_len):
+                    total_log_probs.append(log_probs[0:log_prob_len])
+
+            if transcribed_texts is None:
+                total_texts += [''] * batch_size
+            else:
+                total_texts += transcribed_texts
+
+        if logprobs:
+            return total_log_probs
+
+        if not return_hypotheses:
+            return total_texts
+
+        hyps = []
+        for log_probs, text in zip(total_log_probs, total_texts):
+            hyps.append(Hypothesis(y_sequence=log_probs, text=text, score=0.0, dec_state=None))
+        return hyps
+
+    def _setup_streaming_transcribe_dataloader(self,
+        paths2audio_files: List[str],
+        batch_size: int,
+        online_normalization = False):
+        """
+        Setup function for a temporary data loader which wraps the provided audio file.
+
+        Args:
+            paths2audio_files: (a list) of paths to audio files.
+            batch_size: (int) batch size to use during inference. \
+                Bigger will result in better throughput performance but would use more memory.
+            online_normalization: whether to do online normalization
+        Returns:
+            a new batch streaming buffer
+        """
+        from nemo.collections.asr.parts.utils.streaming_utils import CacheAwareStreamingAudioBuffer
+        streaming_buffer = CacheAwareStreamingAudioBuffer(model=self,
+                                online_normalization=online_normalization)
+        for sample_idx, sample in enumerate(paths2audio_files):
+            processed_signal, processed_signal_length, stream_id = streaming_buffer.append_audio_file(
+                sample, stream_id=-1
+            )
+            logging.info(f'Added this sample to the buffer: {sample}')
+            if (sample_idx + 1) % batch_size == 0 or sample_idx == len(paths2audio_files) - 1:
+                logging.info(f"Starting to stream samples {sample_idx - len(streaming_buffer) + 1} to {sample_idx}...")
+                yield streaming_buffer
+                streaming_buffer.reset_buffer()
 
 
 class DiarizationMixin(ABC):

--- a/nemo/collections/asr/parts/mixins/mixins.py
+++ b/nemo/collections/asr/parts/mixins/mixins.py
@@ -610,7 +610,7 @@ class ASRModuleMixin(ASRAdapterModelMixin):
         for streaming_buffer in data_loader:
             streaming_buffer_iter = iter(streaming_buffer)
             batch_size = len(streaming_buffer.streams_length)
-            cache_last_channel, cache_last_time = self.encoder.get_initial_cache_state(batch_size=batch_size)
+            cache_last_channel, cache_last_time, cache_last_channel_len = self.encoder.get_initial_cache_state(batch_size=batch_size)
             previous_hypotheses = None
             pred_out_stream = None
             encoded_len = None
@@ -625,6 +625,7 @@ class ASRModuleMixin(ASRAdapterModelMixin):
                         processed_signal_length=chunk_lengths,
                         cache_last_channel=cache_last_channel,
                         cache_last_time=cache_last_time,
+                        cache_last_channel_len=cache_last_channel_len,
                         keep_all_outputs=streaming_buffer.is_buffer_empty(),
                         previous_hypotheses=previous_hypotheses,
                         previous_pred_out=pred_out_stream,

--- a/tools/nemo_forced_aligner/align.py
+++ b/tools/nemo_forced_aligner/align.py
@@ -94,6 +94,8 @@ Arguments:
     total_buffer_in_secs: float  Length of buffer (chunk + left and right padding) in seconds
     chunk_batch_size: int batch size for buffered chunk inference,
                       which will cut one audio into segments and do inference on chunk_batch_size segments at a time
+
+    simulate_cache_aware_streaming: False, if set True, using cache aware streaming to do get the logits for alignment
 """
 
 
@@ -121,6 +123,9 @@ class AlignmentConfig:
     chunk_len_in_secs: float = 1.6
     total_buffer_in_secs: float = 4.0
     chunk_batch_size: int = 32
+
+    # Cache aware streaming configs
+    simulate_cache_aware_streaming: Optional[bool] = False
 
 
 @hydra_runner(config_name="AlignmentConfig", schema=AlignmentConfig)
@@ -274,6 +279,7 @@ def main(cfg: AlignmentConfig):
             model,
             cfg.additional_ctm_grouping_separator,
             cfg.align_using_pred_text,
+            cfg.simulate_cache_aware_streaming,
             cfg.use_buffered_chunked_streaming,
             buffered_chunk_params,
         )

--- a/tools/nemo_forced_aligner/utils/data_prep.py
+++ b/tools/nemo_forced_aligner/utils/data_prep.py
@@ -317,9 +317,9 @@ def get_batch_tensors_and_boundary_info(
                 hypotheses = model.transcribe(audio_filepaths_batch, return_hypotheses=True, batch_size=B)
         else:
             with torch.no_grad():
-                hypotheses = model.transcribe_simulate_cache_aware_streaming(audio_filepaths_batch,
-                                                                             return_hypotheses=True,
-                                                                             batch_size=B)
+                hypotheses = model.transcribe_simulate_cache_aware_streaming(
+                    audio_filepaths_batch, return_hypotheses=True, batch_size=B
+                )
         for hypothesis in hypotheses:
             log_probs_list_batch.append(hypothesis.y_sequence)
             T_list_batch.append(hypothesis.y_sequence.shape[0])

--- a/tools/nemo_forced_aligner/utils/data_prep.py
+++ b/tools/nemo_forced_aligner/utils/data_prep.py
@@ -307,7 +307,6 @@ def get_batch_tensors_and_boundary_info(
     # and (optionally) the predicted ASR text from the hypotheses
     audio_filepaths_batch = [line["audio_filepath"] for line in manifest_lines_batch]
     B = len(audio_filepaths_batch)
-
     log_probs_list_batch = []
     T_list_batch = []
     pred_text_batch = []
@@ -319,8 +318,8 @@ def get_batch_tensors_and_boundary_info(
         else:
             with torch.no_grad():
                 hypotheses = model.transcribe_simulate_cache_aware_streaming(audio_filepaths_batch,
-                                                                            return_hypotheses=True,
-                                                                            batch_size=B)
+                                                                             return_hypotheses=True,
+                                                                             batch_size=B)
         for hypothesis in hypotheses:
             log_probs_list_batch.append(hypothesis.y_sequence)
             T_list_batch.append(hypothesis.y_sequence.shape[0])


### PR DESCRIPTION
# What does this PR do ?
Add cache aware streaming model in nemo force aligner

Should be easy for ctc segmentation tool to call and get the log probs as well.

Most of the codes are copied from speech_to_text_cache_aware_streaming_infer.py.

**Collection**: [Note which collection this PR will affect]
ASR

# Changelog 


# Usage
* You can potentially add a usage example below
```
nemo_model="nemo_models/cache_aware_ctc.nemo"
cd NeMo/tools/nemo_forced_aligner/
python3 align.py \
        batch_size=2 \
        model_path=$nemo_model \
        model_downsample_factor=4 \
        manifest_filepath=$manifest \
        output_dir=./streaming_ctm_with_pred \
        align_using_pred_text=true \
        simulate_cache_aware_streaming=true
```


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
