### PR TITLE
Move black parameters to pyproject.toml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,5 +43,4 @@ repos:
     hooks:
       - id: black
         name: Format code
-        args: [--skip-string-normalization, --line-length=119]
         additional_dependencies: ['click==8.0.2']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,12 @@ default_section = "THIRDPARTY"
 extend_skip = ["setup.py", "docs/source/conf.py"]
 
 
+[tool.black]
+line_length = 119
+skip_string_normalization = true
+required_version = "19.10b0"  # recongized by future versions, disallows to reformat code with incompatible versions
+
+
 [tool.pytest.ini_options]
 # durations=0 will display all tests execution time, sorted in ascending order starting from from the slowest one.
 # -vv will also display tests with durration = 0.00s

--- a/setup.py
+++ b/setup.py
@@ -111,9 +111,8 @@ extras_require['slu'] = list(chain([extras_require['slu'], extras_require['asr']
 
 
 class StyleCommand(distutils_cmd.Command):
-    __LINE_WIDTH = 119
-    __ISORT_BASE = 'isort '
-    __BLACK_BASE = f'black --skip-string-normalization --line-length={__LINE_WIDTH}'
+    __ISORT_BASE = 'isort'
+    __BLACK_BASE = 'black'
     description = 'Checks overall project code style.'
     user_options = [
         ('scope=', None, 'Folder of file to operate within.'),


### PR DESCRIPTION
# What does this PR do ?

Move `black` formatter parameters to `pyproject.toml`

Advantages:
- parameters are stored in one place
- one can use `black .`/`black <file>` command to reformat code
- more robust: if someone tries to reformat code with the newest `black` version, the error will be thrown (instead of reformatting the whole codebase)

**Collection**: [Note which collection this PR will affect]

# Changelog 
- add `black` params to `pyproject.toml`
- remove params from `setup.py` and `.pre-commit-config.yaml`

# Usage
* You can potentially add a usage example below

```
black .
black edited_file.py
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
