### PR TITLE
fix bucketing bug issue for picking new bucket

### DIFF
--- a/nemo/collections/asr/data/audio_to_text.py
+++ b/nemo/collections/asr/data/audio_to_text.py
@@ -1341,8 +1341,7 @@ class BucketingIterator:
             try:
                 sample = next(self.wrapped_iter)
             except StopIteration:
-                self.wrapped_iter = iter(self.wrapped_ds)
-                sample = next(self.wrapped_iter)
+                break
             batches.append(sample)
         if len(batches) == 0:
             raise StopIteration


### PR DESCRIPTION
# What does this PR do ?

Fixes issue with bucketing datasets, where loss for new run jumps from a previous run. 
Tested. 

**Collection**: ASR

# Changelog 
- break once bucket finishes, so as to pick next bucket

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information
* Related to #6191 
