### PR TITLE
Add more arithmetic resolvers

### DIFF
--- a/nemo/core/config/hydra_runner.py
+++ b/nemo/core/config/hydra_runner.py
@@ -25,6 +25,13 @@ from omegaconf import DictConfig, OmegaConf
 
 # multiple interpolated values in the config
 OmegaConf.register_new_resolver("multiply", lambda x, y: x * y)
+OmegaConf.register_new_resolver("ceil_div", lambda x,y: (x + y - 1)//y)
+OmegaConf.register_new_resolver("floor_div", lambda x,y: x//y)
+OmegaConf.register_new_resolver("div", lambda x,y: x/y)
+OmegaConf.register_new_resolver("if", lambda x,y,z: y if x else z)
+OmegaConf.register_new_resolver("lt", lambda x,y: x < y)
+OmegaConf.register_new_resolver("eq", lambda x,y: x == y)
+OmegaConf.register_new_resolver("neq", lambda x,y: x != y)
 
 
 def hydra_runner(

--- a/nemo/core/config/hydra_runner.py
+++ b/nemo/core/config/hydra_runner.py
@@ -25,13 +25,13 @@ from omegaconf import DictConfig, OmegaConf
 
 # multiple interpolated values in the config
 OmegaConf.register_new_resolver("multiply", lambda x, y: x * y)
-OmegaConf.register_new_resolver("ceil_div", lambda x,y: (x + y - 1)//y)
-OmegaConf.register_new_resolver("floor_div", lambda x,y: x//y)
-OmegaConf.register_new_resolver("div", lambda x,y: x/y)
-OmegaConf.register_new_resolver("if", lambda x,y,z: y if x else z)
-OmegaConf.register_new_resolver("lt", lambda x,y: x < y)
-OmegaConf.register_new_resolver("eq", lambda x,y: x == y)
-OmegaConf.register_new_resolver("neq", lambda x,y: x != y)
+OmegaConf.register_new_resolver("ceil_div", lambda x, y: (x + y - 1) // y)
+OmegaConf.register_new_resolver("floor_div", lambda x, y: x // y)
+OmegaConf.register_new_resolver("div", lambda x, y: x / y)
+OmegaConf.register_new_resolver("if", lambda x, y, z: y if x else z)
+OmegaConf.register_new_resolver("lt", lambda x, y: x < y)
+OmegaConf.register_new_resolver("eq", lambda x, y: x == y)
+OmegaConf.register_new_resolver("neq", lambda x, y: x != y)
 
 
 def hydra_runner(


### PR DESCRIPTION
# What does this PR do ?

Add arithmetic resolvers other than `multiply`

# Changelog 
- No high level changes
- This PR contains custom resolvers for arithmetic, comparison and ternary expression

# Usage
Now in hydra configs you can use more arithmetic and ternary expressions.

```yaml
hydra_config_field: ${if:${condition},0,${ceil_div:123400,${batch_size}}}}
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
These resolvers are solution to already implemented [here](https://github.com/NVIDIA/NeMo/blob/main/nemo/core/config/hydra_runner.py#L27). It would be beneficial to implement a single resolver for evaluating arithmetic. The approach could be to use ast module to make a custom parser that allows only literals and binary operators.