### PR TITLE
Fix FP8 scales conversion issue from non-nemo checkpoint to nemo checkpoint

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -304,13 +304,13 @@ NeMo Text Processing, specifically (Inverse) Text Normalization, is now a separa
 
 Docker containers:
 ~~~~~~~~~~~~~~~~~~
-We release NeMo containers alongside NeMo releases. For example, NeMo ``r1.18.1`` comes with container ``nemo:23.03``, you may find more details about released containers in `releases page <https://github.com/NVIDIA/NeMo/releases>`_.
+We release NeMo containers alongside NeMo releases. For example, NeMo ``r1.19.0`` comes with container ``nemo:23.04``, you may find more details about released containers in `releases page <https://github.com/NVIDIA/NeMo/releases>`_.
 
 To use built container, please run
 
 .. code-block:: bash
 
-    docker pull nvcr.io/nvidia/nemo:23.03
+    docker pull nvcr.io/nvidia/nemo:23.04
 
 To build a nemo container with Dockerfile from a branch, please run
 

--- a/README.rst
+++ b/README.rst
@@ -290,6 +290,14 @@ Transformer Engine already supports Flash Attention for GPT models. If you want 
   pip install flash-attn
   pip install triton==2.0.0.dev20221202
 
+NLP inference UI
+~~~~~~~~~~~~~~~~~~~~
+To launch the inference web UI server, please install the gradio `gradio <https://gradio.app/>`_. 
+
+.. code-block:: bash
+
+  pip install gradio==3.34.0
+
 NeMo Text Processing
 ~~~~~~~~~~~~~~~~~~~~
 NeMo Text Processing, specifically (Inverse) Text Normalization, is now a separate repository `https://github.com/NVIDIA/NeMo-text-processing <https://github.com/NVIDIA/NeMo-text-processing>`_.

--- a/examples/asr/asr_vad/README.md
+++ b/examples/asr/asr_vad/README.md
@@ -8,10 +8,16 @@ There are two types of input
 -  A manifest passed to `manifest_filepath`, 
 -  A directory containing audios passed to `audio_dir` and also specify `audio_type` (default to `wav`).
 
-The input manifest must be a manifest json file, where each line is a Python dictionary. The fields ["audio_filepath", "offset", "duration",  "text"] are required. An example of a manifest file is:
+The input manifest must be a manifest json file, where each line is a Python dictionary. The fields ["audio_filepath", "offset", "duration"] are required. An example of a manifest file is:
 ```json
-{"audio_filepath": "/path/to/audio_file1", "offset": 0, "duration": 10000,  "text": "a b c d e"}
-{"audio_filepath": "/path/to/audio_file2", "offset": 0, "duration": 10000,  "text": "f g h i j"}
+{"audio_filepath": "/path/to/audio_file1", "offset": 0, "duration": 10000}
+{"audio_filepath": "/path/to/audio_file2", "offset": 0, "duration": 10000}
+```
+
+If you want to calculate WER, provide `text` in manifest as groundtruth. An example of a manifest file is:
+```json
+{"audio_filepath": "/path/to/audio_file1", "offset": 0, "duration": 10000, "text": "hello world"}
+{"audio_filepath": "/path/to/audio_file2", "offset": 0, "duration": 10000, "text": "hello world"}
 ```
 
 ## Output

--- a/examples/asr/speech_classification/README.md
+++ b/examples/asr/speech_classification/README.md
@@ -1,25 +1,88 @@
 # Speech Classification
 
-This directory contains example scripts to train speech classification and voice activity detection models. 
+This directory contains example scripts to train speech classification and voice activity detection models. There are two types of VAD models: Frame-VAD and Segment-VAD.
 
-# Model execution overview
+## Frame-VAD
 
-The training scripts in this directory execute in the following order. When preparing your own training-from-scratch / fine-tuning scripts, please follow this order for correct training/inference.
+The frame-level VAD model predicts for each frame of the audio whether it has speech or not. For example, with the default config file (`../conf/marblenet/marblenet_3x2x64_20ms.yaml`), the model provides a probability for each frame of 20ms length.
 
-```mermaid
-
-graph TD
-    A[Hydra Overrides + Yaml Config] --> B{Config}
-    B --> |Init| C[Trainer]
-    C --> D[ExpManager]
-    B --> D[ExpManager]
-    C --> E[Model]
-    B --> |Init| E[Model]
-    E --> |Constructor| F(Change Labels)
-    F --> G(Setup Train + Validation + Test Data loaders)
-    G --> H(Setup Optimization)
-    H --> I[Maybe init from pretrained]
-    I --> J["trainer.fit(model)"]
+### Training
+```sh
+python speech_to_label.py \
+    --config-path=<path to directory of configs, e.g. "../conf/marblenet">
+    --config-name=<name of config without .yaml, e.g. "marblenet_3x2x64_20ms"> \
+    model.train_ds.manifest_filepath="[<path to train manifest1>,<path to train manifest2>]" \
+    model.validation_ds.manifest_filepath=["<path to val manifest1>","<path to val manifest2>"] \
+    trainer.devices=-1 \
+    trainer.accelerator="gpu" \
+    strategy="ddp" \
+    trainer.max_epochs=100
 ```
 
-During restoration of the model, you may pass the Trainer to the restore_from / from_pretrained call, or set it after the model has been initialized by using `model.set_trainer(Trainer)`.
+The input manifest must be a manifest json file, where each line is a Python dictionary. The fields ["audio_filepath", "offset", "duration",  "label"] are required. An example of a manifest file is:
+```
+{"audio_filepath": "/path/to/audio_file1", "offset": 0, "duration": 10000,  "label": "0 1 0 0 1"}
+{"audio_filepath": "/path/to/audio_file2", "offset": 0, "duration": 10000,  "label": "0 0 0 1 1 1 1 0 0"}
+```
+For example, if you have a 1s audio file, you'll need to have 50 frame labels in the manifest entry like "0 0 0 0 1 1 0 1 .... 0 1".
+However, shorter label strings are also supported for smaller file sizes. For example, you can prepare the `label` in 40ms frame, and the model will properly repeat the label for each 20ms frame.
+
+
+### Inference
+python frame_vad_infer.py \
+    --config-path="../conf/vad" --config-name="frame_vad_infer_postprocess" \
+    dataset=<Path of manifest file containing evaluation data. Audio files should have unique names>
+
+The manifest json file should have the following format (each line is a Python dictionary):
+```
+{"audio_filepath": "/path/to/audio_file1.wav", "offset": 0, "duration": 10000}  
+{"audio_filepath": "/path/to/audio_file2.wav", "offset": 0, "duration": 10000}  
+```
+
+#### Evaluation
+If you want to evaluate tne model's AUROC and DER performance, you need to set `evaluate: True` in config yaml (e.g., `../conf/vad/frame_vad_infer_postprocess.yaml`), and also provide groundtruth in label strings:
+```
+{"audio_filepath": "/path/to/audio_file1.wav", "offset": 0, "duration": 10000, "label": "0 1 0 0 0 1 1 1 0"}
+```
+or RTTM files:
+```
+{"audio_filepath": "/path/to/audio_file1.wav", "offset": 0, "duration": 10000, "rttm_filepath": "/path/to/rttm_file1.rttm"}
+```
+
+
+## Segment-VAD
+
+Segment-level VAD predicts a single label for each segment of audio (e.g., 0.63s by default).
+
+### Training
+```sh
+python speech_to_label.py \
+    --config-path=<path to dir of configs, e.g. "../conf/marblenet"> \
+    --config-name=<name of config without .yaml, e.g., "marblenet_3x2x64"> \
+    model.train_ds.manifest_filepath="[<path to train manifest1>,<path to train manifest2>]" \
+    model.validation_ds.manifest_filepath=["<path to val manifest1>","<path to val manifest2>"] \
+    trainer.devices=-1 \
+    trainer.accelerator="gpu" \
+    strategy="ddp" \
+    trainer.max_epochs=100
+```
+
+The input manifest must be a manifest json file, where each line is a Python dictionary. The fields ["audio_filepath", "offset", "duration",  "label"] are required. An example of a manifest file is:
+```
+{"audio_filepath": "/path/to/audio_file1", "offset": 0, "duration": 0.63,  "label": "0"}
+{"audio_filepath": "/path/to/audio_file2", "offset": 0, "duration": 0.63,  "label": "1"}
+```
+
+
+### Inference
+```sh
+python vad_infer.py \
+    --config-path="../conf/vad" \
+    --config-name="vad_inference_postprocessing.yaml"
+    dataset=<Path of json file of evaluation data. Audio files should have unique names>
+```
+The manifest json file should have the following format (each line is a Python dictionary):
+```
+{"audio_filepath": "/path/to/audio_file1.wav", "offset": 0, "duration": 10000}  
+{"audio_filepath": "/path/to/audio_file2.wav", "offset": 0, "duration": 10000}  
+```

--- a/examples/asr/speech_classification/frame_vad_infer.py
+++ b/examples/asr/speech_classification/frame_vad_infer.py
@@ -26,6 +26,13 @@ python frame_vad_infer.py \
 The manifest json file should have the following format (each line is a Python dictionary):
 {"audio_filepath": "/path/to/audio_file1", "offset": 0, "duration": 10000}  
 {"audio_filepath": "/path/to/audio_file2", "offset": 0, "duration": 10000}  
+
+If you want to evaluate tne model's AUROC and DER performance, you need to set `evaluate=True` in config yaml,
+and also provide groundtruth in either RTTM files or label strings:
+{"audio_filepath": "/path/to/audio_file1", "offset": 0, "duration": 10000, "label": "0 1 0 0 0 1 1 1 0"}
+or
+{"audio_filepath": "/path/to/audio_file1", "offset": 0, "duration": 10000, "rttm_filepath": "/path/to/rttm_file1.rttm"}
+
 """
 
 import os

--- a/examples/asr/speech_classification/speech_to_frame_label.py
+++ b/examples/asr/speech_classification/speech_to_frame_label.py
@@ -32,7 +32,7 @@ python speech_to_label.py \
 The input manifest must be a manifest json file, where each line is a Python dictionary. The fields ["audio_filepath", "offset", "duration",  "label"] are required. An example of a manifest file is:
 ```
 {"audio_filepath": "/path/to/audio_file1", "offset": 0, "duration": 10000,  "label": "0 1 0 0 1"}
-{"audio_filepath": "/path/to/audio_file2", "offset": 0, "duration": 10000,  "text": "0 0 0 1 1 1 1 0 0"}
+{"audio_filepath": "/path/to/audio_file2", "offset": 0, "duration": 10000,  "label": "0 0 0 1 1 1 1 0 0"}
 ```
 For example, if you have a 1s audio file, you'll need to have 50 frame labels in the manifest entry like "0 0 0 0 1 1 0 1 .... 0 1".
 However, shorter label strings are also supported for smaller file sizes. For example, you can prepare the `label` in 40ms frame, and the model will properly repeat the label for each 20ms frame.

--- a/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
+++ b/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
@@ -143,7 +143,9 @@ def convert(local_rank, rank, world_size, args):
     )
 
     if args.model_type == 'gpt':
-        model = MegatroniGPTModel.load_from_checkpoint(checkpoint_path, hparams_file=args.hparams_file, trainer=trainer)
+        model = MegatroniGPTModel.load_from_checkpoint(
+            checkpoint_path, hparams_file=args.hparams_file, trainer=trainer
+        )
 
         # WAR to enable exporting FP8 scales from modules
         # TODO: Need to find a cleaner way

--- a/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
+++ b/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
@@ -143,7 +143,14 @@ def convert(local_rank, rank, world_size, args):
     )
 
     if args.model_type == 'gpt':
-        model = MegatronGPTModel.load_from_checkpoint(checkpoint_path, hparams_file=args.hparams_file, trainer=trainer)
+        model = MegatroniGPTModel.load_from_checkpoint(checkpoint_path, hparams_file=args.hparams_file, trainer=trainer)
+
+        # WAR to enable exporting FP8 scales from modules
+        # TODO: Need to find a cleaner way
+        for name, module in model.named_modules():
+            if hasattr(module, 'fp8'):
+                setattr(module, 'fp8', True)
+
     elif args.model_type == 'sft':
         model = MegatronGPTSFTModel.load_from_checkpoint(
             checkpoint_path, hparams_file=args.hparams_file, trainer=trainer

--- a/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
+++ b/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
@@ -143,7 +143,7 @@ def convert(local_rank, rank, world_size, args):
     )
 
     if args.model_type == 'gpt':
-        model = MegatroniGPTModel.load_from_checkpoint(
+        model = MegatronGPTModel.load_from_checkpoint(
             checkpoint_path, hparams_file=args.hparams_file, trainer=trainer
         )
 

--- a/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
+++ b/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
@@ -143,13 +143,9 @@ def convert(local_rank, rank, world_size, args):
     )
 
     if args.model_type == 'gpt':
-<<<<<<< HEAD
         model = MegatronGPTModel.load_from_checkpoint(
             checkpoint_path, hparams_file=args.hparams_file, trainer=trainer
         )
-=======
-        model = MegatroniGPTModel.load_from_checkpoint(checkpoint_path, hparams_file=args.hparams_file, trainer=trainer)
->>>>>>> For now added a WAR that toggles fp8 value in modules if it exists
 
         # WAR to enable exporting FP8 scales from modules
         # TODO: Need to find a cleaner way

--- a/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
+++ b/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
@@ -143,9 +143,13 @@ def convert(local_rank, rank, world_size, args):
     )
 
     if args.model_type == 'gpt':
+<<<<<<< HEAD
         model = MegatronGPTModel.load_from_checkpoint(
             checkpoint_path, hparams_file=args.hparams_file, trainer=trainer
         )
+=======
+        model = MegatroniGPTModel.load_from_checkpoint(checkpoint_path, hparams_file=args.hparams_file, trainer=trainer)
+>>>>>>> For now added a WAR that toggles fp8 value in modules if it exists
 
         # WAR to enable exporting FP8 scales from modules
         # TODO: Need to find a cleaner way

--- a/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
+++ b/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
@@ -143,9 +143,7 @@ def convert(local_rank, rank, world_size, args):
     )
 
     if args.model_type == 'gpt':
-        model = MegatronGPTModel.load_from_checkpoint(
-            checkpoint_path, hparams_file=args.hparams_file, trainer=trainer
-        )
+        model = MegatronGPTModel.load_from_checkpoint(checkpoint_path, hparams_file=args.hparams_file, trainer=trainer)
 
         # WAR to enable exporting FP8 scales from modules
         # TODO: Need to find a cleaner way

--- a/nemo/collections/nlp/modules/common/chatbot_component.py
+++ b/nemo/collections/nlp/modules/common/chatbot_component.py
@@ -19,8 +19,28 @@ Fix a markdown render problem.
 """
 from __future__ import annotations
 
-from gradio.components import *
+import warnings
+
 from markdown2 import Markdown
+
+try:
+    from typing import Any, Callable, Dict, List, Literal, Tuple
+
+    from gradio.components import (
+        Changeable,
+        Component,
+        Enum,
+        EventListenerMethod,
+        IOComponent,
+        JSONSerializable,
+        Selectable,
+        document,
+        processing_utils,
+    )
+
+    GRADIO_AVAILABLE = True
+except (ImportError, ModuleNotFoundError):
+    GRADIO_AVAILABLE = False
 
 
 class _Keywords(Enum):

--- a/nemo/collections/nlp/modules/common/megatron_web_server.py
+++ b/nemo/collections/nlp/modules/common/megatron_web_server.py
@@ -14,10 +14,14 @@
 
 import asyncio
 
-import gradio as gr
+try:
+    import gradio as gr
+
+    GRADIO_AVAILABLE = True
+except (ImportError, ModuleNotFoundError):
+    GRADIO_AVAILABLE = False
 
 from nemo.collections.nlp.modules.common.chat_css import CSS
-from nemo.collections.nlp.modules.common.chatbot_component import Chatbot
 from nemo.collections.nlp.modules.common.megatron.retrieval_services.util import (
     convert_retrieved_to_md,
     request_data,
@@ -30,8 +34,17 @@ TURN_TOKEN = '<extra_id_1>'
 
 DEFAULT_SYSTEM = "A chat between a curious human and an artificial intelligence assistant. The assistant gives helpful, detailed, and polite answers to the human's questions.\n\n"
 SYSTEM_TOKEN = '<extra_id_0>System\n'
-# HUMAN_TOKEN = 'Human:'
-# ASSITANT_TOKEN = 'Assistant:'
+
+
+def check_gradio_import():
+    if not GRADIO_AVAILABLE:
+        msg = (
+            f"could not find the gradio library.\n"
+            f"****************************************************************\n"
+            f"To install it, please follow the steps below:\n"
+            f"pip install gradio==3.34.0\n"
+        )
+        raise ImportError(msg)
 
 
 def create_gen_function(port=5555, chat=False):
@@ -89,6 +102,7 @@ def create_gen_function(port=5555, chat=False):
 
 
 def get_demo(share, username, password, server_port=5555, web_port=9889, loop=None):
+    check_gradio_import()
     asyncio.set_event_loop(loop)
     with gr.Blocks() as demo:
         with gr.Row():
@@ -132,6 +146,9 @@ def get_demo(share, username, password, server_port=5555, web_port=9889, loop=No
 
 
 def get_chatbot_demo(share, username, password, server_port=5555, web_port=9889, loop=None):
+    check_gradio_import()
+    from nemo.collections.nlp.modules.common.chatbot_component import Chatbot
+
     asyncio.set_event_loop(loop)
     with gr.Blocks(css=CSS) as demo:
         # store the mutliple turn conversation
@@ -294,6 +311,7 @@ class RetroDemoWebApp:
         return request_data(data, self.combo_service_ip, self.combo_service_port)
 
     def run_demo(self, share, username, password, port):
+        check_gradio_import()
         with gr.Blocks(css="table, th, td { border: 1px solid blue; table-layout: fixed; width: 100%; }") as demo:
             with gr.Row():
                 with gr.Column(scale=2, width=200):

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -5,7 +5,6 @@ fasttext
 flask_restful
 ftfy
 gdown
-gradio>=3.28.3
 h5py
 ijson
 inflect

--- a/tutorials/asr/Offline_ASR_with_VAD_for_CTC_models.ipynb
+++ b/tutorials/asr/Offline_ASR_with_VAD_for_CTC_models.ipynb
@@ -50,6 +50,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -57,6 +58,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -72,6 +74,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -132,6 +135,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -139,6 +143,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -154,6 +159,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -182,6 +188,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -198,6 +205,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -215,6 +223,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -239,6 +248,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -255,6 +265,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -262,6 +273,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -289,6 +301,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -313,6 +326,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -320,6 +334,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -374,7 +389,7 @@
             "source": [
                 "# Further Reading\n",
                 "\n",
-                "There are two ways to incorporate VAD into ASR pipeline. The first strategy is to drop the frames that are predicted as `non-speech` by VAD, as already discussed in this tutorial. The second strategy is to keep all the frames and mask the `non-speech` frames with zero-signal values. Also, instead of using segment-VAD as shown in this tutorial, we can use frame-VAD model for faster inference and better accuracy. For more information, please refer to the two scripts [speech_to_text_with_vad.py](https://github.com/NVIDIA/NeMo/blob/stable/examples/asr_vad/speech_to_text_with_vad.py)."
+                "There are two ways to incorporate VAD into ASR pipeline. The first strategy is to drop the frames that are predicted as `non-speech` by VAD, as already discussed in this tutorial. The second strategy is to keep all the frames and mask the `non-speech` frames with zero-signal values. Also, instead of using segment-VAD as shown in this tutorial, we can use frame-VAD model for faster inference and better accuracy. For more information, please refer to the script [speech_to_text_with_vad.py](https://github.com/NVIDIA/NeMo/blob/stable/examples/asr_vad/speech_to_text_with_vad.py)."
             ]
         }
     ],

--- a/tutorials/asr/Voice_Activity_Detection.ipynb
+++ b/tutorials/asr/Voice_Activity_Detection.ipynb
@@ -41,6 +41,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -81,6 +82,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab": {},
@@ -98,6 +100,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -172,6 +175,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -205,6 +209,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -244,6 +249,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -272,6 +278,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -336,6 +343,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -362,6 +370,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -391,6 +400,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -469,6 +479,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -522,6 +533,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -548,6 +560,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -585,6 +598,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -592,6 +606,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -628,6 +643,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -652,6 +668,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -671,6 +688,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -699,6 +717,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -711,6 +730,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -723,6 +743,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -751,6 +772,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -835,6 +857,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -918,6 +941,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -943,6 +967,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -969,6 +994,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -1068,6 +1094,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -1104,6 +1131,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {},
             "source": [
@@ -1117,6 +1145,7 @@
             ]
         },
         {
+            "attachments": {},
             "cell_type": "markdown",
             "metadata": {
                 "colab_type": "text",
@@ -1143,7 +1172,7 @@
                 "\n",
                 "During inference, since frame-VAD model doesn't require splicing input into overlapping segments, it is more efficient than segment-VAD model, with 8x less GPU memory consumption.\n",
                 "\n",
-                "For more information on the frame-VAD model, please refer to the [model class](https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/asr/models/classification_models.py#L840). For training and running inference on frame-VAD, please refer to [speech_to_frame_label.py](https://github.com/NVIDIA/NeMo/blob/stable/examples/asr/speech_classification/speech_to_frame_label.py) and [frame_vad_infer.py](https://github.com/NVIDIA/NeMo/blob/stable/examples/asr/speech_classification/frame_vad_infer.py)."
+                "For more information on the frame-VAD model, please refer to the [README.md](https://github.com/NVIDIA/NeMo/blob/stable/examples/asr/speech_classification/README.md). For training and running inference on frame-VAD, please refer to [speech_to_frame_label.py](https://github.com/NVIDIA/NeMo/blob/stable/examples/asr/speech_classification/speech_to_frame_label.py) and [frame_vad_infer.py](https://github.com/NVIDIA/NeMo/blob/stable/examples/asr/speech_classification/frame_vad_infer.py)."
             ]
         }
     ],


### PR DESCRIPTION
# What does this PR do ?

Converting a non-nemo checkpoint to NeMo with Transformer Engine modules results in truncating of scales in `_extra_state`. This WAR temporarily fixes the issue by manually toggling the `fp8` attribute in TE modules. 

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
