### PR TITLE
Fix for old models in change_attention_model

### DIFF
--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -20,7 +20,7 @@ from typing import List, Optional, Set
 import torch
 import torch.distributed
 import torch.nn as nn
-from omegaconf import DictConfig, ListConfig
+from omegaconf import DictConfig, ListConfig, open_dict
 
 from nemo.collections.asr.models.configs import CacheAwareStreamingConfig
 from nemo.collections.asr.parts.mixins.streaming import StreamingEncoder
@@ -884,8 +884,10 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable, AccessMixin):
 
         if att_context_size:
             att_context_size = list(att_context_size)
-        else:
+        elif hasattr(self._cfg, "att_context_size"):
             att_context_size = self._cfg.att_context_size
+        else:
+            att_context_size = self.att_context_size
 
         if self_attention_model is None:
             self_attention_model = self._cfg.self_attention_model
@@ -971,8 +973,9 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable, AccessMixin):
                 m.self_attention_model = self_attention_model
 
         if update_config:
-            self._cfg.self_attention_model = self_attention_model
-            self._cfg.att_context_size = att_context_size
+            with open_dict(self._cfg):
+                self._cfg.self_attention_model = self_attention_model
+                self._cfg.att_context_size = att_context_size
 
 
 class ConformerEncoderAdapter(ConformerEncoder, adapter_mixins.AdapterModuleMixin):

--- a/nemo/collections/asr/parts/mixins/mixins.py
+++ b/nemo/collections/asr/parts/mixins/mixins.py
@@ -412,6 +412,9 @@ class ASRModuleMixin(ASRAdapterModelMixin):
             update_config (bool): Whether to update the config or not with the new attention model.
                 Defaults to True.
         """
+        if self_attention_model is None and att_context_size is None:
+            return
+
         if not hasattr(self, 'encoder'):
             logging.info(
                 "Could not change the self_attention_model in encoder "
@@ -425,8 +428,9 @@ class ASRModuleMixin(ASRAdapterModelMixin):
 
         self.encoder.change_attention_model(self_attention_model, att_context_size, update_config, self.device)
         if update_config:
-            self.cfg.encoder.self_attention_model = self_attention_model
-            self.cfg.encoder.att_context_size = att_context_size
+            with open_dict(self.cfg):
+                self.cfg.encoder.self_attention_model = self_attention_model
+                self.cfg.encoder.att_context_size = att_context_size
 
     def conformer_stream_step(
         self,


### PR DESCRIPTION
# What does this PR do ?

Fixes some issues:
-change_attention_model should work for old models which don't have some of the relevant parameters in config
-also it shouldn't run when nothing to change was submitted

Original PR: https://github.com/NVIDIA/NeMo/pull/6608

**Collection**: ASR

  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation
