### PR TITLE
fix small issue when running alsd beam-search with stateless decoders

### DIFF
--- a/nemo/collections/asr/modules/rnnt.py
+++ b/nemo/collections/asr/modules/rnnt.py
@@ -302,7 +302,7 @@ class StatelessTransducerDecoder(rnnt_abstract.AbstractRNNTDecoder, Exportable):
 
     def initialize_state(self, y: torch.Tensor) -> List[torch.Tensor]:
         batch = y.size(0)
-        state = [torch.ones([batch, self.context_size], dtype=y.dtype, device=y.device) * self.blank_idx]
+        state = [torch.ones([batch, self.context_size], dtype=torch.long, device=y.device) * self.blank_idx]
         return state
 
     def batch_initialize_states(self, batch_states: List[torch.Tensor], decoder_states: List[List[torch.Tensor]]):

--- a/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
@@ -39,6 +39,7 @@ from nemo.collections.asr.parts.utils.rnnt_utils import Hypothesis, NBestHypothe
 from nemo.core.classes import Typing, typecheck
 from nemo.core.neural_types import AcousticEncodedRepresentation, HypothesisType, LengthsType, NeuralType
 from nemo.utils import logging
+from nemo.collections.asr.modules.rnnt import RNNTDecoder, StatelessTransducerDecoder
 
 try:
     import kenlm
@@ -895,7 +896,17 @@ class BeamRNNTInfer(Typing):
                         sub_batch_ids.remove(id)
 
                     # extract the states of the sub batch only.
-                    beam_state_ = [beam_state[state_id][:, sub_batch_ids, :] for state_id in range(len(beam_state))]
+                    if isinstance(self.decoder, RNNTDecoder):
+                        # LSTM decoder, state is [layer x batch x hidden]
+                        beam_state_ = [
+                            beam_state[state_id][:, sub_batch_ids, :] for state_id in range(len(beam_state))
+                        ]
+                    elif isinstance(self.decoder, StatelessTransducerDecoder):
+                        # stateless decoder, state is [batch x hidden]
+                        beam_state_ = [beam_state[state_id][sub_batch_ids, :] for state_id in range(len(beam_state))]
+                    else:
+                        raise NotImplementedError("Unknown decoder type.")
+
                 else:
                     # If entire batch was used (none were removed), simply take all the states
                     beam_state_ = beam_state
@@ -909,7 +920,14 @@ class BeamRNNTInfer(Typing):
                     for state_id in range(len(beam_state)):
                         # Update the current batch states with the sub-batch states (in the correct indices)
                         # These indices are specified by sub_batch_ids, the ids of samples which were updated.
-                        beam_state[state_id][:, sub_batch_ids, :] = beam_state_[state_id][...]
+                        if isinstance(self.decoder, RNNTDecoder):
+                            # LSTM decoder, state is [layer x batch x hidden]
+                            beam_state[state_id][:, sub_batch_ids, :] = beam_state_[state_id][...]
+                        elif isinstance(self.decoder, StatelessTransducerDecoder):
+                            # stateless decoder, state is [batch x hidden]
+                            beam_state[state_id][sub_batch_ids, :] = beam_state_[state_id][...]
+                        else:
+                            raise NotImplementedError("Unknown decoder type.")
                 else:
                     # If entire batch was updated, simply update all the states
                     beam_state = beam_state_

--- a/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
@@ -816,7 +816,7 @@ class BeamRNNTInfer(Typing):
         """
         # delay this import here instead of at the beginning to avoid circular imports.
         from nemo.collections.asr.modules.rnnt import RNNTDecoder, StatelessTransducerDecoder
-            
+
         if partial_hypotheses is not None:
             raise NotImplementedError("`partial_hypotheses` support is not supported")
 

--- a/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_beam_decoding.py
@@ -39,7 +39,6 @@ from nemo.collections.asr.parts.utils.rnnt_utils import Hypothesis, NBestHypothe
 from nemo.core.classes import Typing, typecheck
 from nemo.core.neural_types import AcousticEncodedRepresentation, HypothesisType, LengthsType, NeuralType
 from nemo.utils import logging
-from nemo.collections.asr.modules.rnnt import RNNTDecoder, StatelessTransducerDecoder
 
 try:
     import kenlm
@@ -815,6 +814,9 @@ class BeamRNNTInfer(Typing):
         Returns:
             nbest_hyps: N-best decoding results
         """
+        # delay this import here instead of at the beginning to avoid circular imports.
+        from nemo.collections.asr.modules.rnnt import RNNTDecoder, StatelessTransducerDecoder
+            
         if partial_hypotheses is not None:
             raise NotImplementedError("`partial_hypotheses` support is not supported")
 


### PR DESCRIPTION
# What does this PR do ?

This PR fixes a small issue when running ALSD beam-search with stateless decoder transducers.

**Collection**: ASR

# Changelog 
Add additional checks in alsd beam-search code to handle different decoders differently.

# Usage
N/A


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
