### PR TITLE
NFA bugfix: remove any empty segments

### DIFF
--- a/tools/nemo_forced_aligner/utils/data_prep.py
+++ b/tools/nemo_forced_aligner/utils/data_prep.py
@@ -249,6 +249,8 @@ def get_utt_obj(
 
     # remove any spaces at start and end of segments
     segments = [seg.strip() for seg in segments]
+    # remove any empty segments
+    segments = [seg for seg in segments if len(seg) > 0]
 
     utt = Utterance(text=text, audio_filepath=audio_filepath, utt_id=utt_id,)
 


### PR DESCRIPTION
# What does this PR do ?

Bugfix to prevent errors being thrown if the substring specified as an `additional_segment_grouping_separator` is placed at the beginning or end of reference text, or if 2+ of these substrings are placed next to each other in the reference text.

**Collection**: tools/nemo_forced_aligner

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
No usage changes

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ N/A ] Did you write any new necessary tests?
- [ N/A ] Did you add or update any necessary documentation?
- [ N/A ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
