### PR TITLE
[TTS] Support audio offsets in TTS data loaders

### DIFF
--- a/nemo/collections/tts/data/text_to_speech_dataset.py
+++ b/nemo/collections/tts/data/text_to_speech_dataset.py
@@ -27,8 +27,8 @@ from nemo.collections.tts.parts.preprocessing.features import Featurizer
 from nemo.collections.tts.parts.utils.tts_dataset_utils import (
     beta_binomial_prior_distribution,
     filter_dataset_by_duration,
-    get_abs_rel_paths,
     get_weighted_sampler,
+    load_audio,
     stack_tensors,
 )
 from nemo.core.classes import Dataset
@@ -78,6 +78,7 @@ class TextToSpeechDataset(Dataset):
             will be ignored.
         max_duration: Optional float, if provided audio files in the training manifest longer than 'max_duration'
             will be ignored.
+        volume_level: Optional float [0, 1], if provided audio will be normalized to the input volume.
     """
 
     def __init__(
@@ -92,6 +93,7 @@ class TextToSpeechDataset(Dataset):
         align_prior_hop_length: Optional[int] = None,
         min_duration: Optional[float] = None,
         max_duration: Optional[float] = None,
+        volume_level: Optional[float] = None,
     ):
         super().__init__()
 
@@ -100,6 +102,7 @@ class TextToSpeechDataset(Dataset):
         self.weighted_sampling_steps_per_epoch = weighted_sampling_steps_per_epoch
         self.align_prior_hop_length = align_prior_hop_length
         self.include_align_prior = self.align_prior_hop_length is not None
+        self.volume_level = volume_level
 
         if speaker_path:
             self.include_speaker = True
@@ -198,21 +201,33 @@ class TextToSpeechDataset(Dataset):
     def __getitem__(self, index):
         data = self.data_samples[index]
 
-        audio_filepath = Path(data.manifest_entry["audio_filepath"])
-        audio_filepath_abs, audio_filepath_rel = get_abs_rel_paths(input_path=audio_filepath, base_path=data.audio_dir)
+        audio_array, _, audio_filepath_rel = load_audio(
+            manifest_entry=data.manifest_entry,
+            audio_dir=data.audio_dir,
+            sample_rate=self.sample_rate,
+            volume_level=self.volume_level,
+        )
+        audio = torch.tensor(audio_array, dtype=torch.float32)
+        audio_len = audio.shape[0]
 
-        audio, _ = librosa.load(audio_filepath_abs, sr=self.sample_rate)
         tokens = self.text_tokenizer(data.text)
+        tokens = torch.tensor(tokens, dtype=torch.int32)
+        text_len = tokens.shape[0]
 
-        example = {"audio_filepath": audio_filepath_rel, "audio": audio, "tokens": tokens}
+        example = {
+            "audio_filepath": audio_filepath_rel,
+            "audio": audio,
+            "audio_len": audio_len,
+            "tokens": tokens,
+            "text_len": text_len,
+        }
 
         if data.speaker is not None:
             example["speaker"] = data.speaker
             example["speaker_index"] = data.speaker_index
 
         if self.include_align_prior:
-            text_len = len(tokens)
-            spec_len = 1 + librosa.core.samples_to_frames(audio.shape[0], hop_length=self.align_prior_hop_length)
+            spec_len = 1 + librosa.core.samples_to_frames(audio_len, hop_length=self.align_prior_hop_length)
             align_prior = beta_binomial_prior_distribution(phoneme_count=text_len, mel_count=spec_len)
             align_prior = torch.tensor(align_prior, dtype=torch.float32)
             example["align_prior"] = align_prior
@@ -240,13 +255,11 @@ class TextToSpeechDataset(Dataset):
         for example in batch:
             audio_filepath_list.append(example["audio_filepath"])
 
-            audio_tensor = torch.tensor(example["audio"], dtype=torch.float32)
-            audio_list.append(audio_tensor)
-            audio_len_list.append(audio_tensor.shape[0])
+            audio_list.append(example["audio"])
+            audio_len_list.append(example["audio_len"])
 
-            token_tensor = torch.tensor(example["tokens"], dtype=torch.int32)
-            token_list.append(token_tensor)
-            token_len_list.append(token_tensor.shape[0])
+            token_list.append(example["tokens"])
+            token_len_list.append(example["text_len"])
 
             if self.include_speaker:
                 speaker_list.append(example["speaker_index"])

--- a/nemo/collections/tts/data/vocoder_dataset.py
+++ b/nemo/collections/tts/data/vocoder_dataset.py
@@ -12,21 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, List, Optional
 
-import librosa
 import torch.utils.data
 
-from nemo.collections.asr.parts.preprocessing.segment import AudioSegment
 from nemo.collections.asr.parts.utils.manifest_utils import read_manifest
 from nemo.collections.tts.parts.preprocessing.feature_processors import FeatureProcessor
 from nemo.collections.tts.parts.utils.tts_dataset_utils import (
     filter_dataset_by_duration,
-    get_abs_rel_paths,
     get_weighted_sampler,
+    load_audio,
+    sample_audio,
     stack_tensors,
 )
 from nemo.core.classes import Dataset
@@ -66,8 +64,7 @@ class VocoderDataset(Dataset):
         max_duration: Optional float, if provided audio files in the training manifest longer than 'max_duration'
             will be ignored.
         trunc_duration: Optional int, if provided audio will be truncated to at most 'trunc_duration' seconds.
-        num_audio_retries: Number of read attempts to make when sampling audio file, to avoid training failing
-            from sporadic IO errors.
+        volume_level: Optional float [0, 1], if provided audio will be normalized to the input volume.
     """
 
     def __init__(
@@ -80,20 +77,16 @@ class VocoderDataset(Dataset):
         min_duration: Optional[float] = None,
         max_duration: Optional[float] = None,
         trunc_duration: Optional[float] = None,
-        num_audio_retries: int = 5,
+        volume_level: Optional[float] = None,
     ):
         super().__init__()
 
         self.sample_rate = sample_rate
         self.n_samples = n_samples
+        self.trunc_duration = trunc_duration
+        self.volume_level = volume_level
         self.weighted_sampling_steps_per_epoch = weighted_sampling_steps_per_epoch
-        self.num_audio_retries = num_audio_retries
         self.load_precomputed_mel = False
-
-        if trunc_duration:
-            self.trunc_samples = int(trunc_duration * self.sample_rate)
-        else:
-            self.trunc_samples = None
 
         if feature_processors:
             logging.info(f"Found feature processors {feature_processors.keys()}")
@@ -119,33 +112,6 @@ class VocoderDataset(Dataset):
             sample_weights=self.sample_weights, batch_size=batch_size, num_steps=self.weighted_sampling_steps_per_epoch
         )
         return sampler
-
-    def _segment_audio(self, audio_filepath: Path) -> AudioSegment:
-        # Retry file read multiple times as file seeking can produce random IO errors.
-        for _ in range(self.num_audio_retries):
-            try:
-                audio_segment = AudioSegment.segment_from_file(
-                    audio_filepath, target_sr=self.sample_rate, n_segments=self.n_samples,
-                )
-                return audio_segment
-            except Exception:
-                traceback.print_exc()
-
-        raise ValueError(f"Failed to read audio {audio_filepath}")
-
-    def _sample_audio(self, audio_filepath: Path) -> Tuple[torch.Tensor, torch.Tensor]:
-        if not self.n_samples:
-            audio_array, _ = librosa.load(audio_filepath, sr=self.sample_rate)
-        else:
-            audio_segment = self._segment_audio(audio_filepath)
-            audio_array = audio_segment.samples
-
-        if self.trunc_samples:
-            audio_array = audio_array[: self.trunc_samples]
-
-        audio = torch.tensor(audio_array)
-        audio_len = torch.tensor(audio.shape[0])
-        return audio, audio_len
 
     @staticmethod
     def _preprocess_manifest(
@@ -177,10 +143,24 @@ class VocoderDataset(Dataset):
     def __getitem__(self, index):
         data = self.data_samples[index]
 
-        audio_filepath = Path(data.manifest_entry["audio_filepath"])
-        audio_filepath_abs, audio_filepath_rel = get_abs_rel_paths(input_path=audio_filepath, base_path=data.audio_dir)
-
-        audio, audio_len = self._sample_audio(audio_filepath_abs)
+        if self.n_samples:
+            audio_array, _, audio_filepath_rel = sample_audio(
+                manifest_entry=data.manifest_entry,
+                audio_dir=data.audio_dir,
+                sample_rate=self.sample_rate,
+                n_samples=self.n_samples,
+                volume_level=self.volume_level,
+            )
+        else:
+            audio_array, _, audio_filepath_rel = load_audio(
+                manifest_entry=data.manifest_entry,
+                audio_dir=data.audio_dir,
+                sample_rate=self.sample_rate,
+                max_duration=self.trunc_duration,
+                volume_level=self.volume_level,
+            )
+        audio = torch.tensor(audio_array, dtype=torch.float32)
+        audio_len = audio.shape[0]
 
         example = {"audio_filepath": audio_filepath_rel, "audio": audio, "audio_len": audio_len}
 

--- a/tests/collections/tts/parts/preprocessing/test_features.py
+++ b/tests/collections/tts/parts/preprocessing/test_features.py
@@ -34,10 +34,15 @@ class TestTTSFeatures:
         self.audio_filename = "test.wav"
         self.spec_dim = 80
         self.hop_len = 100
-        self.audio_len = 10000
-        self.sample_rate = 20000
+        self.audio_len = 50000
+        self.sample_rate = 10000
         self.spec_len = 1 + (self.audio_len // self.hop_len)
         self.manifest_entry = {"audio_filepath": self.audio_filename}
+
+    def _compute_start_end_frames(self, offset, duration):
+        start_frame = int(self.sample_rate * offset // self.hop_len)
+        end_frame = 1 + int(self.sample_rate * (offset + duration) // self.hop_len)
+        return start_frame, end_frame
 
     @contextlib.contextmanager
     def _create_test_dir(self):
@@ -62,7 +67,7 @@ class TestTTSFeatures:
             spec = mel_featurizer.compute_mel_spec(manifest_entry=self.manifest_entry, audio_dir=test_dir)
 
         assert len(spec.shape) == 2
-        assert spec.dtype == torch.float32
+        assert spec.dtype == np.float32
         assert spec.shape[0] == self.spec_dim
         assert spec.shape[1] == self.spec_len
 
@@ -99,15 +104,39 @@ class TestTTSFeatures:
 
         assert len(pitch.shape) == 1
         assert pitch.shape[0] == self.spec_len
-        assert pitch.dtype == torch.float32
+        assert pitch.dtype == np.float32
 
         assert len(voiced.shape) == 1
         assert voiced.shape[0] == self.spec_len
-        assert voiced.dtype == torch.bool
+        assert voiced.dtype == np.bool
 
         assert len(voiced_prob.shape) == 1
         assert voiced_prob.shape[0] == self.spec_len
-        assert voiced_prob.dtype == torch.float32
+        assert voiced_prob.dtype == np.float32
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_compute_pitch_batched(self, test_data_dir):
+        audio_filepath = Path(test_data_dir) / "tts" / "mini_ljspeech" / "wavs" / "LJ003-0182.wav"
+        manifest_entry = {"audio_filepath": audio_filepath}
+
+        # Compute pitch with batching disabled
+        pitch_featurizer = PitchFeaturizer(hop_length=self.hop_len, sample_rate=self.sample_rate, batch_seconds=None)
+        pitch, voiced, voiced_prob = pitch_featurizer.compute_pitch(
+            manifest_entry=manifest_entry, audio_dir=test_data_dir
+        )
+
+        # Compute pitch in 1 second chunks
+        pitch_featurizer_batch = PitchFeaturizer(
+            hop_length=self.hop_len, sample_rate=self.sample_rate, batch_seconds=1.0
+        )
+        pitch_batch, voiced_batch, voiced_prob_batch = pitch_featurizer_batch.compute_pitch(
+            manifest_entry=manifest_entry, audio_dir=test_data_dir
+        )
+
+        torch.testing.assert_close(pitch_batch, pitch)
+        torch.testing.assert_close(voiced_batch, voiced)
+        torch.testing.assert_close(voiced_prob_batch, voiced_prob)
 
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
@@ -148,6 +177,65 @@ class TestTTSFeatures:
 
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
+    def test_save_and_load_pitch_segments(self, test_data_dir):
+        pitch_name = "pitch_test"
+        voiced_mask_name = "voiced_mask_test"
+        voiced_prob_name = "voiced_prob_test"
+        audio_filepath = Path(test_data_dir) / "tts" / "mini_ljspeech" / "wavs" / "LJ003-0182.wav"
+        manifest_entry = {"audio_filepath": audio_filepath}
+
+        offset1 = 1.0
+        duration1 = 1.0
+        offset2 = 2.5
+        duration2 = 1.2
+        start1, end1 = self._compute_start_end_frames(offset=offset1, duration=duration1)
+        start2, end2 = self._compute_start_end_frames(offset=offset2, duration=duration2)
+        manifest_entry_segment1 = {"audio_filepath": audio_filepath, "offset": offset1, "duration": duration1}
+        manifest_entry_segment2 = {"audio_filepath": audio_filepath, "offset": offset2, "duration": duration2}
+
+        pitch_featurizer = PitchFeaturizer(
+            pitch_name=pitch_name,
+            voiced_mask_name=voiced_mask_name,
+            voiced_prob_name=voiced_prob_name,
+            hop_length=self.hop_len,
+            sample_rate=self.sample_rate,
+        )
+
+        with self._create_test_dir() as test_dir:
+            feature_dir = test_dir / "feature"
+            pitch_featurizer.save(manifest_entry=manifest_entry, audio_dir=test_data_dir, feature_dir=feature_dir)
+            pitch_dict = pitch_featurizer.load(
+                manifest_entry=manifest_entry, audio_dir=test_data_dir, feature_dir=feature_dir
+            )
+            pitch_dict_segment1 = pitch_featurizer.load(
+                manifest_entry=manifest_entry_segment1, audio_dir=test_data_dir, feature_dir=feature_dir
+            )
+            pitch_dict_segment2 = pitch_featurizer.load(
+                manifest_entry=manifest_entry_segment2, audio_dir=test_data_dir, feature_dir=feature_dir
+            )
+
+        pitch = pitch_dict[pitch_name]
+        voiced_mask = pitch_dict[voiced_mask_name]
+        voiced_prob = pitch_dict[voiced_prob_name]
+
+        pitch_segment1 = pitch_dict_segment1[pitch_name]
+        voiced_mask_segment1 = pitch_dict_segment1[voiced_mask_name]
+        voiced_prob_segment1 = pitch_dict_segment1[voiced_prob_name]
+
+        pitch_segment2 = pitch_dict_segment2[pitch_name]
+        voiced_mask_segment2 = pitch_dict_segment2[voiced_mask_name]
+        voiced_prob_segment2 = pitch_dict_segment2[voiced_prob_name]
+
+        torch.testing.assert_close(pitch_segment1, pitch[start1:end1])
+        torch.testing.assert_close(voiced_mask_segment1, voiced_mask[start1:end1])
+        torch.testing.assert_close(voiced_prob_segment1, voiced_prob[start1:end1])
+
+        torch.testing.assert_close(pitch_segment2, pitch[start2:end2])
+        torch.testing.assert_close(voiced_mask_segment2, voiced_mask[start2:end2])
+        torch.testing.assert_close(voiced_prob_segment2, voiced_prob[start2:end2])
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
     def test_compute_energy(self):
         mel_featurizer = MelSpectrogramFeaturizer(
             mel_dim=self.spec_dim, hop_length=self.hop_len, sample_rate=self.sample_rate
@@ -159,7 +247,7 @@ class TestTTSFeatures:
 
         assert len(energy.shape) == 1
         assert energy.shape[0] == self.spec_len
-        assert energy.dtype == torch.float32
+        assert energy.dtype == np.float32
 
     @pytest.mark.run_only_on('CPU')
     @pytest.mark.unit
@@ -181,3 +269,41 @@ class TestTTSFeatures:
         assert len(energy.shape) == 1
         assert energy.shape[0] == self.spec_len
         assert energy.dtype == torch.float32
+
+    @pytest.mark.run_only_on('CPU')
+    @pytest.mark.unit
+    def test_save_and_load_energy_segments(self, test_data_dir):
+        energy_name = "energy_test"
+        offset1 = 0.0
+        duration1 = 1.0
+        offset2 = 1.0
+        duration2 = 1.5
+        start1, end1 = self._compute_start_end_frames(offset=offset1, duration=duration1)
+        start2, end2 = self._compute_start_end_frames(offset=offset2, duration=duration2)
+        manifest_entry_segment1 = {"audio_filepath": self.audio_filename, "offset": offset1, "duration": duration1}
+        manifest_entry_segment2 = {"audio_filepath": self.audio_filename, "offset": offset2, "duration": duration2}
+
+        mel_featurizer = MelSpectrogramFeaturizer(
+            mel_dim=self.spec_dim, hop_length=self.hop_len, sample_rate=self.sample_rate
+        )
+        energy_featurizer = EnergyFeaturizer(feature_name=energy_name, spec_featurizer=mel_featurizer)
+
+        with self._create_test_dir() as test_dir:
+            feature_dir = test_dir / "feature"
+            energy_featurizer.save(manifest_entry=self.manifest_entry, audio_dir=test_dir, feature_dir=feature_dir)
+            energy_dict = energy_featurizer.load(
+                manifest_entry=self.manifest_entry, audio_dir=test_dir, feature_dir=feature_dir
+            )
+            energy_dict_segment1 = energy_featurizer.load(
+                manifest_entry=manifest_entry_segment1, audio_dir=test_dir, feature_dir=feature_dir
+            )
+            energy_dict_segment2 = energy_featurizer.load(
+                manifest_entry=manifest_entry_segment2, audio_dir=test_dir, feature_dir=feature_dir
+            )
+
+        energy = energy_dict[energy_name]
+        energy_segment1 = energy_dict_segment1[energy_name]
+        energy_segment2 = energy_dict_segment2[energy_name]
+
+        torch.testing.assert_close(energy_segment1, energy[start1:end1])
+        torch.testing.assert_close(energy_segment2, energy[start2:end2])


### PR DESCRIPTION
# What does this PR do ?

This PR contains all of the changes needed to support training TTS models with large, multi-utterance files.

Related features are all experimental, and the change is not backwards compatible as I had to change feature files from _.pt_ to _.npy_ so I could memory map them to avoid reading the entire feature file into memory.

**Collection**: [TTS]

# Changelog 
- Add support for "offset" and "duration" in manifest (similar to ASR) to allow reading a subset of audio in the data loader.
- Modify featurizer classes so that they save features as .npy files, and reads subsets of the files using numpy memory mapping when "offset" is present in the manifest.
- Add logic for computing pitch in small chunks for large audio files (to avoid out of memory issues).
- Add on-the-fly volume normalization to featurizers and data loader, as we can not do it as a preprocessing step for multi-utterance files. Volume effects feature computation, as energy is proportional to volume, and volume can change the voiced/unvoiced classification during pitch computation.
- Modify feature_stats.py so it can compute feature statistics across multiple manifests at once (technically unrelated to the rest of the PR).
- Unit tests to validate that the saving/loading logic works as expected.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
