### PR TITLE
Conv1d subsampling

### DIFF
--- a/nemo/collections/asr/parts/submodules/subsampling.py
+++ b/nemo/collections/asr/parts/submodules/subsampling.py
@@ -252,7 +252,7 @@ class ConvSubsampling(torch.nn.Module):
                 layers.append(activation)
                 in_channels = conv_channels
 
-        elif subsampling == 'striding_conv1d_k5':
+        elif subsampling == 'striding_conv1d':
 
             in_channels = feat_in
 
@@ -293,7 +293,7 @@ class ConvSubsampling(torch.nn.Module):
                 layers.append(activation)
                 in_channels = conv_channels
 
-        elif subsampling == 'dw_striding_conv1d_k5':
+        elif subsampling == 'dw_striding_conv1d':
 
             in_channels = feat_in
 
@@ -368,7 +368,7 @@ class ConvSubsampling(torch.nn.Module):
             )
             self.out = torch.nn.Linear(conv_channels * int(out_length), feat_out)
             self.conv2d_subsampling = True
-        elif subsampling in ["striding_conv1d_k5", "dw_striding_conv1d_k5"]:
+        elif subsampling in ["striding_conv1d", "dw_striding_conv1d"]:
             self.conv2d_subsampling = False
         else:
             raise ValueError(f"Not valid sub-sampling: {subsampling}!")

--- a/nemo/collections/asr/parts/submodules/subsampling.py
+++ b/nemo/collections/asr/parts/submodules/subsampling.py
@@ -322,7 +322,7 @@ class ConvSubsampling(torch.nn.Module):
                         stride=1,
                         padding=0,
                         groups=1,
-                    )
+                    ),
                 ]
             )
             in_channels = conv_channels
@@ -356,7 +356,7 @@ class ConvSubsampling(torch.nn.Module):
             raise ValueError(f"Not valid sub-sampling: {subsampling}!")
 
         if subsampling in ["vggnet", "dw_striding", "striding"]:
-            
+
             in_length = torch.tensor(feat_in, dtype=torch.float)
             out_length = calc_length(
                 lengths=in_length,

--- a/nemo/collections/asr/parts/submodules/subsampling.py
+++ b/nemo/collections/asr/parts/submodules/subsampling.py
@@ -394,6 +394,9 @@ class ConvSubsampling(torch.nn.Module):
         # Unsqueeze Channel Axis
         if self.conv2d_subsampling:
             x = x.unsqueeze(1)
+        # Transpose to Channel First mode
+        else:
+            x = x.transpose(1, 2)
 
         # split inputs if chunking_factor is set
         if self.subsampling_conv_chunking_factor != -1 and self.conv2d_subsampling:
@@ -426,6 +429,7 @@ class ConvSubsampling(torch.nn.Module):
         if self.conv2d_subsampling:
             b, c, t, f = x.size()
             x = self.out(x.transpose(1, 2).reshape(b, t, -1))
+        # Transpose to Channel Last mode
         else:
             x = x.transpose(1, 2)
 

--- a/nemo/collections/asr/parts/submodules/subsampling.py
+++ b/nemo/collections/asr/parts/submodules/subsampling.py
@@ -18,7 +18,7 @@ import torch
 import torch.nn as nn
 from torch.nn import LayerNorm
 
-from nemo.collections.asr.parts.submodules.causal_convs import CausalConv2D
+from nemo.collections.asr.parts.submodules.causal_convs import CausalConv1D, CausalConv2D
 from nemo.utils import logging
 
 
@@ -251,19 +251,128 @@ class ConvSubsampling(torch.nn.Module):
                     )
                 layers.append(activation)
                 in_channels = conv_channels
+
+        elif subsampling == 'striding_conv1d_k5':
+
+            in_channels = feat_in
+
+            self._stride = 2
+            self._kernel_size = 5
+            self._ceil_mode = False
+
+            if self.is_causal:
+                self._left_padding = self._kernel_size - 1
+                self._right_padding = self._stride - 1
+                self._max_cache_len = subsampling_factor + 1
+            else:
+                self._left_padding = (self._kernel_size - 1) // 2
+                self._right_padding = (self._kernel_size - 1) // 2
+                self._max_cache_len = 0
+
+            for i in range(self._sampling_num):
+                if self.is_causal:
+                    layers.append(
+                        CausalConv1D(
+                            in_channels=in_channels,
+                            out_channels=feat_out if self._sampling_num == i + 1 else conv_channels,
+                            kernel_size=self._kernel_size,
+                            stride=self._stride,
+                            padding=None,
+                        )
+                    )
+                else:
+                    layers.append(
+                        torch.nn.Conv1d(
+                            in_channels=in_channels,
+                            out_channels=feat_out if self._sampling_num == i + 1 else conv_channels,
+                            kernel_size=self._kernel_size,
+                            stride=self._stride,
+                            padding=self._left_padding,
+                        )
+                    )
+                layers.append(activation)
+                in_channels = conv_channels
+
+        elif subsampling == 'dw_striding_conv1d_k5':
+
+            in_channels = feat_in
+
+            self._stride = 2
+            self._kernel_size = 5
+            self._ceil_mode = False
+
+            self._left_padding = (self._kernel_size - 1) // 2
+            self._right_padding = (self._kernel_size - 1) // 2
+
+            # Layer 1
+            layers.extend(
+                [
+                    torch.nn.Conv1d(
+                        in_channels=in_channels,
+                        out_channels=in_channels,
+                        kernel_size=self._kernel_size,
+                        stride=self._stride,
+                        padding=self._left_padding,
+                        groups=in_channels,
+                    ),
+                    torch.nn.Conv1d(
+                        in_channels=in_channels,
+                        out_channels=feat_out if self._sampling_num == 1 else conv_channels,
+                        kernel_size=1,
+                        stride=1,
+                        padding=0,
+                        groups=1,
+                    )
+                ]
+            )
+            in_channels = conv_channels
+            layers.append(activation)
+
+            for i in range(self._sampling_num - 1):
+                layers.extend(
+                    [
+                        torch.nn.Conv1d(
+                            in_channels=in_channels,
+                            out_channels=in_channels,
+                            kernel_size=self._kernel_size,
+                            stride=self._stride,
+                            padding=self._left_padding,
+                            groups=in_channels,
+                        ),
+                        torch.nn.Conv1d(
+                            in_channels=in_channels,
+                            out_channels=feat_out if self._sampling_num == i + 2 else conv_channels,
+                            kernel_size=1,
+                            stride=1,
+                            padding=0,
+                            groups=1,
+                        ),
+                    ]
+                )
+                layers.append(activation)
+                in_channels = conv_channels
+
         else:
             raise ValueError(f"Not valid sub-sampling: {subsampling}!")
 
-        in_length = torch.tensor(feat_in, dtype=torch.float)
-        out_length = calc_length(
-            lengths=in_length,
-            all_paddings=self._left_padding + self._right_padding,
-            kernel_size=self._kernel_size,
-            stride=self._stride,
-            ceil_mode=self._ceil_mode,
-            repeat_num=self._sampling_num,
-        )
-        self.out = torch.nn.Linear(conv_channels * int(out_length), feat_out)
+        if subsampling in ["vggnet", "dw_striding", "striding"]:
+            
+            in_length = torch.tensor(feat_in, dtype=torch.float)
+            out_length = calc_length(
+                lengths=in_length,
+                all_paddings=self._left_padding + self._right_padding,
+                kernel_size=self._kernel_size,
+                stride=self._stride,
+                ceil_mode=self._ceil_mode,
+                repeat_num=self._sampling_num,
+            )
+            self.out = torch.nn.Linear(conv_channels * int(out_length), feat_out)
+            self.conv2d_subsampling = True
+        elif subsampling in ["striding_conv1d_k5", "dw_striding_conv1d_k5"]:
+            self.conv2d_subsampling = False
+        else:
+            raise ValueError(f"Not valid sub-sampling: {subsampling}!")
+
         self.conv = torch.nn.Sequential(*layers)
 
     def get_sampling_frames(self):
@@ -281,10 +390,13 @@ class ConvSubsampling(torch.nn.Module):
             ceil_mode=self._ceil_mode,
             repeat_num=self._sampling_num,
         )
-        x = x.unsqueeze(1)
+
+        # Unsqueeze Channel Axis
+        if self.conv2d_subsampling:
+            x = x.unsqueeze(1)
 
         # split inputs if chunking_factor is set
-        if self.subsampling_conv_chunking_factor != -1:
+        if self.subsampling_conv_chunking_factor != -1 and self.conv2d_subsampling:
             if self.subsampling_conv_chunking_factor == 1:
                 # if subsampling_conv_chunking_factor is 1, we split only if needed
                 # avoiding a bug / feature limiting indexing of tensors to 2**31
@@ -310,8 +422,13 @@ class ConvSubsampling(torch.nn.Module):
         else:
             x = self.conv(x)
 
-        b, c, t, f = x.size()
-        x = self.out(x.transpose(1, 2).reshape(b, t, -1))
+        # Flatten Channel and Frequency Axes
+        if self.conv2d_subsampling:
+            b, c, t, f = x.size()
+            x = self.out(x.transpose(1, 2).reshape(b, t, -1))
+        else:
+            x = x.transpose(1, 2)
+
         return x, lengths
 
     def reset_parameters(self):


### PR DESCRIPTION
# What does this PR do ?

Add conv1d subsampling for ASR

**Collection**: asr

# Changelog 
- Add 'striding_conv1d' and 'dw_striding_conv1d' subsampling options. Subsampling is performed using strided conv1d convolutions with kernel size 5 instead of doing reshape + frequency-temporal conv2d + reshape + linear projection.

# Usage
* Simply use 'subsampling: striding_conv1d in conformer yaml config for example.

```
  encoder:
      _target_: nemo.collections.asr.modules.ConformerEncoder
      feat_in: ${model.video_front_end.dim_output}
      feat_out: -1 # you may set it if you need different output size other than the default d_model
      n_layers: 18
      d_model: 512
  
      # Sub-sampling params
      subsampling: striding_conv1d # vggnet, striding, stacking or stacking_norm, dw_striding, striding_conv1d_k5, dw_striding_conv1d
      subsampling_factor: 8 # must be power of 2 for striding and vggne
...
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
