### PR TITLE
Make sure asr_model.change_attention_model is run if either cfg.model_path or cfg.pretrained_name is specified

### DIFF
--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -189,11 +189,6 @@ def setup_model(cfg: DictConfig, map_location: torch.device) -> Tuple[ASRModel, 
         asr_model = imported_class.restore_from(
             restore_path=cfg.model_path, map_location=map_location,
         )  # type: ASRModel
-        if hasattr(cfg, "model_change"):
-            asr_model.change_attention_model(
-                self_attention_model=cfg.model_change.conformer.get("self_attention_model", None),
-                att_context_size=cfg.model_change.conformer.get("att_context_size", None),
-            )
         model_name = os.path.splitext(os.path.basename(cfg.model_path))[0]
     else:
         # restore model by name
@@ -201,6 +196,12 @@ def setup_model(cfg: DictConfig, map_location: torch.device) -> Tuple[ASRModel, 
             model_name=cfg.pretrained_name, map_location=map_location,
         )  # type: ASRModel
         model_name = cfg.pretrained_name
+
+    if hasattr(cfg, "model_change"):
+        asr_model.change_attention_model(
+            self_attention_model=cfg.model_change.conformer.get("self_attention_model", None),
+            att_context_size=cfg.model_change.conformer.get("att_context_size", None),
+        )
 
     return asr_model, model_name
 


### PR DESCRIPTION
# What does this PR do ?
Makes sure `asr_model.change_attention_model` is run regardless of whether `cfg.model_path` or `cfg.pretrained_name` is specified.

**Collection**: ASR

# Changelog 
- Moved `asr_model.change_attention_model` call outside of if-branch.

# Usage
* You can potentially add a usage example below

```bash
python NeMo/examples/asr/transcribe_speech.py \
        pretrained_name="stt_en_fastconformer_ctc_large" \
        dataset_manifest=$src_manifest \
        ++model_change.conformer.self_attention_model="rel_pos_local_attn" \
        ++model_change.conformer.att_context_size="[128, 128]"
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [N/A] Did you write any new necessary tests?
- [N/A] Did you add or update any necessary documentation?
- [N/A] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
