### PR TITLE
[BugFix] Fix diarization result path errors in tutorial notebook for r1.17.0

### DIFF
--- a/tutorials/speaker_tasks/Speaker_Diarization_Inference.ipynb
+++ b/tutorials/speaker_tasks/Speaker_Diarization_Inference.ipynb
@@ -23,7 +23,7 @@
     "!pip install text-unidecode\n",
     "\n",
     "# ## Install NeMo\n",
-    "BRANCH = 'r1.17.0'\n",
+    "BRANCH = 'main'\n",
     "!python -m pip install git+https://github.com/NVIDIA/NeMo.git@$BRANCH#egg=nemo_toolkit[asr]\n",
     "\n",
     "## Install TorchAudio\n",
@@ -486,6 +486,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Visualize the diarization output of clustering diarizer and compare with the ground-truth speaker labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Clustering Diarizer Result (RTTM format)\")\n",
+    "pred_labels_neural = rttm_to_labels(f'{output_dir}/pred_rttms/an4_diarize_test.rttm')\n",
+    "hypothesis_neural = labels_to_pyannote_object(pred_labels_neural)\n",
+    "hypothesis_neural"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Ground-truth Speaker Labels\")\n",
+    "reference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Neural Diarizer: Multiscale Diarization Decoder with Oracle VAD"
    ]
   },
@@ -546,7 +575,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The output of the neural diarizer is saved in `outputs/pred_ovl_rttms`."
+    "The output of the neural diarizer is saved in `outputs/pred_rttms`."
    ]
   },
   {
@@ -555,21 +584,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cat {output_dir}/pred_ovl_rttms/an4_diarize_test.rttm"
+    "!cat {output_dir}/pred_rttms/an4_diarize_test.rttm"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Visually Check Diarization Results with Oracle VAD"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Visualize the diarization output of clustering diarizer and neural diarizer."
+    "Visualize the diarization output of clustering diarizer and compare with the ground-truth speaker labels."
    ]
   },
   {
@@ -578,20 +600,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Clustering Diarizer Result\")\n",
-    "pred_labels_clus = rttm_to_labels(f'{output_dir}/pred_rttms/an4_diarize_test.rttm')\n",
-    "hypothesis_clus = labels_to_pyannote_object(pred_labels_clus)\n",
-    "hypothesis_clus"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"Neural Diarizer Result\")\n",
-    "pred_labels_neural = rttm_to_labels(f'{output_dir}/pred_ovl_rttms/an4_diarize_test.rttm')\n",
+    "print(\"Neural Diarizer Result (RTTM format)\")\n",
+    "pred_labels_neural = rttm_to_labels(f'{output_dir}/pred_rttms/an4_diarize_test.rttm')\n",
     "hypothesis_neural = labels_to_pyannote_object(pred_labels_neural)\n",
     "hypothesis_neural"
    ]
@@ -599,12 +609,10 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Ground-truth Speaker Label\")\n",
+    "print(\"Ground-truth Speaker Labels\")\n",
     "reference"
    ]
   },
@@ -803,6 +811,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Visualize the diarization output of clustering diarizer and compare with the ground-truth speaker labels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Clustering Diarizer Result (RTTM format)\")\n",
+    "pred_labels_neural = rttm_to_labels(f'{output_dir}/pred_rttms/an4_diarize_test.rttm')\n",
+    "hypothesis_neural = labels_to_pyannote_object(pred_labels_neural)\n",
+    "hypothesis_neural\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Ground-truth Speaker Labels (RTTM format)\")\n",
+    "reference"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "### Neural Diarizer: Multiscale Diarization Decoder with System VAD"
    ]
   },
@@ -837,7 +874,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Check whether diarization saved in `outputs/pred_ovl_rttms` is correct."
+    "Check whether diarization saved in `outputs/pred_rttms` is correct."
    ]
   },
   {
@@ -846,33 +883,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!cat {output_dir}/pred_ovl_rttms/an4_diarize_test.rttm"
+    "!cat {output_dir}/pred_rttms/an4_diarize_test.rttm"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Visually Check Diarization Results with System VAD"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Visualize the diarization output of clustering diarizer and neural diarizer."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "print(\"Clustering Diarizer Result (RTTM format)\")\n",
-    "pred_labels_clus = rttm_to_labels(f'{output_dir}/pred_rttms/an4_diarize_test.rttm')\n",
-    "hypothesis_clus = labels_to_pyannote_object(pred_labels_clus)\n",
-    "hypothesis_clus"
+    "Visualize the diarization output of clustering diarizer and compare with the ground-truth speaker labels."
    ]
   },
   {
@@ -882,7 +900,7 @@
    "outputs": [],
    "source": [
     "print(\"Neural Diarizer Result (RTTM format)\")\n",
-    "pred_labels_neural = rttm_to_labels(f'{output_dir}/pred_ovl_rttms/an4_diarize_test.rttm')\n",
+    "pred_labels_neural = rttm_to_labels(f'{output_dir}/pred_rttms/an4_diarize_test.rttm')\n",
     "hypothesis_neural = labels_to_pyannote_object(pred_labels_neural)\n",
     "hypothesis_neural"
    ]
@@ -893,7 +911,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "print(\"Ground-truth Speaker Label (RTTM format)\")\n",
+    "print(\"Ground-truth Speaker Labels (RTTM format)\")\n",
     "reference"
    ]
   },
@@ -955,7 +973,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.13"
   },
   "pycharm": {
    "stem_cell": {


### PR DESCRIPTION
# What does this PR do ?

Fix diarization result path errors in tutorial notebook for `r1.17.0`
Merging the change happened for main in https://github.com/NVIDIA/NeMo/pull/6217 to release branch


**Collection**: 
ASR 

# Changelog 

- Fixed diarization result path errors and tested notebook again.


# Usage
- Run [Speaker_Diarization_Inference.ipynb](https://github.com/NVIDIA/NeMo/blob/main/tutorials/speaker_tasks/Speaker_Diarization_Inference.ipynb) tutorial notebook

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?
ASR contributors

