### PR TITLE
Make Note usage consistent in adapter_mixins.py

### DIFF
--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -143,7 +143,9 @@ class AdapterModuleMixin(ABC):
         -   `adapter_metadata_cfg_key`: A str representing a key in the model config that is used to preserve the
                 metadata of the adapter config.
 
-    **Note**: This module is **not** responsible for maintaining its config. Subclasses must ensure config is updated
+    .. note::
+    
+        This module is **not** responsible for maintaining its config. Subclasses must ensure config is updated 
         or preserved as needed. It is the responsibility of the subclasses to propagate the most up to date config to
         lower layers.
     """
@@ -435,8 +437,6 @@ class AdapterModuleMixin(ABC):
         Utilizes the implicit merge strategy of each adapter when computing the adapter's output, and
         how that output will be merged back with the original input.
 
-        **Note**:
-
         Args:
             input: The output tensor of the calling module is the input to the first adapter, whose output
                 is then chained to the next adapter until all adapters are consumed.
@@ -519,7 +519,9 @@ class AdapterModuleMixin(ABC):
         """
         Perform the forward step of a single adapter module on some input data.
 
-        **Note**: Subclasses can override this method to accommodate more complicate adapter forward steps.
+        .. note::
+        
+            Subclasses can override this method to accommodate more complicate adapter forward steps.
 
         Args:
             input: input: The output tensor of the calling module is the input to the first adapter, whose output
@@ -756,8 +758,10 @@ class AdapterModelPTMixin(AdapterModuleMixin):
         Utility method that saves only the adapter module(s), and not the entire model itself.
         This allows the sharing of adapters which are often just a fraction of the size of the full model,
         enabling easier deliver.
+        
+        .. note::
 
-        Note: The saved file is a pytorch compatible pickle file, containing the state dicts of the adapter(s),
+            The saved file is a pytorch compatible pickle file, containing the state dicts of the adapter(s),
             as well as a binary representation of the adapter config.
 
         Args:
@@ -835,7 +839,9 @@ class AdapterModelPTMixin(AdapterModuleMixin):
         This allows the sharing of adapters which are often just a fraction of the size of the full model,
         enabling easier deliver.
 
-        Note: During restoration, assumes that the model does not currently already have an adapter with
+        .. note::
+        
+            During restoration, assumes that the model does not currently already have an adapter with
             the name (if provided), or any adapter that shares a name with the state dict's modules
             (if name is not provided). This is to ensure that each adapter name is globally unique
             in a model.
@@ -964,7 +970,9 @@ class AdapterModelPTMixin(AdapterModuleMixin):
         """
         List of valid adapter modules that are supported by the model.
 
-        **Note**: Subclasses should override this property and return a list of str names, of all the modules
+        .. note::
+        
+            Subclasses should override this property and return a list of str names, of all the modules
             that they support, which will enable users to determine where to place the adapter modules.
 
         Returns:


### PR DESCRIPTION
Inconsistent usage of the word Note, which includes a broken reading in one case.

I'm just doing some tidying -- not trying to be critical.

**Before**:

![image](https://github.com/NVIDIA/NeMo/assets/7584774/efceb708-a2fe-46e6-aeed-29b43e988fa0)

**After**:
![image](https://github.com/NVIDIA/NeMo/assets/7584774/8a697ba3-ad4d-42db-8616-f5cf5fd407d5)

**Collection**: NeMo Core (documentation)

# Changelog 
- I changed the inconsistent use of the word Note: in documentation to `.. note:: ` as used elsewhere

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests? (no tests needed -- documentation fix)
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc) (no)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [x] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
