### PR TITLE
Fix masking bug for TTS Aligner

### DIFF
--- a/nemo/collections/tts/models/aligner.py
+++ b/nemo/collections/tts/models/aligner.py
@@ -126,7 +126,7 @@ class AlignerModel(ModelPT):
             attn_soft, attn_logprob = self.alignment_encoder(
                 queries=spec,
                 keys=self.embed(text).transpose(1, 2),
-                mask=get_mask_from_lengths(text_len).unsqueeze(-1),
+                mask=get_mask_from_lengths(text_len).unsqueeze(-1) == 0,
                 attn_prior=attn_prior,
             )
 


### PR DESCRIPTION
# What does this PR do ?

Fixes a masking bug where boolean values were inverted from what was expected. Reverted change from PR #5653.

**Collection**: TTS

# Changelog 
- Added check for `== 0` (applied to the input mask) back to the Aligner forward call. Otherwise the mask is applied incorrectly, as the values are flipped from what is expected in the Aligner module.

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information
* See Issue #6584 
