### PR TITLE
[Fix] AudioCodecModel training fails with PTL 2.0

### DIFF
--- a/examples/tts/audio_codec.py
+++ b/examples/tts/audio_codec.py
@@ -13,14 +13,21 @@
 # limitations under the License.
 
 import pytorch_lightning as pl
+from omegaconf import OmegaConf
 
 from nemo.collections.tts.models import AudioCodecModel
 from nemo.core.config import hydra_runner
+from nemo.utils import logging
 from nemo.utils.exp_manager import exp_manager
 
 
 @hydra_runner(config_path="conf/audio_codec", config_name="audio_codec")
 def main(cfg):
+    # PTL 2.0 has find_unused_parameters as False by default, so its required to set it to True
+    # when there are unused parameters here
+    if cfg.trainer.strategy == 'ddp':
+        cfg.trainer.strategy = "ddp_find_unused_parameters_true"
+    logging.info(f"\nConfig Params:\n{OmegaConf.to_yaml(cfg)}")
     trainer = pl.Trainer(**cfg.trainer)
     exp_manager(trainer, cfg.get("exp_manager", None))
     model = AudioCodecModel(cfg=cfg.model, trainer=trainer)

--- a/nemo/collections/tts/models/audio_codec.py
+++ b/nemo/collections/tts/models/audio_codec.py
@@ -267,7 +267,7 @@ class AudioCodecModel(ModelPT):
         self.log_dict(metrics, on_step=True, sync_dist=True)
         self.log("t_loss", train_loss_mel, prog_bar=True, logger=False, sync_dist=True)
 
-    def training_epoch_end(self, outputs):
+    def on_train_epoch_end(self):
         self.update_lr("epoch")
 
     def validation_step(self, batch, batch_idx):


### PR DESCRIPTION
Currently, `AudioCodecModel` training fails on `main` due to changes in PTL 2.0.

# What does this PR do ?

This PR is fixing two issues when using PTL 2.0.

**Collection**: TTS

# Changelog 
- Support for `training_epoch_end` has been removed in v2.0.0, and we use `on_train_epoch_end`
  - Reference: https://github.com/Lightning-AI/lightning/pull/16520
- Enable the detection of unused parameters in DDP, either by setting the string value `strategy='ddp_find_unused_parameters_true'`
  - Reference: https://github.com/Lightning-AI/lightning/pull/16520

# Usage

N/A

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #6433 
