### PR TITLE
Fix ZeroDivisionError in DistributedBucketSampler

### DIFF
--- a/nemo/collections/tts/data/dataset.py
+++ b/nemo/collections/tts/data/dataset.py
@@ -1547,7 +1547,7 @@ class DistributedBucketSampler(torch.utils.data.distributed.DistributedSampler):
             idx_bucket = self._bisect(length)
             if idx_bucket != -1:
                 buckets[idx_bucket].append(i)
-    
+
         num_samples_per_bucket = []
         total_batch_size = self.num_replicas * self.batch_size
         i = 0
@@ -1557,13 +1557,12 @@ class DistributedBucketSampler(torch.utils.data.distributed.DistributedSampler):
                 buckets.pop(i)
                 self.boundaries.pop(i + 1)
                 continue
-    
+
             rem = (total_batch_size - (len_bucket % total_batch_size)) % total_batch_size
             num_samples_per_bucket.append(len_bucket + rem)
             i += 1
-    
-        return buckets, num_samples_per_bucket
 
+        return buckets, num_samples_per_bucket
 
     def __iter__(self):
         # deterministically shuffle based on epoch

--- a/nemo/collections/tts/data/dataset.py
+++ b/nemo/collections/tts/data/dataset.py
@@ -1547,19 +1547,23 @@ class DistributedBucketSampler(torch.utils.data.distributed.DistributedSampler):
             idx_bucket = self._bisect(length)
             if idx_bucket != -1:
                 buckets[idx_bucket].append(i)
-
-        for i in range(len(buckets) - 1, 0, -1):
-            if len(buckets[i]) == 0:
-                buckets.pop(i)
-                self.boundaries.pop(i + 1)
-
+    
         num_samples_per_bucket = []
         total_batch_size = self.num_replicas * self.batch_size
-        for i in range(len(buckets)):
+        i = 0
+        while i < len(buckets):
             len_bucket = len(buckets[i])
+            if len_bucket == 0:
+                buckets.pop(i)
+                self.boundaries.pop(i + 1)
+                continue
+    
             rem = (total_batch_size - (len_bucket % total_batch_size)) % total_batch_size
             num_samples_per_bucket.append(len_bucket + rem)
+            i += 1
+    
         return buckets, num_samples_per_bucket
+
 
     def __iter__(self):
         # deterministically shuffle based on epoch


### PR DESCRIPTION
In the `_create_buckets` method of the `DistributedBucketSampler` class, a ZeroDivisionError was being raised when `len_bucket` was zero. This fix adds a conditional check to skip the problematic division if `len_bucket` is zero, thus avoiding the error and ensuring that the rest of the code functions as expected.

# What does this PR do ?

Fixes a ZeroDivisionError in the DistributedBucketSampler class to ensure proper functionality.

**Collection**: TTS Collection

# Changelog 
- Added a conditional check in the `_create_buckets` method to prevent division by zero when `len_bucket` is zero.

# Usage

```python
from nemo.collections.tts.data.dataset import DistributedBucketSampler

# Initialize the sampler with your dataset, batch_size, and boundaries
sampler = DistributedBucketSampler(dataset, batch_size, boundaries)

# Use the sampler in your training loop
for batch in sampler:
    # Process the batch
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.
