### PR TITLE
Fix default context size

### DIFF
--- a/nemo/collections/asr/modules/conformer_encoder.py
+++ b/nemo/collections/asr/modules/conformer_encoder.py
@@ -783,7 +783,8 @@ class ConformerEncoder(NeuralModule, StreamingEncoder, Exportable, AccessMixin):
             logging.warning(
                 f"att_context_size={att_context_size} is not among the list of the supported look-aheads: {self.att_context_size_all}"
             )
-        self.att_context_size = att_context_size
+        if att_context_size is not None:
+            self.att_context_size = att_context_size
 
     def setup_streaming_params(
         self,


### PR DESCRIPTION
# What does this PR do ?

There is a bug when performing RNNT/CTC decoding with hybrid models. 

By default `att_context_size` should be [-1,-1] which is what set as default, but if None is passed through cfg, it replaces the current value, which shouldn't be the case. 

**Collection**: ASR

# Changelog 
- change value only if  `cfg.att_context_size` is not None

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation