### PR TITLE
Fix scheduler params registration

### DIFF
--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -912,7 +912,7 @@ def prepare_lr_scheduler(
     scheduler_args['max_steps'] = max_steps
 
     # Get the scheduler class from the config
-    scheduler_cls = get_scheduler(scheduler_name)
+    scheduler_cls = get_scheduler(scheduler_name, **scheduler_args)
 
     # Pop 'max_steps' if it's not required by the scheduler
     if 'max_steps' not in inspect.signature(scheduler_cls).parameters:


### PR DESCRIPTION
# What does this PR do ?

Fixes an issue with scheduler param registration.
The only way to override the scheduler args is via Hydra / OmegaConf at the moment, all defaults are picked directly from the constructor of the scheduler instead of the defaults of the dataclass. 

In effect, it sidesteps the validation and defaults of the dataclass of the scheduler entirely. There is no significant effect as it can still be fully overridden from the yaml config.

**Collection**: [Core]

# Changelog 
- Fix issue with scheduler dataclass registration
- Fix issue with scheduler dataclass validation with config overrides

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

