### PR TITLE
[Core] return_config=True now extracts just config, not full tarfile

### DIFF
--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -372,7 +372,7 @@ class NLPSaveRestoreConnector(SaveRestoreConnector):
         loaded_params = super().load_config_and_state_dict(
             calling_cls, restore_path, override_config_path, map_location, strict, return_config, trainer,
         )
-        if not isinstance(loaded_params, tuple):
+        if not isinstance(loaded_params, tuple) or return_config is True:
             return loaded_params
         conf, instance, state_dict = loaded_params
         state_dict = self.modify_state_dict(conf, state_dict)

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -126,7 +126,9 @@ class SaveRestoreConnector:
 
                 else:
                     # Extract the nemo file into the temporary directory
-                    self._unpack_nemo_file(path2file=restore_path, out_folder=tmpdir)
+                    self._unpack_nemo_file(
+                        path2file=restore_path, out_folder=tmpdir, extract_config_only=return_config is True
+                    )
 
                 # Change current working directory to
                 os.chdir(tmpdir)
@@ -239,7 +241,7 @@ class SaveRestoreConnector:
         loaded_params = self.load_config_and_state_dict(
             calling_cls, restore_path, override_config_path, map_location, strict, return_config, trainer,
         )
-        if not isinstance(loaded_params, tuple):
+        if not isinstance(loaded_params, tuple) or return_config is True:
             return loaded_params
         conf, instance, state_dict = loaded_params
         state_dict = self.modify_state_dict(conf, state_dict)
@@ -532,7 +534,7 @@ class SaveRestoreConnector:
             tar.add(source_dir, arcname=".")
 
     @staticmethod
-    def _unpack_nemo_file(path2file: str, out_folder: str) -> str:
+    def _unpack_nemo_file(path2file: str, out_folder: str, extract_config_only: bool = False) -> str:
         if not os.path.exists(path2file):
             raise FileNotFoundError(f"{path2file} does not exist")
 
@@ -546,7 +548,11 @@ class SaveRestoreConnector:
             # can be older checkpoint => try compressed tar
             tar_header = "r:gz"
         tar = tarfile.open(path2file, tar_header)
-        tar.extractall(path=out_folder)
+        if not extract_config_only:
+            tar.extractall(path=out_folder)
+        else:
+            members = [x for x in tar.getmembers() if ".yaml" in x.name]
+            tar.extractall(path=out_folder, members=members)
         tar.close()
         return out_folder
 


### PR DESCRIPTION
# What does this PR do ?

Make return_config=True now only extract out the yaml files from the tarfile, preventing opening and file extractions of all files (should significantly speedup return_config=True for Billion parameter models).

**Collection**: [Core, ASR, NLP, TTS]

# Changelog 
- Add flag to extract just config from core internals

# Usage

```python
model_config = ModelClass.restore_from(..., return_config=True)
OR
model_config = ModelClass.from_pretrained(..., return_config=True)
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

