### PR TITLE
Fix tensor_parallel function calls to megatron-lm

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/attention.py
+++ b/nemo/collections/nlp/modules/common/megatron/attention.py
@@ -56,6 +56,7 @@ except (ImportError, ModuleNotFoundError):
 try:
     from megatron.core import parallel_state, tensor_parallel
     from megatron.core.model_parallel_config import ModelParallelConfig
+
     HAVE_MEGATRON_CORE = True
 
 except (ImportError, ModuleNotFoundError):
@@ -185,12 +186,7 @@ class ParallelAttention(MegatronModule, adapter_mixins.AdapterModuleMixin):
         else:
             assert attention_type == AttnType.cross_attn
             self.query = tensor_parallel.ColumnParallelLinear(
-                hidden_size,
-                projection_size,
-                gather_output=False,
-                init_method=init_method,
-                config=config,
-                bias=bias,
+                hidden_size, projection_size, gather_output=False, init_method=init_method, config=config, bias=bias,
             )
 
             self.key_value = tensor_parallel.ColumnParallelLinear(

--- a/nemo/collections/nlp/modules/common/megatron/language_model.py
+++ b/nemo/collections/nlp/modules/common/megatron/language_model.py
@@ -53,6 +53,7 @@ except (ImportError, ModuleNotFoundError):
 try:
     from megatron.core import parallel_state, tensor_parallel
     from megatron.core.model_parallel_config import ModelParallelConfig
+
     HAVE_MEGATRON_CORE = True
 
 except (ImportError, ModuleNotFoundError):
@@ -286,10 +287,7 @@ class Embedding(MegatronModule):
         config.params_dtype = dtype
         # Word embeddings (parallel).
         self.word_embeddings = tensor_parallel.VocabParallelEmbedding(
-            vocab_size,
-            self.hidden_size,
-            init_method=self.init_method,
-            config=config,
+            vocab_size, self.hidden_size, init_method=self.init_method, config=config,
         )
         self._word_embeddings_key = 'word_embeddings'
 

--- a/nemo/collections/nlp/modules/common/megatron/mlp.py
+++ b/nemo/collections/nlp/modules/common/megatron/mlp.py
@@ -45,8 +45,8 @@ except (ImportError, ModuleNotFoundError):
 
 try:
     from megatron.core import parallel_state, tensor_parallel
-    from megatron.core.parallel_state import get_tensor_model_parallel_world_size
     from megatron.core.model_parallel_config import ModelParallelConfig
+    from megatron.core.parallel_state import get_tensor_model_parallel_world_size
 
     HAVE_MEGATRON_CORE = True
 


### PR DESCRIPTION
# What does this PR do ?

Megatron-LM has changed its function APIs in tensor_parallel, where a lot of params (e.g., `use_cpu_initialization`) are moved into a config object (e.g., `megatron.core.model_parallel_config.ModelParallelConfig`), for example [here](https://github.com/NVIDIA/Megatron-LM/blob/main/megatron/core/tensor_parallel/layers.py#L148)

This PR fixes such errors when trying to use those functions with the latest Megatron-LM codebase, but there may be some other missed functions. 

**Collection**: [NLP]

