### PR TITLE
Fix confidence ensembles RNNT logprobs selection logic for exclude_blank scenario

### DIFF
--- a/nemo/collections/asr/models/confidence_ensemble.py
+++ b/nemo/collections/asr/models/confidence_ensemble.py
@@ -102,6 +102,8 @@ def get_filtered_logprobs(hypothesis: Hypothesis, exclude_blank: bool) -> torch.
         if exclude_blank:  # filtering blanks
             labels = logprobs.argmax(dim=-1)
             filtered_logprobs = logprobs[labels != logprobs.shape[1] - 1]
+            if filtered_logprobs.shape[0] == 0:  # for the edge-case of all blanks
+                filtered_logprobs = logprobs[:1]
         else:
             filtered_logprobs = logprobs
     return filtered_logprobs
@@ -136,10 +138,8 @@ def compute_confidence(hypothesis: Hypothesis, confidence_cfg: ConfidenceConfig)
         alpha = confidence_cfg.method_cfg.temperature
     conf_func = get_confidence_measure_bank()[conf_type]
 
-    if filtered_logprobs.shape[0] == 0:  # for the edge-case of all blanks, no frames
-        conf_value = 0.0
-    else:
-        conf_value = aggr_func(conf_func(filtered_logprobs, v=vocab_size, t=alpha)).cpu().item()
+    conf_value = aggr_func(conf_func(filtered_logprobs, v=vocab_size, t=alpha)).cpu().item()
+
     return conf_value
 
 

--- a/nemo/collections/asr/models/confidence_ensemble.py
+++ b/nemo/collections/asr/models/confidence_ensemble.py
@@ -86,9 +86,10 @@ def get_filtered_logprobs(hypothesis: Hypothesis, exclude_blank: bool) -> torch.
         filtered_logprobs = []
         for alignment in hypothesis.alignments:
             for align_elem in alignment:
-                if exclude_blank and align_elem[1].item() != align_elem[0].shape[-1] - 1:
+                if not exclude_blank:
                     filtered_logprobs.append(align_elem[0])
-                filtered_logprobs.append(align_elem[0])
+                elif (align_elem[1].item() != align_elem[0].shape[-1] - 1):
+                    filtered_logprobs.append(align_elem[0])
         if not filtered_logprobs:  # for the edge-case of all blanks
             filtered_logprobs.append(align_elem[0])
         filtered_logprobs = torch.stack(filtered_logprobs)
@@ -135,7 +136,10 @@ def compute_confidence(hypothesis: Hypothesis, confidence_cfg: ConfidenceConfig)
         alpha = confidence_cfg.method_cfg.temperature
     conf_func = get_confidence_measure_bank()[conf_type]
 
-    conf_value = aggr_func(conf_func(filtered_logprobs, v=vocab_size, t=alpha)).cpu().item()
+    if (filtered_logprobs.shape[0] == 0):  # for the edge-case of all blanks, no frames
+        conf_value = 0.0
+    else:
+        conf_value = aggr_func(conf_func(filtered_logprobs, v=vocab_size, t=alpha)).cpu().item()
     return conf_value
 
 

--- a/nemo/collections/asr/models/confidence_ensemble.py
+++ b/nemo/collections/asr/models/confidence_ensemble.py
@@ -88,7 +88,7 @@ def get_filtered_logprobs(hypothesis: Hypothesis, exclude_blank: bool) -> torch.
             for align_elem in alignment:
                 if not exclude_blank:
                     filtered_logprobs.append(align_elem[0])
-                elif (align_elem[1].item() != align_elem[0].shape[-1] - 1):
+                elif align_elem[1].item() != align_elem[0].shape[-1] - 1:
                     filtered_logprobs.append(align_elem[0])
         if not filtered_logprobs:  # for the edge-case of all blanks
             filtered_logprobs.append(align_elem[0])
@@ -136,7 +136,7 @@ def compute_confidence(hypothesis: Hypothesis, confidence_cfg: ConfidenceConfig)
         alpha = confidence_cfg.method_cfg.temperature
     conf_func = get_confidence_measure_bank()[conf_type]
 
-    if (filtered_logprobs.shape[0] == 0):  # for the edge-case of all blanks, no frames
+    if filtered_logprobs.shape[0] == 0:  # for the edge-case of all blanks, no frames
         conf_value = 0.0
     else:
         conf_value = aggr_func(conf_func(filtered_logprobs, v=vocab_size, t=alpha)).cpu().item()


### PR DESCRIPTION
# What does this PR do ?

- Fixes the algorithm for filtering blank frames while building confidence ensembles
- Adds checks for confidence value calculation to handle the edge case of all blank frames

**Collection**: [Note which collection this PR will affect]
ASR 

# Changelog 
- changes to get_filtered_logprobs() and compute_confidence() functions in nemo/collections/asr/models/confidence_ensembles.py


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

