### PR TITLE
[ASR] Fix GPU memory leak in transcribe_speech.py

### DIFF
--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -421,13 +421,18 @@ def transcribe_partial_audio(
                 input_signal=test_batch[0].to(device), input_signal_length=test_batch[1].to(device)
             )
             logits, logits_len = outputs[0], outputs[1]
+
             if isinstance(asr_model, EncDecHybridRNNTCTCModel) and decoder_type == "ctc":
                 logits = asr_model.ctc_decoder(encoder_output=logits)
+
+            logits = logits.cpu()
+
             if logprobs:
+                logits = logits.numpy()
                 # dump log probs per file
                 for idx in range(logits.shape[0]):
                     lg = logits[idx][: logits_len[idx]]
-                    hypotheses.append(lg.cpu().numpy())
+                    hypotheses.append(lg)
             else:
                 current_hypotheses, all_hyp = decode_function(logits, logits_len, return_hypotheses=return_hypotheses,)
 


### PR DESCRIPTION
# What does this PR do ?

Fix memory leak in utility used by `transcribe_speech.py` when transcribing partial audio segments, by moving logit tensor stored in results to CPU.

**Collection**: [ASR]

# Changelog 
- Modify `transcribe_partial_audio` to move logits to CPU when when `logprobs=False`.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
