### PR TITLE
bug fix - alibi causal: for ith query, bias is m · [−(i − 1), ..., −2, −1, 0] for the first i keys

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/position_embedding/alibi_relative_position_embedding.py
+++ b/nemo/collections/nlp/modules/common/megatron/position_embedding/alibi_relative_position_embedding.py
@@ -114,7 +114,7 @@ class ALiBiRelativePositionEmbedding(torch.nn.Module):
         # cache the relative position bias. shape (num_attention_heads, max_seq_len, max_seq_len)
         # if we use causal attention (not bidrectional), we can use singleton relative position
         self.relative_position = (
-            build_relative_position(max_seq_len, full=bidirectional).unsqueeze(0).expand(num_attention_heads, -1, -1)
+            build_relative_position(max_seq_len, full=True).unsqueeze(0).expand(num_attention_heads, -1, -1)
         )
 
     def forward(self, query_seq_length, key_seq_length):
@@ -122,7 +122,7 @@ class ALiBiRelativePositionEmbedding(torch.nn.Module):
         max_seq_len = max(query_seq_length, key_seq_length)
         if max_seq_len > self.max_seq_len:
             relative_position = (
-                build_relative_position(max_seq_len, full=self.bidirectional)
+                build_relative_position(max_seq_len, full=True)
                 .unsqueeze(0)
                 .expand(self.num_attention_heads, -1, -1)
             )
@@ -131,6 +131,7 @@ class ALiBiRelativePositionEmbedding(torch.nn.Module):
         # shape (num_attention_heads, query_seq_length, key_seq_length)
         relative_position = relative_position[:, -query_seq_length:, -key_seq_length:]
         # if not bidirectional, mask out the future positions
-
+        if not self.bidirectional:
+            relative_position = torch.tril(relative_position)
         # shape (1, num_heads, query_length, key_length)
         return -relative_position.unsqueeze(0) * self.slopes


### PR DESCRIPTION
# What does this PR do ?

Fix alibi position embedding for causal attention. 


**Collection**: NLP

# Changelog 
Existing: returns (1, num_heads, 1, key_length)
Fixed: returns (1, num_heads, query_length, key_length), where for ith query, the bias is m · [−(i − 1), ..., −2, −1, 0] for the first i keys, as per the alibi paper
  
**PR Type**:
- [ ] Bugfix


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
