### PR TITLE
Add optional index mapping dir in mmap text datasets

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
@@ -51,7 +51,7 @@ class GPTSFTDataset(Dataset):
         file_path: Path to a JSONL GPT supervised fine-tuning dataset. Data is formatted as multiple JSON lines with each line formatted as follows. {'input': 'John von Neumann\nVon Neumann made fundamental contributions .... Q: What did the math of artificial viscosity do?', 'output': 'smoothed the shock transition without sacrificing basic physics'}
         tokenizer: Tokenizer for the dataset. Instance of a class that inherits TokenizerSpec (ex: YTTM, SentencePiece).
         max_seq_length (int): maximum sequence length for each dataset examples. Examples will either be truncated to fit this length or dropped if they cannot be truncated.
-        min_seq_length (int): min length of each data example in the dataset. Data examples will be dropped if they do not meet the min length requirements. 
+        min_seq_length (int): min length of each data example in the dataset. Data examples will be dropped if they do not meet the min length requirements.
         add_bos (bool): Whether to add a beginning of sentence token to each data example
         add_eos (bool): Whether to add an end of sentence token to each data example
         add_sep (bool): Whether to add a separation token to each data example (goes between prompt and answer)
@@ -93,7 +93,9 @@ class GPTSFTDataset(Dataset):
             self.prompt_template = self.prompt_template.encode('utf-8').decode('unicode_escape')
         assert self.truncation_field in ["answer", "context"]
 
-        self.indexed_dataset = JSONLMemMapDataset(dataset_paths=[file_path], tokenizer=None, header_lines=0)
+        self.indexed_dataset = JSONLMemMapDataset(
+            dataset_paths=[file_path], tokenizer=None, header_lines=0, index_mapping_dir=index_mapping_dir
+        )
 
         # Will be None after this call if `max_num_samples` is None
         self._build_samples_mapping()

--- a/tests/collections/nlp/test_mem_map_dataset.py
+++ b/tests/collections/nlp/test_mem_map_dataset.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import csv
+import json
+import os
+
+import pytest
+
+from nemo.collections.nlp.data.language_modeling import text_memmap_dataset
+
+
+@pytest.fixture
+def jsonl_file(tmp_path):
+    # Create a temporary file path
+    file_path = tmp_path / "data.jsonl"
+
+    # Generate data to write to the JSONL file
+    data = [{"name": "John", "age": 30}, {"name": "Jane", "age": 25}, {"name": "Bob", "age": 35}]
+
+    # Write data to the JSONL file
+    with open(file_path, mode="w") as file:
+        for item in data:
+            json.dump(item, file)
+            file.write('\n')
+
+    # Provide the file path to the test function
+    yield str(file_path)
+
+    # Optional: Clean up the temporary file after the test
+    file_path.unlink()
+
+
+@pytest.fixture
+def csv_file(tmp_path):
+    # Create a temporary file path
+    file_path = tmp_path / "data.csv"
+
+    # Generate data to write to the CSV file
+    data = [["ID", "Name"], [1, "John"], [2, "Jane"], [3, "Bob"]]
+
+    # Write data to the CSV file
+    with open(file_path, mode="w", newline="") as file:
+        writer = csv.writer(file)
+        writer.writerows(data)
+
+    # Provide the file path to the test function
+    yield str(file_path)
+
+    # Optional: Clean up the temporary file after the test
+    file_path.unlink()
+
+
+def test_jsonl_mem_map_dataset(jsonl_file):
+    """Test for JSONL memory-mapped datasets."""
+
+    indexed_dataset = text_memmap_dataset.JSONLMemMapDataset(dataset_paths=[jsonl_file], header_lines=0)
+    assert indexed_dataset[0] == {"name": "John", "age": 30}
+    assert indexed_dataset[1] == {"name": "Jane", "age": 25}
+    assert indexed_dataset[2] == {"name": "Bob", "age": 35}
+
+
+def test_csv_mem_map_dataset(csv_file):
+    """Test for CSV memory-mapped datasets."""
+
+    indexed_dataset = text_memmap_dataset.CSVMemMapDataset(dataset_paths=[csv_file], data_col=1, header_lines=1)
+    assert indexed_dataset[0].strip() == "John"
+    assert indexed_dataset[1].strip() == "Jane"
+    assert indexed_dataset[2].strip() == "Bob"
+
+
+@pytest.mark.parametrize(
+    "dataset_class", [text_memmap_dataset.JSONLMemMapDataset, text_memmap_dataset.CSVMemMapDataset]
+)
+@pytest.mark.parametrize("use_alternative_index_mapping_dir", [True, False])
+@pytest.mark.parametrize("relative_index_fn", [True, False])
+def test_mem_map_dataset_index_mapping_dir(
+    tmp_path, dataset_class, jsonl_file, use_alternative_index_mapping_dir, relative_index_fn
+):
+    """Test for index_mapping_dir."""
+    if relative_index_fn:
+        jsonl_file = os.path.relpath(jsonl_file)
+    else:
+        jsonl_file = os.path.abspath(jsonl_file)
+
+    if use_alternative_index_mapping_dir:
+        index_mapping_dir = tmp_path / "subdir"
+        dataset_class(dataset_paths=[jsonl_file], header_lines=0, index_mapping_dir=str(index_mapping_dir))
+        # Index files should not be created in default location.
+        assert not os.path.isfile(f"{jsonl_file}.idx.npy")
+        assert not os.path.isfile(f"{jsonl_file}.idx.info")
+        if relative_index_fn:
+            # Remove leading ".." sequences.
+            while jsonl_file.startswith(("../")):
+                jsonl_file = jsonl_file.lstrip("../")
+        idx_fn = f"{str(index_mapping_dir)}/{jsonl_file}.idx"
+        assert os.path.isfile(f"{idx_fn}.npy")
+        assert os.path.isfile(f"{idx_fn}.info")
+    else:
+        text_memmap_dataset.JSONLMemMapDataset(dataset_paths=[jsonl_file], header_lines=0)
+        assert os.path.isfile(f"{jsonl_file}.idx.npy")
+        assert os.path.isfile(f"{jsonl_file}.idx.info")


### PR DESCRIPTION
If datasets are stored on a read-only medium, index files cannot be created into adjacent files and an
alternative directory must be specified for index
mapping files.

# What does this PR do ?

This commit adds an optional flag to specify the directory to write index files to.

**Collection**: nlp

# Changelog 
- Add an optional `index_mapping_dir` to the constructors of `TextMemMapDataset`,  `CSVMemMapDataset` and `JSONLMemMapDataset`.
- Add unit tests.
- Propagate `index_mapping_dir` from `GPTSFTDataset`.
- 
# Usage

```bash
nvidia-docker run --shm-size=4gb  -v ~/llm/data:/llm/data:ro -it sft:latest  python megatron_gpt_sft.py ++model.data.train_ds.index_mapping_dir=/tmp  ++model.data.validation_ds.index_mapping_dir=/tmp
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
