### PR TITLE
updated lr for FC configs

### DIFF
--- a/examples/asr/conf/fastconformer/fast-conformer_ctc_bpe.yaml
+++ b/examples/asr/conf/fastconformer/fast-conformer_ctc_bpe.yaml
@@ -155,7 +155,7 @@ model:
       # scheduler config override
       warmup_steps: 15000
       warmup_ratio: null
-      min_lr: 1e-6
+      min_lr: 1e-4
 
 trainer:
   devices: -1 # number of GPUs, -1 would use all available GPUs

--- a/examples/asr/conf/fastconformer/fast-conformer_transducer_bpe.yaml
+++ b/examples/asr/conf/fastconformer/fast-conformer_transducer_bpe.yaml
@@ -202,7 +202,7 @@ model:
 
   optim:
     name: adamw
-    lr: 2.5e-3
+    lr: 5e-3
     # optimizer arguments
     betas: [0.9, 0.98]
     weight_decay: 1e-3
@@ -213,7 +213,7 @@ model:
       # scheduler config override
       warmup_steps: 15000
       warmup_ratio: null
-      min_lr: 1e-6
+      min_lr: 5e-4
 
 trainer:
   devices: -1 # number of GPUs, -1 would use all available GPUs


### PR DESCRIPTION
# What does this PR do ?

Refines the suggested training parameters for the Fast Conformer models.

**Collection**: ASR

# Changelog 
- In fast-conformer_ctc_bpe.yaml, change min_lr to 1e-4 (from 1e-6)
- in fast-conformer_transducer_bpe.yaml, change lr to 5e-3 and min_lr to 5e-4 (from 1e-6)

# Usage
* Train as usual but you will be able to use checkpoint averaging to improve results

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
