### PR TITLE
Add inference kv cache support for transformer TE path

### DIFF
--- a/examples/nlp/language_modeling/megatron_gpt_eval.py
+++ b/examples/nlp/language_modeling/megatron_gpt_eval.py
@@ -153,6 +153,13 @@ class RequestDataSet(Dataset):
     def __getitem__(self, idx):
         return self.sentences[idx]
 
+def remove_padded_prompts(response, nb_paddings):
+    result = {}
+    for k, v in response.items():
+        if v != None and (type(v) is list or type(v) is torch.Tensor):
+            v = v[:-nb_paddings]
+        result[k] = v
+    return result
 
 @hydra_runner(config_path="conf", config_name="megatron_gpt_inference")
 def main(cfg) -> None:
@@ -253,22 +260,33 @@ def main(cfg) -> None:
         "compute_logprob": cfg.inference.compute_logprob,
     }
 
+    if model.cfg.fp8 == True:
+        nb_paddings = 0
+        while len(cfg.prompts) % 8 != 0:
+            cfg.prompts.append("")
+            nb_paddings += 1
+
     # First method of running text generation, call model.generate method
     response = model.generate(
         inputs=OmegaConf.to_container(cfg.prompts), length_params=length_params, sampling_params=sampling_params
     )
 
+    if model.cfg.fp8 == True:
+        response = remove_padded_prompts(response, nb_paddings)
     print("***************************")
     print(response)
     print("***************************")
 
     # Second method of running text generation, call trainer.predict
+    bs = 8 if model.cfg.fp8 == True else 2
     ds = RequestDataSet(OmegaConf.to_container(cfg.prompts))
-    request_dl = DataLoader(dataset=ds, batch_size=2)
+    request_dl = DataLoader(dataset=ds, batch_size=bs)
     config = OmegaConf.to_container(cfg.inference)
     model.set_inference_config(config)
     response = trainer.predict(model, request_dl)
 
+    if model.cfg.fp8 == True:
+        response[-1] = remove_padded_prompts(response[-1], nb_paddings)
     print("***************************")
     print(response)
     print("***************************")

--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -945,6 +945,9 @@ class ParallelTransformer(MegatronModule):
         self.position_embedding_type = position_embedding_type
         self.multi_query_attention = multi_query_attention
 
+        self.inference_current_sequence_len = 0
+        self.inference_params = None
+
         self.activations_checkpoint_method = activations_checkpoint_method
         self.activations_checkpoint_num_layers = activations_checkpoint_num_layers
         self.activations_checkpoint_granularity = activations_checkpoint_granularity
@@ -1428,7 +1431,7 @@ class ParallelTransformer(MegatronModule):
             # fp8_autocast will not do anything if TE or FP8 isn't used
             fp8_group = None
             if self.fp8 and parallel_state.model_parallel_is_initialized():
-                fp8_group = parallel_state.get_amax_reduction_group()
+                fp8_group = parallel_state.get_data_parallel_group()
 
             if HAVE_TE:
                 # if TE is installed but fp8 is not available then this will do nothing
@@ -1452,6 +1455,20 @@ class ParallelTransformer(MegatronModule):
                 else:
                     if get_key_value:
                         presents = []
+
+                    if self.transformer_engine:
+                        # Pass key value information to TE through inference_params to pre-allocate memory
+                        if set_inference_key_value_memory:
+                            self.inference_params = type('', (), {})()
+                            self.inference_params.max_sequence_len = inference_max_sequence_len
+                            self.inference_params.max_batch_size = hidden_states.size(1)
+                            self.inference_params.batch_size_offset = 0
+                            self.inference_params.key_value_memory_dict = {}
+                            self.inference_params.sequence_len_offset = 0
+                            self.inference_current_sequence_len = 0
+
+                        if self.inference_params != None:
+                            self.inference_params.sequence_len_offset = self.inference_current_sequence_len
 
                     for index in range(self.num_layers):
                         layer = self._get_layer(index)
@@ -1481,19 +1498,15 @@ class ParallelTransformer(MegatronModule):
                             checkpoint_core_attention = False
 
                         if self.transformer_engine:
-
-                            inference_params = None
-
                             hidden_states = layer(
                                 hidden_states,
                                 attention_mask,
                                 encoder_output=encoder_output,
                                 enc_dec_attn_mask=enc_dec_attn_mask,
-                                inference_params=inference_params,
+                                inference_params=self.inference_params,
                                 is_first_microbatch=self.is_first_microbatch,
                                 checkpoint_core_attention=checkpoint_core_attention,
                             )
-
                         else:
                             hidden_states = layer(
                                 hidden_states,
@@ -1509,6 +1522,9 @@ class ParallelTransformer(MegatronModule):
                                 cross_attention_relative_position_bias=cross_attention_relative_position_bias,
                                 checkpoint_core_attention=checkpoint_core_attention,
                             )
+                    # Update current sequence length outside of the loops
+                    if self.transformer_engine:
+                        self.inference_current_sequence_len += hidden_states.size(0)
 
         # Skip counter update for eval and activation checkpointing
         if torch.is_grad_enabled() and self.training:


### PR DESCRIPTION
# What does this PR do ?

Enable E2E inference for TE FP8 path in transformer with KV cache

**Collection**: NLP

# Changelog 
- Update examples/nlp/language_modeling/megatron_gpt_eval.py for TE FP8 inference, padded inputs to a multiple of 8 to get rid of error `AssertionError: Input and weight dimensions are not compatible for FP8 execution.`.
- Set up `inference_params` correctly and pass to TE for inference. Assume first time calling with `set_inference_key_value_memory=True` and remaining with `set_inference_key_value_memory=False`.
- Revert `parallel_state.get_amax_reduction_group()` back to `parallel_state.get_data_parallel_group()` to WAR the issue https://github.com/NVIDIA/NeMo/issues/6625

# Usage
Get an FP8 NeMo model and run:
```
python megatron_gpt_eval.py gpt_model_file=<FP8_NEMO_MODEL>
```



```python
python megatron_gpt_eval.py gpt_model_file=models/5b_fp8_tp1.nemo

***************************
[{'sentences': ['Q: How are you?\nA1) It is all too easy to get distracted, daydreaming and so forth. On top of that many people lack sufficient rest due to their', 'Q: How big is the universe?\nA: As you’ve probably heard, the universe includes everything that we can know. It stretches from one end of space to another and'], 'tokens': [['<|endoftext|>', 'Q', ':', ' How', ' are', ' you', '?', '\n', 'A', '1', ')', ' It', ' is', ' all', ' too', ' easy', ' to', ' get', ' distracted', ',', ' day', 'dream', 'ing', ' and', ' so', ' forth', '.', ' On', ' top', ' of', ' that', ' many', ' people', ' lack', ' sufficient', ' rest', ' due', ' to', ' their'], ['<|endoftext|>', 'Q', ':', ' How', ' big', ' is', ' the', ' universe', '?', '\n', 'A', ':', ' As', ' you', '�', '�', 've', ' probably', ' heard', ',', ' the', ' universe', ' includes', ' everything', ' that', ' we', ' can', ' know', '.', ' It', ' stretches', ' from', ' one', ' end', ' of', ' space', ' to', ' another', ' and']], 'logprob': tensor([[-3.3044e+00, -1.0319e-02, -8.7674e+00, -3.8337e+00, -2.2173e+00,
         -3.9373e+00, -7.4720e-01, -1.0483e+00, -7.5145e+00, -3.8551e+00,
         -5.1689e+00, -1.2816e+00, -4.9733e+00, -5.4351e+00, -1.8549e+00,
         -3.3207e-01, -1.8963e+00, -3.5398e+00, -3.2054e+00, -7.3057e+00,
         -7.6148e-02, -7.8230e-01, -2.3709e+00, -4.2063e+00, -2.1984e+00,
         -3.6228e-01, -4.6996e+00, -3.0654e+00, -3.2912e-03, -4.0276e-01,
         -6.4977e+00, -1.0216e+00, -4.6901e+00, -3.9250e+00, -4.8088e+00,
         -5.6998e+00, -1.3010e-02, -1.8368e+00],
        [-3.3044e+00, -1.0319e-02, -8.7674e+00, -5.2868e+00, -6.7541e-01,
         -8.7047e-01, -4.0037e+00, -3.9222e-01, -3.4152e-01, -2.2293e+00,
         -2.9142e-02, -4.3188e+00, -5.2750e+00, -4.1764e+00, -6.8956e-03,
         -8.7781e-01, -7.6296e-01, -1.0332e+00, -4.1965e-01, -5.5560e-01,
         -5.0666e-01, -6.7566e+00, -7.0060e-01, -7.9373e-01, -3.1336e+00,
         -7.8659e-01, -4.4716e+00, -1.9113e+00, -2.2779e+00, -4.2088e+00,
         -1.4632e+00, -3.7058e+00, -3.2600e-01, -1.2548e-01, -2.1457e+00,
         -4.3699e-01, -2.8770e+00, -2.3523e+00]]), 'full_logprob': None, 'token_ids': [[50256, 48, 25, 1374, 389, 345, 30, 198, 32, 16, 8, 632, 318, 477, 1165, 2562, 284, 651, 22943, 11, 1110, 25966, 278, 290, 523, 6071, 13, 1550, 1353, 286, 326, 867, 661, 3092, 6751, 1334, 2233, 284, 511], [50256, 48, 25, 1374, 1263, 318, 262, 6881, 30, 198, 32, 25, 1081, 345, 447, 247, 303, 2192, 2982, 11, 262, 6881, 3407, 2279, 326, 356, 460, 760, 13, 632, 23687, 422, 530, 886, 286, 2272, 284, 1194, 290]], 'offsets': [[0, 0, 1, 2, 6, 10, 14, 15, 16, 17, 18, 19, 22, 25, 29, 33, 38, 41, 45, 56, 57, 61, 66, 69, 73, 76, 82, 83, 86, 90, 93, 98, 103, 110, 115, 126, 131, 135, 138], [0, 0, 1, 2, 6, 10, 13, 17, 26, 27, 28, 29, 30, 33, 37, 38, 39, 41, 50, 56, 57, 61, 70, 79, 90, 95, 98, 102, 107, 108, 111, 121, 126, 130, 134, 137, 143, 146, 154]]}]
***************************
```

# Before your PR is "Ready for review"
**Pre checks**:
- [V] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [V] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
