### PR TITLE
[NLP] Bug Fix: Fix `full_logits` Initialization for `all_probs=True` & `compute_logprob=False` in `text_generation_utils.py`

### DIFF
--- a/nemo/collections/nlp/modules/common/text_generation_utils.py
+++ b/nemo/collections/nlp/modules/common/text_generation_utils.py
@@ -701,7 +701,7 @@ def sample_sequence_batch(
 
             if parallel_state.is_pipeline_last_stage():
 
-                if compute_logprob:
+                if compute_logprob or all_probs:
                     output = output[0]['logits']
                     output = tensor_parallel.gather_from_tensor_model_parallel_region(output)
                     assert output is not None
@@ -751,7 +751,7 @@ def sample_sequence_batch(
                 # Insert either new predicted or next prompt token
                 tokens[:, context_length] = new_tokens
 
-                if compute_logprob:
+                if compute_logprob or all_probs:
                     if output_logits is None:
                         output = F.log_softmax(output[:, :context_length, :], 2)
 
@@ -789,7 +789,7 @@ def sample_sequence_batch(
                 src = parallel_state.get_pipeline_model_parallel_last_rank()
                 group = parallel_state.get_pipeline_model_parallel_group()
                 torch.distributed.broadcast(done, src, group)
-                if compute_logprob:
+                if compute_logprob or all_probs:
                     if all_probs:
                         yield tokens, lengths, output_logits, full_logits
                     else:


### PR DESCRIPTION
# What does this PR do ?

This PR ensures that the `sample_sequence_batch` function correctly handles the scenario where `all_probs` is set to `True` but `compute_logprob` is `False`. 

Earlier the `full_logits` variable was not correctly initialized when the `all_probs=True` but `compute_logprob=False` causing a `RuntimeError` due to an attempt to broadcast a `None` value using `torch.distributed.broadcast`.


**Collection**: NLP

# Changelog 
- Updated conditions on lines 704, 754, and 792 in `text_generation_utils.py` to handle cases where `all_probs=True` but `compute_logprob=False`.
This ensures that `full_logits` is correctly initialized, preventing runtime errors during distributed broadcasting.

# Usage
With this fix, users can now set `compute_logprob` to `False` and `all_probs` to `True` in the inference section of the config. This ensures that the `sample_sequence_batch` function correctly handles this specific scenario without encountering the previously observed `RuntimeError`.

For example:

```yaml
inference:
  ...
  all_probs: True  # whether to return the log prob for all the tokens in the vocab
  ...
  compute_logprob: False  # a flag used to compute logprob of all the input text, a very special case of running inference, default False
```
# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
