### PR TITLE
Fix for interctc test random failure

### DIFF
--- a/tests/collections/asr/test_asr_interctc_models.py
+++ b/tests/collections/asr/test_asr_interctc_models.py
@@ -66,7 +66,6 @@ def squeezeformer_encoder_config() -> Dict:
 
 
 class TestInterCTCLoss:
-    @pytest.mark.pleasefixme
     @pytest.mark.unit
     @pytest.mark.parametrize(
         "model_class", [EncDecCTCModel, EncDecHybridRNNTCTCModel],
@@ -199,10 +198,17 @@ class TestInterCTCLoss:
             def __getitem__(self, idx):
                 return self.values
 
+        # this sometimes results in all zeros in the output which breaks tests
+        # so using this only for the ptl calls in the bottom, but using
+        # processed signal directly initially to remove the chance of
+        # this edge-case
         input_signal = torch.randn(size=(1, 512))
         input_length = torch.randint(low=161, high=500, size=[1])
         target = torch.randint(size=(1, input_length[0]), low=0, high=28)
         target_length = torch.tensor([input_length[0]])
+
+        processed_signal = torch.randn(size=([1, 64, 12]))
+        processed_length = torch.tensor([8])
 
         if len(apply_at_layers) != len(loss_weights):
             # has to throw an error here
@@ -216,7 +222,9 @@ class TestInterCTCLoss:
             asr_model = model_class(cfg=model_config)
             asr_model.train()
             AccessMixin.set_access_enabled(access_enabled=True)
-            logprobs, *_ = asr_model.forward(input_signal=input_signal, input_signal_length=input_length)
+            logprobs, *_ = asr_model.forward(
+                processed_signal=processed_signal, processed_signal_length=processed_length
+            )
             captured_tensors = asr_model.get_captured_interctc_tensors()
             AccessMixin.reset_registry(asr_model)
             assert len(captured_tensors) == len(apply_at_layers)


### PR DESCRIPTION
# What does this PR do ?

I finally figured out the reason for random failure of this test. It turns out that sometimes our input signal is such that for some models it results in all-zeros in the output of some initial encoder layers. This is then propagated all the way through the model and so the assert that final layer output is different from middle layer fails. After changing the code to pass processed signal directly, this should not happen anymore.

**Collection**: ASR

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
