### PR TITLE
Fix adapters and ptuning for amp o2 rebased

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
@@ -45,6 +45,8 @@ class MegatronGPTPEFTModel(MegatronGPTSFTModel):
     def first_stage_of_pipeline(self):
         if hasattr(self, "model") and hasattr(self.model, "pre_process"):
             return self.model.pre_process
+        elif hasattr(self, "model") and hasattr(self.model, "module") and hasattr(self.model.module, "pre_process"):
+            return self.model.module.pre_process
         logging.warning("no attribute named model or no model.pre_process found. Can not detect stage of pipeline...")
         return False
 
@@ -228,7 +230,8 @@ class MegatronGPTPTuningModel(MegatronGPTPEFTModel):
         self.virtual_tokens = cfg.peft.p_tuning.virtual_tokens
         self.trainable_keys = self.adapter_keys - set(
             [
-                "model.language_model.adapter_layer.ptuning_adapter.inference_table.prompt_table.taskname.prompt_embeddings.weight"
+                "model.language_model.adapter_layer.ptuning_adapter.inference_table.prompt_table.taskname.prompt_embeddings.weight",
+                "model.module.language_model.adapter_layer.ptuning_adapter.inference_table.prompt_table.taskname.prompt_embeddings.weight", # for Float16Model or BFloat16Model models
             ]
         )
         # we exclude the above parameter from training because it is present for backward compatibility for inference using FasterTransformer (@adithyare)

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
@@ -61,7 +61,7 @@ class MegatronGPTPEFTModel(MegatronGPTSFTModel):
                     peft_cfg = self.name_key_to_cfg[peft_key]
                     if model_utils.import_class_by_path(peft_cfg._target_) in module.get_accepted_adapter_types():
                         module.add_adapter(
-                            name=peft_key, cfg=peft_cfg,
+                            name=peft_key, cfg=peft_cfg, base_model_cfg=self.cfg
                         )
         logging.info(f"After adding PEFT params:\n{self.summarize()}")
         return True


### PR DESCRIPTION
# What does this PR do ?

Fix the issues when using megatron_amp_O2 on PEFT models

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Transform adapters to fp16/bf16 when the base model uses megatron_amp_O2. When using amp_O2 we should make model parameters in fp16/bf16. Previous PR #7232 handles the precision issue in ColumnParallelLinear and RowParallelLinear in PEFT models, and this PR handles precision casting of the rest of the modules such as layernorm.
- Explicitly set the ptuning inference table to untrainable for FP16/BF16 modules. Previous whitelist only includes the name of the inference table as in a FP32 model. We add its name in FP16/BF16 models to whitelist.
- Explicitly set ptuning inference table to be untrainable in AdapterPTuningModel like in PTuningModel

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #7232 
