### PR TITLE
Fix the GPT SFT datasets loss mask  bug

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
@@ -227,7 +227,7 @@ class GPTSFTDataset(Dataset):
         input_ids = processed_example['input_ids']
         answer_start_idx = processed_example['answer_start_idx']
         if self.answer_only_loss:
-            loss_mask = [float(idx > answer_start_idx) for idx in range(len(input_ids))]
+            loss_mask = [float(idx >= answer_start_idx) for idx in range(len(input_ids))]
         else:
             loss_mask = [1.0] * len(input_ids)
 


### PR DESCRIPTION
# What does this PR do ?

Currently the mask position is off by 1. The first token in the label is not included in the loss calculation. 