### PR TITLE
[NLP] Support T5 with Megatron Core

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -146,17 +146,18 @@ class MegatronPretrainingBatchSampler(BaseMegatronBatchSampler):
 
     def __iter__(self):
         batch = []
+
+        data_parallel_micro_batch_size = self.data_parallel_size * self.micro_batch_size
         # Last batch will be dropped if drop_last is not set False
         for idx in range(self.consumed_samples, self.total_samples):
             batch.append(idx)
-            if len(batch) == self.micro_batch_size:
-                # start_idx, end_idx = self.get_start_end_idx()
+            if len(batch) == data_parallel_micro_batch_size:
                 indices = [
-                    batch[i] for i in range(self.data_parallel_rank, self.micro_batch_size, self.data_parallel_size,)
+                    batch[i]
+                    for i in range(self.data_parallel_rank, data_parallel_micro_batch_size, self.data_parallel_size)
                 ]
                 assert len(indices) == self.micro_batch_size
                 yield indices
-                # yield batch[start_idx:end_idx]
                 batch = []
 
         # Check the last partial batch and see drop_last is set

--- a/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -151,10 +151,6 @@ class MegatronPretrainingBatchSampler(BaseMegatronBatchSampler):
             batch.append(idx)
             if len(batch) == self.micro_batch_size:
                 # start_idx, end_idx = self.get_start_end_idx()
-
-                """
-                if data parallel size was 2, batch size was 8
-                """
                 indices = [
                     batch[i] for i in range(self.data_parallel_rank, self.micro_batch_size, self.data_parallel_size,)
                 ]

--- a/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -140,24 +140,23 @@ class BaseMegatronBatchSampler:
 
 class MegatronPretrainingBatchSampler(BaseMegatronBatchSampler):
     def get_start_end_idx(self) -> Tuple[int, int]:
-        start_idx = self.data_parallel_rank * self.micro_batch_size
-        end_idx = start_idx + self.micro_batch_size
+        start_idx = self.data_parallel_rank * self._global_batch_size_on_this_data_parallel_rank
+        end_idx = start_idx + self._global_batch_size_on_this_data_parallel_rank
         return start_idx, end_idx
 
     def __iter__(self):
         batch = []
-
-        data_parallel_micro_batch_size = self.data_parallel_size * self.micro_batch_size
         # Last batch will be dropped if drop_last is not set False
         for idx in range(self.consumed_samples, self.total_samples):
             batch.append(idx)
-            if len(batch) == data_parallel_micro_batch_size:
+            if len(batch) == self._global_batch_size:
+                # start_idx, end_idx = self.get_start_end_idx()
                 indices = [
-                    batch[i]
-                    for i in range(self.data_parallel_rank, data_parallel_micro_batch_size, self.data_parallel_size)
+                    batch[i] for i in range(self.data_parallel_rank, self._global_batch_size, self.data_parallel_size,)
                 ]
-                assert len(indices) == self.micro_batch_size
+                assert len(indices) == self._global_batch_size_on_this_data_parallel_rank
                 yield indices
+                # yield batch[start_idx:end_idx]
                 batch = []
 
         # Check the last partial batch and see drop_last is set

--- a/nemo/collections/nlp/models/language_modeling/megatron_finetune_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_finetune_model.py
@@ -524,6 +524,11 @@ class MegatronT5FinetuneModel(MegatronT5Model):
         )
 
     def setup_training_data(self):
+        if not self.cfg.data.train_ds.drop_last:
+            raise AttributeError(
+                "`drop_last` is required for the training dataset to ensure each batch is the same micro-batch size."
+                "To set this, set the variable `data.train_ds.drop_last=True` in the config."
+            )
         self._train_dl = self.build_data_loader(
             self._train_ds,
             batch_size=self.cfg.data.train_ds.micro_batch_size,

--- a/nemo/collections/nlp/models/language_modeling/megatron_finetune_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_finetune_model.py
@@ -22,7 +22,6 @@ from nemo.collections.common.metrics import MetricStringToTorchMetric
 from nemo.collections.common.metrics.classification_accuracy import ExactStringPerCategoryMatchMetric
 from nemo.collections.nlp.data.common.sequence_to_sequence_dataset import SequenceToSequenceDataset
 from nemo.collections.nlp.models.language_modeling.megatron_t5_model import MegatronT5Model, T5Sentinel
-from nemo.collections.nlp.parts.nlp_overrides import GlobalBatchDataFetcher
 from nemo.utils import AppState, logging
 
 try:
@@ -199,25 +198,6 @@ class MegatronT5FinetuneModel(MegatronT5Model):
         # Same logic as validation epoch end, but this may be need if there is no validation sanity check to trigger validation_epoch_end()
         self.on_validation_epoch_end()
         return super().on_train_epoch_start()
-
-    def training_step(self, batch, batch_idx):
-        global_batch_size_per_gpu = batch['text_enc'].size(0)
-        # This should happen only on the last batch of the dataset.
-        if (
-            global_batch_size_per_gpu
-            != self.cfg.data.train_ds.global_batch_size // parallel_state.get_data_parallel_world_size()
-        ):
-            # NOTE: This should never really be called since `drop_last=True` is required for training datasets.
-            app_state = AppState()
-            _reconfigure_microbatch_calculator(
-                rank=app_state.global_rank,
-                rampup_batch_size=None,
-                global_batch_size=global_batch_size_per_gpu * parallel_state.get_data_parallel_world_size(),
-                micro_batch_size=global_batch_size_per_gpu // get_num_microbatches(),
-                data_parallel_size=parallel_state.get_data_parallel_world_size(),
-            )
-        batch = self._process_global_batch(batch)
-        return super().training_step(batch, batch_idx)
 
     def cast_for_metric(self, pred, label, metric_name, class_labels=None, labels_are_strings=False):
         if metric_name == 'exact_string_match':
@@ -516,7 +496,7 @@ class MegatronT5FinetuneModel(MegatronT5Model):
         _ = self.inference_epoch_end(outputs, 'test', self.cfg.data.test_ds)
 
     def build_data_loader(
-        self, dataset, global_batch_size, shuffle, num_workers, pin_memory, drop_last,
+        self, dataset, batch_size, shuffle, num_workers, pin_memory, drop_last,
     ):
         """Buld dataloader given an input dataset."""
 
@@ -537,7 +517,7 @@ class MegatronT5FinetuneModel(MegatronT5Model):
             dataset,
             collate_fn=collate_fn,
             sampler=sampler,
-            batch_size=global_batch_size // parallel_state.get_data_parallel_world_size(),
+            batch_size=batch_size,
             num_workers=num_workers,
             pin_memory=pin_memory,
             drop_last=drop_last,
@@ -546,7 +526,7 @@ class MegatronT5FinetuneModel(MegatronT5Model):
     def setup_training_data(self):
         self._train_dl = self.build_data_loader(
             self._train_ds,
-            global_batch_size=self.cfg.data.train_ds.global_batch_size,
+            batch_size=self.cfg.data.train_ds.micro_batch_size,
             shuffle=self.cfg.data.train_ds.shuffle,
             num_workers=self.cfg.data.train_ds.num_workers,
             pin_memory=self.cfg.data.train_ds.pin_memory,
@@ -558,7 +538,7 @@ class MegatronT5FinetuneModel(MegatronT5Model):
         for dataset in datasets:
             eval_dl = self.build_data_loader(
                 dataset,
-                global_batch_size=data_cfg.global_batch_size,
+                batch_size=self.cfg.data.train_ds.micro_batch_size,
                 shuffle=data_cfg.shuffle,
                 num_workers=data_cfg.num_workers,
                 pin_memory=data_cfg.pin_memory,

--- a/nemo/collections/nlp/models/language_modeling/megatron_glue_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_glue_model.py
@@ -82,3 +82,11 @@ class MegatronT5GLUEModel(MegatronT5FinetuneModel):
         self._train_ds = self._build_dataset(self.cfg.data.train_ds, check_implict_grad_acc=False)
         logging.info(f'Length of train dataset: {len(self._train_ds)}')
         logging.info(f'Finished building GLUE/XNLI datasets.')
+
+    @property
+    def max_decoder_seq_length(self) -> int:
+        return self._train_ds.max_seq_length_decoder
+
+    @property
+    def max_encoder_seq_length(self) -> int:
+        return self._train_ds.max_seq_length

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -23,9 +23,9 @@ from omegaconf.dictconfig import DictConfig
 from pytorch_lightning.accelerators import CPUAccelerator
 from pytorch_lightning.trainer.trainer import Trainer
 
-from nemo.collections.nlp.data.language_modeling.megatron.megatron_batch_samplers import (
-    MegatronPretrainingBatchSampler,
-    MegatronPretrainingRandomBatchSampler,
+from nemo.collections.nlp.data.language_modeling.megatron.data_samplers import (
+    MegatronPretrainingRandomSampler,
+    MegatronPretrainingSampler,
 )
 from nemo.collections.nlp.models.language_modeling.megatron_base_model import MegatronBaseModel
 from nemo.collections.nlp.modules.common.megatron.build_model import build_model
@@ -803,7 +803,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
         # Megatron sampler
         if hasattr(self._cfg.data, 'dataloader_type') and self._cfg.data.dataloader_type is not None:
             if self._cfg.data.dataloader_type == 'single':
-                batch_sampler = MegatronPretrainingBatchSampler(
+                batch_sampler = MegatronPretrainingSampler(
                     total_samples=len(dataset),
                     consumed_samples=consumed_samples,
                     micro_batch_size=self._cfg.micro_batch_size,
@@ -813,11 +813,11 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
                     drop_last=self._cfg.get('drop_last', True),
                 )
             elif self._cfg.data.dataloader_type == 'cyclic':
-                batch_sampler = MegatronPretrainingRandomBatchSampler(
+                batch_sampler = MegatronPretrainingRandomSampler(
                     total_samples=len(dataset),
                     consumed_samples=consumed_samples,
                     micro_batch_size=self._cfg.micro_batch_size,
-                    global_batch_size=self._cffg.global_batch_size,
+                    global_batch_size=self._cfg.global_batch_size,
                     data_parallel_rank=parallel_state.get_data_parallel_rank(),
                     data_parallel_size=parallel_state.get_data_parallel_world_size(),
                     drop_last=self._cfg.get('drop_last', True),

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -374,17 +374,11 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
             if loss_scale is not None:
                 self.log('loss_scale', loss_scale)
 
-        self.log(
-            'reduced_train_loss', loss_mean, prog_bar=True, rank_zero_only=True, batch_size=self.cfg.global_batch_size
-        )
+        self.log('reduced_train_loss', loss_mean, prog_bar=True, rank_zero_only=True, batch_size=1)
         lr = self._optimizer.param_groups[0]['lr']
-        self.log('lr', lr, rank_zero_only=True, batch_size=self.cfg.global_batch_size)
+        self.log('lr', lr, rank_zero_only=True, batch_size=1)
         self.log(
-            'global_step',
-            self.trainer.global_step,
-            prog_bar=True,
-            rank_zero_only=True,
-            batch_size=self.cfg.global_batch_size,
+            'global_step', self.trainer.global_step, prog_bar=True, rank_zero_only=True, batch_size=1,
         )
         # TODO: make sure compute_consumed_samples works for pipeline parallelism
         self.log(
@@ -392,7 +386,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
             self.compute_consumed_samples(self.trainer.global_step - self.init_global_step),
             prog_bar=True,
             rank_zero_only=True,
-            batch_size=self.cfg.global_batch_size,
+            batch_size=1,
         )
         return loss_mean
 

--- a/nemo/collections/nlp/modules/common/megatron/build_model.py
+++ b/nemo/collections/nlp/modules/common/megatron/build_model.py
@@ -18,8 +18,8 @@ from typing import Any, Callable, Dict, List, Optional
 import torch
 
 try:
-    from apex.transformer.enums import ModelType
     from megatron.core import parallel_state
+    from megatron.core.enums import ModelType
 
     HAVE_MEGATRON_CORE = True
 


### PR DESCRIPTION
# What does this PR do ?

Adds megatron core support for our T5 model. This only works for pre-training, due to dynamic max lengths in the GLUE/XLNI datasets fine-tuning seems to be broken. 

The fix going forward I think will be to pad to the maximum length to ensure the size of sequences are always the same. This is a requirement of the iterator object now used in the `training_step`.

I also need to confirm that the weights of the model are the same between main and this branch.

- [ ] Fix support for GLUE/XLNI Fine-tuning
- [x] Ensure convergence is the same
- [x] Fix support for encode/decode functions

**Collection**: NLP

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
