### PR TITLE
Add support for Numba FP16 RNNT Loss (#6991)

### DIFF
--- a/nemo/collections/asr/losses/rnnt.py
+++ b/nemo/collections/asr/losses/rnnt.py
@@ -38,9 +38,10 @@ from omegaconf import DictConfig, OmegaConf
 from nemo.collections.asr.losses.rnnt_pytorch import MultiblankRNNTLossPytorch, RNNTLossPytorch, TDTLossPytorch
 from nemo.core.classes import Loss, typecheck
 from nemo.core.neural_types import LabelsType, LengthsType, LogprobsType, LossType, NeuralType
+from nemo.core.utils import numba_utils
 from nemo.core.utils.k2_utils import K2_INSTALLATION_MESSAGE
 from nemo.core.utils.numba_utils import NUMBA_INSTALLATION_MESSAGE
-from nemo.utils import logging, model_utils
+from nemo.utils import logging, logging_mode, model_utils
 
 try:
     import warprnnt_pytorch as warprnnt
@@ -98,7 +99,7 @@ RNNT_LOSS_RESOLVER = {
         min_version='0.53.0',
         is_available=NUMBA_RNNT_AVAILABLE,
         installation_msg=NUMBA_INSTALLATION_MESSAGE,
-        force_float32=True,
+        force_float32=not numba_utils.NUMBA_FP16_SUPPORTED,
     ),
     "pytorch": RNNTLossConfig(
         loss_name="pytorch",
@@ -387,7 +388,7 @@ class RNNTLoss(Loss):
                 for the standard "blank" symbol. In particular, say V is the number of non-blank tokens in
                 the vocabulary, then in the case of,
                 standard RNNT: num_classes = V
-                multiblank RNNT: num_classes = V + number-big-blanks (since we store big-blanks before 
+                multiblank RNNT: num_classes = V + number-big-blanks (since we store big-blanks before
                                  standard blank, and the standard blank is the last symbol in the vocab)
                 TDT: num_classes = V. Note, V here does not include any of the "duration outputs".
 
@@ -413,6 +414,7 @@ class RNNTLoss(Loss):
         self.reduction = reduction
         self._loss = resolve_rnnt_loss(loss_name, blank_idx=self._blank, loss_kwargs=loss_kwargs)
         self._force_float32 = RNNT_LOSS_RESOLVER[loss_name].force_float32
+        self._fp16_compat_checked = False
 
     def reduce(self, losses, target_lengths):
 
@@ -442,8 +444,22 @@ class RNNTLoss(Loss):
         max_targets_len = target_lengths.max()
 
         # Force cast joint to float32
-        # TODO: Remove once Numba supports FP16
-        if self._force_float32 and log_probs.dtype != torch.float32:
+        if not self._force_float32 and numba_utils.NUMBA_FP16_SUPPORTED:
+            # Execute the kernel in fp16
+            pass
+        elif self._force_float32 and log_probs.dtype != torch.float32:
+            # Log just once if fp16 tensor was passed and fp16 Numba CUDA loss could not be used.
+            if log_probs.dtype == torch.float16 and not self._fp16_compat_checked:
+                _, reason = numba_utils.is_numba_cuda_fp16_supported(return_reason=True)
+                logging.warning(
+                    f"Provided RNNT Joint tensor is of dtype {log_probs.dtype}, but RNNT loss could not be calculated "
+                    f"in fp16 due to following reason stated below. Loss will be calculated in fp32. \n\n"
+                    f"{reason}",
+                    mode=logging_mode.ONCE,
+                )
+                self._fp16_compat_checked = True
+
+            # Upcast the activation tensor and compute loss and grads in fp32
             logits_orig = log_probs
             log_probs = log_probs.float()
             del logits_orig  # save memory *before* computing the loss

--- a/nemo/collections/asr/losses/rnnt_pytorch.py
+++ b/nemo/collections/asr/losses/rnnt_pytorch.py
@@ -47,7 +47,12 @@ class RNNTLossPytorch(Loss):
         self.reduction = reduction
 
     def forward(self, acts, labels, act_lens, label_lens):
+        # CPU patch for FP16
+        if not acts.is_cuda and acts.dtype == torch.float16:
+            acts = acts.float()
+
         acts = torch.log_softmax(acts, -1)
+
         forward_logprob = self.compute_forward_prob(acts, labels, act_lens, label_lens)
         losses = -forward_logprob
         if self.reduction == 'mean_batch':

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt.py
@@ -186,7 +186,7 @@ def rnnt_loss_gpu(
 
     # Select GPU index
     cuda.select_device(acts.device.index)
-    gpu_workspace = torch.zeros(gpu_size, device=acts.device, dtype=acts.dtype, requires_grad=False)
+    gpu_workspace = torch.zeros(gpu_size, device=acts.device, dtype=torch.float32, requires_grad=False)
 
     ### VIEW TENSORS AS VECTORS FOR POINTER INDEXING ###
     acts, acts_shape = rnnt_helper.flatten_tensor(acts)

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_numpy.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_numpy.py
@@ -344,10 +344,15 @@ class RNNTLoss(Module):
         _assert_no_grad(label_lens)
         certify_inputs(acts, labels, act_lens, label_lens)
 
+        # CPU Patch for fp16 - force cast to fp32
+        if not acts.is_cuda and acts.dtype == torch.float16:
+            acts = acts.float()
+
         if self.clamp > 0.0:
             acts = LogSoftmaxGradModification.apply(acts, self.clamp)
 
         acts = torch.nn.functional.log_softmax(acts, -1)
+
         return self.rnnt(acts, labels, act_lens, label_lens, self.blank, self.fastemit_lambda)
 
 

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/cpu_utils/cpu_rnnt.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/cpu_utils/cpu_rnnt.py
@@ -231,8 +231,8 @@ class CPURNNT:
         )
 
         # Scale llForward by FastEmit lambda
-        llForward *= 1.0 + self.fastemit_lambda_
-        llBackward *= 1.0 + self.fastemit_lambda_
+        llForward += llForward * self.fastemit_lambda_
+        llBackward += llBackward * self.fastemit_lambda_
 
         diff = (llForward - llBackward).abs()
         if diff > 0.1:
@@ -300,6 +300,10 @@ class CPURNNT:
         Returns:
             Loglikelihood of the forward variable and inplace updates the grad tensor.
         """
+        # Patch for CPU + fp16
+        if log_probs.dtype == torch.float16 and not log_probs.is_cuda:
+            log_probs = log_probs.float()
+
         idx = CpuRNNT_index(U, self.maxU_, self.minibatch_, self.alphabet_size_, self.batch_first)
         betas[idx(T - 1, U - 1)] = log_probs[idx(T - 1, U - 1) * 2]
 

--- a/nemo/collections/asr/parts/numba/rnnt_loss/utils/rnnt_helper.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/utils/rnnt_helper.py
@@ -30,6 +30,7 @@
 import math
 from typing import Optional, Tuple
 
+import numba
 import torch
 from numba import cuda
 
@@ -112,7 +113,7 @@ def compute_costs_data(source: torch.Tensor, dest: torch.Tensor, fastemit_lambda
     if idx < length:
         copy_data_1d(source, dest, idx)
         dest[idx] *= -1.0
-        dest[idx] *= 1.0 + fastemit_lambda
+        dest[idx] *= numba.float32(1.0 + fastemit_lambda)
 
 
 def get_workspace_size(

--- a/nemo/core/utils/numba_utils.py
+++ b/nemo/core/utils/numba_utils.py
@@ -17,6 +17,8 @@ import logging as pylogger
 import operator
 import os
 
+from typing import Tuple, Union
+
 from nemo.utils import model_utils
 
 # Prevent Numba CUDA logs from showing at info level
@@ -25,6 +27,11 @@ cuda_logger.setLevel(pylogger.ERROR)  # only show error
 
 __NUMBA_DEFAULT_MINIMUM_VERSION__ = "0.53.0"
 __NUMBA_MINIMUM_VERSION__ = os.environ.get("NEMO_NUMBA_MINVER", __NUMBA_DEFAULT_MINIMUM_VERSION__)
+
+__NUMBA_MINIMUM_VERSION_FP16_SUPPORTED__ = "0.57.0"
+NUMBA_FP16_SUPPORTED = model_utils.check_lib_version(
+    'numba', __NUMBA_MINIMUM_VERSION_FP16_SUPPORTED__, operator=operator.ge
+)[0]
 
 
 NUMBA_INSTALLATION_MESSAGE = (
@@ -146,6 +153,35 @@ def numba_cuda_is_supported(min_version: str) -> bool:
 
     else:
         return False
+
+
+def is_numba_cuda_fp16_supported(return_reason: bool = False) -> Union[bool, Tuple[bool, str]]:
+    """
+    Utility method that returns a bool, stating if FP16 is supported for numba cuda kernels or not.
+
+    Returns:
+        bool, whether Numba CUDA will support fp16 or not.
+    """
+    reason = ""
+    use_nvidia_binding = os.environ.get('NUMBA_CUDA_USE_NVIDIA_BINDING', None)
+    if use_nvidia_binding is not None:
+        use_nvidia_binding = use_nvidia_binding.lower() == "1"
+        reason += "Env variable `NUMBA_CUDA_USE_NVIDIA_BINDING` is available and set to `1`. "
+    else:
+        use_nvidia_binding = False
+        reason += "Env variable `NUMBA_CUDA_USE_NVIDIA_BINDING` is not available or has not set to `1`."
+
+    if NUMBA_FP16_SUPPORTED:
+        reason += f"Numba CUDA FP16 is supported in installed numba version."
+    else:
+        reason += f"Numba CUDA FP16 is not supported in installed numba version."
+
+    result = use_nvidia_binding and NUMBA_FP16_SUPPORTED
+
+    if return_reason:
+        return result, reason
+    else:
+        return result
 
 
 def skip_numba_cuda_test_if_unsupported(min_version: str):

--- a/tests/collections/asr/numba/rnnt_loss/utils/test_reduce.py
+++ b/tests/collections/asr/numba/rnnt_loss/utils/test_reduce.py
@@ -20,17 +20,22 @@ from nemo.collections.asr.parts.numba.rnnt_loss.utils.cuda_utils import reduce
 from nemo.core.utils import numba_utils
 from nemo.core.utils.numba_utils import __NUMBA_MINIMUM_VERSION__
 
+DTYPES = [np.float32]
+if numba_utils.is_numba_cuda_fp16_supported():
+    DTYPES.append(np.float16)
+
 
 class TestRNNTCUDAReductions:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Reductions can only be run when CUDA is available")
     @pytest.mark.unit
-    def test_reduce_max(self):
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_reduce_max(self, dtype):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         random = np.random.RandomState(0)
         original_shape = [1, 5, 4, 3]
-        x = random.randn(*original_shape).reshape([-1])
-        dx = random.randn(*x.shape)
+        x = random.randn(*original_shape).reshape([-1]).astype(dtype)
+        dx = random.randn(*x.shape).astype(dtype)
 
         stream = cuda.stream()
         x_c = cuda.to_device(x, stream=stream)
@@ -53,13 +58,14 @@ class TestRNNTCUDAReductions:
 
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Reductions can only be run when CUDA is available")
     @pytest.mark.unit
-    def test_reduce_exp(self):
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_reduce_exp(self, dtype):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         random = np.random.RandomState(0)
         original_shape = [1, 5, 4, 2]
-        x = random.randn(*original_shape).reshape([-1])
-        dx = np.zeros_like(x)
+        x = random.randn(*original_shape).reshape([-1]).astype(dtype)
+        dx = np.zeros_like(x).astype(dtype)
 
         stream = cuda.stream()
         x_c = cuda.to_device(x, stream=stream)

--- a/tests/collections/asr/numba/rnnt_loss/utils/test_rnnt_helper.py
+++ b/tests/collections/asr/numba/rnnt_loss/utils/test_rnnt_helper.py
@@ -20,11 +20,16 @@ from nemo.collections.asr.parts.numba.rnnt_loss.utils import global_constants, r
 from nemo.core.utils import numba_utils
 from nemo.core.utils.numba_utils import __NUMBA_MINIMUM_VERSION__
 
+DTYPES = [np.float32]
+if numba_utils.is_numba_cuda_fp16_supported():
+    DTYPES.append(np.float16)
+
 
 class TestRNNTHelper:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
-    def test_log_sum_exp(self):
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_log_sum_exp(self, dtype):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         # wrapper kernel for device function that is tested
@@ -34,8 +39,9 @@ class TestRNNTHelper:
             if x_pos < x.shape[0] and x_pos < y.shape[0]:
                 x[x_pos] = rnnt_helper.log_sum_exp(x[x_pos], y[x_pos])
 
-        x = np.zeros([8])  # np.random.rand(8192)
-        y = np.ones([8])  # np.random.rand(8192)
+        x = np.zeros([8]).astype(dtype)  # np.random.rand(8192)
+        y = np.ones([8]).astype(dtype)  # np.random.rand(8192)
+        threshold = 1e-5 if dtype == np.float32 else 2e-3
 
         stream = cuda.stream()
         x_c = cuda.to_device(x, stream=stream)
@@ -52,11 +58,12 @@ class TestRNNTHelper:
         x_new = x_c.copy_to_host(stream=stream)
         del x_c, y_c
 
-        assert (x_new.sum() - 10.506093500145782) <= 1e-5
+        assert (x_new.sum() - 10.506093500145782) <= threshold
 
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
-    def test_log_sum_exp_neg_inf(self):
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_log_sum_exp_neg_inf(self, dtype):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         # wrapper kernel for device function that is tested
@@ -66,8 +73,8 @@ class TestRNNTHelper:
             if x_pos < x.shape[0] and x_pos < y.shape[0]:
                 x[x_pos] = rnnt_helper.log_sum_exp(x[x_pos], y[x_pos])
 
-        x = np.asarray([global_constants.FP32_NEG_INF] * 8)
-        y = np.ones([len(x)])
+        x = np.asarray([global_constants.FP32_NEG_INF] * 8).astype(dtype)
+        y = np.ones([len(x)]).astype(dtype)
 
         stream = cuda.stream()
         x_c = cuda.to_device(x, stream=stream)
@@ -88,7 +95,8 @@ class TestRNNTHelper:
 
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
-    def test_div_up(self):
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_div_up(self, dtype):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         # wrapper kernel for device function that is tested
@@ -98,8 +106,8 @@ class TestRNNTHelper:
             if x_pos < x.shape[0] and x_pos < y.shape[0]:
                 x[x_pos] = rnnt_helper.div_up(x[x_pos], y[x_pos])
 
-        x = np.full([8], fill_value=10)  # np.random.rand(8192)
-        y = np.full([8], fill_value=2)  # np.random.rand(8192)
+        x = np.full([8], fill_value=10).astype(dtype)  # np.random.rand(8192)
+        y = np.full([8], fill_value=2).astype(dtype)  # np.random.rand(8192)
 
         stream = cuda.stream()
         x_c = cuda.to_device(x, stream=stream)
@@ -121,7 +129,8 @@ class TestRNNTHelper:
 
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
-    def test_add(self):
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_add(self, dtype):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         # wrapper kernel for device function that is tested
@@ -131,8 +140,8 @@ class TestRNNTHelper:
             if x_pos < x.shape[0] and x_pos < y.shape[0]:
                 x[x_pos] = rnnt_helper.add(x[x_pos], y[x_pos])
 
-        x = np.full([8], fill_value=10)  # np.random.rand(8192)
-        y = np.full([8], fill_value=2)  # np.random.rand(8192)
+        x = np.full([8], fill_value=10).astype(dtype)  # np.random.rand(8192)
+        y = np.full([8], fill_value=2).astype(dtype)  # np.random.rand(8192)
 
         stream = cuda.stream()
         x_c = cuda.to_device(x, stream=stream)
@@ -154,7 +163,8 @@ class TestRNNTHelper:
 
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
-    def test_maximum(self):
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_maximum(self, dtype):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         # wrapper kernel for device function that is tested
@@ -164,8 +174,8 @@ class TestRNNTHelper:
             if x_pos < x.shape[0] and x_pos < y.shape[0]:
                 x[x_pos] = rnnt_helper.maximum(x[x_pos], y[x_pos])
 
-        x = np.full([8], fill_value=10)  # np.random.rand(8192)
-        y = np.full([8], fill_value=2)  # np.random.rand(8192)
+        x = np.full([8], fill_value=10).astype(dtype)  # np.random.rand(8192)
+        y = np.full([8], fill_value=2).astype(dtype)  # np.random.rand(8192)
 
         stream = cuda.stream()
         x_c = cuda.to_device(x, stream=stream)
@@ -187,7 +197,8 @@ class TestRNNTHelper:
 
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
-    def test_identity(self):
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_identity(self, dtype):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         # wrapper kernel for device function that is tested
@@ -197,7 +208,7 @@ class TestRNNTHelper:
             if x_pos < x.shape[0]:
                 x[x_pos] = rnnt_helper.identity(x[x_pos])
 
-        x = np.full([8], fill_value=10)  # np.random.rand(8192)
+        x = np.full([8], fill_value=10).astype(dtype)  # np.random.rand(8192)
 
         stream = cuda.stream()
         x_c = cuda.to_device(x, stream=stream)
@@ -218,7 +229,8 @@ class TestRNNTHelper:
 
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
-    def test_negate(self):
+    @pytest.mark.parametrize('dtype', [np.float32, np.float16])
+    def test_negate(self, dtype):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         # wrapper kernel for device function that is tested
@@ -228,7 +240,7 @@ class TestRNNTHelper:
             if x_pos < x.shape[0]:
                 x[x_pos] = rnnt_helper.negate(x[x_pos])
 
-        x = np.full([8], fill_value=10)  # np.random.rand(8192)
+        x = np.full([8], fill_value=10).astype(dtype)  # np.random.rand(8192)
 
         stream = cuda.stream()
         x_c = cuda.to_device(x, stream=stream)
@@ -249,7 +261,8 @@ class TestRNNTHelper:
 
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
-    def test_exponential(self):
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_exponential(self, dtype):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         # wrapper kernel for device function that is tested
@@ -259,7 +272,7 @@ class TestRNNTHelper:
             if x_pos < x.shape[0]:
                 x[x_pos] = rnnt_helper.exponential(x[x_pos])
 
-        x = np.random.rand(8)
+        x = np.random.rand(8).astype(dtype)
 
         stream = cuda.stream()
         x_c = cuda.to_device(x, stream=stream)
@@ -281,7 +294,8 @@ class TestRNNTHelper:
 
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.unit
-    def test_log_plus(self):
+    @pytest.mark.parametrize('dtype', DTYPES)
+    def test_log_plus(self, dtype):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
         # wrapper kernel for device function that is tested
@@ -291,8 +305,8 @@ class TestRNNTHelper:
             if x_pos < x.shape[0] and x_pos < y.shape[0]:
                 x[x_pos] = rnnt_helper.log_plus(x[x_pos], y[x_pos])
 
-        x = np.full([8], fill_value=10.0)  # np.random.rand(8192)
-        y = np.full([8], fill_value=2.0)  # np.random.rand(8192)
+        x = np.full([8], fill_value=10.0).astype(dtype)  # np.random.rand(8192)
+        y = np.full([8], fill_value=2.0).astype(dtype)  # np.random.rand(8192)
 
         stream = cuda.stream()
         x_c = cuda.to_device(x, stream=stream)
@@ -317,12 +331,15 @@ class TestRNNTHelper:
     @pytest.mark.skipif(not cuda.is_available(), reason="CUDA Helpers can only be run when CUDA is available")
     @pytest.mark.parametrize('batch_size', [8, 128, 256])
     @pytest.mark.parametrize('fastemit_lambda', [0.0, 0.001])
+    @pytest.mark.parametrize('dtype', DTYPES)
     @pytest.mark.unit
-    def test_compute_costs_data(self, batch_size, fastemit_lambda):
+    def test_compute_costs_data(self, batch_size, fastemit_lambda, dtype):
         numba_utils.skip_numba_cuda_test_if_unsupported(__NUMBA_MINIMUM_VERSION__)
 
+        np.random.seed(0)
         x = np.full([batch_size], fill_value=0.0)  # np.random.rand(8192)
-        y = np.random.randn(batch_size)  # np.random.rand(8192)
+        y = np.random.randn(batch_size).astype(dtype)  # np.random.rand(8192)
+        threshold = 1e-5 if dtype == np.float32 else 1e-5
 
         stream = cuda.stream()
         x_c = cuda.to_device(x, stream=stream)
@@ -340,11 +357,11 @@ class TestRNNTHelper:
         x_new = x_c.copy_to_host(stream=stream)
         del x_c, y_c
 
-        res = -(y.copy())
+        res = -(y.astype(np.float32).copy())
         res *= 1.0 + fastemit_lambda
 
         for i in range(len(x_new)):
-            assert x_new[i] == res[i], f"index failed {i}"
+            assert abs(x_new[i] - res[i]) < threshold, f"index failed {i}"
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Cherry pick RNNT FP 16 Compat to NeMo 1.20

Signed-off-by: smajumdar <titu1994@gmail.com>

# What does this PR do ?

Adds Numba FP 16 support to NeMo 1.20

**Collection**: [ASR]

# Usage

## Install dependencies
[Numba](https://github.com/numba/numba) 0.57+ (conda install numba=0.57.1 -c conda-forge)
[CUDA Python](https://nvidia.github.io/cuda-python/install.html)

After that, train RNNT model with trainer.precision=16

```python
# Set environment variables 
# export NUMBA_CUDA_USE_NVIDIA_BINDING=1
# export STRICT_NUMBA_COMPAT_CHECK=0

from nemo.core.utils import numba_utils

print(numba_utils.numba_cuda_is_supported(numba_utils.__NUMBA_MINIMUM_VERSION_FP16_SUPPORTED__))  # Should be true

# Should also be True. 
# You can also pass True as an argument to this function to possibly get a reason as to why FP 16 is not supported.

print(numba_utils.is_numba_cuda_fp16_supported())
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
