### PR TITLE
NFA: replace ellipses in text with 3 periods

### DIFF
--- a/tools/nemo_forced_aligner/utils/data_prep.py
+++ b/tools/nemo_forced_aligner/utils/data_prep.py
@@ -90,6 +90,12 @@ def get_manifest_lines_batch(manifest_filepath, start, end):
                     # newline chars to spaces
                     data["text"] = data["text"].replace("\ufeff", "")
                     data["text"] = " ".join(data["text"].split())
+
+                    # Replace any horizontal ellipses with 3 separate periods.
+                    # The tokenizer will do this anyway. But making this replacement
+                    # now helps avoid errors when restoring punctuation when saving
+                    # the output files
+                    data["text"] = data["text"].replace("\u2026", "...")
                 manifest_lines_batch.append(data)
 
             if line_i == end:


### PR DESCRIPTION
# What does this PR do ?
Currently NFA breaks if there is a 'horizontal ellipses' character (`…`) in the text - specifically the 'restore punctuation' code breaks because it doesn't reconcile the single ellipses character with the 3 periods generated by the tokenizer. A quick for this is to just replace the ellipses with the 3 periods when we read the data (because the text will always end up being 3 periods even if we don't try to restore the punctuation.

**Collection**: `tools/nemo_forced_aligner/`

# Changelog 
- add a line which replaces horizontal ellipses character with 3 periods when reading the text in the original manifest.

# Usage
No usage change

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ N/A ] Did you write any new necessary tests?
- [ N/A ] Did you add or update any necessary documentation?
- [ N/A ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
