### PR TITLE
Replace prefetch with val iterator check in megatron models

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3157,24 +3157,25 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
         sh "rm -rf examples/nlp/language_modeling/retro_results"
       }
     }
-    stage('L2: BioMegatron Bert NER Task') {
-      when {
-        anyOf {
-          branch 'main'
-          changeRequest target: 'main'
-        }
-      }
-      failFast true
-      steps {
-        sh "python examples/nlp/token_classification/token_classification_train.py \
-        exp_manager.exp_dir=examples/nlp/language_modeling/token_classification_results \
-        trainer.max_epochs=1 \
-        model.dataset.data_dir=/home/TestData/nlp/ner \
-        model.language_model.pretrained_model_name=biomegatron345m_biovocab_30k_cased \
-        model.tokenizer.tokenizer_name=null"
-        sh "rm -rf examples/nlp/language_modeling/token_classification_results"
-      }
-    }
+    // Comment temporarily
+    // stage('L2: BioMegatron Bert NER Task') {
+    //   when {
+    //     anyOf {
+    //       branch 'main'
+    //       changeRequest target: 'main'
+    //     }
+    //   }
+    //   failFast true
+    //   steps {
+    //     sh "python examples/nlp/token_classification/token_classification_train.py \
+    //     exp_manager.exp_dir=examples/nlp/language_modeling/token_classification_results \
+    //     trainer.max_epochs=1 \
+    //     model.dataset.data_dir=/home/TestData/nlp/ner \
+    //     model.language_model.pretrained_model_name=biomegatron345m_biovocab_30k_cased \
+    //     model.tokenizer.tokenizer_name=null"
+    //     sh "rm -rf examples/nlp/language_modeling/token_classification_results"
+    //   }
+    // }
     stage('L2: Megatron GPT Pretraining and Resume Training TP=2') {
       when {
         anyOf {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3189,7 +3189,7 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
         trainer.accelerator=gpu \
         trainer.log_every_n_steps=1 \
         trainer.val_check_interval=2 \
-        trainer.limit_val_batches=1 \
+        trainer.limit_val_batches=2 \
         trainer.accumulate_grad_batches=1 \
         trainer.max_steps=3 \
         trainer.precision=16 \
@@ -4652,7 +4652,7 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
         trainer.accelerator=gpu \
         trainer.log_every_n_steps=1 \
         trainer.val_check_interval=2 \
-        trainer.limit_val_batches=1 \
+        trainer.limit_val_batches=5 \
         trainer.accumulate_grad_batches=1 \
         trainer.max_steps=6 \
         trainer.precision=16 \
@@ -4838,7 +4838,7 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
           steps {
             sh "python examples/nlp/language_modeling/megatron_gpt_pretraining.py \
             trainer.max_steps=10 \
-            trainer.limit_val_batches=1 \
+            trainer.limit_val_batches=7 \
             trainer.val_check_interval=10 \
             exp_manager.exp_dir=examples/nlp/language_modeling/gpt_pretrain_results \
             model.data.data_impl=mock \
@@ -4851,7 +4851,7 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
           steps {
             sh "python examples/nlp/language_modeling/megatron_t5_pretraining.py \
             trainer.max_steps=10 \
-            trainer.limit_val_batches=1 \
+            trainer.limit_val_batches=3 \
             trainer.val_check_interval=10 \
             exp_manager.exp_dir=examples/nlp/language_modeling/t5_pretrain_results \
             model.data.data_impl=mock \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3189,7 +3189,7 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
         trainer.accelerator=gpu \
         trainer.log_every_n_steps=1 \
         trainer.val_check_interval=2 \
-        trainer.limit_val_batches=2 \
+        trainer.limit_val_batches=1 \
         trainer.accumulate_grad_batches=1 \
         trainer.max_steps=3 \
         trainer.precision=16 \
@@ -4652,6 +4652,7 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
         trainer.accelerator=gpu \
         trainer.log_every_n_steps=1 \
         trainer.val_check_interval=2 \
+        trainer.limit_val_batches=1 \
         trainer.accumulate_grad_batches=1 \
         trainer.max_steps=6 \
         trainer.precision=16 \
@@ -4837,6 +4838,7 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
           steps {
             sh "python examples/nlp/language_modeling/megatron_gpt_pretraining.py \
             trainer.max_steps=10 \
+            trainer.limit_val_batches=1 \
             trainer.val_check_interval=10 \
             exp_manager.exp_dir=examples/nlp/language_modeling/gpt_pretrain_results \
             model.data.data_impl=mock \
@@ -4849,6 +4851,7 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
           steps {
             sh "python examples/nlp/language_modeling/megatron_t5_pretraining.py \
             trainer.max_steps=10 \
+            trainer.limit_val_batches=1 \
             trainer.val_check_interval=10 \
             exp_manager.exp_dir=examples/nlp/language_modeling/t5_pretrain_results \
             model.data.data_impl=mock \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3157,25 +3157,24 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
         sh "rm -rf examples/nlp/language_modeling/retro_results"
       }
     }
-    // Comment temporarily
-    // stage('L2: BioMegatron Bert NER Task') {
-    //   when {
-    //     anyOf {
-    //       branch 'main'
-    //       changeRequest target: 'main'
-    //     }
-    //   }
-    //   failFast true
-    //   steps {
-    //     sh "python examples/nlp/token_classification/token_classification_train.py \
-    //     exp_manager.exp_dir=examples/nlp/language_modeling/token_classification_results \
-    //     trainer.max_epochs=1 \
-    //     model.dataset.data_dir=/home/TestData/nlp/ner \
-    //     model.language_model.pretrained_model_name=biomegatron345m_biovocab_30k_cased \
-    //     model.tokenizer.tokenizer_name=null"
-    //     sh "rm -rf examples/nlp/language_modeling/token_classification_results"
-    //   }
-    // }
+    stage('L2: BioMegatron Bert NER Task') {
+      when {
+        anyOf {
+          branch 'main'
+          changeRequest target: 'main'
+        }
+      }
+      failFast true
+      steps {
+        sh "python examples/nlp/token_classification/token_classification_train.py \
+        exp_manager.exp_dir=examples/nlp/language_modeling/token_classification_results \
+        trainer.max_epochs=1 \
+        model.dataset.data_dir=/home/TestData/nlp/ner \
+        model.language_model.pretrained_model_name=biomegatron345m_biovocab_30k_cased \
+        model.tokenizer.tokenizer_name=null"
+        sh "rm -rf examples/nlp/language_modeling/token_classification_results"
+      }
+    }
     stage('L2: Megatron GPT Pretraining and Resume Training TP=2') {
       when {
         anyOf {

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -820,13 +820,29 @@ class MegatronBaseModel(NLPModel):
         """
         Check if we reached trainer.limit_val_batches, if so exhaust the iterator to raise a StopIteration and exit validation_step
         """
-        if self._val_micro_batches_consumed == self.trainer.num_sanity_val_steps or self._val_micro_batches_consumed == self.trainer.limit_val_batches:
+        # if self._val_micro_batches_consumed == self.trainer.num_sanity_val_steps or self._val_micro_batches_consumed == self.trainer.limit_val_batches:
+        #     try:
+        #         element = next(iterator) # exhausting the iterator so that PTL knows to go to validation_epoch_end
+        #         # reinsert the element into the iterator
+        #         return itertools.chain([element], iterator), False
+        #     except StopIteration:
+        #         self._val_micro_batches_consumed=0
+        #         return iterator, True
+        # else:
+        #     return iterator, False
+
+        # try:
+        #     element = next(iterator) # exhausting the iterator so that PTL knows to go to validation_epoch_end
+        #     return itertools.chain([element], iterator), False
+        # except StopIteration:
+        #     return iterator, True
+        
+        if self._val_micro_batches_consumed and (self.trainer.sanity_checking or self._val_micro_batches_consumed == self.trainer.limit_val_batches):
+            self._val_micro_batches_consumed=0
             try:
-                element = next(iterator) # exhausting the iterator so that PTL knows to go to validation_epoch_end
-                # reinsert the element into the iterator
-                return itertools.chain([element], iterator), False
+                _ = next(iterator) # exhausting the iterator so that PTL knows to go to validation_epoch_end
             except StopIteration:
-                self._val_micro_batches_consumed=0
-                return iterator, True
+                return True
         else:
-            return iterator, False
+            return False
+      

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -824,4 +824,3 @@ class MegatronBaseModel(NLPModel):
             return iterator, True
         # reinsert the element back to the iterator
         return itertools.chain([element], iterator), False
-      

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -820,23 +820,6 @@ class MegatronBaseModel(NLPModel):
         """
         Check if we reached trainer.limit_val_batches, if so exhaust the iterator to raise a StopIteration and exit validation_step
         """
-        # if self._val_micro_batches_consumed == self.trainer.num_sanity_val_steps or self._val_micro_batches_consumed == self.trainer.limit_val_batches:
-        #     try:
-        #         element = next(iterator) # exhausting the iterator so that PTL knows to go to validation_epoch_end
-        #         # reinsert the element into the iterator
-        #         return itertools.chain([element], iterator), False
-        #     except StopIteration:
-        #         self._val_micro_batches_consumed=0
-        #         return iterator, True
-        # else:
-        #     return iterator, False
-
-        # try:
-        #     element = next(iterator) # exhausting the iterator so that PTL knows to go to validation_epoch_end
-        #     return itertools.chain([element], iterator), False
-        # except StopIteration:
-        #     return iterator, True
-        
         if self._val_micro_batches_consumed and (self.trainer.sanity_checking or self._val_micro_batches_consumed == self.trainer.limit_val_batches):
             self._val_micro_batches_consumed=0
             try:

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -820,8 +820,8 @@ class MegatronBaseModel(NLPModel):
         """
         try:
             element = next(iterator)
-            # reinsert the element back to the iterator
-            return itertools.chain([element], iterator), False
         except StopIteration:
             return iterator, True
+        # reinsert the element back to the iterator
+        return itertools.chain([element], iterator), False
       

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -814,16 +814,22 @@ class MegatronBaseModel(NLPModel):
         """
         #elements = []
         if self.total_val_micro_batches == 0:
-            return True
-        num_microbatches = get_num_microbatches()
-        for _ in range(num_microbatches):
-            # try:
-            #     element = next(iterator)
-            #     elements.append(element)
-            # except StopIteration:
-            #     return iterator, True
-            self.total_val_micro_batches-=1    
-        return False        
+            #reset
+            self.total_val_micro_batches = self.trainer.limit_val_batches
+            try:
+                element = next(iterator)
+            except StopIteration:
+                return True
+        else:
+            num_microbatches = get_num_microbatches()
+            for _ in range(num_microbatches):
+                # try:
+                #     element = next(iterator)
+                #     elements.append(element)
+                # except StopIteration:
+                #     return iterator, True
+                self.total_val_micro_batches-=1    
+            return False        
 
         # return a new iterator with the prefetched element reinserted at the front
         #return itertools.chain(elements, iterator), False

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -418,7 +418,7 @@ class MegatronBertModel(MegatronBaseModel):
 
     def validation_step(self, dataloader_iter, batch_idx):
         # Check if iterator is exhausted
-        done = self._val_iterator_done(dataloader_iter)
+        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
         if done:
             return
         prefix = "test" if self.trainer.testing else "val"
@@ -438,9 +438,6 @@ class MegatronBertModel(MegatronBaseModel):
             seq_length=seq_length,
             micro_batch_size=self.cfg.micro_batch_size,
         )
-
-        # Increment self._val_micro_batches_consumed so that validation is exited properly
-        self._val_micro_batches_consumed += get_num_microbatches()
 
         if losses_reduced_per_micro_batch:
             loss_tensors_list = [loss_reduced['loss'] for loss_reduced in losses_reduced_per_micro_batch]

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -421,7 +421,7 @@ class MegatronBertModel(MegatronBaseModel):
 
     def validation_step(self, dataloader_iter, batch_idx):
         # Check if iterator is exhausted
-        done = self._val_iterator_done(dataloader_iter)
+        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
         if done:
             return
         prefix = "test" if self.trainer.testing else "val"

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -148,9 +148,6 @@ class MegatronBertModel(MegatronBaseModel):
             self._nsys_profile_start_step *= grad_accum_steps
             self._nsys_profile_end_step *= grad_accum_steps
 
-        # Override limit_val_batches to be a multiple of num microbatches to prevent val_step from exiting in between a step
-        self._reconfigure_val_batches()
-
     def model_provider_func(self, pre_process, post_process):
         cfg = self.cfg
         num_tokentypes = 2 if cfg.bert_binary_head else 0
@@ -594,6 +591,8 @@ class MegatronBertModel(MegatronBaseModel):
         logging.info(f'Finished building LDDL Dataloaders')
 
     def build_train_valid_test_datasets(self):
+        # Override limit_val_batches to be a multiple of num microbatches to prevent val_step from exiting in between a step
+        self._reconfigure_val_batches()
         logging.info('Building Bert datasets.')
         if self.trainer.limit_val_batches > 1.0 and isinstance(self.trainer.limit_val_batches, float):
             raise ValueError("limit_val_batches must be an integer or float less than or equal to 1.0.")

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -148,6 +148,9 @@ class MegatronBertModel(MegatronBaseModel):
             self._nsys_profile_start_step *= grad_accum_steps
             self._nsys_profile_end_step *= grad_accum_steps
 
+        # Override limit_val_batches to be a multiple of num microbatches to prevent val_step from exiting in between a step
+        self._reconfigure_val_batches()
+
     def model_provider_func(self, pre_process, post_process):
         cfg = self.cfg
         num_tokentypes = 2 if cfg.bert_binary_head else 0

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -418,7 +418,7 @@ class MegatronBertModel(MegatronBaseModel):
 
     def validation_step(self, dataloader_iter, batch_idx):
         # Check if iterator is exhausted
-        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
+        done = self._val_iterator_done(dataloader_iter)
         if done:
             return
         prefix = "test" if self.trainer.testing else "val"

--- a/nemo/collections/nlp/models/language_modeling/megatron_finetune_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_finetune_model.py
@@ -298,77 +298,77 @@ class MegatronT5FinetuneModel(MegatronT5Model):
         )
 
     def inference_step(self, dataloader_iter, batch_idx: int, mode: str, dataloader_idx=0):
-        # Add try except since dataloader_iter in PTL 2.0 doesnt catch the end of the iterator
-        try:
-            # Regular finetuning datasets will return a list of dicts for each microbatch.
-            # But T0 datasets will return a single dict for the global batch.
-            batch = next(dataloader_iter)
-            batch_has_lang_information = isinstance(batch, list) and len(batch[0]) == 7
-            data_cfg = self.cfg.data.validation_ds if mode == 'validation' else self.cfg.data.test_ds
-
-            self._reconfigure_and_process_inference_batch(batch, data_cfg)
-
-            # NOTE: There could be extra keys in the processed_batch dictionary such as "langs" for XNLI,
-            # this will be ignored.
-            loss = self.fwd_bwd_step(itertools.chain([batch]), batch_idx, forward_only=True)
-
-            predicted_token_ids, _ = self.decode(
-                tokens_enc=batch['text_enc'],
-                enc_mask=batch['enc_mask'],
-                num_tokens_to_generate=30,
-                bos_id=self.tokenizer.pad_id if data_cfg.get('replace_bos_with_pad', False) else self.tokenizer.bos_id,
-            )
-
-            # Special ids to text function to handle stripping <eos> and special tokens with sentencepiece tokenizers.
-            preds_text = MegatronT5FinetuneModel.ids_to_text(predicted_token_ids, self.tokenizer)
-            labels_text = MegatronT5FinetuneModel.ids_to_text(batch['labels'], self.tokenizer)
-            input_text = MegatronT5FinetuneModel.ids_to_text(batch['text_enc'], self.tokenizer)
-
-            if not batch_has_lang_information:
-                categories = [None] * len(preds_text)
-            else:
-                categories = batch['lang']
-
-            metric = self.val_metric[dataloader_idx] if mode == 'validation' else self.test_metric[dataloader_idx]
-            assert len(categories) == len(preds_text) == len(labels_text)
-            for _, (pred, label, category) in enumerate(zip(preds_text, labels_text, categories)):
-                # To compute metrics like pearson or spearman correlation, we need to cast the predicted string and labels to floats.
-                pred, label = self.cast_for_metric(
-                    pred=pred,
-                    label=label,
-                    metric_name=self.val_metric_name if mode == 'validation' else self.test_metric_name,
-                    class_labels=data_cfg.metric.get('class_labels', None),
-                    labels_are_strings=data_cfg.metric.get('labels_are_strings', False),
-                )
-                if batch_has_lang_information:
-                    _ = metric(pred, label, category)
-                else:
-                    _ = metric(pred, label)
-
-            outputs = {
-                'preds': preds_text,
-                'labels': labels_text,
-                'categories': categories,
-                'inputs': input_text,
-            }
-
-            if isinstance(loss, dict):
-                outputs.update(loss)
-            else:
-                outputs['loss'] = loss
-            if mode == 'validation':
-                if type(self.trainer.val_dataloaders) == list and len(self.trainer.val_dataloaders) > 1:
-                    self.validation_step_outputs[dataloader_idx].append(outputs)
-                else:
-                    self.validation_step_outputs.append(outputs)
-            else:
-                if type(self.trainer.test_dataloaders) == list and len(self.trainer.test_dataloaders) > 1:
-                    self.test_step_outputs[dataloader_idx].append(outputs)
-                else:
-                    self.test_step_outputs.append(outputs)
-            return outputs
-        except StopIteration:
+        # Check if iterator is exhausted
+        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
+        if done:
             return
+        # Regular finetuning datasets will return a list of dicts for each microbatch.
+        # But T0 datasets will return a single dict for the global batch.
+        batch = next(dataloader_iter)
+        batch_has_lang_information = isinstance(batch, list) and len(batch[0]) == 7
+        data_cfg = self.cfg.data.validation_ds if mode == 'validation' else self.cfg.data.test_ds
+
+        self._reconfigure_and_process_inference_batch(batch, data_cfg)
+
+        # NOTE: There could be extra keys in the processed_batch dictionary such as "langs" for XNLI,
+        # this will be ignored.
+        loss = self.fwd_bwd_step(itertools.chain([batch]), batch_idx, forward_only=True)
+
+        predicted_token_ids, _ = self.decode(
+            tokens_enc=batch['text_enc'],
+            enc_mask=batch['enc_mask'],
+            num_tokens_to_generate=30,
+            bos_id=self.tokenizer.pad_id if data_cfg.get('replace_bos_with_pad', False) else self.tokenizer.bos_id,
+        )
+
+        # Special ids to text function to handle stripping <eos> and special tokens with sentencepiece tokenizers.
+        preds_text = MegatronT5FinetuneModel.ids_to_text(predicted_token_ids, self.tokenizer)
+        labels_text = MegatronT5FinetuneModel.ids_to_text(batch['labels'], self.tokenizer)
+        input_text = MegatronT5FinetuneModel.ids_to_text(batch['text_enc'], self.tokenizer)
+
+        if not batch_has_lang_information:
+            categories = [None] * len(preds_text)
+        else:
+            categories = batch['lang']
+
+        metric = self.val_metric[dataloader_idx] if mode == 'validation' else self.test_metric[dataloader_idx]
+        assert len(categories) == len(preds_text) == len(labels_text)
+        for _, (pred, label, category) in enumerate(zip(preds_text, labels_text, categories)):
+            # To compute metrics like pearson or spearman correlation, we need to cast the predicted string and labels to floats.
+            pred, label = self.cast_for_metric(
+                pred=pred,
+                label=label,
+                metric_name=self.val_metric_name if mode == 'validation' else self.test_metric_name,
+                class_labels=data_cfg.metric.get('class_labels', None),
+                labels_are_strings=data_cfg.metric.get('labels_are_strings', False),
+            )
+            if batch_has_lang_information:
+                _ = metric(pred, label, category)
+            else:
+                _ = metric(pred, label)
+
+        outputs = {
+            'preds': preds_text,
+            'labels': labels_text,
+            'categories': categories,
+            'inputs': input_text,
+        }
+
+        if isinstance(loss, dict):
+            outputs.update(loss)
+        else:
+            outputs['loss'] = loss
+        if mode == 'validation':
+            if type(self.trainer.val_dataloaders) == list and len(self.trainer.val_dataloaders) > 1:
+                self.validation_step_outputs[dataloader_idx].append(outputs)
+            else:
+                self.validation_step_outputs.append(outputs)
+        else:
+            if type(self.trainer.test_dataloaders) == list and len(self.trainer.test_dataloaders) > 1:
+                self.test_step_outputs[dataloader_idx].append(outputs)
+            else:
+                self.test_step_outputs.append(outputs)
+        return outputs
 
     @classmethod
     def ids_to_text(cls, batch_ids, tokenizer):

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -912,7 +912,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             The list of microbatches is then piped through the pipeline using megatron-core fwd/bwd functions.
         """
         # Check if iterator is exhausted
-        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
+        done = self._val_iterator_done(dataloader_iter)
         if done:
             return
         mode = 'test' if self.trainer.testing else 'val'

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -915,7 +915,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             The list of microbatches is then piped through the pipeline using megatron-core fwd/bwd functions.
         """
         # Check if iterator is exhausted
-        done = self._val_iterator_done(dataloader_iter)
+        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
         if done:
             return
         mode = 'test' if self.trainer.testing else 'val'

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -912,7 +912,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             The list of microbatches is then piped through the pipeline using megatron-core fwd/bwd functions.
         """
         # Check if iterator is exhausted
-        done = self._val_iterator_done(dataloader_iter)
+        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
         if done:
             return
         mode = 'test' if self.trainer.testing else 'val'
@@ -926,8 +926,6 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
 
         loss = self.fwd_bwd_step(dataloader_iter, batch_idx, True)
         
-        # Increment self._val_micro_batches_consumed so that validation is exited properly
-        self._val_micro_batches_consumed += get_num_microbatches()
         if isinstance(self.model, list):
             for model_module in self.model:
                 model_module.train()

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -912,7 +912,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             The list of microbatches is then piped through the pipeline using megatron-core fwd/bwd functions.
         """
         # Prefetch the dataloader_iter before fwd_bwd func to avoid PP rank 2 from waiting indefinitely when PP rank 1 reaches the end of dataloader_iter
-        dataloader_iter, done = self._prefetch(dataloader_iter)
+        done = self._prefetch(dataloader_iter)
         if done:
             return
         mode = 'test' if self.trainer.testing else 'val'

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -124,6 +124,9 @@ class MegatronGPTExportableModel(torch.nn.Module, Exportable):
         else:
             raise ValueError(f"precision: {model.cfg['precision']} is not supported.")
 
+        # Override limit_val_batches to be a multiple of num microbatches to prevent val_step from exiting in between a step
+        self._reconfigure_val_batches()
+
     def forward(self, tokens, position_ids, attention_mask):
         if self.fp8_enabled and HAVE_TE:
             with transformer_engine.pytorch.onnx_export(self.fp8_enabled), transformer_engine.pytorch.fp8_autocast(

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -925,7 +925,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                 model_module.eval()
 
         loss = self.fwd_bwd_step(dataloader_iter, batch_idx, True)
-        
+
         if isinstance(self.model, list):
             for model_module in self.model:
                 model_module.train()

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -289,9 +289,6 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         self.get_attention_mask_from_fusion = self.cfg.get('get_attention_mask_from_fusion', True)
         self.initialize_ub = self.cfg.get('ub_tp_comm_overlap', False)
 
-        # Override limit_val_batches to be a multiple of num microbatches to prevent val_step from exiting in between a step
-        self._reconfigure_val_batches()
-
     def get_gpt_module_list(self):
         if isinstance(self.model, list):
             return [
@@ -974,6 +971,8 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         return loss
 
     def build_train_valid_test_datasets(self):
+        # Override limit_val_batches to be a multiple of num microbatches to prevent val_step from exiting in between a step
+        self._reconfigure_val_batches()
         logging.info('Building GPT datasets.')
         if self.trainer.limit_val_batches > 1.0 and isinstance(self.trainer.limit_val_batches, float):
             raise ValueError("limit_val_batches must be an integer or float less than or equal to 1.0.")

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -124,9 +124,6 @@ class MegatronGPTExportableModel(torch.nn.Module, Exportable):
         else:
             raise ValueError(f"precision: {model.cfg['precision']} is not supported.")
 
-        # Override limit_val_batches to be a multiple of num microbatches to prevent val_step from exiting in between a step
-        self._reconfigure_val_batches()
-
     def forward(self, tokens, position_ids, attention_mask):
         if self.fp8_enabled and HAVE_TE:
             with transformer_engine.pytorch.onnx_export(self.fp8_enabled), transformer_engine.pytorch.fp8_autocast(
@@ -291,6 +288,9 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
 
         self.get_attention_mask_from_fusion = self.cfg.get('get_attention_mask_from_fusion', True)
         self.initialize_ub = self.cfg.get('ub_tp_comm_overlap', False)
+
+        # Override limit_val_batches to be a multiple of num microbatches to prevent val_step from exiting in between a step
+        self._reconfigure_val_batches()
 
     def get_gpt_module_list(self):
         if isinstance(self.model, list):

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -369,12 +369,12 @@ class MegatronGPTPromptLearningModel(MegatronBasePromptLearningModel):
         return
 
     def validation_step(self, dataloader_iter, batch_idx):
-        mode = 'test' if self.trainer.testing else 'val'
-        # Add try except to catch the end of the iterator and exit
-        try:
-            batch = next(dataloader_iter)
-        except StopIteration:
+        # Check if iterator is exhausted
+        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
+        if done:
             return
+        mode = 'test' if self.trainer.testing else 'val'
+        batch = next(dataloader_iter)
         gbs = self.cfg.get('validation_global_batch_size', self.cfg.global_batch_size)
         self._reconfigure_and_process_inference_batch(batch[0].size(0), gbs)
         loss_mean = self.fwd_bwd_step(itertools.chain([batch]), batch_idx, forward_only=True)

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -369,12 +369,8 @@ class MegatronGPTPromptLearningModel(MegatronBasePromptLearningModel):
         return
 
     def validation_step(self, dataloader_iter, batch_idx):
-        # Check if iterator is exhausted
-        # dataloader_iter, done = self._val_iterator_done(dataloader_iter)
-        # if done:
-        #     return
         mode = 'test' if self.trainer.testing else 'val'
-        # try except is sufficient only one batch is passed to the fwd_bwd_step
+        # Add try except to catch the end of the iterator and exit
         try:
             batch = next(dataloader_iter)
         except StopIteration:

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -385,26 +385,22 @@ class MegatronGPTSFTModel(MegatronGPTModel):
         return loss_mean
 
     def validation_step(self, dataloader_iter, batch_idx, dataloader_idx=0):
-        # Add try except since dataloader_iter in PTL 2.0 doesnt catch the end of iterables
-        try:
-            return self.inference_step(dataloader_iter, batch_idx, 'validation', dataloader_idx)
-        except StopIteration:
-            return
+        return self.inference_step(dataloader_iter, batch_idx, 'validation', dataloader_idx)
 
     def test_step(self, dataloader_iter, batch_idx, dataloader_idx=0):
         # Add try except since dataloader_iter in PTL 2.0 doesnt catch the end of iterables
-        try:
-            return self.inference_step(dataloader_iter, batch_idx, 'test', dataloader_idx)
-        except StopIteration:
-            return
+        return self.inference_step(dataloader_iter, batch_idx, 'test', dataloader_idx)
 
     def inference_step(self, dataloader_iter, batch_idx, mode, dataloader_idx=0):
+        # Check if iterator is exhausted
+        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
+        if done:
+            return
         batch = next(dataloader_iter)
         data_cfg = self.cfg.data.validation_ds if mode == 'validation' else self.cfg.data.test_ds
         self._reconfigure_and_process_inference_batch(batch, data_cfg)
         # Meta data from dataset
         metadata = batch.get('metadata', [{}] * len(batch['tokens']))
-        self._val_micro_batches_consumed = 0 # Forces parent to do validation_step
         loss = super().validation_step(itertools.chain([batch]), batch_idx)
 
         if data_cfg.get("write_predictions_to_file", False) or data_cfg.metric.name != 'loss':

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -404,6 +404,7 @@ class MegatronGPTSFTModel(MegatronGPTModel):
         self._reconfigure_and_process_inference_batch(batch, data_cfg)
         # Meta data from dataset
         metadata = batch.get('metadata', [{}] * len(batch['tokens']))
+        self._val_micro_batches_consumed = 0 # Forces parent to do validation_step
         loss = super().validation_step(itertools.chain([batch]), batch_idx)
 
         if data_cfg.get("write_predictions_to_file", False) or data_cfg.metric.name != 'loss':

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -715,7 +715,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
         Shared code for validation and test step
         """
         # Check if iterator is exhausted
-        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
+        done = self._val_iterator_done(dataloader_iter)
         if done:
             return
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -718,7 +718,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
         Shared code for validation and test step
         """
         # Check if iterator is exhausted
-        done = self._val_iterator_done(dataloader_iter)
+        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
         if done:
             return
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -144,6 +144,9 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
 
         self.enc_dec_model.model_type = ModelType.encoder_and_decoder
 
+        # Override limit_val_batches to be a multiple of num microbatches to prevent val_step from exiting in between a step
+        self._reconfigure_val_batches()
+
     def setup_optimizer_param_groups(self):
         """ModelPT override. Optimizer will get self._optimizer_param_groups"""
         self._optimizer_param_groups = get_params_for_weight_decay_optimization([self.enc_dec_model])

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -715,13 +715,11 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
         Shared code for validation and test step
         """
         # Check if iterator is exhausted
-        done = self._val_iterator_done(dataloader_iter)
+        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
         if done:
             return
 
         loss_dict = self.fwd_bwd_step(dataloader_iter, batch_idx, True)
-        # Increment self._val_micro_batches_consumed so that validation is exited properly
-        self._val_micro_batches_consumed += get_num_microbatches()
         step_outputs.append(loss_dict)
 
         return loss_dict

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -144,9 +144,6 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
 
         self.enc_dec_model.model_type = ModelType.encoder_and_decoder
 
-        # Override limit_val_batches to be a multiple of num microbatches to prevent val_step from exiting in between a step
-        self._reconfigure_val_batches()
-
     def setup_optimizer_param_groups(self):
         """ModelPT override. Optimizer will get self._optimizer_param_groups"""
         self._optimizer_param_groups = get_params_for_weight_decay_optimization([self.enc_dec_model])

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -714,12 +714,14 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
         """
         Shared code for validation and test step
         """
-        # Prefetch the dataloader_iter before fwd_bwd func to avoid PP rank 2 from waiting indefinitely with PP rank 1 reaches the end of dataloader_iter
-        dataloader_iter, done = self._prefetch(dataloader_iter)
+        # Check if iterator is exhausted
+        done = self._val_iterator_done(dataloader_iter)
         if done:
             return
 
         loss_dict = self.fwd_bwd_step(dataloader_iter, batch_idx, True)
+        # Increment self._val_micro_batches_consumed so that validation is exited properly
+        self._val_micro_batches_consumed += get_num_microbatches()
         step_outputs.append(loss_dict)
 
         return loss_dict

--- a/nemo/collections/nlp/models/language_modeling/megatron_t5_adapter_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_t5_adapter_model.py
@@ -147,28 +147,28 @@ class MegatronT5BaseAdapterModel(MegatronT5PromptLearningModel):
         }
 
     def validation_step(self, dataloader_iter, batch_idx, inference=False):
-        # Add try except since dataloader_iter in PTL 2.0 doesnt catch the end of iterables
-        try:
-            batch = next(dataloader_iter)
-            enc_input, dec_input, labels, loss_mask, enc_mask, dec_mask, position_ids, taskname_ids = batch
-
-            mode = self.training
-            self.eval()
-            gbs = self.cfg.get('validation_global_batch_size', self.cfg.global_batch_size)
-            self._reconfigure_and_process_inference_batch(enc_input.size(0), gbs)
-            loss_mean = self.fwd_bwd_step(itertools.chain([batch]), batch_idx, forward_only=True)
-
-            if self.cfg.get('report_validation_metric', False):
-                metrics = self.compute_accuracy(enc_input, enc_mask, labels)
-                metrics['loss'] = loss_mean
-            else:
-                metrics = {'loss': loss_mean}
-
-            self.validation_step_outputs.append(metrics)
-            self.train(mode=mode)
-            return metrics
-        except StopIteration:
+        # Check if iterator is exhausted
+        dataloader_iter, done = self._val_iterator_done(dataloader_iter)
+        if done:
             return
+        batch = next(dataloader_iter)
+        enc_input, dec_input, labels, loss_mask, enc_mask, dec_mask, position_ids, taskname_ids = batch
+
+        mode = self.training
+        self.eval()
+        gbs = self.cfg.get('validation_global_batch_size', self.cfg.global_batch_size)
+        self._reconfigure_and_process_inference_batch(enc_input.size(0), gbs)
+        loss_mean = self.fwd_bwd_step(itertools.chain([batch]), batch_idx, forward_only=True)
+
+        if self.cfg.get('report_validation_metric', False):
+            metrics = self.compute_accuracy(enc_input, enc_mask, labels)
+            metrics['loss'] = loss_mean
+        else:
+            metrics = {'loss': loss_mean}
+
+        self.validation_step_outputs.append(metrics)
+        self.train(mode=mode)
+        return metrics
 
     def predict_step(self, batch: Any, batch_idx: int, dataloader_idx: int = 0) -> Any:
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_t5_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_t5_model.py
@@ -197,6 +197,8 @@ class MegatronT5Model(MegatronLMEncoderDecoderModel):
                         tokenizer.add_special_tokens([f'<extra_id_{mask_type}>'])
 
     def build_train_valid_test_datasets(self):
+        # Override limit_val_batches to be a multiple of num microbatches to prevent val_step from exiting in between a step
+        self._reconfigure_val_batches()
         logging.info(f'Building {self.model_name} datasets.')
         if self.trainer.limit_val_batches > 1.0 and isinstance(self.trainer.limit_val_batches, float):
             raise ValueError("limit_val_batches must be an integer or float less than or equal to 1.0.")


### PR DESCRIPTION
# What does this PR do ?

1) Catch the end of `dataloader_iter` to exit gracefully from `validation_step` without having to prefetch  all `microbatches` in a step which was being done previously. This is a temporary piece of code that is needed until we have lightning's fix that takes care of catching the end of `dataloader_iter`
2) Set `limit_val_batches` and `num_sanity_val_steps` for `pretraining` to be a multiple of num of `microbatches`. `limit_val_batches` is reconfigured so that we run as many global batches or validation_steps as the user entered `limit_val_batches`. 

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
