### PR TITLE
Flashlight improvements and fixes, also fixed potential VRAM leak in ctc_models.transcribe

### DIFF
--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -392,6 +392,7 @@ class _EncDecBaseModel(ASRModel, ExportableEncDecModel):
                             # replace top k value with current top k
                             self._accuracy.top_k = top_k_i
                             labels_k_i = self._accuracy.top_k_predicted_labels(logits)
+                            labels_k_i = labels_k_i.cpu()
                             labels_k.append(labels_k_i)
 
                         # convenience: if only one top_k, pop out the nested list

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -196,7 +196,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
                     logits, logits_len, greedy_predictions = self.forward(
                         input_signal=test_batch[0].to(device), input_signal_length=test_batch[1].to(device)
                     )
-                    logits = logits.cpu()
+
                     if logprobs:
                         # dump log probs per file
                         for idx in range(logits.shape[0]):
@@ -206,6 +206,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
                         current_hypotheses, all_hyp = self.decoding.ctc_decoder_predictions_tensor(
                             logits, decoder_lengths=logits_len, return_hypotheses=return_hypotheses,
                         )
+                        logits = logits.cpu()
 
                         if return_hypotheses:
                             # dump log probs per file

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -90,7 +90,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
             with open_dict(self.cfg):
                 self.cfg.decoding = decoding_cfg
 
-        self.decoding = CTCDecoding(self.cfg.decoding, vocabulary=self.decoder.vocabulary)
+        self.decoding = CTCDecoding(self.cfg.decoding, vocabulary=OmegaConf.to_container(self.decoder.vocabulary))
 
         # Setup metric with decoding strategy
         self._wer = WER(
@@ -196,6 +196,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
                     logits, logits_len, greedy_predictions = self.forward(
                         input_signal=test_batch[0].to(device), input_signal_length=test_batch[1].to(device)
                     )
+                    logits = logits.cpu()
                     if logprobs:
                         # dump log probs per file
                         for idx in range(logits.shape[0]):
@@ -278,7 +279,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
             decoding_cls = OmegaConf.create(OmegaConf.to_container(decoding_cls))
             decoding_cfg = OmegaConf.merge(decoding_cls, decoding_cfg)
 
-            self.decoding = CTCDecoding(decoding_cfg=decoding_cfg, vocabulary=self.decoder.vocabulary)
+            self.decoding = CTCDecoding(decoding_cfg=decoding_cfg, vocabulary=OmegaConf.to_container(self.decoder.vocabulary))
 
             self._wer = WER(
                 decoding=self.decoding,
@@ -320,7 +321,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         decoding_cls = OmegaConf.create(OmegaConf.to_container(decoding_cls))
         decoding_cfg = OmegaConf.merge(decoding_cls, decoding_cfg)
 
-        self.decoding = CTCDecoding(decoding_cfg=decoding_cfg, vocabulary=self.decoder.vocabulary)
+        self.decoding = CTCDecoding(decoding_cfg=decoding_cfg, vocabulary=OmegaConf.to_container(self.decoder.vocabulary))
 
         self._wer = WER(
             decoding=self.decoding,
@@ -693,7 +694,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         dl_config = {
             'manifest_filepath': manifest_filepath,
             'sample_rate': self.preprocessor._sample_rate,
-            'labels': self.decoder.vocabulary,
+            'labels': OmegaConf.to_container(self.decoder.vocabulary),
             'batch_size': batch_size,
             'trim_silence': False,
             'shuffle': False,

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -279,7 +279,9 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
             decoding_cls = OmegaConf.create(OmegaConf.to_container(decoding_cls))
             decoding_cfg = OmegaConf.merge(decoding_cls, decoding_cfg)
 
-            self.decoding = CTCDecoding(decoding_cfg=decoding_cfg, vocabulary=OmegaConf.to_container(self.decoder.vocabulary))
+            self.decoding = CTCDecoding(
+                decoding_cfg=decoding_cfg, vocabulary=OmegaConf.to_container(self.decoder.vocabulary)
+            )
 
             self._wer = WER(
                 decoding=self.decoding,
@@ -321,7 +323,9 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         decoding_cls = OmegaConf.create(OmegaConf.to_container(decoding_cls))
         decoding_cfg = OmegaConf.merge(decoding_cls, decoding_cfg)
 
-        self.decoding = CTCDecoding(decoding_cfg=decoding_cfg, vocabulary=OmegaConf.to_container(self.decoder.vocabulary))
+        self.decoding = CTCDecoding(
+            decoding_cfg=decoding_cfg, vocabulary=OmegaConf.to_container(self.decoder.vocabulary)
+        )
 
         self._wer = WER(
             decoding=self.decoding,

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -186,7 +186,7 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
                         logits, encoded_len, return_hypotheses=return_hypotheses,
                     )
                     logits = logits.cpu()
-                    
+
                     if return_hypotheses:
                         # dump log probs per file
                         for idx in range(logits.shape[0]):

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -185,6 +185,8 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
                     best_hyp, all_hyp = self.ctc_decoding.ctc_decoder_predictions_tensor(
                         logits, encoded_len, return_hypotheses=return_hypotheses,
                     )
+                    logits = logits.cpu()
+                    
                     if return_hypotheses:
                         # dump log probs per file
                         for idx in range(logits.shape[0]):

--- a/nemo/collections/asr/modules/flashlight_decoder.py
+++ b/nemo/collections/asr/modules/flashlight_decoder.py
@@ -30,21 +30,26 @@ class _TokensWrapper:
         self.tokenizer = tokenizer
 
         if tokenizer is None:
-            self.reverse_map = {vocabulary[i]: i for i in range(len(vocabulary))}
+            self.reverse_map = {self.vocabulary[i]: i for i in range(len(self.vocabulary))}
+        
+        self.vocab_len = len(self.vocabulary)
+        
+        if (self.tokenizer is not None) and hasattr(self.tokenizer, 'unk_id') and self.tokenizer.unk_id is not None:
+            self.unknown_id = self.tokenizer.unk_id
+        elif ' ' in self.vocabulary:
+            self.unknown_id = self.token_to_id(' ')
+        elif '<unk>' in self.vocabulary:
+            self.unknown_id = self.token_to_id('<unk>')
+        else:
+            self.unknown_id = -1
 
     @property
     def blank(self):
-        return len(self.vocabulary)
+        return self.vocab_len
 
     @property
     def unk_id(self):
-        if (self.tokenizer is not None) and hasattr(self.tokenizer, 'unk_id') and self.tokenizer.unk_id is not None:
-            return self.tokenizer.unk_id
-
-        if '<unk>' in self.vocabulary:
-            return self.token_to_id('<unk>')
-        else:
-            return -1
+        return self.unknown_id
 
     @property
     def vocab(self):
@@ -53,7 +58,7 @@ class _TokensWrapper:
     @property
     def vocab_size(self):
         # the +1 is because we add the blank id
-        return len(self.vocabulary) + 1
+        return self.vocab_len + 1
 
     def token_to_id(self, token: str):
         if token == self.blank:
@@ -95,7 +100,6 @@ class FlashLightKenLMBeamSearchDecoder(NeuralModule):
         word_score: float = -1.0,
         unk_weight: float = -math.inf,
         sil_weight: float = 0.0,
-        unit_lm: bool = False,
     ):
 
         try:
@@ -122,7 +126,6 @@ class FlashLightKenLMBeamSearchDecoder(NeuralModule):
         self.vocab_size = self.tokenizer_wrapper.vocab_size
         self.blank = self.tokenizer_wrapper.blank
         self.silence = self.tokenizer_wrapper.unk_id
-        self.unit_lm = unit_lm
 
         if lexicon_path is not None:
             self.lexicon = load_words(lexicon_path)
@@ -161,10 +164,9 @@ class FlashLightKenLMBeamSearchDecoder(NeuralModule):
             )
 
             self.decoder = LexiconDecoder(
-                self.decoder_opts, self.trie, self.lm, self.silence, self.blank, self.unk_word, [], self.unit_lm,
+                self.decoder_opts, self.trie, self.lm, self.silence, self.blank, self.unk_word, [], False,
             )
         else:
-            assert self.unit_lm, "lexicon free decoding can only be done with a unit language model"
             from flashlight.lib.text.decoder import LexiconFreeDecoder, LexiconFreeDecoderOptions
 
             d = {
@@ -188,9 +190,17 @@ class FlashLightKenLMBeamSearchDecoder(NeuralModule):
         """Normalize tokens by handling CTC blank, ASG replabels, etc."""
 
         idxs = (g[0] for g in itertools.groupby(idxs))
-        idxs = filter(lambda x: x != self.blank and x != self.silence, idxs)
+        if self.silence < 0:
+            idxs = filter(lambda x: x != self.blank and x != self.silence, idxs)
+        else:
+            idxs = filter(lambda x: x != self.blank, idxs)
+        idxs = list(idxs)
+        if idxs[0] == self.silence:
+            idxs = idxs[1:]
+        if idxs[-1] == self.silence:
+            idxs = idxs[:-1]
 
-        return torch.LongTensor(list(idxs))
+        return torch.LongTensor(idxs)
 
     def _get_timesteps(self, token_idxs: List[int]):
         """Returns frame numbers corresponding to every non-blank token.

--- a/nemo/collections/asr/modules/flashlight_decoder.py
+++ b/nemo/collections/asr/modules/flashlight_decoder.py
@@ -31,9 +31,9 @@ class _TokensWrapper:
 
         if tokenizer is None:
             self.reverse_map = {self.vocabulary[i]: i for i in range(len(self.vocabulary))}
-        
+
         self.vocab_len = len(self.vocabulary)
-        
+
         if (self.tokenizer is not None) and hasattr(self.tokenizer, 'unk_id') and self.tokenizer.unk_id is not None:
             self.unknown_id = self.tokenizer.unk_id
         elif ' ' in self.vocabulary:

--- a/nemo/collections/asr/parts/submodules/ctc_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_beam_decoding.py
@@ -522,7 +522,6 @@ class BeamCTCInfer(AbstractBeamCTCInfer):
                 word_score=self.beam_beta,
                 unk_weight=self.flashlight_cfg.unk_weight,
                 sil_weight=self.flashlight_cfg.sil_weight,
-                unit_lm=self.flashlight_cfg.unit_lm,
             )
 
         x = x.to('cpu')
@@ -587,7 +586,6 @@ class FlashlightConfig:
     beam_threshold: float = 20.0
     unk_weight: float = -math.inf
     sil_weight: float = 0.0
-    unit_lm: bool = False
 
 
 @dataclass


### PR DESCRIPTION
# What does this PR do ?

Flashlight improvements and fixes, also fixed potential VRAM leak in ctc_models.transcribe

**Collection**: ASR

# Changelog 
- Set logits to CPU in ctc_models.transcribe
- Changed all `self.decoder.vocabulary` calls in ctc_models to be `OmegaConf.to_container(self.decoder.vocabulary)`, this is necessary for performance reasons, because downstream decoders like Flashlight access the vocabulary a lot, and if it's passed as a ListConfig, it's incredibly expensive to access repeatedly, hence pass as Python list instead
- Made changes to silence/unknown token handling in flashlight decoder
- Removed the unit_lm boolean requirement in flashlight_cfg. It's not necessary, the decoder knows that if you pass a lexicon it should use it, otherwise do lexicon-free mode. There's no need for a boolean too, it's superfluous, the presence of the lexicon file is the only indicator the class needs

# Usage
No changes to how anything is used, except don't pass `unit_lm` anymore to `flashlight_cfg`

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
