### PR TITLE
Allow applications to control the encoder mask type

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron/gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/gpt_model.py
@@ -167,6 +167,7 @@ class GPTModel(MegatronModule):
         ub_tp_comm_overlap=False,
         use_flash_attention=False,
         seq_len_interpolation_factor=None,
+        encoder_attn_mask_type=AttnMaskType.causal,
     ):
         super(GPTModel, self).__init__(share_token_embeddings=share_embeddings_and_output_weights)
 
@@ -204,7 +205,7 @@ class GPTModel(MegatronModule):
             kv_channels=kv_channels,
             ffn_hidden_size=ffn_hidden_size,
             add_pooler=False,
-            encoder_attn_mask_type=AttnMaskType.causal,
+            encoder_attn_mask_type=encoder_attn_mask_type,
             init_method=init_method_normal(init_method_std),
             scaled_init_method=scaled_init_method,
             pre_process=self.pre_process,

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -60,8 +60,8 @@ from nemo.utils import logging
 
 try:
     import apex.transformer.pipeline_parallel.utils
+    from apex.transformer.enums import AttnMaskType
     from apex.transformer.pipeline_parallel.utils import get_num_microbatches
-    from apex.transformer.enums import AttnMaskType 
 
     HAVE_APEX = True
 
@@ -314,10 +314,9 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         """Model depends on pipeline paralellism."""
 
         encoder_attn_mask_type_cfg = self.cfg.get('encoder_attn_mask_type', None)
-        encoder_attn_mask_type = {
-            'causal':  AttnMaskType.causal,
-            'padding': AttnMaskType.padding
-        }.get(encoder_attn_mask_type_cfg, AttnMaskType.causal)
+        encoder_attn_mask_type = {'causal': AttnMaskType.causal, 'padding': AttnMaskType.padding}.get(
+            encoder_attn_mask_type_cfg, AttnMaskType.causal
+        )
 
         model = GPTModel(
             vocab_size=self.cfg.get('override_vocab_size', self.padded_vocab_size),

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -61,6 +61,7 @@ from nemo.utils import logging
 try:
     import apex.transformer.pipeline_parallel.utils
     from apex.transformer.pipeline_parallel.utils import get_num_microbatches
+    from apex.transformer.enums import AttnMaskType 
 
     HAVE_APEX = True
 


### PR DESCRIPTION
# What does this PR do ?

When TensorRT optimizes Nemo GPT models it uses a different mask shape in the Context phase (triangular mask, i.e. causal) and in the Generation phase (1D mask, i.e. padding).
To support this TensorRT needs to control GPT's encoder mask type (which defaults to causal) via the model configuration.

**Collection**: NLP

# Changelog
- `MegatronGPTModel::model_provider_func` reads an optional `encoder_attn_mask_type` argument from the config file and passes it to the GPTModel constructor. The default value is a causal mask.
- Add an optional `encoder_attn_mask_type` argument to GPTModel constructor. The argument defaults to `AttnMaskType.causal`.
- Pass this argument to `get_language_model`  (previously hard-coded: `encoder_attn_mask_type=AttnMaskType.causal`)

**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.