### PR TITLE
Add missing save restore connector to eval scripts

### DIFF
--- a/examples/nlp/language_modeling/megatron_gpt_eval.py
+++ b/examples/nlp/language_modeling/megatron_gpt_eval.py
@@ -173,8 +173,14 @@ def main(cfg) -> None:
         or cfg.pipeline_model_parallel_size < 0
         or cfg.get('pipeline_model_parallel_split_rank', -1) < 0
     ):
+        save_restore_connector = NLPSaveRestoreConnector()
+        if os.path.isdir(cfg.gpt_model_file):
+            save_restore_connector.model_extracted_dir = cfg.gpt_model_file
         model_config = MegatronGPTModel.restore_from(
-            restore_path=cfg.gpt_model_file, trainer=trainer, return_config=True,
+            restore_path=cfg.gpt_model_file,
+            trainer=trainer,
+            return_config=True,
+            save_restore_connector=save_restore_connector,
         )
 
         with open_dict(cfg):

--- a/examples/nlp/language_modeling/megatron_t5_eval.py
+++ b/examples/nlp/language_modeling/megatron_t5_eval.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 
+import os
 from argparse import ArgumentParser
 
 import torch
@@ -61,8 +62,15 @@ def main():
         or args.pipeline_model_parallel_size < 0
         or args.pipeline_model_parallel_split_rank < 0
     ):
+        save_restore_connector = NLPSaveRestoreConnector()
+        if os.path.isdir(args.model_file):
+            save_restore_connector.model_extracted_dir = args.model_file
+
         model_config = MegatronT5Model.restore_from(
-            restore_path=args.model_file, trainer=Trainer(strategy=NLPDDPStrategy()), return_config=True,
+            restore_path=args.model_file,
+            trainer=Trainer(strategy=NLPDDPStrategy()),
+            return_config=True,
+            save_restore_connector=save_restore_connector,
         )
 
         args.tensor_model_parallel_size = model_config.get('tensor_model_parallel_size', 1)

--- a/examples/nlp/language_modeling/tuning/megatron_gpt_ia3_eval.py
+++ b/examples/nlp/language_modeling/tuning/megatron_gpt_ia3_eval.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
+import os
 import torch
 import torch.multiprocessing as mp
 from megatron.core import parallel_state


### PR DESCRIPTION
# What does this PR do ?

Fix missing save restore connector to eval scripts to allow dynamically determining the values of model parallelism

**Collection**: [NLP]


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
