### PR TITLE
Fix Sentencepiece model not propagated for GPT init.

### DIFF
--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -79,6 +79,7 @@ def get_tokenizer(
     special_tokens: Optional[Dict[str, str]] = None,
     use_fast: Optional[bool] = False,
     bpe_dropout: Optional[float] = 0.0,
+    legacy=False,
 ):
     """
     Args:
@@ -116,7 +117,7 @@ def get_tokenizer(
 
     if tokenizer_name == 'sentencepiece':
         return nemo.collections.common.tokenizers.sentencepiece_tokenizer.SentencePieceTokenizer(
-            model_path=tokenizer_model, special_tokens=special_tokens, legacy=True
+            model_path=tokenizer_model, special_tokens=special_tokens, legacy=legacy
         )
     elif tokenizer_name == 'yttm':
         return YouTokenToMeTokenizer(model_path=tokenizer_model, bpe_dropout=bpe_dropout)
@@ -204,7 +205,7 @@ def get_nmt_tokenizer(
         logging.info(
             f'Getting Megatron tokenizer for pretrained model name: {model_name}, custom vocab file: {vocab_file}, and merges file: {merges_file}'
         )
-        return get_tokenizer(tokenizer_name=model_name, vocab_file=vocab_file, merges_file=merges_file)
+        return get_tokenizer(tokenizer_name=model_name, vocab_file=vocab_file, merges_file=merges_file, tokenizer_model=tokenizer_model, legacy=legacy)
     elif library == 'tabular':
         return TabularTokenizer(vocab_file, delimiter=delimiter)
     else:

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -205,7 +205,13 @@ def get_nmt_tokenizer(
         logging.info(
             f'Getting Megatron tokenizer for pretrained model name: {model_name}, custom vocab file: {vocab_file}, and merges file: {merges_file}'
         )
-        return get_tokenizer(tokenizer_name=model_name, vocab_file=vocab_file, merges_file=merges_file, tokenizer_model=tokenizer_model, legacy=legacy)
+        return get_tokenizer(
+            tokenizer_name=model_name,
+            vocab_file=vocab_file,
+            merges_file=merges_file,
+            tokenizer_model=tokenizer_model,
+            legacy=legacy,
+        )
     elif library == 'tabular':
         return TabularTokenizer(vocab_file, delimiter=delimiter)
     else:


### PR DESCRIPTION
# What does this PR do ?

When using SentencePiece with custom model, `tokenizer.model` was not propagated to GPT Model initialization, hence resulted in error.

**Collection**: NLP

# Changelog 
- `nemo/collections/nlp/modules/common/tokenizer_utils.py`

# Usage
* When using a custom SentencePiece tokenizer model.

```python
model.tokenizer.model=...
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
