### PR TITLE
Fixed small bug with NoisePerturbationWithNormalization

### DIFF
--- a/nemo/collections/asr/parts/preprocessing/perturb.py
+++ b/nemo/collections/asr/parts/preprocessing/perturb.py
@@ -785,7 +785,7 @@ class NoisePerturbationWithNormalization(Perturbation):
         else:
             snr_db = random.uniform(self._min_snr_db, self._max_snr_db)
         if data_rms is None:
-            data_rms = data.rms_db if ref_mic is None else data.rms_db[ref_mic]
+            data_rms = data.rms_db[ref_mic] if isinstance(data.rms_db, (list, np.ndarray)) else data.rms_db
 
         if norm_to_db is None:
             norm_to_db = data_rms


### PR DESCRIPTION
# What does this PR do ?

Fixes a small indexing bug inside the NoisePerturbationWithNormalization class in perturb.py

**Collection**: ASR

# Changelog 
- nemo/collections/asr/parts/preprocessing/perturb.py: added safety check to ensure you don't index into scalar value

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
