### PR TITLE
add PEFT adapter support for mcore gpt path

### DIFF
--- a/examples/nlp/language_modeling/megatron_change_num_partitions.py
+++ b/examples/nlp/language_modeling/megatron_change_num_partitions.py
@@ -24,10 +24,10 @@ from pytorch_lightning import Trainer
 
 from nemo.collections.nlp.parts.nlp_overrides import (
     NEMO_MEGATRON_MODEL_PARALLEL_APPSTATE_OVERRIDE,
-    NLPDDPStrategy,
-    NLPSaveRestoreConnector,
     GradScaler,
     MegatronHalfPrecisionPlugin,
+    NLPDDPStrategy,
+    NLPSaveRestoreConnector,
     PipelineMixedPrecisionPlugin,
 )
 from nemo.utils import logging, model_utils
@@ -902,7 +902,7 @@ def main():
 
     if args.model_file is None and args.model_extracted_dir is None:
         raise ValueError("Cannot pass model_file and model_extracted_dir as None at the same time.")
-    
+
     tmp_cfg = cls.restore_from(
         restore_path=args.model_file,
         trainer=Trainer(devices=1, strategy=NLPDDPStrategy(), accelerator="cpu", precision=precision),
@@ -928,7 +928,7 @@ def main():
         else:
             plugins.append(PipelineMixedPrecisionPlugin(precision=plugin_precision, device='cuda', scaler=scaler))
     trainer = Trainer(plugins=plugins, devices=1, strategy=NLPDDPStrategy(), accelerator="cpu", precision=precision)
-    
+
     if tp_size < 0 or pp_size < 0:
         logging.info(f"Loading model config from {args.model_file} to get TP and PP size")
         model_config_internal = cls.restore_from(
@@ -1169,7 +1169,9 @@ def main():
         if vp_size > 1:
             set_virtual_parallel_rank_safely(None)
 
-        trainer = Trainer(plugins=plugins, devices=1, strategy=NLPDDPStrategy(), accelerator="cpu", precision=precision)
+        trainer = Trainer(
+            plugins=plugins, devices=1, strategy=NLPDDPStrategy(), accelerator="cpu", precision=precision
+        )
 
         with open_dict(model.cfg):
             if args.tokenizer_model_path is not None:
@@ -1374,7 +1376,9 @@ def main():
                 app_state.pipeline_model_parallel_size * app_state.tensor_model_parallel_size
             )
 
-            trainer = Trainer(plugins=plugins, devices=1, strategy=NLPDDPStrategy(), accelerator="cpu", precision=precision)
+            trainer = Trainer(
+                plugins=plugins, devices=1, strategy=NLPDDPStrategy(), accelerator="cpu", precision=precision
+            )
             if args.tokenizer_model_path is not None:
                 with open_dict(model.cfg):
                     model.cfg.tokenizer.model = args.tokenizer_model_path

--- a/examples/nlp/language_modeling/tuning/conf/megatron_llama_peft_tuning_config.yaml
+++ b/examples/nlp/language_modeling/tuning/conf/megatron_llama_peft_tuning_config.yaml
@@ -85,16 +85,22 @@ model:
       type: 'parallel_adapter' # this should be either 'parallel_adapter' or 'linear_adapter'
       adapter_dim: 32
       adapter_dropout: 0.0
-      norm_position: 'pre' # This can be set to 'pre' or 'post', 'pre' is normally what is used.
+      norm_position: 'pre' # This can be set to 'pre', 'post' or null, 'pre' is normally what is used.
       column_init_method: 'xavier' # IGNORED if linear_adapter is used, options: xavier, zero or normal
       row_init_method: 'zero' # IGNORED if linear_adapter is used, options: xavier, zero or normal
       norm_type: 'mixedfusedlayernorm' # IGNORED if layer_adapter is used,  options are ['layernorm', 'mixedfusedlayernorm']
+      layer_selection: null  # selects in which layers to add adapters, e.g. [1,12] will add adapters to layer 1 (lowest) and 12. null will apply adapters to all layers
+      weight_tying: False
+      position_embedding_strategy: null # used only when weight_tying is True
     
     lora_tuning:
       adapter_dim: 32
       adapter_dropout: 0.0
       column_init_method: 'xavier' # IGNORED if linear_adapter is used, options: xavier, zero or normal
       row_init_method: 'zero' # IGNORED if linear_adapter is used, options: xavier, zero or normal
+      layer_selection:  null  # selects in which layers to add lora adapters. e.g. [1,12] will add lora to layer 1 (lowest) and 12. null will apply adapters to all layers
+      weight_tying: False
+      position_embedding_strategy: null # used only when weight_tying is True
     
     # Used for p-tuning peft training
     p_tuning:
@@ -102,6 +108,9 @@ model:
       bottleneck_dim: 2048  # the size of the prompt encoder mlp bottleneck
       embedding_dim: 4096  # the size of the prompt encoder embeddings
       init_std: 0.023
+
+    ia3_tuning:
+      layer_selection:  null  # selects in which layers to add ia3 adapters. e.g. [1,12] will add lora to layer 1 (lowest) and 12. null will apply adapters to all layers
 
   data:
     train_ds:

--- a/examples/nlp/language_modeling/tuning/conf/megatron_llama_peft_tuning_config.yaml
+++ b/examples/nlp/language_modeling/tuning/conf/megatron_llama_peft_tuning_config.yaml
@@ -1,0 +1,211 @@
+name: megatron_gpt_peft_tuning
+
+trainer:
+  devices: 1
+  accelerator: gpu
+  num_nodes: 1
+  precision: 16
+  logger: False # logger provided by exp_manager
+  enable_checkpointing: False
+  use_distributed_sampler: False
+  max_epochs: 9999
+  max_steps: 20000 # consumed_samples = global_step * micro_batch_size * data_parallel_size * accumulate_grad_batches
+  log_every_n_steps: 10 # frequency with which training steps are logged 
+  val_check_interval: 200 # If is an int n > 1, will run val every n training steps, if a float 0.0 - 1.0 will run val every epoch fraction, e.g. 0.25 will run val every quarter epoch
+  gradient_clip_val: 1.0
+
+exp_manager:
+  explicit_log_dir: null
+  exp_dir: null
+  name: ${name}
+  create_wandb_logger: False
+  wandb_logger_kwargs:
+    project: null
+    name: null
+  resume_if_exists: True
+  resume_ignore_no_checkpoint: True
+  create_checkpoint_callback: True
+  checkpoint_callback_params:
+    monitor: validation_${model.data.validation_ds.metric.name}
+    save_top_k: 1
+    mode: min
+    save_nemo_on_train_end: True
+    filename: '${name}--{${exp_manager.checkpoint_callback_params.monitor}:.3f}-{step}-{consumed_samples}'
+    model_parallel_size: ${model.tensor_model_parallel_size}
+    always_save_nemo: False
+    save_best_model: True
+  create_early_stopping_callback: True
+  early_stopping_callback_params:
+    monitor: "val_loss"
+    mode: "min"
+    min_delta: 0.001
+    patience: 10
+    verbose: True
+    strict: False # Should be False to avoid a runtime error where EarlyStopping says monitor is unavailable, which sometimes happens with resumed training.
+
+model:
+  seed: 1234
+  tensor_model_parallel_size: 1 # intra-layer model parallelism
+  pipeline_model_parallel_size: 1 # inter-layer model parallelism
+  
+  global_batch_size: 128
+  micro_batch_size: 4
+  restore_from_path: ??? # Path to an existing .nemo model you wish to add new tasks to or run inference with
+  resume_from_checkpoint: null # The path to a checkpoint file to continue the training, restores the whole state including the epoch, step, LR schedulers, apex, etc.
+  save_nemo_on_validation_end: False # Saves an inference ready .nemo file every time a checkpoint is saved during training. 
+  sync_batch_comm: False
+  megatron_amp_O2: False
+
+  ## Sequence Parallelism
+  # Makes tensor parallelism more memory efficient for LLMs (20B+) by parallelizing layer norms and dropout sequentially
+  # See Reducing Activation Recomputation in Large Transformer Models: https://arxiv.org/abs/2205.05198 for more details.
+  sequence_parallel: False
+
+  ## Activation Checkpoint 
+  activations_checkpoint_granularity: null # 'selective' or 'full' 
+  activations_checkpoint_method: null # 'uniform', 'block', not used with 'selective'
+  # 'uniform' divides the total number of transformer layers and checkpoints the input activation
+  # of each chunk at the specified granularity
+  # 'block' checkpoints the specified number of layers per pipeline stage at the specified granularity
+  activations_checkpoint_num_layers: null # not used with 'selective'
+  activations_checkpoint_layers_per_pipeline: null
+  answer_only_loss: True
+  gradient_as_bucket_view: False
+
+  hidden_dropout: 0.0
+  attention_dropout: 0.0
+  ffn_dropout: 0.0
+
+  peft:
+    peft_scheme: "adapter"  # can be either adapter,ia3, or ptuning
+    restore_from_path: null
+    
+    # Used for adapter peft training
+    adapter_tuning:
+      type: 'parallel_adapter' # this should be either 'parallel_adapter' or 'linear_adapter'
+      adapter_dim: 32
+      adapter_dropout: 0.0
+      norm_position: 'pre' # This can be set to 'pre' or 'post', 'pre' is normally what is used.
+      column_init_method: 'xavier' # IGNORED if linear_adapter is used, options: xavier, zero or normal
+      row_init_method: 'zero' # IGNORED if linear_adapter is used, options: xavier, zero or normal
+      norm_type: 'mixedfusedlayernorm' # IGNORED if layer_adapter is used,  options are ['layernorm', 'mixedfusedlayernorm']
+    
+    lora_tuning:
+      adapter_dim: 32
+      adapter_dropout: 0.0
+      column_init_method: 'xavier' # IGNORED if linear_adapter is used, options: xavier, zero or normal
+      row_init_method: 'zero' # IGNORED if linear_adapter is used, options: xavier, zero or normal
+    
+    # Used for p-tuning peft training
+    p_tuning:
+      virtual_tokens: 10  # The number of virtual tokens the prompt encoder should add at the start of the sequence
+      bottleneck_dim: 2048  # the size of the prompt encoder mlp bottleneck
+      embedding_dim: 4096  # the size of the prompt encoder embeddings
+      init_std: 0.023
+
+  data:
+    train_ds:
+      # Example of how to specify paths to multiple datasets
+      # file_names: 
+      #   - /path/to/squad.jsonl
+      #   - /path/to/mnli.jsonl
+      #   - /path/to/boolq.jsonl
+      # Example of how each dataset is formatted
+      # {'input': 'John von Neumann\nVon Neumann made fundamental contributions .... Q: What did the math of artificial viscosity do?', 'output': 'smoothed the shock transition without sacrificing basic physics'}
+      file_names: ??? # Path to a list of JSONL files corresponding to the source data.
+      global_batch_size: ${model.global_batch_size}
+      micro_batch_size: ${model.micro_batch_size}
+      shuffle: True
+      num_workers: 0
+      memmap_workers: 2
+      pin_memory: True
+      max_seq_length: 2048
+      min_seq_length: 1
+      drop_last: True
+      # Example of how to specify concat_sampling_probabilities
+      # concat_sampling_probabilities:
+      #   - 0.5
+      #   - 0.25
+      #   - 0.25
+      concat_sampling_probabilities: null # When providing a list of datasets, this arg defines the sampling probabilities from each dataset when strategy='random'
+      context_key: 'input'
+      label_key: 'output'
+      add_eos: True
+      add_sep: False
+      add_bos: True
+      separate_prompt_and_response_with_newline: False
+      truncation_field: "context" # Options: ['context', 'answer']
+      index_mapping_dir: null # Path to a directory to write index mapping files.
+      prompt_template: "{input} {output}" # fstring to use for assistant prompt. Example: "Q: {input}\nA: {output}"
+
+    validation_ds:
+      file_names: ??? # Path to a list of JSONL files corresponding to the source data. Data format is identical to train_ds.
+      names: null # Names of the corresponding datasets used to log metrics.
+      global_batch_size: ${model.global_batch_size}
+      micro_batch_size: ${model.micro_batch_size}
+      shuffle: False
+      num_workers: 0
+      memmap_workers: ${model.data.train_ds.memmap_workers}
+      pin_memory: True
+      max_seq_length: 2048
+      min_seq_length: 1
+      drop_last: False
+      context_key: 'input'
+      label_key: 'output'
+      add_eos: ${model.data.train_ds.add_eos}
+      add_sep: ${model.data.train_ds.add_sep}
+      add_bos: ${model.data.train_ds.add_bos}
+      separate_prompt_and_response_with_newline: ${model.data.train_ds.separate_prompt_and_response_with_newline}
+      write_predictions_to_file: False
+      output_file_path_prefix: null # Prefix of the file to write predictions to.
+      truncation_field: "context" # Options: ['context', 'answer']
+      index_mapping_dir: null # Path to a directory to write index mapping files.
+      prompt_template: ${model.data.train_ds.prompt_template} # fstring to use for assistant prompt. Example: "Q: {input}\nA: {output}"
+      tokens_to_generate: 32 # decide how many tokens we want to generate to evaluate performance with string metrics
+      metric:
+        name: "loss" # Name of the evaluation metric to use. Options: ['exact_string_match', 'loss']
+        average: null # Average the metric over the dataset. Options: ['macro', 'micro']. Works only for 'F1', 'accuracy' etc. Refer to torchmetrics for metrics where this is supported.
+        num_classes: null
+    test_ds:
+      file_names: null # Path to a list of JSONL files corresponding to the source data. Data format is identical to train_ds.
+      names: null # Names of the corresponding datasets used to log metrics.
+      global_batch_size: ${model.global_batch_size}
+      micro_batch_size: ${model.micro_batch_size}
+      shuffle: False
+      num_workers: 0
+      memmap_workers: ${model.data.train_ds.memmap_workers}
+      pin_memory: True
+      max_seq_length: 2048
+      min_seq_length: 1
+      drop_last: False
+      context_key: 'input'
+      label_key: 'output'
+      add_eos: ${model.data.train_ds.add_eos}
+      add_sep: ${model.data.train_ds.add_sep}
+      add_bos: ${model.data.train_ds.add_bos}
+      separate_prompt_and_response_with_newline: ${model.data.train_ds.separate_prompt_and_response_with_newline}
+      write_predictions_to_file: False
+      output_file_path_prefix: null # Prefix of the file to write predictions to.
+      truncation_field: "context" # Options: ['context', 'answer']
+      index_mapping_dir: null # Path to a directory to write index mapping files.
+      prompt_template: ${model.data.train_ds.prompt_template}
+      tokens_to_generate: 32 # decide how many tokens we want to generate to evaluate performance with string metrics
+      metric:
+        name: "loss" # Name of the evaluation metric to use. Options: ['exact_string_match', 'loss']
+        average: null # Average the metric over the dataset. Options: ['macro', 'micro']. Works only for 'F1', 'accuracy' etc. Refer to torchmetrics for metrics where this is supported.
+        num_classes: null
+
+  optim:
+    name: fused_adam
+    lr: 1e-4
+    weight_decay: 0.01 
+    betas: 
+    - 0.9
+    - 0.98
+    sched:
+      name: CosineAnnealing
+      warmup_steps: 50
+      min_lr: 0.0 # min_lr must be 0.0 for prompt learning when pipeline parallel > 1
+      constant_steps: 0 # Constant steps should also be 0 when min_lr=0
+      monitor: val_loss
+      reduce_on_plateau: false

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -763,7 +763,9 @@ class MegatronBaseModel(NLPModel):
             "async_tensor_model_parallel_allreduce": self.cfg.get('tensor_model_parallel_world_size', 1) > 1
             and not self.cfg.get('sequence_parallel', False),
             "pipeline_dtype": pipeline_dtype,
-            "grad_scale_func": self.trainer.precision_plugin.scaler.scale if precision in [16, '16', '16-mixed'] else None,
+            "grad_scale_func": self.trainer.precision_plugin.scaler.scale
+            if precision in [16, '16', '16-mixed']
+            else None,
             "enable_autocast": not megatron_amp_O2 and precision in [16, '16', 'bf16'],
             "autocast_dtype": autocast_dtype,
             "variable_seq_lengths": False,  # set dynamically during training

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -71,13 +71,12 @@ except (ImportError, ModuleNotFoundError):
     HAVE_APEX = False
 
 try:
-    from megatron.core import parallel_state
+    from megatron.core import InferenceParams, parallel_state
     from megatron.core.models.gpt import GPTModel as MCoreGPTModel
     from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
     from megatron.core.transformer.module import Float16Module as MCoreFloat16Module
     from megatron.core.transformer.transformer_config import TransformerConfig
     from megatron.core.utils import init_method_normal, scaled_init_method_normal
-    from megatron.core import InferenceParams
 
     # TODO @tmoon: Use once available in Megatron-LM
     # from megatron.core.pipeline_parallel.schedules import DataIteratorList
@@ -292,7 +291,6 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
 
         self.inference_params = None
 
-
     def get_gpt_module_list(self):
         if isinstance(self.model, list):
             return [
@@ -325,9 +323,10 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                 rotary_percent=self.cfg.get('rotary_percentage', 1.0),
             )
         else:
-            assert (
-                self.cfg.get('num_query_groups', None) is None
-                or self.cfg.get('num_query_groups', None) == self.cfg.get('num_attention_heads', None)
+            assert self.cfg.get('num_query_groups', None) is None or self.cfg.get(
+                'num_query_groups', None
+            ) == self.cfg.get(
+                'num_attention_heads', None
             ), "Group Query Attention is only supported in Megatron Core. Set 'mcore_gpt' to use GQA."
 
             model = GPTModel(
@@ -898,8 +897,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                 # if first step, then clear KV cache, otherwise reuse inference_paarms
                 if set_inference_key_value_memory[0].item():
                     self.inference_params = InferenceParams(
-                        max_batch_size=tokens.size(0),
-                        max_sequence_length=inference_max_sequence_len[0].item()
+                        max_batch_size=tokens.size(0), max_sequence_length=inference_max_sequence_len[0].item()
                     )
                 extra_arg['inference_params'] = self.inference_params
             else:
@@ -907,7 +905,6 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                 extra_arg['inference_max_sequence_len'] = inference_max_sequence_len[0].item()
             output_tensor = model(tokens, position_ids, attention_mask, **extra_arg)
 
-            
             # Advance inference sequence offset.
             if self.inference_params:
                 self.inference_params.sequence_len_offset += output_tensor.size(1)
@@ -1349,13 +1346,9 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         # Restore model parameters.
         for module in self.get_gpt_module_list():
             if self.cfg.get('mcore_gpt', False):
-                module.decoder.config.recompute_granularity = (
-                    self.last_activations_checkpoint_granularity
-                )
+                module.decoder.config.recompute_granularity = self.last_activations_checkpoint_granularity
                 module.decoder.config.recompute_method = self.last_activations_checkpoint_method
-                module.decoder.config.recompute_num_layers = (
-                    self.last_activations_checkpoint_num_layers
-                )
+                module.decoder.config.recompute_num_layers = self.last_activations_checkpoint_num_layers
             else:
                 module.language_model.encoder.activations_checkpoint_granularity = (
                     self.last_activations_checkpoint_granularity

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
@@ -70,7 +70,6 @@ class MegatronGPTPEFTModel(MegatronGPTSFTModel):
         assert len(self.name_key_to_cfg) > 0, "name_key_to_cfg has not been set no PEFT modules will be added"
         logging.info(f"Before adding PEFT params:\n{self.summarize()}")
         for name, module in self.named_modules():
-            # if there's an infinite loop here, check that the added adapter modules doesn't use the same key as mcore targets.
             if self.mcore_gpt:
                 for peft_key in self.peft_name_keys:
                     for mcore_target, mcore_mixin in self.name_key_to_mcore_mixins[peft_key]:

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
@@ -518,10 +518,14 @@ class MegatronGPTLoRAModel(MegatronGPTLayerwisePEFTModel):
         else:
             kv_channels = cfg.kv_channels
         projection_size = kv_channels * cfg.num_attention_heads
+        num_query_groups = cfg.get("num_query_groups", None)
+        if num_query_groups is None:
+            num_query_groups = cfg.num_attention_heads
+        qkv_projection_size = projection_size + 2 * kv_channels * num_query_groups
 
         adapter_cfg = LoraKQVAdapterConfig(
             in_features=cfg.hidden_size,
-            out_features=3 * projection_size,
+            out_features=qkv_projection_size,
             dim=lora_cfg.adapter_dim,
             norm_position=None,
             norm_type=None,
@@ -563,6 +567,10 @@ class MegatronGPTLoRAModelWeightTying(MegatronGPTLayerwisePEFTModel):
         else:
             kv_channels = cfg.kv_channels
         projection_size = kv_channels * cfg.num_attention_heads
+        num_query_groups = cfg.get("num_query_groups", None)
+        if num_query_groups is None:
+            num_query_groups = cfg.num_attention_heads
+        qkv_projection_size = projection_size + 2 * kv_channels * num_query_groups
         position_embedding_strategy = lora_cfg.get("position_embedding_strategy", None)
         if position_embedding_strategy is None:
             dim_position_embeddings = 0
@@ -579,7 +587,7 @@ class MegatronGPTLoRAModelWeightTying(MegatronGPTLayerwisePEFTModel):
 
         adapter_cfg = LoraKQVAdapterWeightTyingConfig(
             in_features=cfg.hidden_size,
-            out_features=3 * projection_size,
+            out_features=qkv_projection_size,
             dim=lora_cfg.adapter_dim,
             norm_position=None,
             norm_type=None,

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
@@ -352,6 +352,7 @@ class MegatronGPTPTuningModel(MegatronGPTPEFTModel):
             [
                 "model.language_model.adapter_layer.ptuning_adapter.inference_table.prompt_table.taskname.prompt_embeddings.weight",
                 "model.module.language_model.adapter_layer.ptuning_adapter.inference_table.prompt_table.taskname.prompt_embeddings.weight",  # for Float16Model models
+                "model.embedding.adapter_layer.ptuning_adapter.inference_table.prompt_table.taskname.prompt_embeddings.weight",
             ]
         )
         # we exclude the above parameter from training because it is present for backward compatibility for inference using FasterTransformer (@adithyare)

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
@@ -27,6 +27,11 @@ from nemo.collections.nlp.modules.common.megatron.adapters.parallel_adapters imp
     ParallelLinearAdapterWeightTyingConfig,
     PromptEncoderAdapterConfig,
 )
+from nemo.collections.nlp.modules.common.megatron.adapters.mcore_mixins import (
+    swap_mcore_mixin,
+    LoraTELinear,
+    PtuningGPTEmbedding,
+)
 from nemo.core.classes.mixins import adapter_mixins
 from nemo.utils import logging, model_utils
 
@@ -59,16 +64,30 @@ class MegatronGPTPEFTModel(MegatronGPTSFTModel):
         Randomly initialize the peft params and add them to the appropriate modules.
         """
         assert len(self.peft_name_keys) > 0, "peft_name_keys have not been set no PEFT modules will be added"
+        assert not self.mcore_gpt or hasattr(self, 'name_key_to_mcore_target'), (
+            "some of the PEFT modules are not supported in megatron core mode yet."
+        )
         assert len(self.name_key_to_cfg) > 0, "name_key_to_cfg has not been set no PEFT modules will be added"
         logging.info(f"Before adding PEFT params:\n{self.summarize()}")
-        for _, module in self.named_modules():
-            if isinstance(module, adapter_mixins.AdapterModuleMixin):
+        for name, module in self.named_modules():
+            # if there's an infinite loop here, check that the added adapter modules doesn't use the same key as mcore targets.
+            if self.mcore_gpt:
                 for peft_key in self.peft_name_keys:
-                    peft_cfg = self.name_key_to_cfg[peft_key]
-                    if model_utils.import_class_by_path(peft_cfg._target_) in module.get_accepted_adapter_types():
-                        module.add_adapter(
-                            name=peft_key, cfg=peft_cfg, model_parallel_config=self.model_parallel_config
-                        )
+                    if name.split(".")[-1] == self.name_key_to_mcore_target[peft_key]:  # could also use regex here to match a template
+                        swap_mcore_mixin(module, self.name_key_to_mcore_mixin[peft_key])
+                        peft_cfg = self.name_key_to_cfg[peft_key]
+                        if model_utils.import_class_by_path(peft_cfg._target_) in module.get_accepted_adapter_types():
+                            module.add_adapter(
+                                name=peft_key, cfg=peft_cfg, model_parallel_config=self.model_parallel_config,
+                            )
+            else:
+                if isinstance(module, adapter_mixins.AdapterModuleMixin):
+                    for peft_key in self.peft_name_keys:
+                        peft_cfg = self.name_key_to_cfg[peft_key]
+                        if model_utils.import_class_by_path(peft_cfg._target_) in module.get_accepted_adapter_types():
+                            module.add_adapter(
+                                name=peft_key, cfg=peft_cfg, model_parallel_config=self.model_parallel_config
+                            )
         logging.info(f"After adding PEFT params:\n{self.summarize()}")
         return True
 
@@ -325,6 +344,8 @@ class MegatronGPTPTuningModel(MegatronGPTPEFTModel):
             cfg.hidden_size,
         )
         self.name_key_to_cfg = {AdapterName.PTUNING_ADAPTER: adapter_cfg}
+        self.name_key_to_mcore_target = {AdapterName.PTUNING_ADAPTER: 'embedding'}
+        self.name_key_to_mcore_mixin = {AdapterName.PTUNING_ADAPTER: PtuningGPTEmbedding}
         super().__init__(cfg, trainer)
         self.virtual_tokens = cfg.peft.p_tuning.virtual_tokens
         self.trainable_keys = self.adapter_keys - set(
@@ -490,8 +511,12 @@ class MegatronGPTLoRAModel(MegatronGPTLayerwisePEFTModel):
         )
 
         self.name_key_to_cfg = {}
+        self.name_key_to_mcore_target = {}
+        self.name_key_to_mcore_mixin = {}
         for k in self.peft_name_keys:
             self.name_key_to_cfg[k] = adapter_cfg
+            self.name_key_to_mcore_target[k] = "linear_qkv"
+            self.name_key_to_mcore_mixin[k] = LoraTELinear
         self.layer_selection = lora_cfg.get("layer_selection", None)
         if self.layer_selection is None:
             self.layer_selection = list(range(1, cfg.num_layers + 1))

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
@@ -64,22 +64,23 @@ class MegatronGPTPEFTModel(MegatronGPTSFTModel):
         Randomly initialize the peft params and add them to the appropriate modules.
         """
         assert len(self.peft_name_keys) > 0, "peft_name_keys have not been set no PEFT modules will be added"
-        assert not self.mcore_gpt or hasattr(self, 'name_key_to_mcore_target'), (
-            "some of the PEFT modules are not supported in megatron core mode yet."
-        )
+        assert not self.mcore_gpt or hasattr(
+            self, 'name_key_to_mcore_mixins'
+        ), "some of the PEFT modules are not supported in megatron core mode yet."
         assert len(self.name_key_to_cfg) > 0, "name_key_to_cfg has not been set no PEFT modules will be added"
         logging.info(f"Before adding PEFT params:\n{self.summarize()}")
         for name, module in self.named_modules():
             # if there's an infinite loop here, check that the added adapter modules doesn't use the same key as mcore targets.
             if self.mcore_gpt:
                 for peft_key in self.peft_name_keys:
-                    if name.split(".")[-1] == self.name_key_to_mcore_target[peft_key]:  # could also use regex here to match a template
-                        swap_mcore_mixin(module, self.name_key_to_mcore_mixin[peft_key])
-                        peft_cfg = self.name_key_to_cfg[peft_key]
-                        if model_utils.import_class_by_path(peft_cfg._target_) in module.get_accepted_adapter_types():
-                            module.add_adapter(
-                                name=peft_key, cfg=peft_cfg, model_parallel_config=self.model_parallel_config,
-                            )
+                    for mcore_target, mcore_mixin in self.name_key_to_mcore_mixins[peft_key]:
+                        if name.split(".")[-1] == mcore_target:
+                            swap_mcore_mixin(module, mcore_mixin)
+                            peft_cfg = self.name_key_to_cfg[peft_key]
+                            if model_utils.import_class_by_path(peft_cfg._target_) in module.get_accepted_adapter_types():
+                                module.add_adapter(
+                                    name=peft_key, cfg=peft_cfg, model_parallel_config=self.model_parallel_config,
+                                )
             else:
                 if isinstance(module, adapter_mixins.AdapterModuleMixin):
                     for peft_key in self.peft_name_keys:
@@ -171,7 +172,7 @@ class MegatronGPTLayerwisePEFTModel(MegatronGPTPEFTModel):
         """
         assert len(self.peft_name_keys) > 0, "peft_name_keys have not been set no PEFT modules will be added"
         assert not self.mcore_gpt or hasattr(
-            self, 'name_key_to_mcore_target'
+            self, 'name_key_to_mcore_mixins'
         ), "some of the PEFT modules are not supported in megatron core mode yet."
         assert len(self.name_key_to_cfg) > 0, "name_key_to_cfg has not been set no PEFT modules will be added"
         logging.info(f"Before adding PEFT params:\n{self.summarize()}")
@@ -184,15 +185,17 @@ class MegatronGPTLayerwisePEFTModel(MegatronGPTPEFTModel):
                 for name, module in layer.named_modules():
                     if self.mcore_gpt:
                         for peft_key in self.peft_name_keys:
-                            if (
-                                name.split(".")[-1] == self.name_key_to_mcore_target[peft_key]
-                            ):  # could also use regex here to match a template
-                                swap_mcore_mixin(module, self.name_key_to_mcore_mixin[peft_key])
-                                peft_cfg = self.name_key_to_cfg[peft_key]
-                                if model_utils.import_class_by_path(peft_cfg._target_) in module.get_accepted_adapter_types():
-                                    module.add_adapter(
-                                        name=peft_key, cfg=peft_cfg, model_parallel_config=self.model_parallel_config,
-                                    )
+                            for mcore_target, mcore_mixin in self.name_key_to_mcore_mixins[peft_key]:
+                                if name.split(".")[-1] == mcore_target:
+                                    swap_mcore_mixin(module, mcore_mixin)
+                                    peft_cfg = self.name_key_to_cfg[peft_key]
+                                    if (
+                                        model_utils.import_class_by_path(peft_cfg._target_)
+                                        in module.get_accepted_adapter_types()
+                                    ):
+                                        module.add_adapter(
+                                            name=peft_key, cfg=peft_cfg, model_parallel_config=self.model_parallel_config,
+                                        )
                     else:
                         if isinstance(module, adapter_mixins.AdapterModuleMixin):
                             for peft_key in self.peft_name_keys:
@@ -363,8 +366,7 @@ class MegatronGPTPTuningModel(MegatronGPTPEFTModel):
             cfg.hidden_size,
         )
         self.name_key_to_cfg = {AdapterName.PTUNING_ADAPTER: adapter_cfg}
-        self.name_key_to_mcore_target = {AdapterName.PTUNING_ADAPTER: 'embedding'}
-        self.name_key_to_mcore_mixin = {AdapterName.PTUNING_ADAPTER: PtuningGPTEmbedding}
+        self.name_key_to_mcore_mixins = {AdapterName.PTUNING_ADAPTER: [('embedding', PtuningGPTEmbedding)]}
         super().__init__(cfg, trainer)
         self.virtual_tokens = cfg.peft.p_tuning.virtual_tokens
         self.trainable_keys = self.adapter_keys - set(
@@ -531,12 +533,10 @@ class MegatronGPTLoRAModel(MegatronGPTLayerwisePEFTModel):
         )
 
         self.name_key_to_cfg = {}
-        self.name_key_to_mcore_target = {}
-        self.name_key_to_mcore_mixin = {}
+        self.name_key_to_mcore_mixins = {}  # maps peft_key to a list of tuples (mcore_target, mcore_mixin)
         for k in self.peft_name_keys:
             self.name_key_to_cfg[k] = adapter_cfg
-            self.name_key_to_mcore_target[k] = "linear_qkv"
-            self.name_key_to_mcore_mixin[k] = LoraTELinear
+            self.name_key_to_mcore_mixins[k] = [("linear_qkv", LoraTELinear)]
         self.layer_selection = lora_cfg.get("layer_selection", None)
         if self.layer_selection is None:
             self.layer_selection = list(range(1, cfg.num_layers + 1))

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
@@ -74,7 +74,10 @@ class MegatronGPTPEFTModel(MegatronGPTSFTModel):
             if self.mcore_gpt:
                 for peft_key in self.peft_name_keys:
                     for mcore_target, mcore_mixin in self.name_key_to_mcore_mixins[peft_key]:
-                        if name in [f'model.{mcore_target}', f'model.module.{mcore_target}']: # simple string match for now
+                        if name in [
+                            f'model.{mcore_target}',
+                            f'model.module.{mcore_target}',
+                        ]:  # simple string match for now
                             swap_mcore_mixin(module, mcore_mixin)
                             peft_cfg = self.name_key_to_cfg[peft_key]
                             if (

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
@@ -18,8 +18,8 @@ from pytorch_lightning.trainer.trainer import Trainer
 
 from nemo.collections.nlp.models.language_modeling.megatron_gpt_sft_model import MegatronGPTSFTModel
 from nemo.collections.nlp.modules.common.megatron.adapters.mcore_mixins import (
-    LoraTELinear,
-    PtuningGPTEmbedding,
+    MCoreGPTEmbeddingMixin,
+    MCoreSelfAttentionMixin,
     swap_mcore_mixin,
 )
 from nemo.collections.nlp.modules.common.megatron.adapters.parallel_adapters import (
@@ -385,7 +385,7 @@ class MegatronGPTPTuningModel(MegatronGPTPEFTModel):
             cfg.hidden_size,
         )
         self.name_key_to_cfg = {AdapterName.PTUNING_ADAPTER: adapter_cfg}
-        self.name_key_to_mcore_mixins = {AdapterName.PTUNING_ADAPTER: [('embedding', PtuningGPTEmbedding)]}
+        self.name_key_to_mcore_mixins = {AdapterName.PTUNING_ADAPTER: [('embedding', MCoreGPTEmbeddingMixin)]}
         super().__init__(cfg, trainer)
         self.virtual_tokens = cfg.peft.p_tuning.virtual_tokens
         self.trainable_keys = self.adapter_keys - set(
@@ -560,7 +560,7 @@ class MegatronGPTLoRAModel(MegatronGPTLayerwisePEFTModel):
         self.name_key_to_mcore_mixins = {}  # maps peft_key to a list of tuples (mcore_target, mcore_mixin)
         for k in self.peft_name_keys:
             self.name_key_to_cfg[k] = adapter_cfg
-            self.name_key_to_mcore_mixins[k] = [("linear_qkv", LoraTELinear)]
+            self.name_key_to_mcore_mixins[k] = [("self_attention", MCoreSelfAttentionMixin)]
         self.layer_selection = lora_cfg.get("layer_selection", None)
         if self.layer_selection is None:
             self.layer_selection = list(range(1, cfg.num_layers + 1))

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
@@ -632,14 +632,20 @@ class MegatronGPTLoRAModelWeightTying(MegatronGPTLayerwisePEFTModel):
 
     def tie_weights(self,):
         pos_idx = 0
-        layer0 = self.model.language_model.encoder.layers[0]
+
+        if self.mcore_gpt:
+            layers = self.model.decoder.layers
+        else:
+            layers = self.model.language_model.encoder.layers
+
+        layer0 = layers[0]
         for adapter_name in layer0.self_attention.adapter_layer:
             adapter = layer0.self_attention.get_adapter_module(adapter_name)
             print(adapter_name, pos_idx)
             adapter.set_position(pos_idx)
             pos_idx += 1
 
-        for layer in self.model.language_model.encoder.layers[1:]:
+        for layer in layers[1:]:
             for adapter_name in layer.self_attention.adapter_layer:
                 print(adapter_name, pos_idx)
                 adapter_l = layer.self_attention.get_adapter_module(adapter_name)

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_peft_models.py
@@ -119,7 +119,6 @@ class MegatronGPTPEFTModel(MegatronGPTSFTModel):
             # state_dict keys needs to be in non-O2 format and will be corrected in PEFTSaveRestoreConnector if O2=True
             new_k = k.replace("model.module.", "model.", 1)
             peft_state_dict[new_k] = state_dict[k]
-            peft_state_dict[k] = state_dict[k]
         return peft_state_dict
 
     def state_dict(self, destination=None, prefix=None, keep_vars=False):
@@ -130,7 +129,7 @@ class MegatronGPTPEFTModel(MegatronGPTSFTModel):
             # we want all the params with the same keys as calling self.state_dict()
             # but we can't call self.state_dict() here as it would be a recursive call.
             # so we call self.model.state_dict(prefix="model.") which will return all the keys and params same as calling self.state_dict()
-            return self.model.state_dict(prefix="model.module." if self.cfg.megatron_amp_O2 else "model.")
+            return self.model.state_dict(prefix="model.")
 
     def load_state_dict(self, state_dict, strict: bool = True):
         if self.setup_complete:
@@ -418,7 +417,7 @@ class MegatronGPTPTuningModel(MegatronGPTPEFTModel):
             # there should be no params in the state_dict
             return {}
         else:
-            return self.model.state_dict(prefix="model.module." if self.cfg.megatron_amp_O2 else "model.")
+            return self.model.state_dict(prefix="model.")
 
     def load_state_dict(self, state_dict, strict: bool = True):
         """ 

--- a/nemo/collections/nlp/modules/common/megatron/adapters/mcore_mixins.py
+++ b/nemo/collections/nlp/modules/common/megatron/adapters/mcore_mixins.py
@@ -1,0 +1,67 @@
+import torch
+
+from nemo.collections.nlp.modules.common.megatron.adapters.parallel_adapters import (
+    AdapterName,
+    LoraKQVAdapterConfig,
+    PromptEncoderAdapterConfig
+)
+from nemo.core import adapter_mixins
+from nemo.utils import model_utils
+
+from megatron.core.models.gpt.gpt_embedding import GPTEmbedding
+from megatron.core.transformer.custom_layers.transformer_engine import TELinear
+
+
+def swap_mcore_mixin(module, mcore_mixin):
+    """
+    Casts module to mcore_mixin and register corresponding adapters.
+    """
+    module.__class__ = mcore_mixin
+    module.mcore_register_adapters()
+
+
+class McoreAdapterModuleMixin(adapter_mixins.AdapterModuleMixin):
+    def mcore_register_adapters(self):
+        raise NotImplementedError("Mcore mixins should implement setup_adapters on a subclass of MyBase")
+
+
+class LoraTELinear(TELinear, McoreAdapterModuleMixin):
+    def mcore_register_adapters(self):
+        self.set_accepted_adapter_types(
+            [
+                LoraKQVAdapterConfig._target_,  # only self attn (packed qkv) for now
+                # LoraQAdapterConfig._target_,
+                # LoraKVAdapterConfig._target_,
+            ]
+        )
+
+    def forward(self, x):
+        mixed_x_layer, bias = super().forward(x)
+
+        if self.is_adapter_available():
+                lora_kqv_adapter = self.get_adapter_module(AdapterName.LORA_KQV_ADAPTER)
+                if lora_kqv_adapter:
+                    lora_mixed_x_layer = lora_kqv_adapter(x)
+                    mixed_x_layer = mixed_x_layer + lora_mixed_x_layer
+        
+        return mixed_x_layer, bias
+
+
+class PtuningGPTEmbedding(GPTEmbedding, McoreAdapterModuleMixin):
+    def mcore_register_adapters(self):
+        self.set_accepted_adapter_types([PromptEncoderAdapterConfig._target_])
+
+    def forward(self, input_ids, position_ids):
+        encoder_input = super().forward(input_ids, position_ids)
+
+        if self.is_adapter_available():
+            _sq, _bs, _hs = encoder_input.size()
+            ptuning_adapter = self.get_adapter_module(AdapterName.PTUNING_ADAPTER)
+            v = ptuning_adapter.virtual_tokens
+            if ptuning_adapter and _sq >= v:  # The sequence should be longer the v to insert virtual embeddings.
+                virtual_embeddings = ptuning_adapter(_bs)
+                encoder_input = encoder_input[
+                    v:, :, :
+                ]  # the first v tokens are pads so that they can be swapped out with virtual embeddings.
+                encoder_input = torch.concat([virtual_embeddings, encoder_input], dim=0)
+        return encoder_input

--- a/nemo/collections/nlp/modules/common/megatron/adapters/mcore_mixins.py
+++ b/nemo/collections/nlp/modules/common/megatron/adapters/mcore_mixins.py
@@ -1,15 +1,14 @@
 import torch
+from megatron.core.models.gpt.gpt_embedding import GPTEmbedding
+from megatron.core.transformer.custom_layers.transformer_engine import TELinear
 
 from nemo.collections.nlp.modules.common.megatron.adapters.parallel_adapters import (
     AdapterName,
     LoraKQVAdapterConfig,
-    PromptEncoderAdapterConfig
+    PromptEncoderAdapterConfig,
 )
 from nemo.core import adapter_mixins
 from nemo.utils import model_utils
-
-from megatron.core.models.gpt.gpt_embedding import GPTEmbedding
-from megatron.core.transformer.custom_layers.transformer_engine import TELinear
 
 
 def swap_mcore_mixin(module, mcore_mixin):
@@ -39,11 +38,11 @@ class LoraTELinear(TELinear, McoreAdapterModuleMixin):
         mixed_x_layer, bias = super().forward(x)
 
         if self.is_adapter_available():
-                lora_kqv_adapter = self.get_adapter_module(AdapterName.LORA_KQV_ADAPTER)
-                if lora_kqv_adapter:
-                    lora_mixed_x_layer = lora_kqv_adapter(x)
-                    mixed_x_layer = mixed_x_layer + lora_mixed_x_layer
-        
+            lora_kqv_adapter = self.get_adapter_module(AdapterName.LORA_KQV_ADAPTER)
+            if lora_kqv_adapter:
+                lora_mixed_x_layer = lora_kqv_adapter(x)
+                mixed_x_layer = mixed_x_layer + lora_mixed_x_layer
+
         return mixed_x_layer, bias
 
 

--- a/nemo/collections/nlp/modules/common/megatron/adapters/mcore_mixins.py
+++ b/nemo/collections/nlp/modules/common/megatron/adapters/mcore_mixins.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import torch
 from megatron.core.models.gpt.gpt_embedding import GPTEmbedding
 from megatron.core.transformer.attention import SelfAttention

--- a/nemo/collections/nlp/modules/common/megatron/adapters/parallel_adapters.py
+++ b/nemo/collections/nlp/modules/common/megatron/adapters/parallel_adapters.py
@@ -322,7 +322,7 @@ class PromptEncoderAdapter(nn.Module, AdapterModuleUtil):
         gradient_accumulation_fusion = False
         # (@adithyare) the persistent=False will not pollute the indices into the state_dict of this module.
         self.register_buffer("indices", torch.LongTensor(list(range(self.virtual_tokens))), persistent=False)
-        self.prompt_embedding = torch.nn.Embedding(self.virtual_tokens, self.embedding_dim)
+        self.embedding = torch.nn.Embedding(self.virtual_tokens, self.embedding_dim)
         self.inference_table = InferenceTable("taskname", self.output_dim, self.virtual_tokens)
         self.first = ColumnParallelLinear(
             self.embedding_dim,
@@ -366,7 +366,7 @@ class PromptEncoderAdapter(nn.Module, AdapterModuleUtil):
         return self.inference_table.get_prompt_table()
 
     def inner_forward(self,):
-        input_embeds = self.prompt_embedding(self.indices).unsqueeze(0)
+        input_embeds = self.embedding(self.indices).unsqueeze(0)
         intermediate_parallel, bias_parallel = self.first(input_embeds)
         intermediate_parallel = fused_bias_gelu(intermediate_parallel, bias_parallel)
         output_embeds, bias_parallel = self.second(intermediate_parallel)

--- a/nemo/collections/nlp/modules/common/megatron/adapters/parallel_adapters.py
+++ b/nemo/collections/nlp/modules/common/megatron/adapters/parallel_adapters.py
@@ -322,7 +322,7 @@ class PromptEncoderAdapter(nn.Module, AdapterModuleUtil):
         gradient_accumulation_fusion = False
         # (@adithyare) the persistent=False will not pollute the indices into the state_dict of this module.
         self.register_buffer("indices", torch.LongTensor(list(range(self.virtual_tokens))), persistent=False)
-        self.embedding = torch.nn.Embedding(self.virtual_tokens, self.embedding_dim)
+        self.prompt_embedding = torch.nn.Embedding(self.virtual_tokens, self.embedding_dim)
         self.inference_table = InferenceTable("taskname", self.output_dim, self.virtual_tokens)
         self.first = ColumnParallelLinear(
             self.embedding_dim,
@@ -366,7 +366,7 @@ class PromptEncoderAdapter(nn.Module, AdapterModuleUtil):
         return self.inference_table.get_prompt_table()
 
     def inner_forward(self,):
-        input_embeds = self.embedding(self.indices).unsqueeze(0)
+        input_embeds = self.prompt_embedding(self.indices).unsqueeze(0)
         intermediate_parallel, bias_parallel = self.first(input_embeds)
         intermediate_parallel = fused_bias_gelu(intermediate_parallel, bias_parallel)
         output_embeds, bias_parallel = self.second(intermediate_parallel)

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -55,6 +55,7 @@ except (ImportError, ModuleNotFoundError):
     HAVE_APEX = False
 
 try:
+    from megatron.core.transformer.module import Float16Module as MCoreFloat16Module
     from megatron.core import parallel_state
 
     HAVE_MEGATRON_CORE = True
@@ -227,7 +228,7 @@ class NLPDDPStrategy(DDPStrategy):
             model_key = 'enc_dec_model'
             model_attr = self.lightning_module.enc_dec_model
         if model_key is not None:
-            if isinstance(model_attr, Float16Module):
+            if isinstance(model_attr, Float16Module) or isinstance(model_attr, MCoreFloat16Module):
                 new_state_dict = {}
                 for key in checkpoint['state_dict'].keys():
                     new_key = key.replace(f'{model_key}.', f'{model_key}.module.', 1)

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -55,8 +55,8 @@ except (ImportError, ModuleNotFoundError):
     HAVE_APEX = False
 
 try:
-    from megatron.core.transformer.module import Float16Module as MCoreFloat16Module
     from megatron.core import parallel_state
+    from megatron.core.transformer.module import Float16Module as MCoreFloat16Module
 
     HAVE_MEGATRON_CORE = True
 

--- a/scripts/nlp_language_modeling/convert_hf_llama_to_nemo.py
+++ b/scripts/nlp_language_modeling/convert_hf_llama_to_nemo.py
@@ -41,7 +41,8 @@ from transformers import LlamaForCausalLM, LlamaTokenizer
 
 
 from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel
-#from nemo.collections.nlp.modules.common.megatron.megatron_init import initialize_model_parallel_for_nemo
+
+# from nemo.collections.nlp.modules.common.megatron.megatron_init import initialize_model_parallel_for_nemo
 from nemo.collections.nlp.parts.nlp_overrides import (
     GradScaler,
     MegatronHalfPrecisionPlugin,
@@ -49,8 +50,9 @@ from nemo.collections.nlp.parts.nlp_overrides import (
     PipelineMixedPrecisionPlugin,
 )
 from nemo.utils import AppState, logging
-#from nemo.utils.distributed import initialize_distributed
-#from nemo.utils.model_utils import inject_model_parallel_rank, uninject_model_parallel_rank
+
+# from nemo.utils.distributed import initialize_distributed
+# from nemo.utils.model_utils import inject_model_parallel_rank, uninject_model_parallel_rank
 
 
 def get_args():
@@ -88,7 +90,9 @@ def load_model(cls, checkpoint, strict, **kwargs):
 
 
 def load_config(args, llama_config):
-    nemo_config = OmegaConf.load(os.path.join(os.path.dirname(__file__), '../../examples/nlp/language_modeling/conf/megatron_llama_config.yaml')).model
+    nemo_config = OmegaConf.load(
+        os.path.join(os.path.dirname(__file__), '../../examples/nlp/language_modeling/conf/megatron_llama_config.yaml')
+    ).model
     nemo_config.encoder_seq_length = llama_config['max_position_embeddings']
     nemo_config.num_layers = int(llama_config['num_hidden_layers'])
     nemo_config.hidden_size = llama_config['hidden_size']
@@ -117,8 +121,8 @@ def convert(args):
     print(f"hf_config: {hf_config}")
     print("named parameters:")
     for name, param in model.named_parameters():
-       print(f"- {name}")
-    
+        print(f"- {name}")
+
     nemo_config = load_config(args, hf_config)
 
     if args.precision in ["32", "16"]:
@@ -129,7 +133,7 @@ def convert(args):
             precision = args.precision
         else:
             logging.warning("BF16 is not supported on this device. Using FP16 instead.")
-            precision = args.precision[2:] # prune bf in string
+            precision = args.precision[2:]  # prune bf in string
 
     plugins = []
     if precision in [16, '16', 'bf16', '16-mixed', 'bf16-mixed']:
@@ -201,29 +205,25 @@ def convert(args):
         num_query_groups = head_num
     else:
         num_query_groups = nemo_config.num_query_groups
-        assert (
-            head_num % num_query_groups == 0
-        ), 'head_num must be divisible by num_query_groups'
+        assert head_num % num_query_groups == 0, 'head_num must be divisible by num_query_groups'
     if mcore_gpt:
-        assert (
-            nemo_config.activation.startswith('fast-')
-        ), 'mcore only supports fast version of gated linear unit.'
+        assert nemo_config.activation.startswith('fast-'), 'mcore only supports fast version of gated linear unit.'
 
     for l in range(int(num_layers)):
         print(f"converting layer {l}")
         old_tensor_shape = model.state_dict()[f'model.layers.{l}.self_attn.q_proj.weight'].size()
         new_q_tensor_shape = (head_num, head_size) + old_tensor_shape[1:]
-        new_kv_tensor_shape = (num_query_groups,  head_size) + old_tensor_shape[1:]
+        new_kv_tensor_shape = (num_query_groups, head_size) + old_tensor_shape[1:]
         q = model.state_dict()[f'model.layers.{l}.self_attn.q_proj.weight'].view(*new_q_tensor_shape)
         k = model.state_dict()[f'model.layers.{l}.self_attn.k_proj.weight'].view(*new_kv_tensor_shape)
         v = model.state_dict()[f'model.layers.{l}.self_attn.v_proj.weight'].view(*new_kv_tensor_shape)
-        qkv_weights=torch.empty((0, head_size) + old_tensor_shape[1:])
+        qkv_weights = torch.empty((0, head_size) + old_tensor_shape[1:])
         heads_per_group = head_num // num_query_groups
         for i in range(num_query_groups):
-            qkv_weights = torch.cat((qkv_weights, q[i * heads_per_group : (i+1) * heads_per_group,:,:]))
-            qkv_weights = torch.cat((qkv_weights, k[i:i+1,:,:]))
-            qkv_weights = torch.cat((qkv_weights, v[i:i+1,:,:]))
-        #qkv_weights = torch.cat((q, k, v), axis=1)
+            qkv_weights = torch.cat((qkv_weights, q[i * heads_per_group : (i + 1) * heads_per_group, :, :]))
+            qkv_weights = torch.cat((qkv_weights, k[i : i + 1, :, :]))
+            qkv_weights = torch.cat((qkv_weights, v[i : i + 1, :, :]))
+        # qkv_weights = torch.cat((q, k, v), axis=1)
         qkv_weights = qkv_weights.reshape([head_size * (head_num + 2 * num_query_groups), hidden_size])
         if mcore_gpt:
             qkv_weights_base_name = f'model.decoder.layers.{l}.self_attention.linear_qkv.weight'
@@ -307,12 +307,12 @@ def convert(args):
     # cast to target precision and disable cpu init
     model = model.to(dtype=dtype)
     model.cfg.use_cpu_initialization = False
-    
+
     model.save_to(args.out_file)
     logging.info(f'NeMo model saved to: {args.out_file}')
 
 
 if __name__ == '__main__':
     args = get_args()
-    #os.chdir(args.in_file)
+    # os.chdir(args.in_file)
     convert(args)


### PR DESCRIPTION
Add PEFT adapter support for mcore gpt path.

contains a nemo.core change to accept kwargs to pass into hydra instantiate.

currently only support Ptuning and Lora now.

tested on llama2 7b TP SP PP DP