### PR TITLE
Sharded manifests setting in config files

### DIFF
--- a/examples/asr/conf/asr_adapters/asr_adaptation.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation.yaml
@@ -138,8 +138,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     # sample_rate will be merged with model config

--- a/examples/asr/conf/asr_adapters/asr_adaptation.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation.yaml
@@ -138,6 +138,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     # sample_rate will be merged with model config

--- a/examples/asr/conf/asr_adapters/asr_adaptation_hp.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation_hp.yaml
@@ -138,8 +138,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     # sample_rate will be merged with model config

--- a/examples/asr/conf/asr_adapters/asr_adaptation_hp.yaml
+++ b/examples/asr/conf/asr_adapters/asr_adaptation_hp.yaml
@@ -138,6 +138,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     # sample_rate will be merged with model config

--- a/examples/asr/conf/asr_tts/hybrid_asr_tts.yaml
+++ b/examples/asr/conf/asr_tts/hybrid_asr_tts.yaml
@@ -46,8 +46,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/asr_tts/hybrid_asr_tts.yaml
+++ b/examples/asr/conf/asr_tts/hybrid_asr_tts.yaml
@@ -46,6 +46,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/carnelinet/carnelinet_384.yaml
+++ b/examples/asr/conf/carnelinet/carnelinet_384.yaml
@@ -44,6 +44,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
 
   validation_ds:

--- a/examples/asr/conf/carnelinet/carnelinet_384.yaml
+++ b/examples/asr/conf/carnelinet/carnelinet_384.yaml
@@ -44,8 +44,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
 
   validation_ds:

--- a/examples/asr/conf/citrinet/citrinet_1024.yaml
+++ b/examples/asr/conf/citrinet/citrinet_1024.yaml
@@ -34,6 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/citrinet/citrinet_1024.yaml
+++ b/examples/asr/conf/citrinet/citrinet_1024.yaml
@@ -34,8 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/citrinet/citrinet_384.yaml
+++ b/examples/asr/conf/citrinet/citrinet_384.yaml
@@ -34,6 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/citrinet/citrinet_384.yaml
+++ b/examples/asr/conf/citrinet/citrinet_384.yaml
@@ -34,8 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/citrinet/citrinet_512.yaml
+++ b/examples/asr/conf/citrinet/citrinet_512.yaml
@@ -33,6 +33,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/citrinet/citrinet_512.yaml
+++ b/examples/asr/conf/citrinet/citrinet_512.yaml
@@ -33,8 +33,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/citrinet/config_bpe.yaml
+++ b/examples/asr/conf/citrinet/config_bpe.yaml
@@ -22,8 +22,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/citrinet/config_bpe.yaml
+++ b/examples/asr/conf/citrinet/config_bpe.yaml
@@ -22,6 +22,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -24,6 +24,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/config.yaml
+++ b/examples/asr/conf/config.yaml
@@ -24,8 +24,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/cache_aware_streaming/conformer_ctc_bpe_streaming.yaml
+++ b/examples/asr/conf/conformer/cache_aware_streaming/conformer_ctc_bpe_streaming.yaml
@@ -33,6 +33,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/cache_aware_streaming/conformer_ctc_bpe_streaming.yaml
+++ b/examples/asr/conf/conformer/cache_aware_streaming/conformer_ctc_bpe_streaming.yaml
@@ -33,8 +33,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/cache_aware_streaming/conformer_transducer_bpe_streaming.yaml
+++ b/examples/asr/conf/conformer/cache_aware_streaming/conformer_transducer_bpe_streaming.yaml
@@ -38,8 +38,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/cache_aware_streaming/conformer_transducer_bpe_streaming.yaml
+++ b/examples/asr/conf/conformer/cache_aware_streaming/conformer_transducer_bpe_streaming.yaml
@@ -38,6 +38,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/conformer_ctc_bpe.yaml
+++ b/examples/asr/conf/conformer/conformer_ctc_bpe.yaml
@@ -65,6 +65,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/conformer_ctc_bpe.yaml
+++ b/examples/asr/conf/conformer/conformer_ctc_bpe.yaml
@@ -65,8 +65,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/conformer_ctc_char.yaml
+++ b/examples/asr/conf/conformer/conformer_ctc_char.yaml
@@ -30,6 +30,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/conformer_ctc_char.yaml
+++ b/examples/asr/conf/conformer/conformer_ctc_char.yaml
@@ -30,8 +30,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/conformer_transducer_bpe.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_bpe.yaml
@@ -70,6 +70,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/conformer_transducer_bpe.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_bpe.yaml
@@ -70,8 +70,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/conformer_transducer_char.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_char.yaml
@@ -34,6 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/conformer_transducer_char.yaml
+++ b/examples/asr/conf/conformer/conformer_transducer_char.yaml
@@ -34,8 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/hat/conformer_hat_bpe.yaml
+++ b/examples/asr/conf/conformer/hat/conformer_hat_bpe.yaml
@@ -52,8 +52,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/hat/conformer_hat_bpe.yaml
+++ b/examples/asr/conf/conformer/hat/conformer_hat_bpe.yaml
@@ -52,6 +52,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/hat/conformer_hat_char.yaml
+++ b/examples/asr/conf/conformer/hat/conformer_hat_char.yaml
@@ -52,8 +52,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/hat/conformer_hat_char.yaml
+++ b/examples/asr/conf/conformer/hat/conformer_hat_char.yaml
@@ -52,6 +52,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/hybrid_transducer_ctc/conformer_hybrid_transducer_ctc_bpe.yaml
+++ b/examples/asr/conf/conformer/hybrid_transducer_ctc/conformer_hybrid_transducer_ctc_bpe.yaml
@@ -36,6 +36,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/hybrid_transducer_ctc/conformer_hybrid_transducer_ctc_bpe.yaml
+++ b/examples/asr/conf/conformer/hybrid_transducer_ctc/conformer_hybrid_transducer_ctc_bpe.yaml
@@ -36,8 +36,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/hybrid_transducer_ctc/conformer_hybrid_transducer_ctc_char.yaml
+++ b/examples/asr/conf/conformer/hybrid_transducer_ctc/conformer_hybrid_transducer_ctc_char.yaml
@@ -40,6 +40,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/hybrid_transducer_ctc/conformer_hybrid_transducer_ctc_char.yaml
+++ b/examples/asr/conf/conformer/hybrid_transducer_ctc/conformer_hybrid_transducer_ctc_char.yaml
@@ -40,8 +40,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/multiblank/conformer_multiblank_transducer_bpe.yaml
+++ b/examples/asr/conf/conformer/multiblank/conformer_multiblank_transducer_bpe.yaml
@@ -61,6 +61,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/multiblank/conformer_multiblank_transducer_bpe.yaml
+++ b/examples/asr/conf/conformer/multiblank/conformer_multiblank_transducer_bpe.yaml
@@ -61,8 +61,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/multilang/conformer_ctc_bpe_multilang.yaml
+++ b/examples/asr/conf/conformer/multilang/conformer_ctc_bpe_multilang.yaml
@@ -48,8 +48,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/multilang/conformer_ctc_bpe_multilang.yaml
+++ b/examples/asr/conf/conformer/multilang/conformer_ctc_bpe_multilang.yaml
@@ -48,6 +48,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/multilang/conformer_transducer_bpe_multilang.yaml
+++ b/examples/asr/conf/conformer/multilang/conformer_transducer_bpe_multilang.yaml
@@ -50,8 +50,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/multilang/conformer_transducer_bpe_multilang.yaml
+++ b/examples/asr/conf/conformer/multilang/conformer_transducer_bpe_multilang.yaml
@@ -50,6 +50,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/tdt/conformer_tdt_bpe.yaml
+++ b/examples/asr/conf/conformer/tdt/conformer_tdt_bpe.yaml
@@ -64,6 +64,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/tdt/conformer_tdt_bpe.yaml
+++ b/examples/asr/conf/conformer/tdt/conformer_tdt_bpe.yaml
@@ -64,8 +64,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/tdt/conformer_tdt_bpe_stateless.yaml
+++ b/examples/asr/conf/conformer/tdt/conformer_tdt_bpe_stateless.yaml
@@ -59,8 +59,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/conformer/tdt/conformer_tdt_bpe_stateless.yaml
+++ b/examples/asr/conf/conformer/tdt/conformer_tdt_bpe_stateless.yaml
@@ -59,6 +59,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/contextnet_rnnt/config_rnnt.yaml
+++ b/examples/asr/conf/contextnet_rnnt/config_rnnt.yaml
@@ -25,8 +25,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/contextnet_rnnt/config_rnnt.yaml
+++ b/examples/asr/conf/contextnet_rnnt/config_rnnt.yaml
@@ -25,6 +25,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/contextnet_rnnt/config_rnnt_bpe.yaml
+++ b/examples/asr/conf/contextnet_rnnt/config_rnnt_bpe.yaml
@@ -25,8 +25,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/contextnet_rnnt/config_rnnt_bpe.yaml
+++ b/examples/asr/conf/contextnet_rnnt/config_rnnt_bpe.yaml
@@ -25,6 +25,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
@@ -44,8 +44,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
   validation_ds:
     manifest_filepath: ???
     sample_rate: ${model.sample_rate}

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt.yaml
@@ -44,6 +44,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
   validation_ds:
     manifest_filepath: ???
     sample_rate: ${model.sample_rate}

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_char.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_char.yaml
@@ -47,8 +47,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_char.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_char.yaml
@@ -47,6 +47,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_multilang.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_multilang.yaml
@@ -45,8 +45,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
   validation_ds:
     manifest_filepath: ???
     sample_rate: ${model.sample_rate}

--- a/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_multilang.yaml
+++ b/examples/asr/conf/contextnet_rnnt/contextnet_rnnt_multilang.yaml
@@ -45,6 +45,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
   validation_ds:
     manifest_filepath: ???
     sample_rate: ${model.sample_rate}

--- a/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_ctc_bpe_streaming.yaml
+++ b/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_ctc_bpe_streaming.yaml
@@ -29,6 +29,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_ctc_bpe_streaming.yaml
+++ b/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_ctc_bpe_streaming.yaml
@@ -29,8 +29,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_ctc_char_streaming.yaml
+++ b/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_ctc_char_streaming.yaml
@@ -33,6 +33,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_ctc_char_streaming.yaml
+++ b/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_ctc_char_streaming.yaml
@@ -33,8 +33,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_transducer_bpe_streaming.yaml
+++ b/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_transducer_bpe_streaming.yaml
@@ -34,6 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_transducer_bpe_streaming.yaml
+++ b/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_transducer_bpe_streaming.yaml
@@ -34,8 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_transducer_char_streaming.yaml
+++ b/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_transducer_char_streaming.yaml
@@ -39,8 +39,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_transducer_char_streaming.yaml
+++ b/examples/asr/conf/fastconformer/cache_aware_streaming/fastconformer_transducer_char_streaming.yaml
@@ -39,6 +39,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/fast-conformer_ctc_bpe.yaml
+++ b/examples/asr/conf/fastconformer/fast-conformer_ctc_bpe.yaml
@@ -47,8 +47,8 @@ model:
     # bucketing params
     bucketing_strategy: "fully_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/fast-conformer_ctc_bpe.yaml
+++ b/examples/asr/conf/fastconformer/fast-conformer_ctc_bpe.yaml
@@ -47,6 +47,8 @@ model:
     # bucketing params
     bucketing_strategy: "fully_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/fast-conformer_transducer_bpe.yaml
+++ b/examples/asr/conf/fastconformer/fast-conformer_transducer_bpe.yaml
@@ -53,8 +53,8 @@ model:
     # bucketing params
     bucketing_strategy: "fully_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/fast-conformer_transducer_bpe.yaml
+++ b/examples/asr/conf/fastconformer/fast-conformer_transducer_bpe.yaml
@@ -53,6 +53,8 @@ model:
     # bucketing params
     bucketing_strategy: "fully_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/hybrid_cache_aware_streaming/fastconformer_hybrid_transducer_ctc_bpe_streaming.yaml
+++ b/examples/asr/conf/fastconformer/hybrid_cache_aware_streaming/fastconformer_hybrid_transducer_ctc_bpe_streaming.yaml
@@ -37,6 +37,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/hybrid_cache_aware_streaming/fastconformer_hybrid_transducer_ctc_bpe_streaming.yaml
+++ b/examples/asr/conf/fastconformer/hybrid_cache_aware_streaming/fastconformer_hybrid_transducer_ctc_bpe_streaming.yaml
@@ -37,8 +37,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/hybrid_cache_aware_streaming/fastconformer_hybrid_transducer_ctc_char_streaming.yaml
+++ b/examples/asr/conf/fastconformer/hybrid_cache_aware_streaming/fastconformer_hybrid_transducer_ctc_char_streaming.yaml
@@ -41,8 +41,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/hybrid_cache_aware_streaming/fastconformer_hybrid_transducer_ctc_char_streaming.yaml
+++ b/examples/asr/conf/fastconformer/hybrid_cache_aware_streaming/fastconformer_hybrid_transducer_ctc_char_streaming.yaml
@@ -41,6 +41,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/hybrid_transducer_ctc/fastconformer_hybrid_transducer_ctc_bpe.yaml
+++ b/examples/asr/conf/fastconformer/hybrid_transducer_ctc/fastconformer_hybrid_transducer_ctc_bpe.yaml
@@ -36,6 +36,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/hybrid_transducer_ctc/fastconformer_hybrid_transducer_ctc_bpe.yaml
+++ b/examples/asr/conf/fastconformer/hybrid_transducer_ctc/fastconformer_hybrid_transducer_ctc_bpe.yaml
@@ -36,8 +36,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/hybrid_transducer_ctc/fastconformer_hybrid_transducer_ctc_char.yaml
+++ b/examples/asr/conf/fastconformer/hybrid_transducer_ctc/fastconformer_hybrid_transducer_ctc_char.yaml
@@ -40,6 +40,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/hybrid_transducer_ctc/fastconformer_hybrid_transducer_ctc_char.yaml
+++ b/examples/asr/conf/fastconformer/hybrid_transducer_ctc/fastconformer_hybrid_transducer_ctc_char.yaml
@@ -40,8 +40,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/long_fastconformer/fast-conformer-long_ctc_bpe.yaml
+++ b/examples/asr/conf/fastconformer/long_fastconformer/fast-conformer-long_ctc_bpe.yaml
@@ -34,8 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "fully_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/long_fastconformer/fast-conformer-long_ctc_bpe.yaml
+++ b/examples/asr/conf/fastconformer/long_fastconformer/fast-conformer-long_ctc_bpe.yaml
@@ -34,6 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "fully_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/long_fastconformer/fast-conformer-long_transducer_bpe.yaml
+++ b/examples/asr/conf/fastconformer/long_fastconformer/fast-conformer-long_transducer_bpe.yaml
@@ -40,6 +40,8 @@ model:
     # bucketing params
     bucketing_strategy: "fully_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/fastconformer/long_fastconformer/fast-conformer-long_transducer_bpe.yaml
+++ b/examples/asr/conf/fastconformer/long_fastconformer/fast-conformer-long_transducer_bpe.yaml
@@ -40,8 +40,8 @@ model:
     # bucketing params
     bucketing_strategy: "fully_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/jasper/jasper_10x5dr.yaml
+++ b/examples/asr/conf/jasper/jasper_10x5dr.yaml
@@ -23,8 +23,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/jasper/jasper_10x5dr.yaml
+++ b/examples/asr/conf/jasper/jasper_10x5dr.yaml
@@ -23,6 +23,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/lstm/lstm_ctc_bpe.yaml
+++ b/examples/asr/conf/lstm/lstm_ctc_bpe.yaml
@@ -34,6 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/lstm/lstm_ctc_bpe.yaml
+++ b/examples/asr/conf/lstm/lstm_ctc_bpe.yaml
@@ -34,8 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/lstm/lstm_transducer_bpe.yaml
+++ b/examples/asr/conf/lstm/lstm_transducer_bpe.yaml
@@ -40,6 +40,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/lstm/lstm_transducer_bpe.yaml
+++ b/examples/asr/conf/lstm/lstm_transducer_bpe.yaml
@@ -40,8 +40,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/marblenet/marblenet_3x2x64.yaml
+++ b/examples/asr/conf/marblenet/marblenet_3x2x64.yaml
@@ -24,8 +24,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
     bucketing_weights: null
     augmentor:
       shift:

--- a/examples/asr/conf/marblenet/marblenet_3x2x64.yaml
+++ b/examples/asr/conf/marblenet/marblenet_3x2x64.yaml
@@ -24,6 +24,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
     bucketing_weights: null
     augmentor:
       shift:

--- a/examples/asr/conf/marblenet/marblenet_3x2x64_20ms.yaml
+++ b/examples/asr/conf/marblenet/marblenet_3x2x64_20ms.yaml
@@ -24,8 +24,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
     bucketing_weights: null
     augmentor:
       white_noise:

--- a/examples/asr/conf/marblenet/marblenet_3x2x64_20ms.yaml
+++ b/examples/asr/conf/marblenet/marblenet_3x2x64_20ms.yaml
@@ -24,6 +24,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
     bucketing_weights: null
     augmentor:
       white_noise:

--- a/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v1.yaml
+++ b/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v1.yaml
@@ -30,6 +30,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
     bucketing_weights: null
     augmentor:
       shift:

--- a/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v1.yaml
+++ b/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v1.yaml
@@ -30,8 +30,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
     bucketing_weights: null
     augmentor:
       shift:

--- a/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v2.yaml
+++ b/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v2.yaml
@@ -30,6 +30,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
     bucketing_weights: null
     augmentor:
       shift:

--- a/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v2.yaml
+++ b/examples/asr/conf/matchboxnet/matchboxnet_3x1x64_v2.yaml
@@ -30,8 +30,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
     bucketing_weights: null
     augmentor:
       shift:

--- a/examples/asr/conf/quartznet/quartznet_15x5.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5.yaml
@@ -25,8 +25,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/quartznet/quartznet_15x5.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5.yaml
@@ -25,6 +25,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/quartznet/quartznet_15x5_aug.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5_aug.yaml
@@ -23,6 +23,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
     augmentor:
       rir_noise_aug:
         prob: 0.5

--- a/examples/asr/conf/quartznet/quartznet_15x5_aug.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5_aug.yaml
@@ -23,8 +23,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
     augmentor:
       rir_noise_aug:
         prob: 0.5

--- a/examples/asr/conf/quartznet/quartznet_15x5_ru.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5_ru.yaml
@@ -23,6 +23,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
     parser: ru
 
   validation_ds:

--- a/examples/asr/conf/quartznet/quartznet_15x5_ru.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5_ru.yaml
@@ -23,8 +23,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
     parser: ru
 
   validation_ds:

--- a/examples/asr/conf/quartznet/quartznet_15x5_zh.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5_zh.yaml
@@ -231,8 +231,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/quartznet/quartznet_15x5_zh.yaml
+++ b/examples/asr/conf/quartznet/quartznet_15x5_zh.yaml
@@ -231,6 +231,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/squeezeformer/squeezeformer_ctc_bpe.yaml
+++ b/examples/asr/conf/squeezeformer/squeezeformer_ctc_bpe.yaml
@@ -44,6 +44,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/squeezeformer/squeezeformer_ctc_bpe.yaml
+++ b/examples/asr/conf/squeezeformer/squeezeformer_ctc_bpe.yaml
@@ -44,8 +44,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/squeezeformer/squeezeformer_ctc_char.yaml
+++ b/examples/asr/conf/squeezeformer/squeezeformer_ctc_char.yaml
@@ -33,6 +33,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/squeezeformer/squeezeformer_ctc_char.yaml
+++ b/examples/asr/conf/squeezeformer/squeezeformer_ctc_char.yaml
@@ -33,8 +33,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/ssl/citrinet/citrinet_ssl_1024.yaml
+++ b/examples/asr/conf/ssl/citrinet/citrinet_ssl_1024.yaml
@@ -33,6 +33,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/ssl/citrinet/citrinet_ssl_1024.yaml
+++ b/examples/asr/conf/ssl/citrinet/citrinet_ssl_1024.yaml
@@ -33,8 +33,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/ssl/citrinet/citrinet_ssl_ci.yaml
+++ b/examples/asr/conf/ssl/citrinet/citrinet_ssl_ci.yaml
@@ -21,6 +21,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/ssl/citrinet/citrinet_ssl_ci.yaml
+++ b/examples/asr/conf/ssl/citrinet/citrinet_ssl_ci.yaml
@@ -21,8 +21,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/ssl/conformer/conformer_ssl.yaml
+++ b/examples/asr/conf/ssl/conformer/conformer_ssl.yaml
@@ -43,8 +43,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/ssl/conformer/conformer_ssl.yaml
+++ b/examples/asr/conf/ssl/conformer/conformer_ssl.yaml
@@ -43,6 +43,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/ssl/contextnet/contextnet_ssl.yaml
+++ b/examples/asr/conf/ssl/contextnet/contextnet_ssl.yaml
@@ -38,8 +38,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/ssl/contextnet/contextnet_ssl.yaml
+++ b/examples/asr/conf/ssl/contextnet/contextnet_ssl.yaml
@@ -38,6 +38,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/ssl/fastconformer/fast-conformer.yaml
+++ b/examples/asr/conf/ssl/fastconformer/fast-conformer.yaml
@@ -39,8 +39,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/ssl/fastconformer/fast-conformer.yaml
+++ b/examples/asr/conf/ssl/fastconformer/fast-conformer.yaml
@@ -39,6 +39,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/ssl/wav2vec/wav2vec_ci.yaml
+++ b/examples/asr/conf/ssl/wav2vec/wav2vec_ci.yaml
@@ -30,6 +30,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/conf/ssl/wav2vec/wav2vec_ci.yaml
+++ b/examples/asr/conf/ssl/wav2vec/wav2vec_ci.yaml
@@ -30,8 +30,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/k2/conf/citrinet/citrinet_mmi_1024.yaml
+++ b/examples/asr/experimental/k2/conf/citrinet/citrinet_mmi_1024.yaml
@@ -34,6 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/k2/conf/citrinet/citrinet_mmi_1024.yaml
+++ b/examples/asr/experimental/k2/conf/citrinet/citrinet_mmi_1024.yaml
@@ -34,8 +34,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/k2/conf/conformer/conformer_ctc_bpe.yaml
+++ b/examples/asr/experimental/k2/conf/conformer/conformer_ctc_bpe.yaml
@@ -48,8 +48,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/k2/conf/conformer/conformer_ctc_bpe.yaml
+++ b/examples/asr/experimental/k2/conf/conformer/conformer_ctc_bpe.yaml
@@ -48,6 +48,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/k2/conf/conformer/conformer_transducer_bpe.yaml
+++ b/examples/asr/experimental/k2/conf/conformer/conformer_transducer_bpe.yaml
@@ -51,8 +51,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/asr/experimental/k2/conf/conformer/conformer_transducer_bpe.yaml
+++ b/examples/asr/experimental/k2/conf/conformer/conformer_transducer_bpe.yaml
@@ -51,6 +51,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/slu/speech_intent_slot/configs/conformer_transformer_large_bpe.yaml
+++ b/examples/slu/speech_intent_slot/configs/conformer_transformer_large_bpe.yaml
@@ -29,6 +29,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
+    shard_manifests: True
+    defer_setup: True
 
   validation_ds:
     manifest_filepath: ???

--- a/examples/slu/speech_intent_slot/configs/conformer_transformer_large_bpe.yaml
+++ b/examples/slu/speech_intent_slot/configs/conformer_transformer_large_bpe.yaml
@@ -29,8 +29,8 @@ model:
     # bucketing params
     bucketing_strategy: "synced_randomized"
     bucketing_batch_size: null
-    shard_manifests: True
-    defer_setup: True
+    shard_manifests: False
+    defer_setup: False
 
   validation_ds:
     manifest_filepath: ???


### PR DESCRIPTION
# What does this PR do ?

Makes sharded manifests default for train dataloader in ASR config files

**Collection**: ASR

# Changelog 
Adding these flags to the train_ds section of config files:
shard_manifests: False
defer_setup: False

# Usage
Set these flags to true if you wish to use the sharded manifest feature

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation
- [X ]  Config

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
