### PR TITLE
pin numba=0.57.1 to fix reinstall.sh error

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -20,7 +20,7 @@ if [ -n "${NVIDIA_PYTORCH_VERSION}" ]; then
   echo 'Installing NeMo in NVIDIA PyTorch container:' "${NVIDIA_PYTORCH_VERSION}" 'so will not install numba'
 else
   if [ -n "${CONDA_PREFIX}" ]; then
-    NUMBA_VERSION=0.55
+    NUMBA_VERSION=0.57.1
     echo 'Installing numba=='${NUMBA_VERSION}
     conda install -y -c conda-forge numba==${NUMBA_VERSION}
   fi


### PR DESCRIPTION
# What does this PR do ?

I observed our Dockerfile had constrained `numba>=0.57.1` (see [here](https://github.com/NVIDIA/NeMo/blob/main/Dockerfile#L86)) while `reinstall.sh` still pins `NUMBA_VERSION=0.55` (see [here](https://github.com/NVIDIA/NeMo/blob/main/reinstall.sh#L23)). When I run `reinstall.sh` from the latest main, it will raise installation error for `llvmlite` (see error below). Once I pinned `NUMBA_VERSION=0.57.1`, and run `reinstall.sh` again, the problem is resolved.

```bash
  Attempting uninstall: llvmlite
    Found existing installation: llvmlite 0.38.1
ERROR: Cannot uninstall 'llvmlite'. It is a distutils installed project and thus we cannot accurately determine which files belong to it which would lead to only a partial uninstall.
```

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
