### PR TITLE
Raise value error when it falls back to native pytorch softmax and attn_mask is None

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/fused_softmax.py
+++ b/nemo/collections/nlp/modules/common/megatron/fused_softmax.py
@@ -51,7 +51,12 @@ if HAVE_APEX:
                 input = input * self.scale
             mask_output = self.mask_func(input, mask) if mask is not None else input
             probs = torch.nn.Softmax(dim=-1)(mask_output)
-            if mask is not None:
+            if mask is None:
+                raise ValueError(
+                    "Attention mask should not be `None` when falling back to native pytorch softmax" \
+                    " forward. The behavior will most likely be different from the fused softmax."
+                )
+            else:
                 all_k_masked = mask.all(axis=-1)
                 zero_attention_mask = (1.0 - all_k_masked.float())[:, :, :, None]
                 probs = probs * zero_attention_mask


### PR DESCRIPTION
# What does this PR do ?

When softmax fused kernel is [not available](https://github.com/NVIDIA/apex/blob/85e9eddece9d4ac72b48c2407f8162f2173e1bf4/apex/transformer/functional/fused_softmax.py#L222), it will fall back to pytorch softmax forward in NeMo.

In apex, the mask is override based on your `attn_layer_type`. So it will always be set to either [causal or padding type of masking](https://github.com/NVIDIA/apex/blob/85e9eddece9d4ac72b48c2407f8162f2173e1bf4/apex/transformer/functional/fused_softmax.py#L205). While when it falls back to NeMo, it will actually do None masking fwd. This will cause in issues in training and inference when your tensor shape doesn't fit kernel or you are using 32 precision. 

We propose few improvement:
1. In apex, the user should be warned, no matter what they set in mask, it will be override based on `attn_layer_type`.
2. In every NeMo models, the attn mask should always be set when it's trying to use `MatchedScaleMaskSoftmax`.

**Collection**: Megatron models use fused softmax from apex, but attn_mask is None.

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
