### PR TITLE
Add semi sorted sampler.

### DIFF
--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -16,6 +16,7 @@ import json
 import math
 import multiprocessing
 import os
+from collections.abc import Iterable as IterableABC
 from typing import Callable, Dict, Iterable, List, Optional, Tuple, Union
 
 import braceexpand
@@ -424,7 +425,7 @@ class _AudioTextDataset(Dataset):
     def get_manifest_sample(self, sample_id):
         return self.manifest_processor.collection[sample_id]
 
-    def __getitem__(self, index):
+    def process_sample(self, index):
         sample = self.manifest_processor.collection[index]
         offset = sample.offset
 
@@ -449,6 +450,12 @@ class _AudioTextDataset(Dataset):
             output = f, fl, torch.tensor(t).long(), torch.tensor(tl).long()
 
         return output
+
+    def __getitem__(self, index):
+        if isinstance(index, IterableABC):
+            return [self.process_sample(_index) for _index in index]
+        else:
+            return self.process_sample(index)
 
     def __len__(self):
         return len(self.manifest_processor.collection)

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -25,6 +25,7 @@ from nemo.collections.asr.losses.ctc import CTCLoss
 from nemo.collections.asr.metrics.wer_bpe import WERBPE, CTCBPEDecoding, CTCBPEDecodingConfig
 from nemo.collections.asr.models.ctc_models import EncDecCTCModel
 from nemo.collections.asr.parts.mixins import ASRBPEMixin
+from nemo.collections.asr.parts.utils.asr_batching import get_semi_sorted_batch_sampler
 from nemo.core.classes.common import PretrainedModelInfo
 from nemo.utils import logging, model_utils
 
@@ -117,6 +118,19 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
         else:
             # support datasets that are lists of lists
             collate_fn = dataset.datasets[0].datasets[0].collate_fn
+
+        if config.get('use_semi_sorted_batching', False):
+            batch_sampler = get_semi_sorted_batch_sampler(self, dataset, config)
+            # set batch_size and batch_sampler to None to disable automatic batching
+            return torch.utils.data.DataLoader(
+                dataset=dataset,
+                batch_size=None,
+                sampler=batch_sampler,
+                batch_sampler=None,
+                collate_fn=collate_fn,
+                num_workers=config.get('num_workers', 0),
+                pin_memory=config.get('pin_memory', False),
+            )
 
         return torch.utils.data.DataLoader(
             dataset=dataset,

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -29,6 +29,7 @@ from nemo.collections.asr.losses.ctc import CTCLoss
 from nemo.collections.asr.metrics.wer import WER, CTCDecoding, CTCDecodingConfig
 from nemo.collections.asr.models.asr_model import ASRModel, ExportableEncDecModel
 from nemo.collections.asr.parts.mixins import ASRModuleMixin, InterCTCMixin
+from nemo.collections.asr.parts.utils.asr_batching import get_semi_sorted_batch_sampler
 from nemo.collections.asr.parts.utils.audio_utils import ChannelSelectorType
 from nemo.core.classes.common import PretrainedModelInfo, typecheck
 from nemo.core.classes.mixins import AccessMixin
@@ -374,6 +375,19 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         else:
             # support datasets that are lists of lists
             collate_fn = dataset.datasets[0].datasets[0].collate_fn
+
+        if config.get('use_semi_sorted_batching', False):
+            batch_sampler = get_semi_sorted_batch_sampler(self, dataset, config)
+            # set batch_size and batch_sampler to None to disable automatic batching
+            return torch.utils.data.DataLoader(
+                dataset=dataset,
+                batch_size=None,
+                sampler=batch_sampler,
+                batch_sampler=None,
+                collate_fn=collate_fn,
+                num_workers=config.get('num_workers', 0),
+                pin_memory=config.get('pin_memory', False),
+            )
 
         return torch.utils.data.DataLoader(
             dataset=dataset,

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -28,6 +28,7 @@ from nemo.collections.asr.models.rnnt_models import EncDecRNNTModel
 from nemo.collections.asr.parts.mixins import ASRBPEMixin
 from nemo.core.classes.common import PretrainedModelInfo
 from nemo.utils import logging, model_utils
+from nemo.collections.asr.parts.utils.asr_batching import get_semi_sorted_batch_sampler
 
 
 class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
@@ -482,6 +483,19 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
         else:
             # support datasets that are lists of lists
             collate_fn = dataset.datasets[0].datasets[0].collate_fn
+
+        if config.get('use_semi_sorted_batching', False):
+            batch_sampler = get_semi_sorted_batch_sampler(self, dataset, config)
+            # set batch_size and batch_sampler to None to disable automatic batching
+            return torch.utils.data.DataLoader(
+                dataset=dataset,
+                batch_size=None,
+                sampler=batch_sampler,
+                batch_sampler=None,
+                collate_fn=collate_fn,
+                num_workers=config.get('num_workers', 0),
+                pin_memory=config.get('pin_memory', False),
+            )
 
         return torch.utils.data.DataLoader(
             dataset=dataset,

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -26,9 +26,9 @@ from nemo.collections.asr.losses.rnnt import RNNTLoss
 from nemo.collections.asr.metrics.rnnt_wer_bpe import RNNTBPEWER, RNNTBPEDecoding, RNNTBPEDecodingConfig
 from nemo.collections.asr.models.rnnt_models import EncDecRNNTModel
 from nemo.collections.asr.parts.mixins import ASRBPEMixin
+from nemo.collections.asr.parts.utils.asr_batching import get_semi_sorted_batch_sampler
 from nemo.core.classes.common import PretrainedModelInfo
 from nemo.utils import logging, model_utils
-from nemo.collections.asr.parts.utils.asr_batching import get_semi_sorted_batch_sampler
 
 
 class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -31,13 +31,13 @@ from nemo.collections.asr.metrics.rnnt_wer import RNNTWER, RNNTDecoding, RNNTDec
 from nemo.collections.asr.models.asr_model import ASRModel
 from nemo.collections.asr.modules.rnnt import RNNTDecoderJoint
 from nemo.collections.asr.parts.mixins import ASRModuleMixin
+from nemo.collections.asr.parts.utils.asr_batching import get_semi_sorted_batch_sampler
 from nemo.collections.asr.parts.utils.audio_utils import ChannelSelectorType
 from nemo.core.classes import Exportable
 from nemo.core.classes.common import PretrainedModelInfo, typecheck
 from nemo.core.classes.mixins import AccessMixin
 from nemo.core.neural_types import AcousticEncodedRepresentation, AudioSignal, LengthsType, NeuralType, SpectrogramType
 from nemo.utils import logging
-from nemo.collections.asr.parts.utils.asr_batching import get_semi_sorted_batch_sampler
 
 
 class EncDecRNNTModel(ASRModel, ASRModuleMixin, Exportable):

--- a/nemo/collections/asr/parts/utils/asr_batching.py
+++ b/nemo/collections/asr/parts/utils/asr_batching.py
@@ -1,0 +1,222 @@
+# Copyright (c) 2022, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+from typing import Iterator, List, Optional, Union
+
+import numpy as np
+import torch
+from torch.utils.data.distributed import DistributedSampler
+
+from nemo.collections.asr.data.audio_to_text import AudioToBPEDataset, AudioToCharDataset
+from nemo.collections.asr.models.asr_model import ASRModel
+from nemo.utils import logging
+
+
+# class SemiSortBatchSampler(DistributedSampler):
+class SemiSortBatchSampler:
+    def __init__(
+        self,
+        global_rank: int,
+        world_size: int,
+        durations: List[int],
+        batch_size: int,
+        batch_shuffle: bool = True,
+        drop_last: bool = False,
+        randomization_factor: Optional[float] = None,
+        seed: int = 42,
+    ) -> None:
+        """
+        Semi Sorted Batching, as proposed in _SSB ("Speed up training with variable 
+        length inputs by efficient batching strategies.", Zhenhao Ge et al. (2021).).
+
+        The Semi Sorted Batch Sampler (SSB) samples the indices by their duration 
+        with the addition of pseudo noise that is sampled from the uniform 
+        distribution \mathbb{U}\left[ -delta * r, delta * r \right], where delta is 
+        defined as the difference between the maximum and minimum duration and r is 
+        the randomization factor that controls the strength of the noise (when r = 0, 
+        there will be a strong sorting). The heuristic value of the r according to 
+        the experiments from paper is 0.2. 
+
+        The torch calls the set_epoch method from the distributed data loader sampler 
+        at the end of each epoch to shuffle the samples according to the seed and 
+        epoch number. So the SSB is passed to the dataloader as a sampler with the 
+        dataloader's batch size options and the batch_sampler option set to None to 
+        disable automatical batching. In this case, the sampler has become an iterator 
+        that returns a list of batch indices.
+
+        Args:
+            global_rank: Rank among all GPUs.
+            world_size: The number of GPUs used.
+            durations: Sample durations parsed from `dataset.manifest_processor`.
+            batch_size: Micro batch size or batch size per singe gpu.
+            batch_shuffle: Batch sort before each epoch.
+            drop_last: Drop the last batch if the number of samples is less than batch 
+                size. Defaults to False.
+            randomization_factor: The strength of noise that will be added to the sample
+                duration. If no value is passed, the value 0.2 will be used.
+            seed: Seed for batch shuffleling. Defaults to 42.
+
+        Raises:
+            ValueError: Wrong randomization factor value.
+            RuntimeError: Unexpected behavior.
+
+        .. SSB_: 
+            https://www.isca-speech.org/archive/pdfs/interspeech_2021/ge21_interspeech.pdf
+        """
+        if randomization_factor is None:
+            randomization_factor = 0.2
+            logging.info("Randomization factor not found in config, default value 0.2 will be set.")
+        else:
+            logging.info(f"A randomization factor {randomization_factor} will be used.")
+
+        if randomization_factor < 0.0:
+            raise ValueError(f'Randomization factor must be non-negative but found {randomization_factor}.')
+
+        self.rank: List = global_rank
+        self.num_replicas: int = world_size
+
+        self.durations: np.array = np.array(durations, dtype=np.float32)
+
+        self.shuffle: bool = batch_shuffle
+        self.micro_batch_size: int = batch_size
+        self.drop_last: bool = drop_last
+        self.epoch: int = 0
+        self.seed: int = seed
+        self.randomization_factor: float = randomization_factor
+
+        self.local_num_batches: int = self._calculate_local_num_batches()
+
+    def _calculate_local_num_batches(self) -> int:
+        init_num_samples = len(self.durations)
+
+        # delete batches with a non-integer number of samples
+        if self.drop_last:
+            init_num_samples -= init_num_samples % self.micro_batch_size
+
+        # calculate the number of batches according to the counted number of samples
+        global_num_batches = math.ceil(init_num_samples / self.micro_batch_size)
+
+        # add extra batches to make it divisible by world size (num replicas)
+        num_batches_pad = (self.num_replicas - global_num_batches % self.num_replicas) % self.num_replicas
+        global_num_batches += num_batches_pad
+
+        # calculate the number of batches per rank
+        local_num_batches = global_num_batches // self.num_replicas
+
+        return local_num_batches
+
+    def _make_batches(self) -> List[np.array]:
+        max_duration: float = np.max(self.durations)
+        min_duration: float = np.min(self.durations)
+        bound: float = (max_duration - min_duration) * self.randomization_factor / 2
+
+        noise: np.array = np.random.uniform(low=-bound, high=bound, size=len(self.durations))
+
+        # sort indices accroding to pseudo noise
+        sorted_indices: np.array = np.argsort(self.durations + noise)
+
+        # delete batches with a non-integer number of samples
+        tail = 0
+        if self.drop_last:
+            tail: int = len(sorted_indices) % self.micro_batch_size
+            exclude = np.random.choice(len(sorted_indices), tail, replace=False)
+            sorted_indices = np.delete(sorted_indices, exclude)
+
+        global_num_batches: int = math.ceil(len(sorted_indices) / self.micro_batch_size)
+
+        # add extra batches to make it divisible by world size (num replicas)
+        pad_batches_num: int = (self.num_replicas - global_num_batches % self.num_replicas) % self.num_replicas
+        if global_num_batches < self.num_replicas:
+            logging.warning(
+                f"The number of all batches is {global_num_batches}, which is less than the "
+                f"world size of {self.num_replicas}. SSB Sampler will add {pad_batches_num} "
+                "batches. To avoid this try to decrease batch size or world size."
+            )
+
+        if pad_batches_num != 0:
+            # randomly select batch indeces to pad and concatenate them
+            batch_indeces_pad: np.array = np.random.randint(
+                low=0, high=len(sorted_indices), size=pad_batches_num * self.micro_batch_size,
+            )
+            sorted_indices: np.array = np.concatenate(
+                (sorted_indices, sorted_indices[batch_indeces_pad]), axis=0,
+            )
+
+        # local indeces are selected by world size and local rank
+        local_indices: np.array = sorted_indices[self.rank :: self.num_replicas]
+
+        # split local batches
+        size_mask = range(self.micro_batch_size, len(local_indices), self.micro_batch_size)
+        local_batches = np.split(local_indices, size_mask, axis=0)
+
+        if len(local_batches) != self.local_num_batches:
+            raise RuntimeError('Number of calculated indices is not equa to calculated number of local batches.')
+
+        return local_batches
+
+    def __iter__(self) -> Iterator[List[int]]:
+        local_batches = self._make_batches()
+
+        if self.shuffle:
+            g = torch.Generator()
+            g.manual_seed(self.seed + self.epoch + 1)
+            indices = torch.randperm(self.local_num_batches, generator=g)
+        else:
+            indices = torch.arange(0, self.local_num_batches)
+
+        for _, index in enumerate(indices):
+            yield local_batches[index]
+
+    def __len__(self) -> int:
+        return self.local_num_batches
+
+
+def get_semi_sorted_batch_sampler(
+    model: ASRModel, dataset: Union[AudioToCharDataset, AudioToBPEDataset], config: dict
+) -> SemiSortBatchSampler:
+    """
+    Instantiates a Semi Sorted (Batch) Sampler.
+
+    Args:
+        model: ASR Model.
+        dataset: Dataset which allow iterate over all object and parse durations.
+        config: Train, Vaidation or Test dataset config.
+
+    Raises:
+        ValueError: Wrong dataset type.
+
+    Returns:
+        SemiSortBatchSampler: Semi Sorted Batch Sampler class.
+    """
+    if not (isinstance(dataset, AudioToCharDataset) or isinstance(dataset, AudioToBPEDataset)):
+        raise ValueError(
+            "Only AudioToCharDataset or AudioToBPEDataset supported with semi sorted batching, "
+            f"but found {type(dataset)}."
+        )
+
+    durations = [sample.duration for sample in dataset.manifest_processor.collection.data]
+
+    sampler = SemiSortBatchSampler(
+        global_rank=model.global_rank,
+        world_size=model.world_size,
+        durations=durations,
+        batch_size=config['batch_size'],
+        batch_shuffle=config.get('shuffle', True),
+        drop_last=config.get('drop_last', False),
+        randomization_factor=config.get('randomization_factor', None),
+        seed=config.get('semi_sort_sampler_seed', 42),
+    )
+
+    return sampler

--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -872,6 +872,11 @@ def prepare_lr_scheduler(
                 batch_size = train_dataloader.batch_sampler.micro_batch_size
             else:
                 raise ValueError(f'Could not find batch_size from batch_sampler: {train_dataloader.batch_sampler}')
+        elif hasattr(train_dataloader, 'sampler') and train_dataloader.sampler is not None:
+            if train_dataloader.sampler.micro_batch_size is not None:
+                batch_size = train_dataloader.sampler.micro_batch_size
+            else:
+                raise ValueError(f'Could not find batch_size from sampler: {train_dataloader.sampler}')
         else:
             raise ValueError(f'Could not find batch_size from train_dataloader: {train_dataloader}')
         drop_last = train_dataloader.drop_last


### PR DESCRIPTION
# What does this PR do ?

Helps to speed up ASR models training without quality degradation.

**Collection**: ASR, Core

# Changelog 
- Adds a semi sorted batch sampler and its prepare function to a new file (in the future it might be some other samplers or new techniques like dynamic batching):
  `nemo/collections/asr/parts/utils/asr_batching.py`
- Added changes to the data loader preparation function in the following model classes:
  `nemo/collections/asr/models/ctc_models.py`
   `nemo/collections/asr/models/rnnt_bpe_models.py`
- Adds changes to the scheduler prepare function because the batch sampler is passed to the dataloader as a sampler and we need to parse the batch size from it. 
  `nemo/core/optim/lr_scheduler.py`
- Adds a change to the `__getitem__` dataset method, as the batch sampler becomes an iterator and returns a list of indices instead of a single index.
  `nemo/collections/asr/data/audio_to_text.py`

# Usage
The sampler is currently added to the following models:
    * `nemo.collections.asr.models.EncDecCTCModel`
    * `nemo.collections.asr.models.EncDecCTCModelBPE`
    * `nemo.collections.asr.models.EncDecRNNTModel`
    * `nemo.collections.asr.models.EncDecRNNTBPEModel`

Needs just to add one line in config.
```bash
++config.model.train_ds.use_semi_sorted_batching=true
```
and two line if we want to specify randomization factor (see more in additional information).
```bash
++config.model.train_ds.randomization_factor=0.1
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Semi Sorted Batching, was proposed in "Speed up training with variable length inputs by efficient batching strategies.", Zhenhao Ge et al. (2021).
* **Idea**: let's sort the samples by their duration, after adding pseudo noise to them, and then sample the batches from the sorted list. This way we avoid strict sorting and keep some level of randomness.
* Experiment for Conformer RNNT BPE:
   * Experiment setup
      The config is used from the [example configs](https://github.com/NVIDIA/NeMo/blob/main/examples/asr/conf/conformer/conformer_transducer_bpe.yaml) with overridden parameters of  ` trainer.epochs=50`, `trainer.devices=8` after the divergence of the first experiment `model.optim.lr=1.0`. For the train data LibriSpeech clean 100 and train clean 360, as well as for the test data, LibriSpeech test clean was used. For data processing, a BPE with a dictionary size of 512 was used.

   * first experiment
        <img src="https://github.com/fedorovgv/asr_ckpt/blob/main/step_1.png?raw=true" width="500" height="250">
        <img src="https://github.com/fedorovgv/asr_ckpt/blob/main/wer_1.png?raw=true" width="500" height="250">
   * second experiment
        <img src="https://github.com/fedorovgv/asr_ckpt/blob/main/step_2.png?raw=true" width="500" height="250">
        <img src="https://github.com/fedorovgv/asr_ckpt/blob/main/wer_2.png?raw=true" width="500" height="250">
        
   * Interesting, that in the first experiment, the training of the model broke up without ssb. 
   * In the second experiment, after reducing the learning rate (from default 5.0 to 1.0), it can be seen that the ssb model converges without quality degradation to ~4.4 WER in the first 50k steps and at **17.5%** faster in time.
   * In paper experiments, it was shown that with further training, the quality of training improves compared to the model without sbb for the same number of epochs with decreasing time.