### PR TITLE
[Fix] load_state_dict in nlp_model.py

### DIFF
--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -396,4 +396,3 @@ class NLPModel(ModelPT, Exportable):
             del state_dict["bert_model.embeddings.position_ids"]
         results = super(NLPModel, self).load_state_dict(state_dict, strict=strict)
         return results
-

--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -394,4 +394,6 @@ class NLPModel(ModelPT, Exportable):
             and "bert_model.embeddings.position_ids" in state_dict
         ):
             del state_dict["bert_model.embeddings.position_ids"]
-        super(NLPModel, self).load_state_dict(state_dict, strict=strict)
+        results = super(NLPModel, self).load_state_dict(state_dict, strict=strict)
+        return results
+


### PR DESCRIPTION
# What does this PR do ?

Fix error in loading checkpoints. The pytorch [load_state_dict()](https://pytorch.org/docs/stable/generated/torch.nn.Module.html?highlight=load_state_dict#torch.nn.Module.load_state_dict) function has return variable that was not returned by this function in this file. 


**Collection**: [NLP]

