### PR TITLE
Adapter tuning accepts expanded language model dir

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_adapter_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_adapter_model.py
@@ -18,6 +18,7 @@
 
 
 import torch
+import os
 from omegaconf.dictconfig import DictConfig
 from pytorch_lightning.trainer.trainer import Trainer
 
@@ -37,11 +38,18 @@ from nemo.collections.nlp.modules.common.megatron.utils import average_losses_ac
 from nemo.collections.nlp.parts.utils_funcs import get_last_rank
 from nemo.core.classes.mixins import adapter_mixins
 from nemo.utils import logging, model_utils
+from nemo.collections.nlp.parts.nlp_overrides import NLPSaveRestoreConnector
 
 
 class MegatronGPTBaseAdapterModel(MegatronGPTPromptLearningModel):
     def __init__(self, cfg: DictConfig, trainer: Trainer):
         super().__init__(cfg, trainer)
+        save_restore_connector = NLPSaveRestoreConnector()
+        if os.path.isdir(cfg.get('language_model_path')):
+            save_restore_connector.model_extracted_dir = cfg.get('language_model_path')
+        self.frozen_model_cfg = MegatronGPTModel.restore_from(
+            cfg.get('language_model_path'), trainer=trainer, return_config=True, save_restore_connector=save_restore_connector,
+        )
         self.adapter_name_keys = []
 
     def forward(
@@ -246,9 +254,6 @@ class MegatronGPTAdapterLearningModel(MegatronGPTBaseAdapterModel):
         ], "Adapter type should be 'linear_adapter' or 'parallel_adapter'"
 
         self.adapter_name_keys = [AdapterName.PRE_ATTN_ADAPTER, AdapterName.POST_ATTN_ADAPTER]
-        frozen_model_cfg = MegatronGPTModel.restore_from(
-            cfg.get('language_model_path'), trainer=trainer, return_config=True
-        )
         for _, layer in self.frozen_model.named_modules():
             if hasattr(layer, 'activations_checkpoint_method'):
                 layer.activations_checkpoint_method = (
@@ -259,7 +264,7 @@ class MegatronGPTAdapterLearningModel(MegatronGPTBaseAdapterModel):
 
         if cfg.adapter_tuning.type == "parallel_adapter":
             adapter_cfg = ParallelLinearAdapterConfig(
-                in_features=frozen_model_cfg.hidden_size,
+                in_features=self.frozen_model_cfg.hidden_size,
                 dim=cfg.adapter_tuning.adapter_dim,
                 norm_position=cfg.adapter_tuning.get('norm_position', 'pre'),
                 norm_type=cfg.adapter_tuning.get('norm_type', 'mixedfusedlayernorm'),
@@ -269,7 +274,7 @@ class MegatronGPTAdapterLearningModel(MegatronGPTBaseAdapterModel):
             )
         else:
             adapter_cfg = LinearAdapterConfig(
-                in_features=frozen_model_cfg.hidden_size,
+                in_features=self.frozen_model_cfg.hidden_size,
                 dim=cfg.adapter_tuning.adapter_dim,
                 norm_position=cfg.adapter_tuning.get('norm_position', 'pre'),
                 dropout=cfg.adapter_tuning.adapter_dropout,
@@ -306,9 +311,6 @@ class MegatronGPTInfusedAdapterModel(MegatronGPTBaseAdapterModel):
     def __init__(self, cfg: DictConfig, trainer: Trainer):
         super().__init__(cfg, trainer)
         self.adapter_name_keys = [AdapterName.KEY_INFUSED, AdapterName.VALUE_INFUSED, AdapterName.MLP_INFUSED]
-        frozen_model_cfg = MegatronGPTModel.restore_from(
-            cfg.get('language_model_path'), trainer=trainer, return_config=True
-        )
         for _, layer in self.frozen_model.named_modules():
             if hasattr(layer, 'activations_checkpoint_method'):
                 layer.activations_checkpoint_method = (
@@ -323,11 +325,11 @@ class MegatronGPTInfusedAdapterModel(MegatronGPTBaseAdapterModel):
                 for adapter_key in self.adapter_name_keys:
                     if adapter_key == AdapterName.MLP_INFUSED:
                         cfg = MLPInfusedAdapterConfig(
-                            in_features=frozen_model_cfg.ffn_hidden_size // frozen_model_cfg.tensor_model_parallel_size
+                            in_features=self.frozen_model_cfg.ffn_hidden_size // self.frozen_model_cfg.tensor_model_parallel_size
                         )
                     elif adapter_key in [AdapterName.KEY_INFUSED, AdapterName.VALUE_INFUSED]:
                         cfg = InfusedAdapterConfig(
-                            in_features=frozen_model_cfg.hidden_size // frozen_model_cfg.tensor_model_parallel_size
+                            in_features=self.frozen_model_cfg.hidden_size // self.frozen_model_cfg.tensor_model_parallel_size
                         )
                     else:
                         raise ValueError(f"Adapter Key {adapter_key} is unknown.")

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_adapter_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_adapter_model.py
@@ -17,8 +17,9 @@
 # Adapted by: @adithyare
 
 
-import torch
 import os
+
+import torch
 from omegaconf.dictconfig import DictConfig
 from pytorch_lightning.trainer.trainer import Trainer
 
@@ -35,10 +36,10 @@ from nemo.collections.nlp.modules.common.megatron.adapters.parallel_adapters imp
     ParallelLinearAdapterConfig,
 )
 from nemo.collections.nlp.modules.common.megatron.utils import average_losses_across_data_parallel_group
+from nemo.collections.nlp.parts.nlp_overrides import NLPSaveRestoreConnector
 from nemo.collections.nlp.parts.utils_funcs import get_last_rank
 from nemo.core.classes.mixins import adapter_mixins
 from nemo.utils import logging, model_utils
-from nemo.collections.nlp.parts.nlp_overrides import NLPSaveRestoreConnector
 
 
 class MegatronGPTBaseAdapterModel(MegatronGPTPromptLearningModel):
@@ -48,7 +49,10 @@ class MegatronGPTBaseAdapterModel(MegatronGPTPromptLearningModel):
         if os.path.isdir(cfg.get('language_model_path')):
             save_restore_connector.model_extracted_dir = cfg.get('language_model_path')
         self.frozen_model_cfg = MegatronGPTModel.restore_from(
-            cfg.get('language_model_path'), trainer=trainer, return_config=True, save_restore_connector=save_restore_connector,
+            cfg.get('language_model_path'),
+            trainer=trainer,
+            return_config=True,
+            save_restore_connector=save_restore_connector,
         )
         self.adapter_name_keys = []
 
@@ -325,11 +329,13 @@ class MegatronGPTInfusedAdapterModel(MegatronGPTBaseAdapterModel):
                 for adapter_key in self.adapter_name_keys:
                     if adapter_key == AdapterName.MLP_INFUSED:
                         cfg = MLPInfusedAdapterConfig(
-                            in_features=self.frozen_model_cfg.ffn_hidden_size // self.frozen_model_cfg.tensor_model_parallel_size
+                            in_features=self.frozen_model_cfg.ffn_hidden_size
+                            // self.frozen_model_cfg.tensor_model_parallel_size
                         )
                     elif adapter_key in [AdapterName.KEY_INFUSED, AdapterName.VALUE_INFUSED]:
                         cfg = InfusedAdapterConfig(
-                            in_features=self.frozen_model_cfg.hidden_size // self.frozen_model_cfg.tensor_model_parallel_size
+                            in_features=self.frozen_model_cfg.hidden_size
+                            // self.frozen_model_cfg.tensor_model_parallel_size
                         )
                     else:
                         raise ValueError(f"Adapter Key {adapter_key} is unknown.")


### PR DESCRIPTION
# What does this PR do ?

set model extracted dir such that the save restore connector can load expanded base models. This is required to load large base models so that we can avoid the untaring step during training.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
