### PR TITLE
Fix k2 build topo helper

### DIFF
--- a/nemo/collections/asr/parts/k2/topologies.py
+++ b/nemo/collections/asr/parts/k2/topologies.py
@@ -46,9 +46,11 @@ def build_topo(name: str, tokens: List[int], blank_num: int, with_self_loops: bo
     else:
         raise ValueError(f"Unknown topo name: {name}")
     if blank_num != 0:
-        blank_mask = ans.labels == 0
-        ans.labels[(ans.labels != -1) & (ans.labels <= blank_num)] -= 1
-        ans.labels[blank_mask] = blank_num
+        labels = ans.labels
+        blank_mask = labels == 0
+        labels[(ans.labels != -1) & (ans.labels <= blank_num)] -= 1
+        labels[blank_mask] = blank_num
+        ans.labels = labels  # force update ans.labels property to notify FSA about modifications, required by k2
     ans = k2.arc_sort(ans)
     return ans
 

--- a/nemo/collections/asr/parts/k2/topologies.py
+++ b/nemo/collections/asr/parts/k2/topologies.py
@@ -48,7 +48,7 @@ def build_topo(name: str, tokens: List[int], blank_num: int, with_self_loops: bo
     if blank_num != 0:
         labels = ans.labels
         blank_mask = labels == 0
-        labels[(ans.labels != -1) & (ans.labels <= blank_num)] -= 1
+        labels[(labels != -1) & (labels <= blank_num)] -= 1
         labels[blank_mask] = blank_num
         ans.labels = labels  # force update ans.labels property to notify FSA about modifications, required by k2
     ans = k2.arc_sort(ans)


### PR DESCRIPTION
# What does this PR do ?

Fix `build_topo` function for `k2`-based topologies. 
This solution fixes failing tests `tests/collections/asr/k2/test_ctc.py::TestCTCLossK2::test_case_small_blank_last` + `tests/collections/asr/k2/test_rnnt.py::TestRNNTLossK2::test_case_small_blank_last`

**Collection**: [ASR]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
