### PR TITLE
[TTS] Audio codec fixes

### DIFF
--- a/examples/tts/conf/audio_codec/encodec.yaml
+++ b/examples/tts/conf/audio_codec/encodec.yaml
@@ -35,6 +35,8 @@ model:
 
   sample_rate: ${sample_rate}
   samples_per_frame: ${samples_per_frame}
+
+  mel_loss_scale: 5.0
   time_domain_loss_scale: 0.1
   # Probability of updating the discriminator during each training step
   # For example, update the discriminator 2/3 times (2 updates for every 3 batches)

--- a/nemo/collections/tts/models/audio_codec.py
+++ b/nemo/collections/tts/models/audio_codec.py
@@ -236,9 +236,9 @@ class AudioCodecModel(ModelPT):
             loss_disc = self.disc_loss_fn(disc_scores_real=disc_scores_real, disc_scores_gen=disc_scores_gen)
             train_disc_loss = loss_disc
 
+            optim_disc.zero_grad()
             self.manual_backward(train_disc_loss)
             optim_disc.step()
-            optim_disc.zero_grad()
         else:
             loss_disc = None
 
@@ -260,9 +260,9 @@ class AudioCodecModel(ModelPT):
         if commit_loss is not None:
             loss_gen_all += commit_loss
 
+        optim_gen.zero_grad()
         self.manual_backward(loss_gen_all)
         optim_gen.step()
-        optim_gen.zero_grad()
 
         self.update_lr()
 
@@ -290,9 +290,13 @@ class AudioCodecModel(ModelPT):
 
     def validation_step(self, batch, batch_idx):
         audio, audio_len, audio_gen, _ = self._process_batch(batch)
-        loss_audio = self.time_domain_loss_fn(audio_real=audio, audio_gen=audio_gen, audio_len=audio_len)
+        loss_time_domain = self.time_domain_loss_fn(audio_real=audio, audio_gen=audio_gen, audio_len=audio_len)
         loss_mel = self.mel_loss_fn(audio_real=audio, audio_gen=audio_gen, audio_len=audio_len)
-        metrics = {"val_loss": loss_audio + loss_mel, "val_loss_audio": loss_audio, "val_loss_mel": loss_mel}
+        metrics = {
+            "val_loss": loss_time_domain + loss_mel,
+            "val_loss_time_domain": loss_time_domain,
+            "val_loss_mel": loss_mel,
+        }
         self.log_dict(metrics, on_epoch=True, sync_dist=True)
 
     @staticmethod


### PR DESCRIPTION
# What does this PR do ?

A few minor fixes for the audio codec training recipe.

Most important, moving the zero_gradient() call back before the loss calculations. Having it after `optim_disc.step()` results in it saving discriminator gradients during the generator `self.manual_backward(loss_gen_all)` calculation which stops the discriminator from learning (adversarial and feature losses quickly become 0).

**Collection**: [TTS]

# Changelog 
- Zero gradient before discriminator loss calculation
- Change default mel loss scale from 1.0 to 5.0 as it significantly improves ViSQOL and makes training more consistent.
- Fix name of validation time domain loss

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
