### PR TITLE
add Cython build requirement to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,3 +64,6 @@ markers = [
     "skipduringci: marks tests that are skipped ci as they are addressed by Jenkins jobs but should be run to test user setups",
     "pleasefixme: marks tests that are broken and need fixing",
 ]
+
+[build-system]
+requires = ["cython>=0.29.34"]


### PR DESCRIPTION
# What does this PR do ?

Add Cython as a build requirement to pyproject.toml.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
This is related to https://github.com/NVIDIA/NeMo/issues/6854 and solves the issue for me in Python 3.9 and Python 3.10. Instead of requiring the user to manually install cython beforehand, why not specify it as a build requirement as per [PEP-0518](https://peps.python.org/pep-0518/).