### PR TITLE
Fix an invalid link in get_data.py of ljspeech

### DIFF
--- a/scripts/dataset_processing/tts/ljspeech/get_data.py
+++ b/scripts/dataset_processing/tts/ljspeech/get_data.py
@@ -60,7 +60,7 @@ def __extract_file(filepath, data_dir):
 def __process_data(data_root, whitelist_path):
     if whitelist_path is None:
         wget.download(
-            "https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/data/whitelist/lj_speech.tsv",
+            "https://raw.githubusercontent.com/NVIDIA/NeMo-text-processing/main/nemo_text_processing/text_normalization/en/data/whitelist/lj_speech.tsv",
             out=str(data_root),
         )
         whitelist_path = data_root / "lj_speech.tsv"


### PR DESCRIPTION
# What does this PR do ?

It fixes an invalid link in get_data.py of ljspeech. Usage of the link in line 63 leads to downloading a html file not a tsv file, so we need to change it to a raw link.

**Collection**: [TTS]

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation