### PR TITLE
[TTS] Create initial TTS dataset feature processors

### DIFF
--- a/nemo/collections/tts/parts/preprocessing/feature_processors.py
+++ b/nemo/collections/tts/parts/preprocessing/feature_processors.py
@@ -178,7 +178,7 @@ class MeanVarianceSpeakerNormalization(FeatureProcessor):
             stats_path: JSON file with feature mean and variance.
             speaker_field: field containing speaker ID string.
             mask_field: Optional, field in example dictionary with boolean array indicating which values to
-                mask to 0. Defaults to 'voiced_mask', expected to be by pyin pitch estimator.
+                mask to 0. Defaults to 'voiced_mask', expected to be computed by pyin pitch estimator.
             fallback_to_default: Whether to use 'default' feature statistics when speaker is not found in
                 the statistics dictionary.
         """

--- a/nemo/collections/tts/parts/preprocessing/feature_processors.py
+++ b/nemo/collections/tts/parts/preprocessing/feature_processors.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import json
-import os
 from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
@@ -67,7 +66,7 @@ class LogCompression(FeatureProcessor):
 
         Args:
             field: Field to apply log compression to.
-            log_zero_guard_type: Method to avoid dividing by 0, either "add" or "clamp".
+            log_zero_guard_type: Method to avoid logarithm approaching -inf, either "add" or "clamp".
             log_zero_guard_value: Value to add or clamp input with.
         """
 
@@ -124,9 +123,6 @@ class MeanVarianceNormalization(FeatureProcessor):
 
         self.field = field
         self.mask_field = mask_field
-
-        if not os.path.exists(stats_path):
-            raise ValueError(f"Statistics file does not exist: {stats_path}")
 
         with open(stats_path, 'r', encoding="utf-8") as stats_f:
             stats_dict = json.load(stats_f)
@@ -193,9 +189,6 @@ class MeanVarianceSpeakerNormalization(FeatureProcessor):
         self.speaker_field = speaker_field
         self.mask_field = mask_field
         self.fallback_to_default = fallback_to_default
-
-        if not os.path.exists(stats_path):
-            raise ValueError(f"Statistics file does not exist: {stats_path}")
 
         with open(stats_path, 'r', encoding="utf-8") as stats_f:
             self.stats_dict = json.load(stats_f)

--- a/nemo/collections/tts/parts/preprocessing/feature_processors.py
+++ b/nemo/collections/tts/parts/preprocessing/feature_processors.py
@@ -43,7 +43,7 @@ class FeatureScaler(FeatureProcessor):
         Specifically: input[field] = (input[field] + add_value) / div_value
 
         Args:
-            field: field to scale
+            field: Field to scale
             add_value: Constant float value to add to feature.
             div_value: Constant float value to divide feature by.
         """
@@ -66,7 +66,7 @@ class LogCompression(FeatureProcessor):
         For clamp mode: input[field] = log(max(log_zero_guard_value, input[field]))
 
         Args:
-            field: field to apply log compression to.
+            field: Field to apply log compression to.
             log_zero_guard_type: Method to avoid dividing by 0, either "add" or "clamp".
             log_zero_guard_value: Value to add or clamp input with.
         """
@@ -116,7 +116,7 @@ class MeanVarianceNormalization(FeatureProcessor):
         }
 
         Args:
-            field: field to apply normalization to.
+            field: Field to apply normalization to.
             stats_path: JSON file with feature mean and variance.
             mask_field: Optional, field in example dictionary with boolean array indicating which values to
                 mask to 0. Defaults to 'voiced_mask', expected to be computed by pyin pitch estimator.
@@ -128,8 +128,8 @@ class MeanVarianceNormalization(FeatureProcessor):
         if not os.path.exists(stats_path):
             raise ValueError(f"Statistics file does not exist: {stats_path}")
 
-        with open(stats_path, 'r', encoding="utf-8") as pitch_f:
-            stats_dict = json.load(pitch_f)
+        with open(stats_path, 'r', encoding="utf-8") as stats_f:
+            stats_dict = json.load(stats_f)
             self.mean = stats_dict["default"][f"{self.field}_mean"]
             self.std = stats_dict["default"][f"{self.field}_std"]
 
@@ -178,7 +178,7 @@ class MeanVarianceSpeakerNormalization(FeatureProcessor):
         }
 
         Args:
-            field: field to apply normalization to.
+            field: Field to apply normalization to.
             stats_path: JSON file with feature mean and variance.
             speaker_field: field containing speaker ID string.
             mask_field: Optional, field in example dictionary with boolean array indicating which values to
@@ -197,8 +197,8 @@ class MeanVarianceSpeakerNormalization(FeatureProcessor):
         if not os.path.exists(stats_path):
             raise ValueError(f"Statistics file does not exist: {stats_path}")
 
-        with open(stats_path, 'r', encoding="utf-8") as pitch_f:
-            self.stats_dict = json.load(pitch_f)
+        with open(stats_path, 'r', encoding="utf-8") as stats_f:
+            self.stats_dict = json.load(stats_f)
 
     def process(self, training_example: dict) -> None:
         feature = training_example[self.field]

--- a/nemo/collections/tts/parts/preprocessing/feature_processors.py
+++ b/nemo/collections/tts/parts/preprocessing/feature_processors.py
@@ -1,0 +1,223 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+import torch
+
+from nemo.utils.decorators import experimental
+
+
+@experimental
+class FeatureProcessor(ABC):
+    @abstractmethod
+    def process(self, training_example: dict) -> None:
+        """
+        Process the input training example dictionary, modifying necessary fields in place.
+
+        Args:
+            training_example: training example dictionary.
+        """
+
+
+class FeatureScaler(FeatureProcessor):
+    def __init__(self, field: str, add_value: float = 0.0, div_value: float = 1.0):
+        """
+        Scales a field by constant factors. For example, for mean-variance normalization.
+
+        Specifically: input[field] = (input[field] + add_value) / div_value
+
+        Args:
+            field: field to scale
+            add_value: Constant float value to add to feature.
+            div_value: Constant float value to divide feature by.
+        """
+        self.field = field
+        self.add_value = add_value
+        self.div_value = div_value
+
+    def process(self, training_example: dict) -> None:
+        feature = training_example[self.field]
+        feature = (feature + self.add_value) / self.div_value
+        training_example[self.field] = feature
+
+
+class LogCompression(FeatureProcessor):
+    def __init__(self, field: str, log_zero_guard_type: str = "add", log_zero_guard_value: float = 1.0):
+        """
+        Apply log compression to a field.
+
+        By default: input[field] = log(1.0 + input[field])
+        For clamp mode: input[field] = log(max(log_zero_guard_value, input[field]))
+
+        Args:
+            field: field to apply log compression to.
+            log_zero_guard_type: Method to avoid dividing by 0, either "add" or "clamp".
+            log_zero_guard_value: Value to add or clamp input with.
+        """
+
+        self.field = field
+
+        if log_zero_guard_type == "add":
+            self.guard_fn = self._add_guard
+        elif log_zero_guard_type == "clamp":
+            self.guard_fn = self._clamp_guard
+        else:
+            raise ValueError(f"Unsupported log zero guard type: '{log_zero_guard_type}'")
+
+        self.guard_type = log_zero_guard_type
+        self.guard_value = log_zero_guard_value
+
+    def _add_guard(self, feature: torch.Tensor):
+        return feature + self.guard_value
+
+    def _clamp_guard(self, feature: torch.Tensor):
+        return torch.clamp(feature, min=self.guard_value)
+
+    def process(self, training_example: dict) -> None:
+        feature = training_example[self.field]
+
+        feature = self.guard_fn(feature)
+        feature = torch.log(feature)
+
+        training_example[self.field] = feature
+
+
+class MeanVarianceNormalization(FeatureProcessor):
+    def __init__(self, field: str, stats_path: Path, mask_field: Optional[str] = "voiced_mask"):
+        """
+        Apply mean and variance to the input field. Statistics are provided in JSON format, and can be
+        computed using scripts.dataset_processing.tts.compute_feature_stats.py
+
+        Specifically: input[field] = (input[field] + mean) / standard_deviation
+
+        Stats file format example for field 'pitch':
+
+        {
+            "default": {
+                "pitch_mean": 100.0,
+                "pitch_std": 50.0,
+            }
+        }
+
+        Args:
+            field: field to apply normalization to.
+            stats_path: JSON file with feature mean and variance.
+            mask_field: Optional, field in example dictionary with boolean array indicating which values to
+                mask to 0. Defaults to 'voiced_mask', expected to be computed by pyin pitch estimator.
+        """
+
+        self.field = field
+        self.mask_field = mask_field
+
+        if not os.path.exists(stats_path):
+            raise ValueError(f"Statistics file does not exist: {stats_path}")
+
+        with open(stats_path, 'r', encoding="utf-8") as pitch_f:
+            stats_dict = json.load(pitch_f)
+            self.mean = stats_dict["default"][f"{self.field}_mean"]
+            self.std = stats_dict["default"][f"{self.field}_std"]
+
+    def process(self, training_example: dict) -> None:
+        feature = training_example[self.field]
+
+        feature = (feature - self.mean) / self.std
+        if self.mask_field:
+            voiced_mask = training_example[self.mask_field]
+            feature[~voiced_mask] = 0.0
+
+        training_example[self.field] = feature
+
+
+class MeanVarianceSpeakerNormalization(FeatureProcessor):
+    def __init__(
+        self,
+        field: str,
+        stats_path: Path,
+        speaker_field: str = "speaker",
+        mask_field: Optional[str] = "voiced_mask",
+        fallback_to_default: bool = False,
+    ):
+        """
+        Apply speaker level mean and variance to the input field. Statistics are provided in JSON format, and can be
+        computed using scripts.dataset_processing.tts.compute_feature_stats.py
+
+        Specifically: input[field] = (input[field] + speaker_mean) / speaker_standard_deviation
+
+        Stats file format example for field 'pitch':
+
+        {
+            "default": {
+                "pitch_mean": 100.0,
+                "pitch_std": 50.0,
+            },
+            "speaker1": {
+                "pitch_mean": 110.0,
+                "pitch_std": 45.0,
+            },
+            "speaker2": {
+                "pitch_mean": 105.0,
+                "pitch_std": 30.0,
+            },
+            ...
+        }
+
+        Args:
+            field: field to apply normalization to.
+            stats_path: JSON file with feature mean and variance.
+            speaker_field: field containing speaker ID string.
+            mask_field: Optional, field in example dictionary with boolean array indicating which values to
+                mask to 0. Defaults to 'voiced_mask', expected to be by pyin pitch estimator.
+            fallback_to_default: Whether to use 'default' feature statistics when speaker is not found in
+                the statistics dictionary.
+        """
+
+        self.field = field
+        self.key_mean = f"{self.field}_mean"
+        self.key_std = f"{self.field}_std"
+        self.speaker_field = speaker_field
+        self.mask_field = mask_field
+        self.fallback_to_default = fallback_to_default
+
+        if not os.path.exists(stats_path):
+            raise ValueError(f"Statistics file does not exist: {stats_path}")
+
+        with open(stats_path, 'r', encoding="utf-8") as pitch_f:
+            self.stats_dict = json.load(pitch_f)
+
+    def process(self, training_example: dict) -> None:
+        feature = training_example[self.field]
+
+        speaker = training_example[self.speaker_field]
+        if speaker in self.stats_dict:
+            stats = self.stats_dict[speaker]
+        elif self.fallback_to_default:
+            stats = self.stats_dict["default"]
+        else:
+            raise ValueError(f"Statistics not found for speaker: {speaker}")
+
+        feature_mean = stats[self.key_mean]
+        feature_std = stats[self.key_std]
+
+        feature = (feature - feature_mean) / feature_std
+
+        if self.mask_field:
+            mask = training_example[self.mask_field]
+            feature[~mask] = 0.0
+
+        training_example[self.field] = feature

--- a/tests/collections/tts/parts/preprocessing/test_feature_processors.py
+++ b/tests/collections/tts/parts/preprocessing/test_feature_processors.py
@@ -1,0 +1,182 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import json
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+import torch
+
+from nemo.collections.tts.parts.preprocessing.feature_processors import (
+    FeatureScaler,
+    LogCompression,
+    MeanVarianceNormalization,
+    MeanVarianceSpeakerNormalization,
+)
+
+
+class TestTTSFeatureProcessors:
+    @contextlib.contextmanager
+    def _write_test_dict(self, test_dict, filename):
+        temp_dir = tempfile.TemporaryDirectory()
+        try:
+            test_dir = Path(temp_dir.name)
+            test_dict_filepath = test_dir / filename
+            with open(test_dict_filepath, 'w', encoding="utf-8") as stats_f:
+                json.dump(test_dict, stats_f, indent=4)
+
+            yield test_dict_filepath
+        finally:
+            temp_dir.cleanup()
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_feature_scalar(self):
+        field = "test_feat"
+        input_tensor = torch.tensor([-2.5, 0.0, 1.0], dtype=torch.float32)
+        expected_tensor = torch.tensor([0.0, 2.0, 2.8], dtype=torch.float32)
+        processor = FeatureScaler(field, add_value=2.5, div_value=1.25)
+
+        training_example = {field: input_tensor}
+        processor.process(training_example)
+        output_tensor = training_example[field]
+
+        torch.testing.assert_close(output_tensor, expected_tensor)
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_log_compression(self):
+        field = "test_feat"
+
+        input_tensor = torch.tensor([-0.5, 0.0, 2.0], dtype=torch.float32)
+        expected_tensor = torch.tensor([np.log(0.5), 0.0, np.log(3.0)], dtype=torch.float32)
+        processor = LogCompression(field)
+
+        training_example = {field: input_tensor}
+        processor.process(training_example)
+        output_tensor = training_example[field]
+
+        torch.testing.assert_close(output_tensor, expected_tensor)
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_log_compression_clamp(self):
+        field = "test_feat"
+
+        input_tensor = torch.tensor([0.1, 1.0, 2.0], dtype=torch.float32)
+        expected_tensor = torch.tensor([np.log(0.5), 0.0, np.log(2.0)], dtype=torch.float32)
+        processor = LogCompression(field, log_zero_guard_type="clamp", log_zero_guard_value=0.5)
+
+        training_example = {field: input_tensor}
+        processor.process(training_example)
+        output_tensor = training_example[field]
+
+        torch.testing.assert_close(output_tensor, expected_tensor)
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_mean_variance_normalization(self):
+        field = "test_feat"
+        filename = "stats.json"
+        stat_dict = {"default": {"test_feat_mean": 1.5, "test_feat_std": 0.5}}
+
+        input_tensor = torch.tensor([0.0, 1.5, 2.0], dtype=torch.float32)
+        expected_tensor = torch.tensor([-3.0, 0.0, 1.0], dtype=torch.float32)
+        training_example = {field: input_tensor}
+
+        with self._write_test_dict(stat_dict, filename=filename) as stat_dict_filepath:
+            processor = MeanVarianceNormalization(field, stats_path=stat_dict_filepath, mask_field=None)
+            processor.process(training_example)
+
+        output_tensor = training_example[field]
+        torch.testing.assert_close(output_tensor, expected_tensor)
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_mean_variance_normalization_masked(self):
+        field = "test_feat"
+        mask_field = "mask"
+        filename = "stats.json"
+        stat_dict = {"default": {"test_feat_mean": 1.0, "test_feat_std": 0.5}}
+
+        input_tensor = torch.tensor([2.0, 3.0, 4.0, 5.0], dtype=torch.float32)
+        input_mask = torch.tensor([True, False, False, True], dtype=torch.bool)
+        expected_tensor = torch.tensor([2.0, 0.0, 0.0, 8.0], dtype=torch.float32)
+        training_example = {field: input_tensor, mask_field: input_mask}
+
+        with self._write_test_dict(stat_dict, filename=filename) as stat_dict_filepath:
+            processor = MeanVarianceNormalization(field, stats_path=stat_dict_filepath, mask_field=mask_field)
+            processor.process(training_example)
+
+        output_tensor = training_example[field]
+        torch.testing.assert_close(output_tensor, expected_tensor)
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_mean_variance_speaker_normalization(self):
+        field = "pitch"
+        filename = "stats.json"
+        stat_dict = {
+            "default": {"pitch_mean": 1.5, "pitch_std": 0.5},
+            "speaker1": {"pitch_mean": 0.5, "pitch_std": 1.0},
+            "speaker2": {"pitch_mean": 0.0, "pitch_std": 2.0},
+        }
+
+        input_tensor = torch.tensor([0.0, 1.0], dtype=torch.float32)
+
+        training_example1 = {field: input_tensor, "speaker": "speaker1"}
+        training_example2 = {field: input_tensor, "speaker": "speaker2"}
+        training_example3 = {field: input_tensor, "speaker": "unknown"}
+        expected_tensor1 = torch.tensor([-0.5, 0.5], dtype=torch.float32)
+        expected_tensor2 = torch.tensor([0.0, 0.5], dtype=torch.float32)
+        expected_tensor3 = torch.tensor([-3.0, -1.0], dtype=torch.float32)
+
+        with self._write_test_dict(stat_dict, filename=filename) as stat_dict_filepath:
+            processor = MeanVarianceSpeakerNormalization(
+                field, stats_path=stat_dict_filepath, mask_field=None, fallback_to_default=True
+            )
+            processor.process(training_example1)
+            processor.process(training_example2)
+            processor.process(training_example3)
+
+        output_tensor1 = training_example1[field]
+        output_tensor2 = training_example2[field]
+        output_tensor3 = training_example3[field]
+        torch.testing.assert_close(output_tensor1, expected_tensor1)
+        torch.testing.assert_close(output_tensor2, expected_tensor2)
+        torch.testing.assert_close(output_tensor3, expected_tensor3)
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_mean_variance_speaker_normalization_masked(self):
+        field = "test_feat"
+        mask_field = "test_mask"
+        filename = "stats.json"
+        stat_dict = {"steve": {"test_feat_mean": -1.0, "test_feat_std": 2.0}}
+
+        input_tensor = torch.tensor([1.0, 2.0, 3.0, 4.0], dtype=torch.float32)
+        input_mask = torch.tensor([False, True, False, True], dtype=torch.bool)
+        expected_tensor = torch.tensor([0.0, 1.5, 0.0, 2.5], dtype=torch.float32)
+
+        training_example = {field: input_tensor, "speaker": "steve", mask_field: input_mask}
+
+        with self._write_test_dict(stat_dict, filename=filename) as stat_dict_filepath:
+            processor = MeanVarianceSpeakerNormalization(field, stats_path=stat_dict_filepath, mask_field=mask_field)
+            processor.process(training_example)
+
+        output_tensor = training_example[field]
+        torch.testing.assert_close(output_tensor, expected_tensor)


### PR DESCRIPTION
# What does this PR do ?

Add an interface and initial implementations to process features at training time, as part of TTS data loading refactoring.

The intention is for the data loader to load and merge feature dictionaries (produced by tts.parts.preprocessing.feature.py) and to use these processors to apply on necessary on the fly calculations, such as feature normalization.

I can provide a diff for the data loader itself if it helps provide context. Otherwise I will post PR for the data loader after this one, as it depends on this change.

**Collection**: [TTS]

# Changelog 
- Define interface to processing dataset features
- Provide implementation for feature scaling, log compression, and mean-variance normalization.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
