### PR TITLE
[TTS] relax hardcoded prefix for phonemes and tones and infer phoneme set through dict

### DIFF
--- a/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
+++ b/nemo/collections/common/tokenizers/text_to_speech/tts_tokenizers.py
@@ -673,12 +673,6 @@ class IPATokenizer(BaseTokenizer):
 
 class ChinesePhonemesTokenizer(BaseTokenizer):
     # fmt: off
-    PRONUNCIATION_LIST = ['#' + i for i in ['^', 'A', 'AI', 'AN', 'ANG', 'AO', 'B', 'C', 'CH', 'D', 
-                    'E', 'EI', 'EN', 'ENG', 'ER', 'F', 'G', 'H', 'I', 'IE', 
-                    'IN', 'ING', 'IU', 'J', 'K', 'L', 'M', 'N', 'O', 'ONG', 
-                    'OU', 'P', 'Q', 'R', 'S', 'SH', 'T', 'U', 'UI', 'UN', 
-                    'V', 'VE', 'VN', 'W', 'X', 'Y', 'Z', 'ZH']]
-    TONES_LIST = ['#1', '#2', '#3', '#4', '#5']
     PUNCT_LIST = (  # Derived from LJSpeech and "/" additionally
         ',', '.', '!', '?', '-',
         ':', ';', '/', '"', '(',
@@ -722,8 +716,11 @@ class ChinesePhonemesTokenizer(BaseTokenizer):
         if silence is not None:
             self.silence, tokens = len(tokens), tokens + [silence]  # Silence
 
-        tokens.extend(self.PRONUNCIATION_LIST)
-        tokens.extend(self.TONES_LIST)
+        self.phonemes_list = g2p.phonemes_list
+        self.tones_list = g2p.tones_list
+
+        tokens.extend(self.phonemes_list)
+        tokens.extend(self.tones_list)
         tokens.extend(string.ascii_lowercase)
 
         if apostrophe:
@@ -766,7 +763,7 @@ class ChinesePhonemesTokenizer(BaseTokenizer):
             if p == space and len(ps) > 0 and ps[-1] != space:
                 ps.append(p)
             # Add next phoneme or char (if chars=True)
-            elif (p.isalnum() or p == "'" or p in self.PRONUNCIATION_LIST or p in self.TONES_LIST) and p in tokens:
+            elif (p.isalnum() or p == "'" or p in self.phonemes_list or p in self.tones_list) and p in tokens:
                 ps.append(p)
             # Add punct
             elif (p in self.PUNCT_LIST) and self.punct:

--- a/nemo/collections/tts/g2p/models/zh_cn_pinyin.py
+++ b/nemo/collections/tts/g2p/models/zh_cn_pinyin.py
@@ -14,7 +14,7 @@
 
 import pathlib
 from collections import defaultdict
-from typing import Optional, Union, Dict, List
+from typing import Dict, List, Optional, Union
 
 from nemo.collections.tts.g2p.models.base import BaseG2p
 from nemo.utils import logging
@@ -53,6 +53,11 @@ class ChineseG2p(BaseG2p):
             None,
             'jieba',
         ], f"{word_segmenter} is not supported now. Please choose correct word_segmenter."
+
+        if phoneme_prefix is None:
+            phoneme_prefix = ""
+        if tone_prefix is None:
+            tone_prefix = ""
 
         phoneme_dict = (
             self._parse_as_pinyin_dict(phoneme_dict, phoneme_prefix)
@@ -103,7 +108,9 @@ class ChineseG2p(BaseG2p):
         self._Style = Style
 
     @staticmethod
-    def _parse_as_pinyin_dict(phoneme_dict_path: Union[str, pathlib.Path], phoneme_prefix: str) -> Dict[str, List[str]]:
+    def _parse_as_pinyin_dict(
+        phoneme_dict_path: Union[str, pathlib.Path], phoneme_prefix: str
+    ) -> Dict[str, List[str]]:
         """Loads pinyin dict file, and generates a set of all valid symbols."""
         g2p_dict = defaultdict(list)
         with open(phoneme_dict_path, 'r') as file:

--- a/nemo/collections/tts/g2p/models/zh_cn_pinyin.py
+++ b/nemo/collections/tts/g2p/models/zh_cn_pinyin.py
@@ -14,7 +14,7 @@
 
 import pathlib
 from collections import defaultdict
-from typing import Optional
+from typing import Optional, Union, Dict, List
 
 from nemo.collections.tts.g2p.models.base import BaseG2p
 from nemo.utils import logging
@@ -23,7 +23,9 @@ from nemo.utils import logging
 class ChineseG2p(BaseG2p):
     def __init__(
         self,
-        phoneme_dict=None,
+        phoneme_dict: Union[str, pathlib.Path, Dict[str, List[str]]],
+        phoneme_prefix: str = "#",
+        tone_prefix: str = "#",
         word_tokenize_func=None,
         apply_to_oov_word=None,
         mapping_file: Optional[str] = None,
@@ -33,7 +35,12 @@ class ChineseG2p(BaseG2p):
            be further converted into phoneme sequences using pinyin_dict_nv_22.10.txt dict file. For Chinese and English bilingual sentences, the English words
            would be converted into letters.
         Args:
-            phoneme_dict (str, Path, Dict): Path to pinyin_dict_nv_22.10.txt dict file.
+            phoneme_dict (str, Path, Dict): Path to pinyin_dict_nv_22.10.txt dict file or a dict object.
+            phoneme_prefix (str): Prepend a special symbol to any phonemes in order to distinguish phonemes from
+                graphemes because there may be overlaps between the two sets. Phoneme dictionary typically applies
+                uppercase initials and finals. It is suggested to choose a prefix that
+                is not used or preserved somewhere else. Default to "#".
+            tone_prefix (str): Prepend a special symbol to any tone digits. Default to "#".
             word_tokenize_func: Function for tokenizing text to words.
                 It has to return List[Tuple[Union[str, List[str]], bool]] where every tuple denotes word representation and flag whether to leave unchanged or not.
                 It is expected that unchangeable word representation will be represented as List[str], other cases are represented as str.
@@ -48,10 +55,11 @@ class ChineseG2p(BaseG2p):
         ], f"{word_segmenter} is not supported now. Please choose correct word_segmenter."
 
         phoneme_dict = (
-            self._parse_as_pinyin_dict(phoneme_dict)
+            self._parse_as_pinyin_dict(phoneme_dict, phoneme_prefix)
             if isinstance(phoneme_dict, str) or isinstance(phoneme_dict, pathlib.Path)
             else phoneme_dict
         )
+        self.phonemes_list = list({pron for prons in phoneme_dict.values() for pron in prons})
 
         if apply_to_oov_word is None:
             logging.warning(
@@ -67,7 +75,9 @@ class ChineseG2p(BaseG2p):
             apply_to_oov_word=apply_to_oov_word,
             mapping_file=mapping_file,
         )
-        self.tones = {'1': '#1', '2': '#2', '3': '#3', '4': '#4', '5': '#5'}
+
+        self.tones = {str(x): tone_prefix + str(x) for x in range(1, 6)}
+        self.tones_list = list(self.tones.values())
 
         if word_segmenter == "jieba":
             try:
@@ -93,20 +103,27 @@ class ChineseG2p(BaseG2p):
         self._Style = Style
 
     @staticmethod
-    def _parse_as_pinyin_dict(phoneme_dict_path):
+    def _parse_as_pinyin_dict(phoneme_dict_path: Union[str, pathlib.Path], phoneme_prefix: str) -> Dict[str, List[str]]:
         """Loads pinyin dict file, and generates a set of all valid symbols."""
         g2p_dict = defaultdict(list)
         with open(phoneme_dict_path, 'r') as file:
             for line in file:
+                # skip empty lines and comment lines starting with `;;;`.
+                if line.startswith(";;;") or len(line.strip()) == 0:
+                    continue
+
                 parts = line.split('\t')
-                # let the key be lowercased, since pypinyin would give lower representation
-                pinyin = parts[0].lower()
+                # lowercase the Chinese syllables because pypinyin requires lowercase inputs.
+                syllable = parts[0].lower()
                 pronunciation = parts[1].split()
-                pronunciation_with_sharp = ['#' + pron for pron in pronunciation]
-                g2p_dict[pinyin] = pronunciation_with_sharp
+
+                # add phoneme prefix to distinguish from other symbols.
+                pronunciation_with_prefix = [phoneme_prefix + pron for pron in pronunciation]
+                g2p_dict[syllable] = pronunciation_with_prefix
+
         return g2p_dict
 
-    def __call__(self, text):
+    def __call__(self, text: str) -> List[str]:
         """
         errors func handle below is to process the bilingual situation,
         where English words would be split into letters.
@@ -119,6 +136,8 @@ class ChineseG2p(BaseG2p):
         pinyin_seq = []
         words_list = self.word_segmenter(text)
 
+        # TODO @xueyang: add a g2p process for non-pinyin words by customizing a function for `errors` argument. For
+        #  example, add a dict look up for English words.
         for word in words_list:
             pinyin_seq += self._lazy_pinyin(
                 word,
@@ -128,12 +147,14 @@ class ChineseG2p(BaseG2p):
             )
         phoneme_seq = []
         for pinyin in pinyin_seq:
-            if pinyin[-1] in self.tones:
-                assert pinyin[:-1] in self.phoneme_dict, pinyin[:-1]
-                phoneme_seq += self.phoneme_dict[pinyin[:-1]]
-                phoneme_seq.append(self.tones[pinyin[-1]])
+            tone_hyp = pinyin[-1]
+            if tone_hyp in self.tones:
+                syllable = pinyin[:-1]
+                assert syllable in self.phoneme_dict, f"Syllable <{syllable}> does not exist in the dictionary."
+                phoneme_seq += self.phoneme_dict[syllable]
+                phoneme_seq.append(self.tones[tone_hyp])
             # All pinyin would end up with a number in 1-5, which represents tones of the pinyin.
-            # For symbols which are not pinyin, e.g. English letters, Chinese puncts, we directly
+            # For symbols which are not pinyin, such as English letters and Chinese punctuations, we directly
             # use them as inputs.
             else:
                 phoneme_seq.append(pinyin)


### PR DESCRIPTION
# What does this PR do ?

1. previously, '#' was hardcoded as a prefix for Chinese phonemes and tones in both g2p and tokenizer. It is apt to raise errors if mismatched prefix symbols are applied for g2p and tokenizer.

2. previously, phoneme set and tone set are hardcoded as well. It would raise errors when the input phoneme dict contains different set of phonemes. Fixed this by inferring phoneme set based on input dictionary.

3. run pytest nightly and old NGC model checkpoint passed.
```
$ pytest --nightly tests/collections/tts/models/test_fastpitch.py::test_inference[tts_zh_fastpitch_sfspeech]

tests/collections/tts/models/test_fastpitch.py::test_inference[tts_zh_fastpitch_sfspeech] PASSED
```


**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
