### PR TITLE
Fix sequence parallel compatibility issues

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_dataset.py
@@ -28,6 +28,7 @@ from nemo.collections.nlp.data.language_modeling.megatron.base_dataset_utils imp
 from nemo.collections.nlp.data.language_modeling.megatron.blendable_dataset import BlendableDataset
 from nemo.collections.nlp.data.language_modeling.megatron.indexed_dataset import deallocate_indexed_dataset_memory
 from nemo.collections.nlp.data.language_modeling.megatron.indexed_dataset import make_dataset as make_indexed_dataset
+from nemo.collections.nlp.data.language_modeling.wikitext_dataset import WikitextDataset
 from nemo.core import Dataset
 from nemo.utils import logging
 
@@ -103,6 +104,15 @@ def build_train_valid_test_datasets(
         train_ds = MockGPTDataset(cfg, tokenizer, "train", int(train_valid_test_num_samples[0]), seq_length, seed,)
         valid_ds = MockGPTDataset(cfg, tokenizer, "valid", int(train_valid_test_num_samples[1]), seq_length, seed,)
         test_ds = MockGPTDataset(cfg, tokenizer, "test", int(train_valid_test_num_samples[2]), seq_length, seed,)
+        return train_ds, valid_ds, test_ds
+
+    if data_impl.startswith('hf_wikitext'):
+        _, config_name = data_impl.split(' ')
+        logging.info("Initializing Huggingface Wikitext dataset for train, validate, and test")
+        train_ds = WikitextDataset(tokenizer, seq_length, name=config_name, split="train")
+        valid_ds = WikitextDataset(tokenizer, seq_length, name=config_name, split="validation")
+        test_ds = WikitextDataset(tokenizer, seq_length, name=config_name, split="test")
+
         return train_ds, valid_ds, test_ds
 
     if isinstance(data_prefix, DictConfig):

--- a/nemo/collections/nlp/data/language_modeling/wikitext_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/wikitext_dataset.py
@@ -1,0 +1,105 @@
+import itertools
+import os
+
+import torch
+from datasets import load_dataset
+
+from nemo.core.classes import Dataset
+
+
+def fixed_seq_length_of_datasets(
+    datasets, fixed_seq_length, load_from_cache_file=False,
+):
+    block_size = fixed_seq_length
+
+    # Main data processing function that will concatenate all texts from our dataset and generate chunks of block_size.
+    def group_texts(examples):
+        # Concatenate all texts.
+        concatenated_examples = {k: list(itertools.chain(*examples[k])) for k in examples.keys()}
+        input_ids = concatenated_examples["input_ids"]
+        total_length = len(input_ids)
+
+        if total_length < block_size:
+            return {"input_ids": []}
+
+        # Cut off the excess tokens to align it with the group size.
+        if total_length % block_size != 0:
+            input_ids = input_ids[: total_length - total_length % block_size]
+
+        # Split by chunks of max_len.
+        result = {"input_ids": [input_ids[i : i + block_size] for i in range(0, total_length, block_size)]}
+
+        return result
+
+    lm_datasets = datasets.map(
+        group_texts,
+        batched=True,
+        num_proc=os.cpu_count(),
+        load_from_cache_file=load_from_cache_file,
+        desc=f"Grouping texts in chunks of {block_size}",
+    )
+    lm_datasets = lm_datasets.filter(
+        function=lambda batch: [len(ids) > 0 for ids in batch["input_ids"]],
+        batched=True,
+        num_proc=os.cpu_count(),
+        load_from_cache_file=load_from_cache_file,
+        desc=f"Delete empty ids generated in the previous process.",
+    )
+
+    return lm_datasets
+
+
+class WikitextDataset(Dataset):
+    def __init__(
+        self, tokenizer, seq_length, split="test", name=None, load_from_cache_file=True,
+    ):
+        """HuggingFace's WikiText dataset.
+        link: https://huggingface.co/datasets/wikitext
+        """
+        super().__init__()
+        self.seq_length = seq_length
+        self.name = name
+        raw_dataset = load_dataset("wikitext", name, split=split)
+        column_names = raw_dataset.column_names
+
+        def tokenize(examples):
+            ids = []
+            for text in examples["text"]:
+                id_or_ids = tokenizer.text_to_ids(text)
+                if id_or_ids is not list:
+                    id_or_ids = [id_or_ids]
+                ids += id_or_ids
+            return ids
+
+        tokenized_dataset = raw_dataset.map(
+            lambda examples: {"input_ids": tokenize(examples)},
+            batched=True,
+            remove_columns=column_names,
+            num_proc=os.cpu_count(),
+            load_from_cache_file=load_from_cache_file,
+            desc="Running tokenizer on dataset",
+        )
+
+        lm_dataset = fixed_seq_length_of_datasets(
+            tokenized_dataset, seq_length, load_from_cache_file=load_from_cache_file,
+        )
+        self.dataset = lm_dataset
+        self.attention_mask = torch.tril(torch.ones((self.seq_length, self.seq_length))).unsqueeze(0)
+        self.attention_mask = self.attention_mask < 0.5
+        self.loss_mask = torch.ones(self.seq_length, dtype=torch.float)
+        self.position_ids = torch.arange(self.seq_length, dtype=torch.int64)
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, idx):
+        item = self.dataset[idx]
+        data_item = dict(
+            tokens=torch.tensor(item["input_ids"], dtype=torch.int64),
+            labels=torch.tensor(item["input_ids"], dtype=torch.int64),
+            attention_mask=self.attention_mask,
+            loss_mask=self.loss_mask,
+            position_ids=self.position_ids,
+        )
+
+        return data_item

--- a/nemo/collections/nlp/models/language_modeling/megatron/bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/bert_model.py
@@ -18,7 +18,7 @@ import torch
 
 from nemo.collections.nlp.modules.common.megatron.language_model import get_language_model
 from nemo.collections.nlp.modules.common.megatron.module import MegatronModule
-from nemo.collections.nlp.modules.common.megatron.transformer import get_layer_norm
+from nemo.collections.nlp.modules.common.megatron.layer_norm import get_layer_norm
 from nemo.collections.nlp.modules.common.megatron.utils import (
     ApexGuardDefaults,
     build_position_ids,
@@ -102,7 +102,7 @@ class BertLMHead(MegatronModule):
         self.sequence_parallel = config.sequence_parallel
 
         self.dense = get_linear_layer(hidden_size, hidden_size, init_method)
-        self.layernorm = get_layer_norm(hidden_size, eps=layernorm_epsilon)
+        self.layernorm = get_layer_norm("layernorm", hidden_size, eps=layernorm_epsilon)
         self.gelu = torch.nn.functional.gelu
         if use_openai_gelu:
             self.gelu = openai_gelu

--- a/nemo/collections/nlp/models/language_modeling/megatron/bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/bert_model.py
@@ -17,8 +17,8 @@
 import torch
 
 from nemo.collections.nlp.modules.common.megatron.language_model import get_language_model
-from nemo.collections.nlp.modules.common.megatron.module import MegatronModule
 from nemo.collections.nlp.modules.common.megatron.layer_norm import get_layer_norm
+from nemo.collections.nlp.modules.common.megatron.module import MegatronModule
 from nemo.collections.nlp.modules.common.megatron.utils import (
     ApexGuardDefaults,
     build_position_ids,

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -964,6 +964,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
 
         # we can only log on one rank if it is rank zero so we broadcast from last rank
         torch.distributed.broadcast(averaged_loss, get_last_rank())
+        self._loss = averaged_loss
 
         self.log('val_loss', averaged_loss, prog_bar=True, rank_zero_only=True, batch_size=1)
         self.validation_step_outputs.clear()  # free memory

--- a/nemo/collections/nlp/modules/common/megatron/layer_norm.py
+++ b/nemo/collections/nlp/modules/common/megatron/layer_norm.py
@@ -1,0 +1,43 @@
+from nemo.collections.nlp.modules.common.megatron.fused_layer_norm import get_layer_norm as get_fused_layer_norm
+from nemo.collections.nlp.modules.common.megatron.layer_norm_1p import LayerNorm1P, LPLayerNorm
+from nemo.collections.nlp.modules.common.megatron.utils import ApexGuardDefaults
+
+try:
+    from apex.normalization import MixedFusedRMSNorm
+
+    HAVE_APEX = True
+
+except (ImportError, ModuleNotFoundError):
+    HAVE_APEX = False
+    # fake missing classes with None attributes
+    ModelType = AttnMaskType = AttnType = LayerType = ApexGuardDefaults()
+
+
+def get_layer_norm(
+    ln_type, hidden_size, eps, persist=False, sequence_parallel=False,
+):
+    """Get the specified type from many layernorms.
+
+    ln_type: 'layernorm', 'layernorm1p', 'rmsnorm', 'low_precision_layernorm'
+    hidden_size: hidden size of the transformer layer
+    layernorm_epsilon: epsilon value for layer norm
+    persist_layer_norm: whether to use the persistent layer norm kernel
+    sequence_parallel: whether to use sequence parallelism
+    """
+    if ln_type == 'layernorm':
+        ln = get_fused_layer_norm(hidden_size=hidden_size, eps=eps, persist_layer_norm=persist,)
+    elif ln_type == 'layernorm1p':
+        ln = LayerNorm1P(hidden_size=hidden_size, eps=eps, sequence_parallel_enabled=sequence_parallel,)
+    elif ln_type == 'low_precision_layernorm':
+        ln = LPLayerNorm(normalized_shape=hidden_size, eps=eps)
+    elif ln_type == 'rmsnorm':
+        ln = MixedFusedRMSNorm(normalized_shape=hidden_size, eps=eps)
+    else:
+        raise Exception("Unsupported layer norm type: {}".format(ln_type))
+
+    if sequence_parallel:
+        # mark sequence parallelism in layer norm parameters
+        for param in ln.parameters():
+            setattr(param, 'sequence_parallel', True)
+
+    return ln

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -20,7 +20,7 @@ if [ -n "${NVIDIA_PYTORCH_VERSION}" ]; then
   echo 'Installing NeMo in NVIDIA PyTorch container:' "${NVIDIA_PYTORCH_VERSION}" 'so will not install numba'
 else
   if [ -n "${CONDA_PREFIX}" ]; then
-    NUMBA_VERSION=0.55
+    NUMBA_VERSION=0.57.1
     echo 'Installing numba=='${NUMBA_VERSION}
     conda install -y -c conda-forge numba==${NUMBA_VERSION}
   fi

--- a/tests/collections/nlp/test_gpt_model_parallel.py
+++ b/tests/collections/nlp/test_gpt_model_parallel.py
@@ -1,0 +1,158 @@
+import os
+import time
+
+import pytest
+import torch
+from megatron.core import parallel_state
+from omegaconf import DictConfig, open_dict
+from pytorch_lightning import seed_everything
+
+from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel
+from nemo.collections.nlp.parts.megatron_trainer_builder import MegatronTrainerBuilder
+
+
+@pytest.mark.run_only_on('GPU')
+class TestGPTModelParallel:
+    DEFAULT_SEED = 1234
+    EXPECTED_LOSS = torch.tensor(0.5541142225265503)
+
+    @pytest.mark.unit
+    def test_tensor_parallel(self, gpt_cfg, trainer_cfg):
+        cfg = DictConfig({"model": gpt_cfg, "trainer": trainer_cfg,})
+        with open_dict(cfg):
+            cfg.model.tensor_model_parallel_size = 2
+            cfg.trainer.devices = 2
+
+        with TrainingBenchmark(self.DEFAULT_SEED):
+            trainer = MegatronTrainerBuilder(cfg).create_trainer()
+            gpt = MegatronGPTModel(cfg.model, trainer)
+
+            trainer.fit(gpt)
+
+        torch.testing.assert_close(gpt._loss, self.EXPECTED_LOSS, check_device=False)
+
+    @pytest.mark.unit
+    def test_sequence_parallel(self, gpt_cfg, trainer_cfg):
+        cfg = DictConfig({"model": gpt_cfg, "trainer": trainer_cfg,})
+        with open_dict(cfg):
+            cfg.model.tensor_model_parallel_size = 2
+            cfg.model.sequence_parallel = True
+            cfg.trainer.devices = 2
+
+        with TrainingBenchmark(self.DEFAULT_SEED):
+            trainer = MegatronTrainerBuilder(cfg).create_trainer()
+            gpt = MegatronGPTModel(cfg.model, trainer)
+
+            trainer.fit(gpt)
+
+        torch.testing.assert_close(
+            gpt._loss, self.EXPECTED_LOSS, check_device=False, atol=0.01, rtol=0.01,
+        )
+
+    def teardown_torch_dist_group(self):
+        torch.distributed.destroy_process_group()
+        # sleep for a bit to avoid race conditions with new process group.
+        time.sleep(3)
+
+
+class TrainingBenchmark:
+    def __init__(self, seed):
+        seed_everything(seed)
+
+    def __enter__(self):
+        torch.backends.cudnn.deterministic = True
+
+    def __exit__(self, *args):
+        torch.distributed.barrier()
+        parallel_state.destroy_model_parallel()
+
+
+@pytest.fixture()
+def gpt_cfg(test_data_dir):
+
+    model_cfg = {
+        'precision': 32,
+        'micro_batch_size': 4,
+        'global_batch_size': 8,
+        'tensor_model_parallel_size': 1,
+        'pipeline_model_parallel_size': 1,
+        'resume_from_checkpoint': None,
+        'encoder_seq_length': 512,
+        'max_position_embeddings': 512,
+        'num_layers': 1,
+        'hidden_size': 128,
+        'ffn_hidden_size': 512,
+        'num_attention_heads': 2,
+        'init_method_std': 0.02,
+        'hidden_dropout': 0.1,
+        'kv_channels': None,
+        'apply_query_key_layer_scaling': True,
+        'layernorm_epsilon': 1e-5,
+        'make_vocab_size_divisible_by': 128,
+        'pre_process': True,
+        'post_process': True,
+        'persist_layer_norm': True,
+        'gradient_as_bucket_view': True,
+        'tokenizer': {
+            'library': 'megatron',
+            'type': 'GPT2BPETokenizer',
+            'model': None,
+            'vocab_file': os.path.join(test_data_dir, 'nlp/gpt_vocab_merges/vocab.json'),
+            'merge_file': os.path.join(test_data_dir, 'nlp/gpt_vocab_merges/merges.txt'),
+            'delimiter': None,
+        },
+        'native_amp_init_scale': 4294967296,
+        'native_amp_growth_interval': 1000,
+        'hysteresis': 2,
+        'fp32_residual_connection': False,
+        'fp16_lm_cross_entropy': False,
+        'megatron_amp_O2': False,
+        'seed': 1234,
+        'use_cpu_initialization': False,
+        'onnx_safe': False,
+        'apex_transformer_log_level': 30,
+        'activations_checkpoint_method': None,
+        'activations_checkpoint_num_layers': 1,
+        'data': {
+            'data_impl': 'hf_wikitext wikitext-2-v1',
+            "data_prefix": [],
+            'splits_string': '8,1,1',
+            'seq_length': 512,
+            'skip_warmup': True,
+            'num_workers': 0,
+            'dataloader_type': 'single',
+            'reset_position_ids': False,
+            'reset_attention_mask': False,
+            'eod_mask_loss': False,
+        },
+        'optim': {
+            'name': 'fused_adam',
+            'lr': 2e-3,
+            'weight_decay': 0.01,
+            'betas': [0.9, 0.98],
+            'sched': {'name': 'CosineAnnealing', 'warmup_steps': 10, 'constant_steps': 200, 'min_lr': 2e-4},
+        },
+    }
+    return model_cfg
+
+
+@pytest.fixture()
+def trainer_cfg():
+
+    trainer_cfg = {
+        'devices': 2,
+        'num_nodes': 1,
+        'accelerator': 'gpu',
+        'precision': 32,
+        'logger': False,
+        'enable_checkpointing': False,
+        'use_distributed_sampler': False,
+        'max_epochs': 1,
+        'max_steps': 500,
+        'val_check_interval': 100,
+        'limit_val_batches': 1,
+        'accumulate_grad_batches': 1,
+        'gradient_clip_val': 1.0,
+    }
+
+    return trainer_cfg


### PR DESCRIPTION
# What does this PR do ?

When you do not enable mcore or use loss mask, sequence parallel will not work properly. This PR fixes this problem.

**Collection**: NLP

# Changelog 
- Modify post_language_model_processing to make sequence-parallel and loss-mask compatible.
- Mark the parameters of layernorms with sequence-parallel so that sequence-parallel can be calculated correctly on layernorms.
- For the correctness check of sequence-parallel(unit test), the wikitext dataset has been added.

# Usage
* This is a feature compatibility fix, you can now use sequence-parallel without enabling mcore.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Please help review, thank you! @MaximumEntropy, @ericharper, @ekmb, @yzhang123, @VahidooX, @vladgets, @okuchaiev

# Additional Information

The new unit test will start the PyTorch TCP Store and may conflict with other unit tests. Please use an independent process for unit testing.
