### PR TITLE
Speech Simulator, update README.md: output_path --> output_manifest_filepath

### DIFF
--- a/tools/speech_data_simulator/README.md
+++ b/tools/speech_data_simulator/README.md
@@ -89,7 +89,7 @@ python scripts/dataset_processing/get_librispeech_data.py \
 python <NeMo base path>/scripts/speaker_tasks/create_alignment_manifest.py \
   --input_manifest_filepath <Path to train_clean_100.json manifest file> \
   --base_alignment_path <Path to LibriSpeech_Alignments directory> \
-  --output_path train-clean-100-align.json \
+  --output_manifest_filepath train-clean-100-align.json \
   --ctm_output_directory ./ctm_out \
   --libri_dataset_split train-clean-100
 ```


### PR DESCRIPTION
I think the correct option for 

```bash
python <NeMo base path>/scripts/speaker_tasks/create_alignment_manifest.py \
  --input_manifest_filepath <Path to train_clean_100.json manifest file> \
  --base_alignment_path <Path to LibriSpeech_Alignments directory> \
  --output_path train-clean-100-align.json \
  --output_manifest_filepath train-clean-100-align.json \
  --ctm_output_directory ./ctm_out \
  --libri_dataset_split train-clean-100
```

is `--output_manifest_filepath` not `--output_path` in the current version. 