### PR TITLE
Separate punctuation by whitespace

### DIFF
--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -460,7 +460,7 @@ class PunctuationCapitalization:
     def separate_punctuation(self, lines: List[str]) -> List[str]:
         if self.regex_punctuation is not None:
             return [
-                self.regex_extra_space.sub('', self.regex_punctuation.sub(r' \1 ', line)).strip() for line in lines
+                self.regex_extra_space.sub(' ', self.regex_punctuation.sub(r' \1 ', line)).strip() for line in lines
             ]
         else:
             return lines
@@ -470,7 +470,7 @@ class PunctuationCapitalization:
 
     def rm_punctuation(self, lines: List[str]) -> List[str]:
         if self.regex_punctuation is not None:
-            return [self.regex_extra_space.sub('', self.regex_punctuation.sub(' ', line)).strip() for line in lines]
+            return [self.regex_extra_space.sub(' ', self.regex_punctuation.sub(' ', line)).strip() for line in lines]
         else:
             return lines
 


### PR DESCRIPTION
# What does this PR do ?

Fix separate_punctuation=True option 

**Collection**: ASR

# Changelog 
Do 
```
'some text.' -> 'some text .'
'some text .' -> some text .'
```

instead of 
```
'some text.' -> 'some text .'
'some text .' -> some text.'
```

**PR Type**:
- [V ] Bugfix


## Who can review?

@Kipok 
