### PR TITLE
Update setup_os2s_decoders.py

### DIFF
--- a/scripts/installers/setup_os2s_decoders.py
+++ b/scripts/installers/setup_os2s_decoders.py
@@ -29,7 +29,7 @@ import os
 import platform
 import sys
 
-from setuptools import Extension, distutils, setup
+from setuptools import Extension, setup
 
 parser = argparse.ArgumentParser(description=__doc__)
 parser.add_argument(


### PR DESCRIPTION
# What does this PR do ?

Install ctc_decoders without distutils duplication to avoid `AttributeError: module 'distutils' has no attribute 'ccompiler'`.

**Collection**: ASR

# Changelog 
- Fix install_beamsearch_decoders.sh to work outside container

# Usage

```
# make NeMo venv
conda create --name nemo python==3.8.10
conda activate nemo

# install NeMo
sudo apt-get update && apt-get install -y libsndfile1 ffmpeg
git clone https://github.com/NVIDIA/NeMo
cd NeMo
./reinstall.sh

# install ctc-decoders
./scripts/asr_language_modeling/ngram_lm/install_beamsearch_decoders.sh $(pwd)
```
  
**PR Type**:
- [ x ] Bugfix

# Who can review?
@titu1994