### PR TITLE
[TTS] fix inconsistent type hints for IpaG2p

### DIFF
--- a/nemo/collections/tts/g2p/models/i18n_ipa.py
+++ b/nemo/collections/tts/g2p/models/i18n_ipa.py
@@ -42,7 +42,7 @@ class IpaG2p(BaseG2p):
 
     def __init__(
         self,
-        phoneme_dict: Union[str, pathlib.Path, dict],
+        phoneme_dict: Union[str, pathlib.Path, Dict[str, List[List[str]]]],
         locale: str = "en-US",
         apply_to_oov_word: Optional[Callable[[str], str]] = None,
         ignore_ambiguous_words: bool = True,


### PR DESCRIPTION
# What does this PR do ?

The type hint was mismatched with https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/tts/g2p/models/i18n_ipa.py#L159.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
