### PR TITLE
[TTS] Fix TTS recipes with PTL 2.0

### DIFF
--- a/examples/tts/conf/audio_codec/encodec.yaml
+++ b/examples/tts/conf/audio_codec/encodec.yaml
@@ -138,7 +138,7 @@ trainer:
   num_nodes: 1
   devices: 1
   accelerator: gpu
-  strategy: ddp
+  strategy: ddp_find_unused_parameters_true
   precision: 32 # Vector quantization only works with 32-bit precision.
   max_epochs: ${max_epochs}
   accumulate_grad_batches: 1

--- a/examples/tts/conf/hifigan/hifigan.yaml
+++ b/examples/tts/conf/hifigan/hifigan.yaml
@@ -72,7 +72,7 @@ trainer:
   num_nodes: 1
   devices: 1
   accelerator: gpu
-  strategy: ddp
+  strategy: ddp_find_unused_parameters_true
   precision: 32
   max_steps: ${model.max_steps}
   accumulate_grad_batches: 1

--- a/examples/tts/conf/hifigan/hifigan_44100.yaml
+++ b/examples/tts/conf/hifigan/hifigan_44100.yaml
@@ -72,7 +72,7 @@ trainer:
   num_nodes: 1
   devices: -1
   accelerator: gpu
-  strategy: ddp
+  strategy: ddp_find_unused_parameters_true
   precision: 16
   max_steps: ${model.max_steps}
   accumulate_grad_batches: 1

--- a/examples/tts/conf/hifigan_dataset/hifigan_22050.yaml
+++ b/examples/tts/conf/hifigan_dataset/hifigan_22050.yaml
@@ -129,7 +129,7 @@ trainer:
   num_nodes: 1
   devices: 1
   accelerator: gpu
-  strategy: ddp
+  strategy: ddp_find_unused_parameters_true
   precision: 16
   max_epochs: ${max_epochs}
   accumulate_grad_batches: 1

--- a/examples/tts/conf/hifigan_dataset/hifigan_44100.yaml
+++ b/examples/tts/conf/hifigan_dataset/hifigan_44100.yaml
@@ -129,7 +129,7 @@ trainer:
   num_nodes: 1
   devices: 1
   accelerator: gpu
-  strategy: ddp
+  strategy: ddp_find_unused_parameters_true
   precision: 16
   max_epochs: ${max_epochs}
   accumulate_grad_batches: 1

--- a/examples/tts/conf/univnet/univnet.yaml
+++ b/examples/tts/conf/univnet/univnet.yaml
@@ -78,7 +78,7 @@ trainer:
   num_nodes: 1
   devices: 1
   accelerator: gpu
-  strategy: ddp
+  strategy: ddp_find_unused_parameters_true
   precision: 32
   max_steps: ${model.max_steps}
   accumulate_grad_batches: 1

--- a/nemo/collections/tts/models/audio_codec.py
+++ b/nemo/collections/tts/models/audio_codec.py
@@ -267,7 +267,7 @@ class AudioCodecModel(ModelPT):
         self.log_dict(metrics, on_step=True, sync_dist=True)
         self.log("t_loss", train_loss_mel, prog_bar=True, logger=False, sync_dist=True)
 
-    def training_epoch_end(self, outputs):
+    def on_train_epoch_end(self):
         self.update_lr("epoch")
 
     def validation_step(self, batch, batch_idx):


### PR DESCRIPTION
# What does this PR do ?

Update TTS configs so they run with PTL 2.0

**Collection**: [TTS]

# Changelog 
- Replace _ddp_ with _ddp_find_unused_parameters_true_ for all vocoder recipes, otherwise it fails because there are unused parameters during the alternating generator and discriminator training steps.
- Update training_epoch_end() for AudioCodec to be compatible with new PTL interface.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
