### PR TITLE
[Bugfix] Move nemo file config logic of GPT eval script

### DIFF
--- a/examples/nlp/language_modeling/megatron_gpt_eval.py
+++ b/examples/nlp/language_modeling/megatron_gpt_eval.py
@@ -171,9 +171,9 @@ def main(cfg) -> None:
 
     if cfg.gpt_model_file:
         if (
-                cfg.tensor_model_parallel_size < 0
-                or cfg.pipeline_model_parallel_size < 0
-                or cfg.get('pipeline_model_parallel_split_rank', -1) < 0
+            cfg.tensor_model_parallel_size < 0
+            or cfg.pipeline_model_parallel_size < 0
+            or cfg.get('pipeline_model_parallel_split_rank', -1) < 0
         ):
             model_config = MegatronGPTModel.restore_from(
                 restore_path=cfg.gpt_model_file, trainer=trainer, return_config=True,
@@ -185,8 +185,8 @@ def main(cfg) -> None:
                 cfg.pipeline_model_parallel_split_rank = model_config.get('pipeline_model_parallel_split_rank', 0)
 
         assert (
-                cfg.trainer.devices * cfg.trainer.num_nodes
-                == cfg.tensor_model_parallel_size * cfg.pipeline_model_parallel_size
+            cfg.trainer.devices * cfg.trainer.num_nodes
+            == cfg.tensor_model_parallel_size * cfg.pipeline_model_parallel_size
         ), "devices * num_nodes should equal tensor_model_parallel_size * pipeline_model_parallel_size"
 
         save_restore_connector = NLPSaveRestoreConnector()

--- a/examples/nlp/language_modeling/megatron_gpt_eval.py
+++ b/examples/nlp/language_modeling/megatron_gpt_eval.py
@@ -165,6 +165,7 @@ def remove_padded_prompts(response, nb_paddings):
 
 @hydra_runner(config_path="conf", config_name="megatron_gpt_inference")
 def main(cfg) -> None:
+
     # trainer required for restoring model parallel models
     trainer = Trainer(strategy=NLPDDPStrategy(), **cfg.trainer)
 


### PR DESCRIPTION
# What does this PR do ?

Move the cfg.gpt_model_file logic into the "if" block to avoid error during ckpt eval

**Collection**: [Note which collection this PR will affect] 
NLP
examples/nlp/language_modelling

# Changelog 
- Add specific line by line info of high level changes in this PR.
Move https://github.com/NVIDIA/NeMo/blob/main/examples/nlp/language_modeling/megatron_gpt_eval.py#L172-L189
to after https://github.com/NVIDIA/NeMo/blob/main/examples/nlp/language_modeling/megatron_gpt_eval.py#L191

# Usage
* You can potentially add a usage example below
Otherwise, if following this
```python
        python megatron_gpt_eval.py \
            checkpoint_dir=PATH_TO_CHECKPOINT_FILE \
            checkpoint_name=CHECKPOINT_FILE_NAME \
            hparams_file=HPARAMS_FILE \
            inference.greedy=True \
            inference.add_BOS=True \
            trainer.devices=1 \
            trainer.num_nodes=1 \
            tensor_model_parallel_size=-1 \
            pipeline_model_parallel_size=-1 \
            prompts=[prompt1,prompt2]
```
Since in this case gpt_model_file=null, the current script will error out due to restore path unknown
```
Traceback (most recent call last):
  File "megatron_gpt_eval.py", line 176, in main
    model_config = MegatronGPTModel.restore_from(
  File "/workspace/NeMo-1.18.0/nemo/core/classes/modelPT.py", line 425, in restore_from
    restore_path = os.path.abspath(os.path.expanduser(restore_path))
  File "/usr/lib/python3.8/posixpath.py", line 231, in expanduser
    path = os.fspath(path)
TypeError: expected str, bytes or os.PathLike object, not NoneType

```


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? No
- [ ] Did you add or update any necessary documentation? No
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc) No
- [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
