### PR TITLE
Fix k2 installation in Docker with CUDA 12

### DIFF
--- a/scripts/speech_recognition/k2/setup.sh
+++ b/scripts/speech_recognition/k2/setup.sh
@@ -15,10 +15,12 @@
 # limitations under the License.
 
 K2_REPO=https://github.com/k2-fsa/k2
-LATEST_RELEASE=$(git -c 'versionsort.suffix=-' \
-    ls-remote --exit-code --refs --sort='version:refname' --tags ${K2_REPO} '*.*' \
-    | tail --lines=1 \
-    | cut -d '/' -f 3)
+LATEST_RELEASE=e5671de  # Temporary fix for CUDA 12
+# uncomment the following line after the next k2 version is released (>1.24.3)
+#LATEST_RELEASE=$(git -c 'versionsort.suffix=-' \
+#    ls-remote --exit-code --refs --sort='version:refname' --tags ${K2_REPO} '*.*' \
+#    | tail --lines=1 \
+#    | cut -d '/' -f 3)
 # "cut --delimiter '/' --fields 3" doesn't work on macOS, use "-d ... -f ..." instead
 
 K2_MAKE_ARGS="-j" pip install -v "git+${K2_REPO}@${LATEST_RELEASE}#egg=k2" || { echo "k2 could not be installed!"; exit 1; }


### PR DESCRIPTION
# What does this PR do ?

Fix k2 installation in Docker with CUDA 12. 
Currently k2 is not installed in Docker (fails silently).
Relies on a fix in https://github.com/k2-fsa/k2/pull/1200

**Collection**: [ASR]

# Changelog 
- fix k2 installation source in `scripts/speech_recognition/k2/setup.sh`

# Usage

```python
import k2
# do anything you want with k2
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
