### PR TITLE
Fix a bug, use _ceil_to_nearest instead as _round_to_nearest is not d…

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_chat_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_chat_dataset.py
@@ -183,7 +183,7 @@ class GPTSFTChatDataset(GPTSFTDataset):
         if self.pad_to_max_length:
             max_length = self.max_seq_length
         else:
-            max_length = min(self.max_seq_length, self._round_to_nearest(max_length, 8))
+            max_length = min(self.max_seq_length, self._ceil_to_nearest(max_length, 8))
         assert max_length <= self.max_seq_length
 
         attention_mask = [self._create_attention_mask(max_length) for _ in batch]


### PR DESCRIPTION
# What does this PR do ?

Fix a bug when training SFT model with dialog dataset when setting `self.pad_to_max_length=False`

**Collection**: [Note which collection this PR will affect]

# Changelog 
```
#gpt_sft_chat_dataset.py

## original code
## max_length = min(self.max_seq_length, self._round_to_nearest(max_length, 8))

## Changed to
max_length = min(self.max_seq_length, self._ceil_to_nearest(max_length, 8))
```
In [gpt_sft_chat_dataset.py](https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py#LL270C56-L270C72), we use `_ceil_to_nearest` which is also defined in this file. However, `_round_to_nearest` is not defined in NeMo.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.
