### PR TITLE
Not doing CastToFloat by default

### DIFF
--- a/nemo/utils/export_utils.py
+++ b/nemo/utils/export_utils.py
@@ -463,7 +463,7 @@ def add_casts_around_norms(model: nn.Module):
     """
     Function to put additional to/from float32 casts around operations known to require full precision.
     It was used with an extra post-parse script to have TRT preserve extra precision when --fp16 needed.
-    Should not be needed with TRT 8.6.1+
+    Should not be needed with TRT 8.6.1 or later.
     """
     default_cast_replacements = {
         "BatchNorm1d": wrap_module(nn.BatchNorm1d, CastToFloat),

--- a/nemo/utils/export_utils.py
+++ b/nemo/utils/export_utils.py
@@ -440,7 +440,7 @@ script_replacements = {}
 
 def replace_for_export(model: nn.Module) -> nn.Module:
     """
-    Top-level function to replace default set of modules in model
+    Top-level function to replace 'default set' of modules in model, called from _prepare_for_export. 
     NOTE: This occurs in place, if you want to preserve model then make sure to copy it first.
     Args:
         model : top level module
@@ -460,6 +460,11 @@ def replace_for_export(model: nn.Module) -> nn.Module:
 
 
 def add_casts_around_norms(model: nn.Module):
+    """
+    Function to put additional to/from float32 casts around operations known to require full precision.
+    It was used with an extra post-parse script to have TRT preserve extra precision when --fp16 needed.
+    Should not be needed with TRT 8.6.1+
+    """
     default_cast_replacements = {
         "BatchNorm1d": wrap_module(nn.BatchNorm1d, CastToFloat),
         "BatchNorm2d": wrap_module(nn.BatchNorm2d, CastToFloat),

--- a/nemo/utils/export_utils.py
+++ b/nemo/utils/export_utils.py
@@ -444,18 +444,12 @@ def replace_for_export(model: nn.Module) -> nn.Module:
     NOTE: This occurs in place, if you want to preserve model then make sure to copy it first.
     Args:
         model : top level module
-        replace_1D_2D : include 1D -> 2D replacements
     Returns:
         model, possibly modified in-place
     """
     from nemo.collections.tts.modules.submodules import MaskedInstanceNorm1d
 
     default_replacements = {
-        "BatchNorm1d": wrap_module(nn.BatchNorm1d, CastToFloat),
-        "BatchNorm2d": wrap_module(nn.BatchNorm2d, CastToFloat),
-        "LayerNorm": wrap_module(nn.LayerNorm, CastToFloat),
-        "InstanceNorm1d": wrap_module(nn.InstanceNorm1d, CastToFloat),
-        "MaskedInstanceNorm1d": wrap_module(MaskedInstanceNorm1d, CastToFloatAll),
         "MatchedScaleMaskSoftmax": wrap_module(None, replace_MatchedScaleMaskSoftmax),
     }
 
@@ -463,3 +457,14 @@ def replace_for_export(model: nn.Module) -> nn.Module:
     replace_modules(model, default_replacements)
     # This one has to be the last
     replace_modules(model, script_replacements)
+
+
+def add_casts_around_norms(model: nn.Module):
+    default_cast_replacements = {
+        "BatchNorm1d": wrap_module(nn.BatchNorm1d, CastToFloat),
+        "BatchNorm2d": wrap_module(nn.BatchNorm2d, CastToFloat),
+        "LayerNorm": wrap_module(nn.LayerNorm, CastToFloat),
+        "InstanceNorm1d": wrap_module(nn.InstanceNorm1d, CastToFloat),
+        "MaskedInstanceNorm1d": wrap_module(MaskedInstanceNorm1d, CastToFloatAll),
+    }
+    replace_modules(model, default_cast_replacements)


### PR DESCRIPTION
# What does this PR do ?

Removing casts around norms from the set of default pre-export replacements and moving them to a separate function.
Latest TRT should not need that anymore - also the casts may prevent some fusion.
That function may still be used from Nemo2Riva explicitly should it be needed on case-by-case basis. 

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
