### PR TITLE
[TTS] Fix FastPitch energy code

### DIFF
--- a/nemo/collections/tts/modules/fastpitch.py
+++ b/nemo/collections/tts/modules/fastpitch.py
@@ -317,7 +317,7 @@ class FastPitchModule(NeuralModule, adapter_mixins.AdapterModuleMixin):
 
         # Predict energy
         if self.energy_predictor is not None:
-            energy_pred = self.energy_predictor(prosody_input, enc_mask).squeeze(-1)
+            energy_pred = self.energy_predictor(enc_out, enc_mask, conditioning=spk_emb).squeeze(-1)
 
             if energy is not None:
                 # Average energy over characters
@@ -402,7 +402,7 @@ class FastPitchModule(NeuralModule, adapter_mixins.AdapterModuleMixin):
                 assert energy.shape[-1] == text.shape[-1], f"energy.shape[-1]: {energy.shape[-1]} != len(text)"
                 energy_emb = self.energy_emb(energy)
             else:
-                energy_pred = self.energy_predictor(prosody_input, enc_mask).squeeze(-1)
+                energy_pred = self.energy_predictor(enc_out, enc_mask, conditioning=spk_emb).squeeze(-1)
                 energy_emb = self.energy_emb(energy_pred.unsqueeze(1))
             enc_out = enc_out + energy_emb.transpose(1, 2)
 


### PR DESCRIPTION
# What does this PR do ?

Update the energy prediction logic in FastPitch to match the new conditioning logic, similar to pitch. Current code throws a syntax error because `prosody_input `is no longer defined.

**Collection**: [TTS]

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation