### PR TITLE
pin mkdocs-video==1.4.0, hope will fix build error

### DIFF
--- a/.github/workflows/gh-docs.yml
+++ b/.github/workflows/gh-docs.yml
@@ -38,7 +38,7 @@ jobs:
       - name: "Install dependencies"
         if: github.event.repository.fork == false
         run: |
-          pip install mkdocs-video
+          pip install mkdocs-video==1.4.0
 
       - name: "Deploy Github Page"
         continue-on-error: true


### PR DESCRIPTION
# What does this PR do ?

Make sure to `pip install mkdocs-video==1.4.0`, this should make sure the mkdocs build successfully.

**Collection**: Website