### PR TITLE
fix evaluator.py for various exceptions by ast

### DIFF
--- a/examples/slu/speech_intent_slot/eval_utils/evaluator.py
+++ b/examples/slu/speech_intent_slot/eval_utils/evaluator.py
@@ -42,7 +42,7 @@ def parse_semantics_str2dict(semantics_str: Union[List[str], str, Dict]) -> Tupl
                 "entities": [],
             }
             invalid = True
-    except SyntaxError:  # need this if the output is not a valid dict
+    except Exception:  # need this if the output is not a valid dict
         _dict = {
             "scenario": "none",
             "action": "none",


### PR DESCRIPTION
the python `ast` package throws both `SyntaxError` and `ValueError` during evaluating an invalid dict object, so exception handling needs to catch all possible kinds of exceptions.