### PR TITLE
Fix missing pip package 'einops'

### DIFF
--- a/tutorials/asr/Online_Offline_Speech_Commands_Demo.ipynb
+++ b/tutorials/asr/Online_Offline_Speech_Commands_Demo.ipynb
@@ -672,7 +672,8 @@
                 "# !git clone --depth 1 --branch v1.8.0 https://github.com/microsoft/onnxruntime.git .\n",
                 "# !./build.sh --skip_tests --config Release --build_shared_lib --parallel --use_cuda --cuda_home /usr/local/cuda --cudnn_home /usr/lib/x86_64-linux-gnu --build_wheel\n",
                 "# !pip install ./build/Linux/Release/dist/onnxruntime*.whl\n",
-                "# %cd .."
+                "# %cd ..\n",
+                "!pip install einops\n"
             ]
         },
         {


### PR DESCRIPTION
# What does this PR do ?
When running `tutorials/asr/Online_Offline_Speech_Commands_Demo.ipynb` in Google Colab, it failed at the last code block because of lacking package `einops`:

![Screenshot 2023-09-08 at 20 47 25](https://github.com/NVIDIA/NeMo/assets/1953397/9d9a7334-7958-45bc-8e00-379f5e2b9c02)

So add a install command for it.

# Changelog 
- Fix missing pip package 'einops' in 'Online_Offline_Speech_Commands_Demo.ipynb'

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?
@titu1994, @redoctopus, @jbalam-nv
