### PR TITLE
Fix absolute path in path join call

### DIFF
--- a/nemo/collections/asr/parts/utils/vad_utils.py
+++ b/nemo/collections/asr/parts/utils/vad_utils.py
@@ -276,7 +276,7 @@ def generate_overlap_vad_seq(
         overlap_out_dir = out_dir
     else:
         overlap_out_dir = os.path.join(
-            frame_pred_dir, "/overlap_smoothing_output" + "_" + smoothing_method + "_" + str(overlap)
+            frame_pred_dir, "overlap_smoothing_output" + "_" + smoothing_method + "_" + str(overlap)
         )
 
     if not os.path.exists(overlap_out_dir):


### PR DESCRIPTION
# What does this PR do ?

This fixes a regression introduced in 39aff5ca3d52247e136a86429d567255c02a5d44 when joining paths was changed from string concatenation to `os.path.join`. At the moment the call disregards the first part (`frame_pred_dir`) and always returns a path starting with `/overlap_smoothing_output`.

**Collection**:  asr

# Changelog 

- Remove leading slash in argument to `os.path.join`

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [-] Did you write any new necessary tests?
- [-] Did you add or update any necessary documentation?
- [-] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [-] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

