### PR TITLE
Move model precision copy

### DIFF
--- a/examples/nlp/language_modeling/megatron_bart_pretraining.py
+++ b/examples/nlp/language_modeling/megatron_bart_pretraining.py
@@ -73,10 +73,6 @@ def main(cfg) -> None:
 
     logging.info(f'Resuming training from checkpoint: {trainer.ckpt_path}')
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     model = MegatronBARTModel(cfg.model, trainer)
     trainer.fit(model)
 

--- a/examples/nlp/language_modeling/megatron_bert_pretraining.py
+++ b/examples/nlp/language_modeling/megatron_bert_pretraining.py
@@ -33,10 +33,6 @@ def main(cfg) -> None:
     trainer = MegatronBertTrainerBuilder(cfg).create_trainer()
     exp_manager(trainer, cfg.exp_manager)
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     model = MegatronBertModel(cfg.model, trainer)
 
     trainer.fit(model)

--- a/examples/nlp/language_modeling/megatron_gpt_continue_training.py
+++ b/examples/nlp/language_modeling/megatron_gpt_continue_training.py
@@ -182,9 +182,6 @@ def main(cfg) -> None:
         model = load_from_checkpoint_dir(MegatronGPTModel, cfg, trainer, gpt_cfg, modify_confg_fn=_modify_config)
     else:
         print(' > WARNING: No checkpoint provided. Starting from scratch.')
-        # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-        with open_dict(cfg):
-            cfg.model.precision = cfg.trainer.precision
         model = MegatronGPTModel(cfg.model, trainer)
     trainer.fit(model)
 

--- a/examples/nlp/language_modeling/megatron_gpt_pretraining.py
+++ b/examples/nlp/language_modeling/megatron_gpt_pretraining.py
@@ -33,10 +33,6 @@ def main(cfg) -> None:
     trainer = MegatronTrainerBuilder(cfg).create_trainer()
     exp_manager(trainer, cfg.exp_manager)
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     model = MegatronGPTModel(cfg.model, trainer)
 
     trainer.fit(model)

--- a/examples/nlp/language_modeling/megatron_gpt_prompt_learning.py
+++ b/examples/nlp/language_modeling/megatron_gpt_prompt_learning.py
@@ -77,10 +77,6 @@ def main(cfg) -> None:
     trainer = Trainer(plugins=plugins, strategy=strategy, **cfg.trainer)
     exp_manager(trainer, cfg.exp_manager)
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     # load existing or init new soft prompt GPT model
     if cfg.model.get("restore_path", None):
         model = MegatronGPTPromptLearningModel.restore_from(

--- a/examples/nlp/language_modeling/megatron_retro_mutransfer_pretrain.py
+++ b/examples/nlp/language_modeling/megatron_retro_mutransfer_pretrain.py
@@ -69,10 +69,6 @@ def main(cfg) -> None:
     # resume_from_checkpoint = uninject_model_parallel_rank(resume_from_checkpoint)
     logging.info(f'Resuming training from checkpoint: {trainer.ckpt_path}')
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     model = MegatronRetrievalModel(cfg.model, trainer)
 
     trainer.fit(model)

--- a/examples/nlp/language_modeling/megatron_retro_pretraining.py
+++ b/examples/nlp/language_modeling/megatron_retro_pretraining.py
@@ -72,9 +72,6 @@ def main(cfg) -> None:
     # resume_from_checkpoint = uninject_model_parallel_rank(resume_from_checkpoint)
     logging.info(f'Resuming training from checkpoint: {trainer.ckpt_path}')
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
     # load existing nemo retro model
     if cfg.get("restore_from_path", None) is not None:
         save_restore_connector = NLPSaveRestoreConnector()

--- a/examples/nlp/language_modeling/megatron_t5_lm_adaptation_finetune.py
+++ b/examples/nlp/language_modeling/megatron_t5_lm_adaptation_finetune.py
@@ -72,10 +72,6 @@ def main(cfg) -> None:
         trainer.ckpt_path = cfg.model.resume_from_checkpoint
     logging.info(f'Resuming training from checkpoint: {trainer.ckpt_path}')
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     if hasattr(cfg.model, 'pretrained_model_path') and cfg.model.pretrained_model_path is not None:
         pretrained_cfg = MegatronT5Model.restore_from(
             cfg.model.pretrained_model_path, trainer=trainer, return_config=True

--- a/examples/nlp/language_modeling/megatron_t5_pretraining.py
+++ b/examples/nlp/language_modeling/megatron_t5_pretraining.py
@@ -30,10 +30,6 @@ def main(cfg) -> None:
     trainer = MegatronT5TrainerBuilder(cfg).create_trainer()
     exp_manager(trainer, cfg.exp_manager)
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     model = MegatronT5Model(cfg.model, trainer)
     trainer.fit(model)
 

--- a/examples/nlp/language_modeling/megatron_t5_prompt_learning.py
+++ b/examples/nlp/language_modeling/megatron_t5_prompt_learning.py
@@ -67,10 +67,6 @@ def main(cfg) -> None:
     trainer = Trainer(plugins=plugins, strategy=strategy, **cfg.trainer)
     exp_manager(trainer, cfg.exp_manager)
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     # load existing or init new soft prompt T5 model
     if cfg.model.get("restore_path", None):
         model = MegatronT5PromptLearningModel.restore_from(

--- a/examples/nlp/language_modeling/tuning/megatron_gpt_adapter_tuning.py
+++ b/examples/nlp/language_modeling/tuning/megatron_gpt_adapter_tuning.py
@@ -93,10 +93,6 @@ def main(cfg) -> None:
     trainer = Trainer(plugins=plugins, strategy=strategy, **cfg.trainer)
     exp_manager(trainer, cfg.exp_manager)
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     # load existing or init new soft prompt GPT model
     if cfg.model.get("restore_path", None):
         model = MegatronGPTAdapterLearningModel.restore_from(

--- a/examples/nlp/language_modeling/tuning/megatron_gpt_ia3_tuning.py
+++ b/examples/nlp/language_modeling/tuning/megatron_gpt_ia3_tuning.py
@@ -92,10 +92,6 @@ def main(cfg) -> None:
     trainer = Trainer(plugins=plugins, strategy=strategy, **cfg.trainer)
     exp_manager(trainer, cfg.exp_manager)
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     # load existing or init new soft prompt GPT model
     if cfg.model.get("restore_path", None):
         model = MegatronGPTInfusedAdapterModel.restore_from(

--- a/examples/nlp/language_modeling/tuning/megatron_gpt_peft_tuning.py
+++ b/examples/nlp/language_modeling/tuning/megatron_gpt_peft_tuning.py
@@ -220,10 +220,6 @@ def main(cfg) -> None:
         trainer.ckpt_path = cfg.model.resume_from_checkpoint
     logging.info(f'Resuming training from checkpoint: {trainer.ckpt_path}')
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     if cfg.model.restore_from_path:
         base_model_save_restore_connector = NLPSaveRestoreConnector()
         if os.path.isdir(cfg.model.restore_from_path):

--- a/examples/nlp/language_modeling/tuning/megatron_gpt_sft.py
+++ b/examples/nlp/language_modeling/tuning/megatron_gpt_sft.py
@@ -183,10 +183,6 @@ def main(cfg) -> None:
         trainer.ckpt_path = cfg.model.resume_from_checkpoint
     logging.info(f'Resuming training from checkpoint: {trainer.ckpt_path}')
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     if cfg.model.restore_from_path:
         save_restore_connector = NLPSaveRestoreConnector()
         if os.path.isdir(cfg.model.restore_from_path):

--- a/examples/nlp/language_modeling/tuning/megatron_t5_adapter_tuning.py
+++ b/examples/nlp/language_modeling/tuning/megatron_t5_adapter_tuning.py
@@ -92,10 +92,6 @@ def main(cfg) -> None:
     trainer = Trainer(plugins=plugins, strategy=strategy, **cfg.trainer)
     exp_manager(trainer, cfg.exp_manager)
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     # load existing or init new soft prompt GPT model
     if cfg.model.get("restore_path", None):
         model = MegatronT5AdapterLearningModel.restore_from(

--- a/examples/nlp/language_modeling/tuning/megatron_t5_ia3_tuning.py
+++ b/examples/nlp/language_modeling/tuning/megatron_t5_ia3_tuning.py
@@ -95,7 +95,6 @@ def main(cfg) -> None:
 
     # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
     with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
         cfg.model.pretrained_language_model_path = cfg.model.language_model_path
 
     # load existing or init new soft prompt GPT model

--- a/examples/nlp/language_modeling/tuning/megatron_t5_lora_tuning.py
+++ b/examples/nlp/language_modeling/tuning/megatron_t5_lora_tuning.py
@@ -92,10 +92,6 @@ def main(cfg) -> None:
     trainer = Trainer(plugins=plugins, strategy=strategy, **cfg.trainer)
     exp_manager(trainer, cfg.exp_manager)
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     # load existing or init new soft prompt GPT model
     if cfg.model.get("restore_path", None):
         model = MegatronT5LoraModel.restore_from(

--- a/examples/nlp/machine_translation/megatron_nmt_training.py
+++ b/examples/nlp/machine_translation/megatron_nmt_training.py
@@ -81,10 +81,6 @@ def main(cfg) -> None:
 
     trainer._checkpoint_connector = _CheckpointConnector(trainer)
 
-    # hydra interpolation does not work here as the interpolation key is lost when PTL saves hparams
-    with open_dict(cfg):
-        cfg.model.precision = cfg.trainer.precision
-
     if hasattr(cfg.model, 'pretrained_model_path') and cfg.model.pretrained_model_path is not None:
         if not hasattr(cfg.model, 'pretrained_model_type'):
             raise ValueError(f"Pretrained model type must be in [T5, BART].")

--- a/nemo/collections/nlp/models/language_modeling/megatron/gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/gpt_model.py
@@ -176,7 +176,7 @@ class GPTModel(MegatronModule):
         self.fp16_lm_cross_entropy = fp16_lm_cross_entropy
         self.sequence_parallel = self.config.sequence_parallel
         self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
-        self.dtype = utils_funcs.dtype_from_precision(precision, megatron_amp_O2)
+        self.dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
 
         if kv_channels is None:
             assert (

--- a/nemo/collections/nlp/models/language_modeling/megatron/gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/gpt_model.py
@@ -176,7 +176,7 @@ class GPTModel(MegatronModule):
         self.fp16_lm_cross_entropy = fp16_lm_cross_entropy
         self.sequence_parallel = self.config.sequence_parallel
         self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
-        self.dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
+        self.dtype = utils_funcs.torch_dtype_from_precision(precision, megatron_amp_O2)
 
         if kv_channels is None:
             assert (

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -753,10 +753,10 @@ class MegatronBaseModel(NLPModel):
 
         # map precision related configs
         precision = cfg.get('precision', 32)  # PTL trainer precision
-        megatron_amp_O2 = cfg.get('megatron_amp_O2')
+        megatron_amp_O2 = cfg.get('megatron_amp_O2', False)
 
         # instantiate weights in bfloat16 if using megatron amp O2 and bf16
-        params_dtype = utils_funcs.torch_dtype_from_precision(precision, megatron_amp_O2)
+        params_dtype = self.torch_dtype
 
         # dtype used in p2p communication
         pipeline_dtype = self.torch_dtype

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -756,7 +756,7 @@ class MegatronBaseModel(NLPModel):
         megatron_amp_O2 = cfg.get('megatron_amp_O2', False)
 
         # instantiate weights in bfloat16 if using megatron amp O2 and bf16
-        params_dtype = self.torch_dtype
+        params_dtype = torch.bfloat16 if self.torch_dtype == torch.bfloat16 and megatron_amp_O2 else torch.float32
 
         # dtype used in p2p communication
         pipeline_dtype = self.torch_dtype
@@ -768,7 +768,7 @@ class MegatronBaseModel(NLPModel):
         config_mapping = {
             "perform_initialization": True,  # initailize weights when constructing the module
             "fp16": False,  # NeMo does not currently support fp16 training with megatron amp O2
-            "bf16": self.torch_dtype == torch.bfloat16,
+            "bf16": self.torch_dtype == torch.bfloat16 and megatron_amp_O2,
             "params_dtype": params_dtype,
             "timers": None,  # NeMo does not currently support megatron core timers
             "async_tensor_model_parallel_allreduce": self.cfg.get('tensor_model_parallel_world_size', 1) > 1

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -475,10 +475,10 @@ class MegatronBaseModel(NLPModel):
 
         # Wrap the baseline optimizer with the optimizer class with master parameters
         if self.megatron_amp_o2 and not self.with_distributed_adam and self._optimizer is not None:
-            if self.cfg.precision == 'bf16':
+            if self.cfg.precision in ['bf16', 'bf16-mixed']:
                 fp32_grad_accum = True
                 contiguous_grad_bucket = True
-            elif self.cfg.precision == 16:
+            elif self.cfg.precision == [16, '16', '16-mixed']:
                 fp32_grad_accum = False
                 # TODO: contiguous grad bucket for fp16 is also planned to be supported
                 contiguous_grad_bucket = False
@@ -774,10 +774,8 @@ class MegatronBaseModel(NLPModel):
             "async_tensor_model_parallel_allreduce": self.cfg.get('tensor_model_parallel_world_size', 1) > 1
             and not self.cfg.get('sequence_parallel', False),
             "pipeline_dtype": pipeline_dtype,
-            "grad_scale_func": self.trainer.precision_plugin.scaler.scale
-            if precision in [16, '16', '16-mixed']
-            else None,
-            "enable_autocast": not megatron_amp_O2 and precision in [16, '16', 'bf16'],
+            "grad_scale_func": self.trainer.precision_plugin.scaler.scale if pipeline_dtype == torch.float16 else None,
+            "enable_autocast": not megatron_amp_O2 and pipeline_dtype in [torch.bfloat16, torch.float16],
             "autocast_dtype": autocast_dtype,
             "variable_seq_lengths": False,  # set dynamically during training
             "num_microbatches_with_partial_activation_checkpoints": self.cfg.get(

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -103,6 +103,9 @@ class MegatronBaseModel(NLPModel):
 
         super().__init__(cfg, trainer=trainer, no_lm_init=no_lm_init)
 
+        with open_dict(cfg):
+            cfg.precision = trainer.precision
+
         # set the megatron core model parallel config
         self.model_parallel_config: ModelParallelConfig = self.build_model_parallel_config()
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -103,8 +103,8 @@ class MegatronBaseModel(NLPModel):
 
         super().__init__(cfg, trainer=trainer, no_lm_init=no_lm_init)
 
-        with open_dict(cfg):
-            cfg.precision = trainer.precision
+        with open_dict(self.cfg):
+            self.cfg.precision = trainer.precision
 
         # set the megatron core model parallel config
         self.model_parallel_config: ModelParallelConfig = self.build_model_parallel_config()

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -753,10 +753,10 @@ class MegatronBaseModel(NLPModel):
 
         # map precision related configs
         precision = cfg.get('precision', 32)  # PTL trainer precision
-        megatron_amp_O2 = cfg.get('megatron_amp_O2', False)
+        megatron_amp_O2 = cfg.get('megatron_amp_O2')
 
         # instantiate weights in bfloat16 if using megatron amp O2 and bf16
-        params_dtype = self.torch_dtype
+        params_dtype = utils_funcs.torch_dtype_from_precision(precision, megatron_amp_O2)
 
         # dtype used in p2p communication
         pipeline_dtype = self.torch_dtype

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -109,6 +109,12 @@ class MegatronBaseModel(NLPModel):
         # TODO: @maanug-nv consolidate into one attribute (requires lots of changes in subclasses)
         self.torch_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)  # Mixed precision datatype
         self.autocast_dtype = self.torch_dtype  # Mixed precision datatype
+        # instantiate weights in mixed precision datatype if using megatron amp O2
+        self.params_dtype = (
+            self.torch_dtype
+            if self.torch_dtype in [torch.bfloat16, torch.float16] and self.cfg.get('megatron_amp_O2', False)
+            else torch.float32
+        )
 
         # set the megatron core model parallel config
         self.model_parallel_config: ModelParallelConfig = self.build_model_parallel_config()
@@ -757,18 +763,16 @@ class MegatronBaseModel(NLPModel):
         precision = cfg.get('precision', 32)  # PTL trainer precision
         megatron_amp_O2 = cfg.get('megatron_amp_O2', False)
 
-        # instantiate weights in bfloat16 if using megatron amp O2 and bf16
-        params_dtype = torch.bfloat16 if self.torch_dtype == torch.bfloat16 and megatron_amp_O2 else torch.float32
-
         # dtype used in p2p communication
         pipeline_dtype = self.torch_dtype
 
         # maps NeMo model configs to ModelParallelConfig from megatron core
         config_mapping = {
             "perform_initialization": True,  # initailize weights when constructing the module
-            "fp16": False,  # NeMo does not currently support fp16 training with megatron amp O2
+            "fp16": self.torch_dtype == torch.float16
+            and megatron_amp_O2,  # NeMo does not currently support fp16 training with megatron amp O2, eval and inference is supported
             "bf16": self.torch_dtype == torch.bfloat16 and megatron_amp_O2,
-            "params_dtype": params_dtype,
+            "params_dtype": self.params_dtype,
             "timers": None,  # NeMo does not currently support megatron core timers
             "async_tensor_model_parallel_allreduce": self.cfg.get('tensor_model_parallel_world_size', 1) > 1
             and not self.cfg.get('sequence_parallel', False),

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -36,6 +36,7 @@ from nemo.collections.nlp.modules.common.megatron.clip_grads import (
 from nemo.collections.nlp.modules.common.megatron.megatron_init import initialize_model_parallel_for_nemo
 from nemo.collections.nlp.modules.common.megatron.utils import ApexGuardDefaults
 from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenizer
+from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.parts.nlp_overrides import NEMO_MEGATRON_MODEL_PARALLEL_APPSTATE_OVERRIDE, GradScaler
 from nemo.core.optim import MainParamsOptimizerWrapper, prepare_lr_scheduler
 from nemo.utils import AppState, logging
@@ -754,16 +755,11 @@ class MegatronBaseModel(NLPModel):
         megatron_amp_O2 = cfg.get('megatron_amp_O2', False)
 
         # instantiate weights in bfloat16 if using megatron amp O2 and bf16
-        params_dtype = torch.bfloat16 if precision in ['bf16', 'bf16-mixed'] and megatron_amp_O2 else torch.float32
+        params_dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
+        params_dtype = params_dtype if params_dtype == torch.bfloat16 else torch.float32
 
         # dtype used in p2p communication
-        pipeline_dtype = (
-            torch.bfloat16
-            if precision in ['bf16', 'bf16-mixed']
-            else torch.half
-            if precision in [16, '16']
-            else torch.float32
-        )
+        pipeline_dtype = utils_funcs.params_dtype_from_precision(precision)
 
         # same as pipeline_dtype when not using megatron amp O2
         autocast_dtype = pipeline_dtype if not megatron_amp_O2 else None

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
@@ -35,7 +35,6 @@ from nemo.collections.nlp.modules.common import (
 )
 from nemo.collections.nlp.modules.common.megatron.utils import ApexGuardDefaults
 from nemo.collections.nlp.modules.common.transformer.text_generation import TextGeneration
-from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.parts.nlp_overrides import GradScaler
 from nemo.utils import AppState, logging
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
@@ -136,7 +136,6 @@ class MegatronBasePromptLearningModel(MegatronBaseModel, TextGeneration):
         self.pad_token_id = self.tokenizer.pad_id if self.tokenizer.pad_id is not None else self.tokenizer.unk_id
         self.decoder_seq_length = cfg.get('decoder_seq_length', 40)
 
-        self.autocast_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)
         # make sure the default pytorch lightning gradient clipping in the basemodel
         self.grad_clip_pl_default = True
         self.lowest_val_loss = None

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
@@ -35,6 +35,7 @@ from nemo.collections.nlp.modules.common import (
 )
 from nemo.collections.nlp.modules.common.megatron.utils import ApexGuardDefaults
 from nemo.collections.nlp.modules.common.transformer.text_generation import TextGeneration
+from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.parts.nlp_overrides import GradScaler
 from nemo.utils import AppState, logging
 
@@ -138,14 +139,7 @@ class MegatronBasePromptLearningModel(MegatronBaseModel, TextGeneration):
         self.pad_token_id = self.tokenizer.pad_id if self.tokenizer.pad_id is not None else self.tokenizer.unk_id
         self.decoder_seq_length = cfg.get('decoder_seq_length', 40)
 
-        if self.trainer.precision in ['bf16', 'bf16-mixed']:
-            self.autocast_dtype = torch.bfloat16
-        elif self.trainer.precision in [32, '32', '32-true']:
-            self.autocast_dtype = torch.float
-        elif self.trainer.precision in [16, '16', '16-mixed']:
-            self.autocast_dtype = torch.half
-        else:
-            raise ValueError('precision must be in ["32-true", "16-mixed", "bf16-mixed"]')
+        self.autocast_dtype = utils_funcs.params_dtype_from_precision(self.cfg.precision)
         # make sure the default pytorch lightning gradient clipping in the basemodel
         self.grad_clip_pl_default = True
         self.lowest_val_loss = None

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
@@ -136,7 +136,7 @@ class MegatronBasePromptLearningModel(MegatronBaseModel, TextGeneration):
         self.pad_token_id = self.tokenizer.pad_id if self.tokenizer.pad_id is not None else self.tokenizer.unk_id
         self.decoder_seq_length = cfg.get('decoder_seq_length', 40)
 
-        self.autocast_dtype = utils_funcs.params_dtype_from_precision(self.cfg.precision)
+        self.autocast_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)
         # make sure the default pytorch lightning gradient clipping in the basemodel
         self.grad_clip_pl_default = True
         self.lowest_val_loss = None

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_prompt_learning_model.py
@@ -84,10 +84,7 @@ class MegatronBasePromptLearningModel(MegatronBaseModel, TextGeneration):
 
     def __init__(self, cfg: DictConfig, trainer: Trainer):
         super().__init__(cfg, trainer)
-        self.init_model(cfg, trainer)
 
-    def init_model(self, cfg: DictConfig, trainer: Trainer):
-        self.cfg = cfg
         self.config: ModelParallelConfig = self.model_parallel_config
 
         self.load_frozen_model(cfg, trainer)

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -90,7 +90,7 @@ class MegatronBertModel(MegatronBaseModel):
 
         self._validate_trainer()
 
-        self.autocast_dtype = utils_funcs.params_dtype_from_precision(self.cfg.precision)
+        self.autocast_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)
 
         self.enable_autocast = (
             True if (not self.megatron_amp_o2) and (self.autocast_dtype in [torch.float16, torch.bfloat16]) else False

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -33,7 +33,6 @@ from nemo.collections.nlp.modules.common.megatron.utils import (
     average_losses_across_data_parallel_group,
     get_params_for_weight_decay_optimization,
 )
-from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.parts.nlp_overrides import GradScaler
 from nemo.collections.nlp.parts.utils_funcs import get_last_rank
 from nemo.core.classes.common import PretrainedModelInfo

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -90,8 +90,6 @@ class MegatronBertModel(MegatronBaseModel):
 
         self._validate_trainer()
 
-        self.autocast_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)
-
         self.enable_autocast = (
             True if (not self.megatron_amp_o2) and (self.autocast_dtype in [torch.float16, torch.bfloat16]) else False
         )

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -54,6 +54,7 @@ from nemo.collections.nlp.modules.common.transformer.text_generation import (
     SamplingParam,
     TextGeneration,
 )
+from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.parts.utils_funcs import activation_to_func, get_last_rank
 from nemo.core.classes import Exportable
 from nemo.core.classes.common import PretrainedModelInfo
@@ -114,15 +115,7 @@ class MegatronGPTExportableModel(torch.nn.Module, Exportable):
                 margin=0, interval=1, fp8_format=transformer_engine.common.recipe.Format.E4M3
             )
 
-        self.dtype = None
-        if model.cfg['precision'] == 'bf16':
-            self.dtype = torch.bfloat16
-        elif int(model.cfg['precision']) == 32:
-            self.dtype = torch.float
-        elif int(model.cfg['precision']) == 16:
-            self.dtype = torch.float16
-        else:
-            raise ValueError(f"precision: {model.cfg['precision']} is not supported.")
+        self.dtype = utils_funcs.params_dtype_from_precision(model.cfg.precision)
 
     def forward(self, tokens, position_ids, attention_mask):
         if self.fp8_enabled and HAVE_TE:
@@ -260,14 +253,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
 
             self._wrap_model_for_O2()
 
-        if self.trainer.precision in ['bf16', 'bf16-mixed']:
-            self.autocast_dtype = torch.bfloat16
-        elif self.trainer.precision in [32, '32', '32-true']:
-            self.autocast_dtype = torch.float
-        elif self.trainer.precision in [16, '16', '16-mixed']:
-            self.autocast_dtype = torch.half
-        else:
-            raise ValueError('precision must be in ["32-true", "16-mixed", "bf16-mixed"]')
+        self.autocast_dtype = utils_funcs.params_dtype_from_precision(self.cfg.precision)
 
         self.enable_autocast = (
             True if (not self.megatron_amp_o2) and (self.autocast_dtype in [torch.float16, torch.bfloat16]) else False

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -253,8 +253,6 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
 
             self._wrap_model_for_O2()
 
-        self.autocast_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)
-
         self.enable_autocast = (
             True if (not self.megatron_amp_o2) and (self.autocast_dtype in [torch.float16, torch.bfloat16]) else False
         )

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -115,7 +115,7 @@ class MegatronGPTExportableModel(torch.nn.Module, Exportable):
                 margin=0, interval=1, fp8_format=transformer_engine.common.recipe.Format.E4M3
             )
 
-        self.dtype = utils_funcs.params_dtype_from_precision(model.cfg.precision)
+        self.dtype = utils_funcs.torch_dtype_from_precision(model.cfg.precision)
 
     def forward(self, tokens, position_ids, attention_mask):
         if self.fp8_enabled and HAVE_TE:
@@ -253,7 +253,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
 
             self._wrap_model_for_O2()
 
-        self.autocast_dtype = utils_funcs.params_dtype_from_precision(self.cfg.precision)
+        self.autocast_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)
 
         self.enable_autocast = (
             True if (not self.megatron_amp_o2) and (self.autocast_dtype in [torch.float16, torch.bfloat16]) else False

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -131,8 +131,6 @@ class MegatronGPTPromptLearningModel(MegatronBasePromptLearningModel):
             )
             frozen_model_cfg.activations_checkpoint_method = self.cfg.get("activations_checkpoint_method", None)
 
-        self.autocast_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)
-
         if cfg.get('language_model_path', None):
             self.frozen_model = MegatronGPTModel.restore_from(
                 cfg.get('language_model_path'),

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -41,6 +41,7 @@ from nemo.collections.nlp.modules.common.text_generation_utils import (
     megatron_gpt_generate,
 )
 from nemo.collections.nlp.modules.common.transformer.text_generation import LengthParam, SamplingParam
+from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.parts.nlp_overrides import GradScaler, NLPSaveRestoreConnector
 from nemo.collections.nlp.parts.utils_funcs import get_last_rank
 from nemo.utils import AppState, logging
@@ -130,14 +131,7 @@ class MegatronGPTPromptLearningModel(MegatronBasePromptLearningModel):
             )
             frozen_model_cfg.activations_checkpoint_method = self.cfg.get("activations_checkpoint_method", None)
 
-        if self.trainer.precision in ['bf16', 'bf16-mixed']:
-            self.autocast_dtype = torch.bfloat16
-        elif self.trainer.precision in [32, '32', '32-true']:
-            self.autocast_dtype = torch.float
-        elif self.trainer.precision in [16, '16', '16-mixed']:
-            self.autocast_dtype = torch.half
-        else:
-            raise ValueError('precision must be in ["32-true", "16-mixed", "bf16-mixed"]')
+        self.autocast_dtype = utils_funcs.params_dtype_from_precision(self.cfg.precision)
 
         if cfg.get('language_model_path', None):
             self.frozen_model = MegatronGPTModel.restore_from(

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -131,7 +131,7 @@ class MegatronGPTPromptLearningModel(MegatronBasePromptLearningModel):
             )
             frozen_model_cfg.activations_checkpoint_method = self.cfg.get("activations_checkpoint_method", None)
 
-        self.autocast_dtype = utils_funcs.params_dtype_from_precision(self.cfg.precision)
+        self.autocast_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)
 
         if cfg.get('language_model_path', None):
             self.frozen_model = MegatronGPTModel.restore_from(

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py
@@ -41,7 +41,6 @@ from nemo.collections.nlp.modules.common.text_generation_utils import (
     megatron_gpt_generate,
 )
 from nemo.collections.nlp.modules.common.transformer.text_generation import LengthParam, SamplingParam
-from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.parts.nlp_overrides import GradScaler, NLPSaveRestoreConnector
 from nemo.collections.nlp.parts.utils_funcs import get_last_rank
 from nemo.utils import AppState, logging

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -129,8 +129,6 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
                 config=self.model_parallel_config, module=self.enc_dec_model, precision=self.cfg.precision
             )
 
-        self.autocast_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)
-
         self.enable_autocast = (
             True if (not self.megatron_amp_o2) and (self.autocast_dtype in [torch.float16, torch.bfloat16]) else False
         )

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -398,7 +398,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
             n = f'reduced_train_{k}'
             self.log(n, v, prog_bar=n.endswith("_loss"), rank_zero_only=True, batch_size=1)
 
-        if self.cfg.precision in [16, '16', '16-mixed']:
+        if self.torch_dtype == torch.float16:
             loss_scale = self.trainer.precision_plugin.scaler._scale
             if loss_scale is not None:
                 self.log('loss_scale', loss_scale, batch_size=1)

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -129,7 +129,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
                 config=self.model_parallel_config, module=self.enc_dec_model, precision=self.cfg.precision
             )
 
-        self.autocast_dtype = utils_funcs.params_dtype_from_precision(self.cfg.precision)
+        self.autocast_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)
 
         self.enable_autocast = (
             True if (not self.megatron_amp_o2) and (self.autocast_dtype in [torch.float16, torch.bfloat16]) else False

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -42,7 +42,6 @@ from nemo.collections.nlp.modules.common.text_generation_utils import (
     compute_beam_search_len_penalty,
     get_sampling_token_fn,
 )
-from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.parts.utils_funcs import get_last_rank
 from nemo.utils import AppState, logging
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -126,7 +126,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
 
             # Model wrapper to convert both model and inputs to half precision
             self.enc_dec_model = Float16Module(
-                config=self.model_parallel_config, module=self.enc_dec_model, precision=cfg.precision
+                config=self.model_parallel_config, module=self.enc_dec_model, precision=self.cfg.precision
             )
 
         self.autocast_dtype = utils_funcs.params_dtype_from_precision(self.cfg.precision)
@@ -398,7 +398,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
             n = f'reduced_train_{k}'
             self.log(n, v, prog_bar=n.endswith("_loss"), rank_zero_only=True, batch_size=1)
 
-        if self.cfg.precision == 16:
+        if self.cfg.precision in [16, '16', '16-mixed']:
             loss_scale = self.trainer.precision_plugin.scaler._scale
             if loss_scale is not None:
                 self.log('loss_scale', loss_scale, batch_size=1)

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -42,7 +42,7 @@ from nemo.collections.nlp.modules.common.text_generation_utils import (
     compute_beam_search_len_penalty,
     get_sampling_token_fn,
 )
-from nemo.collections.nlp.parts import nlp_overrides, utils_funcs
+from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.parts.utils_funcs import get_last_rank
 from nemo.utils import AppState, logging
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -42,7 +42,7 @@ from nemo.collections.nlp.modules.common.text_generation_utils import (
     compute_beam_search_len_penalty,
     get_sampling_token_fn,
 )
-from nemo.collections.nlp.parts import nlp_overrides
+from nemo.collections.nlp.parts import nlp_overrides, utils_funcs
 from nemo.collections.nlp.parts.utils_funcs import get_last_rank
 from nemo.utils import AppState, logging
 
@@ -129,14 +129,7 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
                 config=self.model_parallel_config, module=self.enc_dec_model, precision=cfg.precision
             )
 
-        if self.cfg.precision in ['bf16', 'bf16-mixed']:
-            self.autocast_dtype = torch.bfloat16
-        elif self.cfg.precision in [32, '32', '32-true']:
-            self.autocast_dtype = torch.float
-        elif self.cfg.precision in [16, '16', '16-mixed']:
-            self.autocast_dtype = torch.half
-        else:
-            raise ValueError('precision must be in ["32-true", "16-mixed", "bf16-mixed"]')
+        self.autocast_dtype = utils_funcs.params_dtype_from_precision(self.cfg.precision)
 
         self.enable_autocast = (
             True if (not self.megatron_amp_o2) and (self.autocast_dtype in [torch.float16, torch.bfloat16]) else False

--- a/nemo/collections/nlp/models/language_modeling/megatron_retrieval_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_retrieval_model.py
@@ -54,7 +54,6 @@ from nemo.collections.nlp.modules.common.transformer.text_generation import (
     SamplingParam,
     TextGeneration,
 )
-from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.parts.nlp_overrides import GradScaler
 from nemo.utils import AppState, logging
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_retrieval_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_retrieval_model.py
@@ -54,6 +54,7 @@ from nemo.collections.nlp.modules.common.transformer.text_generation import (
     SamplingParam,
     TextGeneration,
 )
+from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.parts.nlp_overrides import GradScaler
 from nemo.utils import AppState, logging
 
@@ -96,14 +97,7 @@ class MegatronRetrievalModel(MegatronBaseModel, TextGeneration):
             )
 
         # self.setup_optimizer_param_groups()
-        if self.cfg.precision == 'bf16':
-            self.autocast_dtype = torch.bfloat16
-        elif int(self.cfg.precision) == 32:
-            self.autocast_dtype = torch.float
-        elif int(self.cfg.precision) == 16:
-            self.autocast_dtype = torch.half
-        else:
-            raise ValueError('precision must be in ["32-true", "16-mixed", "bf16-mixed"]')
+        self.autocast_dtype = utils_funcs.params_dtype_from_precision(self.cfg.precision)
         self.model.model_type = ModelType.encoder_and_decoder
 
         self.enable_autocast = (

--- a/nemo/collections/nlp/models/language_modeling/megatron_retrieval_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_retrieval_model.py
@@ -97,7 +97,6 @@ class MegatronRetrievalModel(MegatronBaseModel, TextGeneration):
             )
 
         # self.setup_optimizer_param_groups()
-        self.autocast_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)
         self.model.model_type = ModelType.encoder_and_decoder
 
         self.enable_autocast = (

--- a/nemo/collections/nlp/models/language_modeling/megatron_retrieval_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_retrieval_model.py
@@ -97,7 +97,7 @@ class MegatronRetrievalModel(MegatronBaseModel, TextGeneration):
             )
 
         # self.setup_optimizer_param_groups()
-        self.autocast_dtype = utils_funcs.params_dtype_from_precision(self.cfg.precision)
+        self.autocast_dtype = utils_funcs.torch_dtype_from_precision(self.cfg.precision)
         self.model.model_type = ModelType.encoder_and_decoder
 
         self.enable_autocast = (

--- a/nemo/collections/nlp/modules/common/megatron/attention.py
+++ b/nemo/collections/nlp/modules/common/megatron/attention.py
@@ -146,7 +146,7 @@ class ParallelAttention(MegatronModule, adapter_mixins.AdapterModuleMixin):
         self.multi_query_attention = multi_query_attention
 
         self.megatron_legacy = megatron_legacy
-        self.dtype = utils_funcs.dtype_from_precision(precision, megatron_amp_O2)
+        self.dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
 
         self.set_accepted_adapter_types(
             [

--- a/nemo/collections/nlp/modules/common/megatron/attention.py
+++ b/nemo/collections/nlp/modules/common/megatron/attention.py
@@ -146,7 +146,7 @@ class ParallelAttention(MegatronModule, adapter_mixins.AdapterModuleMixin):
         self.multi_query_attention = multi_query_attention
 
         self.megatron_legacy = megatron_legacy
-        self.dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
+        self.dtype = utils_funcs.torch_dtype_from_precision(precision, megatron_amp_O2)
 
         self.set_accepted_adapter_types(
             [

--- a/nemo/collections/nlp/modules/common/megatron/language_model.py
+++ b/nemo/collections/nlp/modules/common/megatron/language_model.py
@@ -524,7 +524,7 @@ class TransformerLanguageModel(MegatronModule, adapter_mixins.AdapterModuleMixin
         self.position_embedding_type = position_embedding_type
         self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
         self.sequence_parallel = config.sequence_parallel
-        self.dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
+        self.dtype = utils_funcs.torch_dtype_from_precision(precision, megatron_amp_O2)
         if kv_channels is None:
 
             assert (

--- a/nemo/collections/nlp/modules/common/megatron/language_model.py
+++ b/nemo/collections/nlp/modules/common/megatron/language_model.py
@@ -524,7 +524,7 @@ class TransformerLanguageModel(MegatronModule, adapter_mixins.AdapterModuleMixin
         self.position_embedding_type = position_embedding_type
         self.share_embeddings_and_output_weights = share_embeddings_and_output_weights
         self.sequence_parallel = config.sequence_parallel
-        self.dtype = utils_funcs.dtype_from_precision(precision, megatron_amp_O2)
+        self.dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
         if kv_channels is None:
 
             assert (

--- a/nemo/collections/nlp/modules/common/megatron/retrieval_token_level_encoder_decoder.py
+++ b/nemo/collections/nlp/modules/common/megatron/retrieval_token_level_encoder_decoder.py
@@ -126,7 +126,7 @@ class MegatronRetrievalTokenLevelEncoderDecoderModule(MegatronModule):
         self.num_chunked_cross_attention = len(dec_cross_attention)
         self.megatron_lm_compatible = megatron_lm_compatible
 
-        self.dtype = utils_funcs.dtype_from_precision(precision, megatron_amp_O2)
+        self.dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
 
         if kv_channels is None:
             assert (

--- a/nemo/collections/nlp/modules/common/megatron/retrieval_token_level_encoder_decoder.py
+++ b/nemo/collections/nlp/modules/common/megatron/retrieval_token_level_encoder_decoder.py
@@ -126,7 +126,7 @@ class MegatronRetrievalTokenLevelEncoderDecoderModule(MegatronModule):
         self.num_chunked_cross_attention = len(dec_cross_attention)
         self.megatron_lm_compatible = megatron_lm_compatible
 
-        self.dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
+        self.dtype = utils_funcs.torch_dtype_from_precision(precision, megatron_amp_O2)
 
         if kv_channels is None:
             assert (

--- a/nemo/collections/nlp/modules/common/megatron/token_level_encoder_decoder.py
+++ b/nemo/collections/nlp/modules/common/megatron/token_level_encoder_decoder.py
@@ -148,7 +148,7 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
 
         encoder_kv_channels, decoder_kv_channels = self._validate_config()
 
-        self.dtype = utils_funcs.dtype_from_precision(precision, megatron_amp_O2)
+        self.dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
 
         encoder, decoder = None, None
         if add_encoder:

--- a/nemo/collections/nlp/modules/common/megatron/token_level_encoder_decoder.py
+++ b/nemo/collections/nlp/modules/common/megatron/token_level_encoder_decoder.py
@@ -148,7 +148,7 @@ class MegatronTokenLevelEncoderDecoderModule(MegatronModule):
 
         encoder_kv_channels, decoder_kv_channels = self._validate_config()
 
-        self.dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
+        self.dtype = utils_funcs.torch_dtype_from_precision(precision, megatron_amp_O2)
 
         encoder, decoder = None, None
         if add_encoder:

--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -187,7 +187,7 @@ class ParallelTransformerLayer_(MegatronModule, adapter_mixins.AdapterModuleMixi
         self.bias = bias
         self.transformer_block_type = transformer_block_type
         self.position_embedding_type = position_embedding_type
-        self.param_dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
+        self.param_dtype = utils_funcs.torch_dtype_from_precision(precision, megatron_amp_O2)
 
         self.set_accepted_adapter_types(
             [
@@ -729,7 +729,7 @@ class ParallelTransformerLayer(ParallelTransformerLayer_):
         )
 
         # Dtype for forward pass - ignore amp O2
-        self.dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2=None)
+        self.dtype = utils_funcs.torch_dtype_from_precision(precision, megatron_amp_O2=None)
 
     def forward(
         self,
@@ -845,7 +845,7 @@ class AutocastTransformerLayer(TransformerLayer):
         # use_emha=use_emha,
 
         # Dtype for forward pass - ignore amp O2
-        self.dtype = utils_funcs.params_dtype_from_precision(autocast_dtype, megatron_amp_O2=None)
+        self.dtype = utils_funcs.torch_dtype_from_precision(autocast_dtype, megatron_amp_O2=None)
 
     def forward(
         self,

--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -187,7 +187,7 @@ class ParallelTransformerLayer_(MegatronModule, adapter_mixins.AdapterModuleMixi
         self.bias = bias
         self.transformer_block_type = transformer_block_type
         self.position_embedding_type = position_embedding_type
-        self.param_dtype = utils_funcs.dtype_from_precision(precision, megatron_amp_O2)
+        self.param_dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2)
 
         self.set_accepted_adapter_types(
             [
@@ -729,7 +729,7 @@ class ParallelTransformerLayer(ParallelTransformerLayer_):
         )
 
         # Dtype for forward pass - ignore amp O2
-        self.dtype = utils_funcs.dtype_from_precision(precision, megatron_amp_O2=None)
+        self.dtype = utils_funcs.params_dtype_from_precision(precision, megatron_amp_O2=None)
 
     def forward(
         self,
@@ -845,7 +845,7 @@ class AutocastTransformerLayer(TransformerLayer):
         # use_emha=use_emha,
 
         # Dtype for forward pass - ignore amp O2
-        self.dtype = utils_funcs.dtype_from_precision(autocast_dtype, megatron_amp_O2=None)
+        self.dtype = utils_funcs.params_dtype_from_precision(autocast_dtype, megatron_amp_O2=None)
 
     def forward(
         self,

--- a/nemo/collections/nlp/parts/utils_funcs.py
+++ b/nemo/collections/nlp/parts/utils_funcs.py
@@ -31,7 +31,7 @@ from nemo.collections.nlp.modules.common.megatron.utils import squared_relu
 from nemo.utils import logging
 
 
-def params_dtype_from_precision(precision: Union[int, str], megatron_amp_O2: Optional[bool] = None) -> torch.dtype:
+def torch_dtype_from_precision(precision: Union[int, str], megatron_amp_O2: Optional[bool] = None) -> torch.dtype:
     """ Mapping from PTL precision types to corresponding PyTorch parameter datatype."""
     if megatron_amp_O2 is not None and megatron_amp_O2 is False:
         return torch.float32

--- a/nemo/collections/nlp/parts/utils_funcs.py
+++ b/nemo/collections/nlp/parts/utils_funcs.py
@@ -31,7 +31,7 @@ from nemo.collections.nlp.modules.common.megatron.utils import squared_relu
 from nemo.utils import logging
 
 
-def params_dtype_from_precision(precision: Union[int, str], megatron_amp_O2: Optional[bool]) -> torch.dtype:
+def params_dtype_from_precision(precision: Union[int, str], megatron_amp_O2: Optional[bool] = None) -> torch.dtype:
     """ Mapping from PTL precision types to corresponding PyTorch parameter datatype."""
     if megatron_amp_O2 is not None and megatron_amp_O2 is False:
         return torch.float32

--- a/nemo/collections/nlp/parts/utils_funcs.py
+++ b/nemo/collections/nlp/parts/utils_funcs.py
@@ -31,7 +31,8 @@ from nemo.collections.nlp.modules.common.megatron.utils import squared_relu
 from nemo.utils import logging
 
 
-def dtype_from_precision(precision: Union[int, str], megatron_amp_O2: Optional[bool]) -> torch.dtype:
+def params_dtype_from_precision(precision: Union[int, str], megatron_amp_O2: Optional[bool]) -> torch.dtype:
+    """ Mapping from PTL precision types to corresponding PyTorch parameter datatype."""
     if megatron_amp_O2 is not None and megatron_amp_O2 is False:
         return torch.float32
 

--- a/tests/collections/nlp/test_gpt_model.py
+++ b/tests/collections/nlp/test_gpt_model.py
@@ -199,11 +199,11 @@ class TestGPTModel:
     def test_forward(self, gpt_model, test_text):
 
         dtype = None
-        if gpt_model.cfg['precision'] == 32:
+        if gpt_model.cfg['precision'] in [32, '32', '32-true']:
             dtype = torch.float
-        elif gpt_model.cfg['precision'] == 16:
+        elif gpt_model.cfg['precision'] in [16, '16', '16-mixed']:
             dtype = torch.float16
-        elif gpt_model.cfg['precision'] == 'bf16':
+        elif gpt_model.cfg['precision'] in ['bf16', 'bf16-mixed']:
             dtype = torch.bfloat16
         else:
             raise ValueError(f"precision: {gpt_model.cfg['precision']} is not supported.")

--- a/tests/collections/nlp/test_gpt_model.py
+++ b/tests/collections/nlp/test_gpt_model.py
@@ -198,15 +198,7 @@ class TestGPTModel:
     @pytest.mark.unit
     def test_forward(self, gpt_model, test_text):
 
-        dtype = None
-        if gpt_model.cfg['precision'] in [32, '32', '32-true']:
-            dtype = torch.float
-        elif gpt_model.cfg['precision'] in [16, '16', '16-mixed']:
-            dtype = torch.float16
-        elif gpt_model.cfg['precision'] in ['bf16', 'bf16-mixed']:
-            dtype = torch.bfloat16
-        else:
-            raise ValueError(f"precision: {gpt_model.cfg['precision']} is not supported.")
+        dtype = gpt_model.torch_dtype
 
         gpt_model.eval()
 


### PR DESCRIPTION
# What does this PR do ?

Move model precision copy to MegatronBaseModel to reduce boilerplate.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Remove `cfg.model.precision` = `cfg.trainer.precision` copy from several examples
- Set precision in `MegatronBaseModel` which all Megatron models inherit from
- Fix some mapping of PTL 2.0 precision to torch datatypes that were exposed by above

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
- [X] Refactor

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
