### PR TITLE
Fix checking of cuda/cpu device for inputs of Decoder

### DIFF
--- a/nemo/collections/tts/modules/tacotron2.py
+++ b/nemo/collections/tts/modules/tacotron2.py
@@ -312,11 +312,8 @@ class Decoder(NeuralModule):
 
         self.initialize_decoder_states(memory, mask=mask)
 
-        mel_lengths = torch.zeros([memory.size(0)], dtype=torch.int32)
-        not_finished = torch.ones([memory.size(0)], dtype=torch.int32)
-        if next(self.parameters()).is_cuda:
-            mel_lengths = mel_lengths.cuda()
-            not_finished = not_finished.cuda()
+        mel_lengths = torch.zeros([memory.size(0)], dtype=torch.int32).to(memory.device)
+        not_finished = torch.ones([memory.size(0)], dtype=torch.int32).to(memory.device)
 
         mel_outputs, gate_outputs, alignments = [], [], []
         stepped = False

--- a/nemo/collections/tts/modules/tacotron2.py
+++ b/nemo/collections/tts/modules/tacotron2.py
@@ -314,7 +314,7 @@ class Decoder(NeuralModule):
 
         mel_lengths = torch.zeros([memory.size(0)], dtype=torch.int32)
         not_finished = torch.ones([memory.size(0)], dtype=torch.int32)
-        if torch.cuda.is_available():
+        if next(self.parameters()).is_cuda:
             mel_lengths = mel_lengths.cuda()
             not_finished = not_finished.cuda()
 


### PR DESCRIPTION
# What does this PR do?
When running the below snippet from the [document](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/nemo/models/tts_en_tacotron2) on a machine with GPU
```python
# Load Tacotron2
from nemo.collections.tts.models import Tacotron2Model
spec_generator = Tacotron2Model.from_pretrained("tts_en_tacotron2")

# Load vocoder
from nemo.collections.tts.models import HifiGanModel
vocoder = HifiGanModel.from_pretrained(model_name="tts_en_hifigan")

# Generate audio
import soundfile as sf
import torch
with torch.no_grad():
    parsed = spec_generator.parse("You can type your sentence here to get nemo to produce speech.")
    spectrogram = spec_generator.generate_spectrogram(tokens=parsed)
    audio = vocoder.convert_spectrogram_to_audio(spec=spectrogram)

# Save the audio to disk in a file called speech.wav
if isinstance(audio, torch.Tensor):
    audio = audio.to('cpu').numpy()
sf.write("speech.wav", audio.T, 22050, format="WAV")
```
It works well.
But if change it to using CPU:
```python
spec_generator = Tacotron2Model.from_pretrained("tts_en_tacotron2").to("cpu")
...
vocoder = HifiGanModel.from_pretrained(model_name="tts_en_hifigan").to("cpu")
```
The snippet will report the error:
```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu! 
```
The reason is the code directly sets input to GPU when it's available.

# Changelog 
- Fix checking of cuda/cpu device for inputs Decoder

# Usage
```python
# Load Tacotron2
from nemo.collections.tts.models import Tacotron2Model
spec_generator = Tacotron2Model.from_pretrained("tts_en_tacotron2").to("cpu")

# Load vocoder
from nemo.collections.tts.models import HifiGanModel
vocoder = HifiGanModel.from_pretrained(model_name="tts_en_hifigan").to("cpu")

# Generate audio
import soundfile as sf
import torch
with torch.no_grad():
    parsed = spec_generator.parse("You can type your sentence here to get nemo to produce speech.")
    spectrogram = spec_generator.generate_spectrogram(tokens=parsed)
    audio = vocoder.convert_spectrogram_to_audio(spec=spectrogram)

# Save the audio to disk in a file called speech.wav
if isinstance(audio, torch.Tensor):
    audio = audio.to('cpu').numpy()
sf.write("speech.wav", audio.T, 22050, format="WAV")
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?
@blisc @okuchaiev @titu1994 

# Additional Information
This fix is learned from the [PyTorch forum](https://discuss.pytorch.org/t/how-to-check-if-model-is-on-cuda/180/4?u=robindong)
