### PR TITLE
exceptions with empty test / val ds config sections

### DIFF
--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -280,7 +280,7 @@ def resolve_validation_dataloaders(model: 'ModelPT'):
             dataloaders.append(model._validation_dl)
 
         model._validation_dl = dataloaders
-        if isinstance(ds_values[0], (dict, DictConfig)):
+        if len(ds_values) > 0 and isinstance(ds_values[0], (dict, DictConfig)):
             # using the name of each of the nested dataset
             model._validation_names = [ds.name for ds in ds_values]
         else:
@@ -359,7 +359,7 @@ def resolve_test_dataloaders(model: 'ModelPT'):
             dataloaders.append(model._test_dl)
 
         model._test_dl = dataloaders
-        if isinstance(ds_values[0], (dict, DictConfig)):
+        if len(ds_values) > 0 and isinstance(ds_values[0], (dict, DictConfig)):
             # using the name of each of the nested dataset
             model._test_names = [ds.name for ds in ds_values]
         else:


### PR DESCRIPTION
# What does this PR do ?

Resolves exceptions when trying to train with empty test/ val ds config sections

**Collection**: ASR

# Changelog 
In `nemo/utils/model_utils.py` check if ds_values has values in it before trying to assign names to entries within. These names would have become visible in the test / validation sections of experiment manager (e.g. wandb) - but if these sections are emptty, there is no need to try.

# Usage
* You can potentially add a usage example below

```python
# should no longer fail:
python asr_transducer/speech_to_text_rnnt_bpe.py --config-path=../conf/contextnet_rnnt/ --config-name=config_rnnt_bpe.yaml model.tokenizer.dir=data/tokenizer/tokenizer_bpe_v1024/ model.tokenizer.type="bpe" model.train_ds.manifest_filepath=data/LibriSpeech/train_clean_100.json model.train_ds.batch_size=32 model.joint.fuse_loss_wer=true model.joint.fused_batch_size=8 model.decoding.greedy.max_symbols=5 ~model.validation_ds +accelerator="gpu" +strategy="ddp" +devices=4 trainer.max_epochs=1 exp_manager.checkpoint_callback_params.monitor="train_loss" "
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to bug 4067510
