### PR TITLE
Fix wrong calling of librosa.get_duration() in notebook

### DIFF
--- a/tutorials/asr/Online_Offline_Speech_Commands_Demo.ipynb
+++ b/tutorials/asr/Online_Offline_Speech_Commands_Demo.ipynb
@@ -497,7 +497,7 @@
                 "\n",
                 "CHANNELS = 1\n",
                 "audio, sample_rate = librosa.load(wave_file, sr=SAMPLE_RATE)\n",
-                "dur = librosa.get_duration(audio)\n",
+                "dur = librosa.get_duration(y=audio, sr=sample_rate)\n",
                 "print(dur)"
             ]
         },


### PR DESCRIPTION
# What does this PR do ?

When running notebook `tutorials/asr/Online_Offline_Speech_Commands_Demo.ipynb` of `main` branch in the Google Colab, it will report the error:
```
TypeError                                 Traceback (most recent call last)
[<ipython-input-18-1dea7463f5dd>](https://localhost:8080/#) in <cell line: 5>()
      3 CHANNELS = 1
      4 audio, sample_rate = librosa.load(wave_file, sr=SAMPLE_RATE)
----> 5 dur = librosa.get_duration(audio)
      6 print(dur)

TypeError: get_duration() takes 0 positional arguments but 1 was given
```

The calling of `librosa.get_duration(audio)` is wrong. This PR is fixing it.

# Changelog 
- Fix the error of calling librosa.get_duration() in notebook.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

@titu1994, @redoctopus, @jbalam-nv

# Additional Information
* Related to #7179 
