### PR TITLE
Reduce number of nodes produced in ConformerEncoder export

### DIFF
--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -664,7 +664,7 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable, AccessMixin):
 
     def _create_masks(self, att_context_size, padding_length, max_audio_length, offset, device):
         if self.self_attention_model != "rel_pos_local_attn":
-            att_mask = torch.ones(1, max_audio_length, max_audio_length, dtype=torch.bool, device=device)
+            att_mask = torch.ones(1, max_audio_length, max_audio_length, device=device)
 
             if self.att_context_style == "regular":
                 if att_context_size[0] >= 0:

--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -506,7 +506,7 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable, AccessMixin):
             )
 
         if cache_last_time is not None:
-            cache_last_time_next = torch.zeros_like(cache_last_time)
+            cache_last_time_next = [torch.zeros_like(cache_last_time[0]) for _ in range(cache_last_time.shape[0])]
         else:
             cache_last_time_next = None
 
@@ -536,7 +536,9 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable, AccessMixin):
         if cache_last_channel is not None:
             cache_len = self.streaming_cfg.last_channel_cache_size
             cache_keep_size = max_audio_length - self.streaming_cfg.cache_drop_size
-            cache_last_channel_next = torch.zeros_like(cache_last_channel)
+            cache_last_channel_next = [
+                torch.zeros_like(cache_last_channel[0]) for _ in range(cache_last_channel.shape[0])
+            ]
             max_audio_length = max_audio_length + cache_len
             padding_length = length + cache_len
             offset = torch.neg(cache_last_channel_len) + cache_len
@@ -626,6 +628,8 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable, AccessMixin):
         length = length.to(dtype=torch.int64)
 
         if cache_last_channel is not None:
+            cache_last_channel_next = torch.stack(cache_last_channel_next, dim=0)
+            cache_last_time_next = torch.stack(cache_last_time_next, dim=0)
             return (
                 audio_signal,
                 length,

--- a/nemo/collections/asr/parts/submodules/causal_convs.py
+++ b/nemo/collections/asr/parts/submodules/causal_convs.py
@@ -138,9 +138,14 @@ class CausalConv1D(nn.Conv1d):
             # todo: we should know input_x.size(-1) at config time
             if cache_next is not None:
                 cache_keep_size = torch.tensor(x.size(-1) - self.cache_drop_size, dtype=torch.int64, device=x.device)
-                cache_keep_size = torch.clip(cache_keep_size, min=1, max=cache_next.size(-1))
-                cache_next[self._cache_id, :, :, :-cache_keep_size] = cache[self._cache_id, :, :, cache_keep_size:]
-                cache_next[self._cache_id, :, :, -cache_keep_size:] = x[:, :, :cache_keep_size]
+                cache_keep_size = torch.clip(cache_keep_size, min=1, max=cache_next[0].size(-1))
+                cache_next[self._cache_id] = torch.cat(
+                    [
+                        cache[self._cache_id, :, :, cache_keep_size:],
+                        x[:, :, :cache_keep_size],
+                    ],
+                    dim=2
+                )
         return new_x
 
     def forward(self, x, cache=None, cache_next=None):

--- a/nemo/collections/asr/parts/submodules/causal_convs.py
+++ b/nemo/collections/asr/parts/submodules/causal_convs.py
@@ -140,11 +140,7 @@ class CausalConv1D(nn.Conv1d):
                 cache_keep_size = torch.tensor(x.size(-1) - self.cache_drop_size, dtype=torch.int64, device=x.device)
                 cache_keep_size = torch.clip(cache_keep_size, min=1, max=cache_next[0].size(-1))
                 cache_next[self._cache_id] = torch.cat(
-                    [
-                        cache[self._cache_id, :, :, cache_keep_size:],
-                        x[:, :, :cache_keep_size],
-                    ],
-                    dim=2
+                    [cache[self._cache_id, :, :, cache_keep_size:], x[:, :, :cache_keep_size],], dim=2
                 )
         return new_x
 

--- a/nemo/collections/asr/parts/submodules/multi_head_attention.py
+++ b/nemo/collections/asr/parts/submodules/multi_head_attention.py
@@ -151,11 +151,7 @@ class MultiHeadAttention(nn.Module):
             q_keep_size = query.shape[1] - self.cache_drop_size
             if cache_next is not None:
                 cache_next[self._cache_id] = torch.cat(
-                    [
-                        cache[self._cache_id, :, q_keep_size:, :],
-                        query[:, :q_keep_size, :]
-                    ],
-                    dim=1
+                    [cache[self._cache_id, :, q_keep_size:, :], query[:, :q_keep_size, :]], dim=1
                 )
         return key, value, query
 

--- a/nemo/collections/asr/parts/submodules/multi_head_attention.py
+++ b/nemo/collections/asr/parts/submodules/multi_head_attention.py
@@ -150,8 +150,13 @@ class MultiHeadAttention(nn.Module):
             key = value = torch.cat([cache[self._cache_id], key], dim=1)
             q_keep_size = query.shape[1] - self.cache_drop_size
             if cache_next is not None:
-                cache_next[self._cache_id, :, :-q_keep_size, :] = cache[self._cache_id, :, q_keep_size:, :]
-                cache_next[self._cache_id, :, -q_keep_size:, :] = query[:, :q_keep_size, :]
+                cache_next[self._cache_id] = torch.cat(
+                    [
+                        cache[self._cache_id, :, q_keep_size:, :],
+                        query[:, :q_keep_size, :]
+                    ],
+                    dim=1
+                )
         return key, value, query
 
 


### PR DESCRIPTION
This commit breaks up the output cache tensor into a list of tensors. Each layer which writes to the output cache now writes to its own tensor. The output cache tensors are then stacked into one tensor before being returned, so ConformerEncoder still has the same inputs and outputs as before.

The reason for this change is from an ONNX perspective, updating a tensor creates a new copy with the changes. So minimizing the sizes of the tensors that get updated makes the exported ONNX model more efficient.

The number of nodes produced in the ONNX export is also reduced. In the example I tested, the exported ONNX model had 11.484 nodes before this change, and only 4,892 nodes after this change.

Signed off by: Ilya Sherstyuk <isherstyuk@nvidia.com>
