### PR TITLE
Fix failure of ljspeech's get_data.py

### DIFF
--- a/scripts/dataset_processing/tts/ljspeech/get_data.py
+++ b/scripts/dataset_processing/tts/ljspeech/get_data.py
@@ -27,11 +27,6 @@ from tqdm import tqdm
 def get_args():
     parser = argparse.ArgumentParser(description='Download LJSpeech and create manifests with predefined split')
     parser.add_argument("--data-root", required=True, type=Path)
-    parser.add_argument(
-        '--whitelist-path',
-        type=str,
-        default="lj_speech.tsv extracted from the readme file in the dataset. You can also download the file from https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/data/whitelist/lj_speech.tsv",
-    )
 
     args = parser.parse_args()
     return args
@@ -57,18 +52,10 @@ def __extract_file(filepath, data_dir):
         print(f"Error while extracting {filepath}. Already extracted?")
 
 
-def __process_data(data_root, whitelist_path):
-    if whitelist_path is None:
-        wget.download(
-            "https://raw.githubusercontent.com/NVIDIA/NeMo-text-processing/main/nemo_text_processing/text_normalization/en/data/whitelist/lj_speech.tsv",
-            out=str(data_root),
-        )
-        whitelist_path = data_root / "lj_speech.tsv"
-
+def __process_data(data_root):
     text_normalizer = Normalizer(
         lang="en",
         input_case="cased",
-        whitelist=whitelist_path,
         overwrite_cache=True,
         cache_dir=data_root / "cache_dir",
     )
@@ -117,9 +104,8 @@ def main():
     __extract_file(str(tarred_data_path), str(args.data_root))
 
     data_root = args.data_root / "LJSpeech-1.1"
-    whitelist_path = args.whitelist_path
 
-    __process_data(data_root, whitelist_path)
+    __process_data(data_root)
 
 
 if __name__ == '__main__':

--- a/scripts/dataset_processing/tts/ljspeech/get_data.py
+++ b/scripts/dataset_processing/tts/ljspeech/get_data.py
@@ -54,10 +54,7 @@ def __extract_file(filepath, data_dir):
 
 def __process_data(data_root):
     text_normalizer = Normalizer(
-        lang="en",
-        input_case="cased",
-        overwrite_cache=True,
-        cache_dir=data_root / "cache_dir",
+        lang="en", input_case="cased", overwrite_cache=True, cache_dir=data_root / "cache_dir",
     )
     text_normalizer_call_kwargs = {"punct_pre_process": True, "punct_post_process": True}
     normalizer_call = lambda x: text_normalizer.normalize(x, **text_normalizer_call_kwargs)


### PR DESCRIPTION
# What does this PR do?

When running `python scripts/dataset_processing/tts/ljspeech/get_data.py --data-root <your_local_dataset_root>` to get the data of LJSpeech as the [document](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/main/tts/datasets.html#ljspeech), it reported error:
```
FileNotFoundError: [Errno 2] No such file or directory: 'lj_speech.tsv extracted from the readme file in the dataset. You can also download the file from https://github.com/NVIDIA/NeMo-text-processing/blob/main/nemo_text_processing/text_normalization/en/data/whitelist/lj_speech.tsv'
```
Solution: The default value of argument `--whitelist-path` of `get_data.py` should be `None` (so the get_data.py will automatically download the lj_speech.tsv) instead of a long string.

# Changelog 
- Fix failure of ljspeech's get_data.py.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

@blisc @okuchaiev @titu1994