### PR TITLE
Limit urllib3 version to patch issue with RTD

### DIFF
--- a/requirements/requirements_docs.txt
+++ b/requirements/requirements_docs.txt
@@ -9,4 +9,5 @@ sphinx-book-theme
 sphinx-copybutton
 sphinxcontrib-bibtex
 sphinxext-opengraph
+urllib3<2.0.0
 wrapt


### PR DESCRIPTION
# What does this PR do ?

Docs build fails currently due to older version of OpenSSL on readthedocs. Limit urllib3 version to <2

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
