### PR TITLE
support torch.jit for maj_vote_spk_count=True

### DIFF
--- a/nemo/collections/asr/parts/utils/offline_clustering.py
+++ b/nemo/collections/asr/parts/utils/offline_clustering.py
@@ -1010,7 +1010,7 @@ class NMESC:
 
         p_hat_value = (subsample_ratio * rp_p_value).type(torch.int)
         if self.maj_vote_spk_count:
-            est_num_of_spk = torch.mode(torch.tensor(est_num_of_spk_list))[0]
+            est_num_of_spk = torch.mode(input=est_num_of_spk_list)[0]
         else:
             est_num_of_spk = est_spk_n_dict[rp_p_value.item()]
         return est_num_of_spk, p_hat_value

--- a/tests/collections/asr/test_diar_utils.py
+++ b/tests/collections/asr/test_diar_utils.py
@@ -603,12 +603,15 @@ class TestSpeakerClustering:
     @pytest.mark.parametrize("n_spks", [1, 2, 3, 4, 5, 6, 7])
     @pytest.mark.parametrize("total_sec, SSV, perturb_sigma, seed", [(30, 10, 0.1, 0)])
     @pytest.mark.parametrize("jit_script", [False, True])
-    def test_offline_speaker_clustering(self, n_spks, total_sec, SSV, perturb_sigma, seed, jit_script, cuda=True):
+    @pytest.mark.parametrize("maj_vote_spk_count", [False, True])
+    def test_offline_speaker_clustering(
+        self, n_spks, total_sec, SSV, perturb_sigma, seed, jit_script, maj_vote_spk_count, cuda=True
+    ):
         spk_dur = total_sec / n_spks
         em, ts, mc, mw, spk_ts, gt = generate_toy_data(
             n_spks=n_spks, spk_dur=spk_dur, perturb_sigma=perturb_sigma, torch_seed=seed
         )
-        offline_speaker_clustering = SpeakerClustering(maj_vote_spk_count=False, cuda=cuda)
+        offline_speaker_clustering = SpeakerClustering(maj_vote_spk_count=maj_vote_spk_count, cuda=cuda)
         assert isinstance(offline_speaker_clustering, SpeakerClustering)
         if jit_script:
             offline_speaker_clustering = torch.jit.script(offline_speaker_clustering)


### PR DESCRIPTION
# What does this PR do ?

support torch.jit.save for offline clustering maj_vote_spk_count=True

**Collection**: [Note which collection this PR will affect]

# Changelog 

- for torch.jit, remove redundant torch.tensor on `est_num_of_spk_list` in `offline_clustering.py`

# Usage

```bash
pytest tests/collections/asr/test_diar_utils.py::TestSpeakerClustering::test_offline_speaker_clustering
```


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

main reviewer: @tango4j 

This is a part of ASR, diarizer.
@titu1994 @redoctopus, @jbalam-nv, or @okuchaiev



# Additional Information
* Related to # (issue)
