### PR TITLE
[TTS] Fix aligner nan loss in fp32

### DIFF
--- a/nemo/collections/tts/losses/aligner_loss.py
+++ b/nemo/collections/tts/losses/aligner_loss.py
@@ -59,7 +59,7 @@ class ForwardSumLoss(Loss):
         # Note: Mask out probs beyond key_len
         key_inds = torch.arange(max_key_len + 1, device=attn_logprob.device, dtype=torch.long)
         attn_logprob.masked_fill_(
-            key_inds.view(1, 1, -1) > key_lens.view(1, -1, 1), -float("inf")  # key_inds >= key_lens+1
+            key_inds.view(1, 1, -1) > key_lens.view(1, -1, 1), -1e15  # key_inds >= key_lens+1
         )
         attn_logprob = self.log_softmax(attn_logprob)
 

--- a/nemo/collections/tts/losses/aligner_loss.py
+++ b/nemo/collections/tts/losses/aligner_loss.py
@@ -58,9 +58,7 @@ class ForwardSumLoss(Loss):
         # Convert to log probabilities
         # Note: Mask out probs beyond key_len
         key_inds = torch.arange(max_key_len + 1, device=attn_logprob.device, dtype=torch.long)
-        attn_logprob.masked_fill_(
-            key_inds.view(1, 1, -1) > key_lens.view(1, -1, 1), -1e15  # key_inds >= key_lens+1
-        )
+        attn_logprob.masked_fill_(key_inds.view(1, 1, -1) > key_lens.view(1, -1, 1), -1e15)  # key_inds >= key_lens+1
         attn_logprob = self.log_softmax(attn_logprob)
 
         # Target sequences


### PR DESCRIPTION
# What does this PR do ?

Fix FastPitch training appear `nan` loss in aligner loss when precision=32.  

**Collection**: [TTS]

# Changelog 
- `nemo/collections/tts/losses/aligner_loss`

# Usage
* To reproduce the bug, we can run `FastPitch and Mixer-TTS Training` tutorial by adding `trainer.precision=32` in training command. 

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
