### PR TITLE
Add steps for document of getting dataset 'SF Bilingual Speech'

### DIFF
--- a/docs/source/tts/datasets.rst
+++ b/docs/source/tts/datasets.rst
@@ -176,8 +176,14 @@ SFSpeech Chinese/English Bilingual Speech
 
 .. code-block:: bash
 
+    # [prerequisite] Install and setup 'ngc' cli tool by following document https://docs.ngc.nvidia.com/cli/cmd.html
+
+    $ ngc registry resource download-version "nvidia/sf_bilingual_speech_zh_en:v1"
+
+    $ unzip sf_bilingual_speech_zh_en_vv1/SF_bilingual.zip -d <your_local_dataset_root>
+
     $ python scripts/dataset_processing/tts/sfbilingual/get_data.py \
-        --data-root <your_local_dataset_root> \
+        --data-root <your_local_dataset_root>/SF_bilingual \
         --val-size 0.1 \
         --test-size 0.2 \
         --seed-for-ds-split 100


### PR DESCRIPTION
# What does this PR do ?

When following the [document](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/tts/datasets.html#sfspeech-chinese-english-bilingual-speech) to get dataset `SFSpeech Chinese/English Bilingual Speech`, the first command
```bash
python scripts/dataset_processing/tts/sfbilingual/get_data.py \
    --data-root <your_local_dataset_root> \
    --val-size 0.1 \
    --test-size 0.2 \
    --seed-for-ds-split 100
```
 directly raise error:
```
Traceback (most recent call last):
  File "/home/xxx/NeMo/scripts/dataset_processing/tts/sfbilingual/get_data.py", line 122, in <module>
    main()
  File "/home/xxx/NeMo/scripts/dataset_processing/tts/sfbilingual/get_data.py", line 116, in main
    __process_data(
  File "/home/xxx/NeMo/scripts/dataset_processing/tts/sfbilingual/get_data.py", line 91, in __process_data
    entries = __process_transcript(dataset_path)
  File "/home/xxx/NeMo/scripts/dataset_processing/tts/sfbilingual/get_data.py", line 65, in __process_transcript
    with open(file_path / "text_SF.txt", encoding="utf-8") as fin:
FileNotFoundError: [Errno 2] No such file or directory: 'tryit/text_SF.txt'
```

The reason: `scripts/dataset_processing/tts/sfbilingual/get_data.py` actually doesn't download the dataset. The `SFSpeech Chinese/English Bilingual Speech` could only be downloaded through [Nvidia NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/resources/sf_bilingual_speech_zh_en).

# Changelog
- Add steps in the document of dataset SFSpeech to download by ngc-cli tool at first

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and follow [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [x] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?
@blisc  @okuchaiev @titu1994 