### PR TITLE
[BugFix] Fix the wrong branch name in speaker diarization inference notebook

### DIFF
--- a/tutorials/speaker_tasks/Speaker_Diarization_Inference.ipynb
+++ b/tutorials/speaker_tasks/Speaker_Diarization_Inference.ipynb
@@ -23,7 +23,7 @@
     "!pip install text-unidecode\n",
     "\n",
     "# ## Install NeMo\n",
-    "BRANCH = 'main'\n",
+    "BRANCH = 'r1.17.0'\n",
     "!python -m pip install git+https://github.com/NVIDIA/NeMo.git@$BRANCH#egg=nemo_toolkit[asr]\n",
     "\n",
     "## Install TorchAudio\n",


### PR DESCRIPTION
# What does this PR do ?

Fix the wrong branch name in speaker diarization inference notebook

**Collection**: [Note which collection this PR will affect]


# Changelog 
It should be BRANCH="r1.17.0" but it was BRANCH="main" in r1.17.0

# Usage
Run Speaker_Diarization_Inference.ipynb


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in ASR 

