### PR TITLE
Fix CustomProgressBar for resume

### DIFF
--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -1097,12 +1097,11 @@ class CustomProgressBar(TQDMProgressBar):
         return self.bar
 
     def on_train_epoch_start(self, trainer, *_):
-        if trainer.max_steps != -1:
-            #num_training_batches = min(trainer.max_steps, trainer.num_training_batches)
-            # update with max_steps for both training from scratch and resuming
+        if trainer.max_steps > 0 and (trainer.ckpt_path is not None):
+            # while resuming from a ckpt use trainer.max_steps as the total for progress bar as trainer.num_training_batches
+            # is truncated to max_steps - step being resumed at
             num_training_batches = trainer.max_steps
         else:
-            # TODO: fix for resume with multiple epochs
             num_training_batches = trainer.num_training_batches
         self.train_progress_bar.reset(num_training_batches)
         self.train_progress_bar.initial = 0

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -1098,8 +1098,11 @@ class CustomProgressBar(TQDMProgressBar):
 
     def on_train_epoch_start(self, trainer, *_):
         if trainer.max_steps != -1:
-            num_training_batches = min(trainer.max_steps, trainer.num_training_batches)
+            #num_training_batches = min(trainer.max_steps, trainer.num_training_batches)
+            # update with max_steps for both training from scratch and resuming
+            num_training_batches = trainer.max_steps
         else:
+            # TODO: fix for resume with multiple epochs
             num_training_batches = trainer.num_training_batches
         self.train_progress_bar.reset(num_training_batches)
         self.train_progress_bar.initial = 0

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -1082,6 +1082,7 @@ class CustomProgressBar(TQDMProgressBar):
     Add CustomProgressBar to remove 's/it' and display progress per step instead of per microbatch
     for megatron models
     """
+
     def get_current_epoch_step(self, trainer):
         """
         Get the value of step within an epoch


### PR DESCRIPTION
# What does this PR do ?

- Fix the CustomProgressBar for cases when we are resuming training from a checkpoint. Currently when we are resuming from a checkpoint total value in `iter_num/total` of the progress bar is the number of remaining training steps instead of total training steps which leads to the progress bar displaying` iter_num/?` when iter_num > remaining training steps. This PR fixes the issue by reseting the total with `max_steps`.
- Also, in case of multiple epochs the PR updates the current step number (n) to be the current step number within an epoch (default was current step across an epoch and this can lead to an errored progress bar).

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
