### PR TITLE
[TTS] Filter out silent audio files during preprocessing

### DIFF
--- a/scripts/dataset_processing/tts/compute_feature_stats.py
+++ b/scripts/dataset_processing/tts/compute_feature_stats.py
@@ -98,7 +98,9 @@ def get_args():
         help="Path to output JSON file with dataset feature statistics.",
     )
     parser.add_argument(
-        "--overwrite", default=False, type=bool, help="Whether to overwrite the output stats file if it exists.",
+        "--overwrite",
+        action=argparse.BooleanOptionalAction,
+        help="Whether to overwrite the output stats file if it exists.",
     )
 
     args = parser.parse_args()
@@ -132,7 +134,7 @@ def main():
 
     if not feature_dir.exists():
         raise ValueError(
-            f"Feature directory {audio_dir} does not exist. "
+            f"Feature directory {feature_dir} does not exist. "
             f"Please check that the path is correct and that you ran compute_features.py"
         )
 

--- a/scripts/dataset_processing/tts/create_speaker_map.py
+++ b/scripts/dataset_processing/tts/create_speaker_map.py
@@ -54,7 +54,9 @@ def get_args():
         "--speaker_map_path", required=True, type=Path, help="Path for output speaker index JSON",
     )
     parser.add_argument(
-        "--overwrite", default=False, type=bool, help="Whether to overwrite the output speaker file if it exists.",
+        "--overwrite",
+        action=argparse.BooleanOptionalAction,
+        help="Whether to overwrite the output speaker file if it exists.",
     )
     args = parser.parse_args()
     return args

--- a/tests/collections/tts/parts/preprocessing/test_audio_trimming.py
+++ b/tests/collections/tts/parts/preprocessing/test_audio_trimming.py
@@ -47,7 +47,7 @@ class TestAudioTrimming:
         )
 
         assert start_frame == 0
-        assert end_frame == 4
+        assert end_frame == 0
 
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit


### PR DESCRIPTION
# What does this PR do ?

First version of preprocessing ignored audio files where start/end of speech could not be detected. During testing I find that all such examples are silent audio files with no speech. And that most public datasets have several such files. This updates the script to remove such files from the final training manifest.

**Collection**: [TTS]

# Changelog 
- Update preprocessing script to remove silent/empty audio files from final training manifest.
- Add `overwrite_audio` so that is script fails partway, you can resume where you left off instead of having to reprocess the entire dataset.
- Fix parsing of `overwrite` arguments, as trying to parse them as a bool results in `True` regardless of what value you provide in the CLI.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
