### PR TITLE
Fix None dataloader issue in PTL2.0

### DIFF
--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -866,9 +866,9 @@ class ModelPT(LightningModule, Model):
         if self._test_dl is None:
             # None dataloader no longer supported in PTL2.0
             self._test_dl = []
-            
+
         return self._test_dl
-    
+
     def on_validation_epoch_end(self) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
         """
         Default DataLoader for Validation set which automatically supports multiple data loaders

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -858,10 +858,14 @@ class ModelPT(LightningModule, Model):
     def val_dataloader(self):
         if self._validation_dl is not None:
             return self._validation_dl
+        else: # None dataloader no longer supported in PTL2.0
+            return []
 
     def test_dataloader(self):
         if self._test_dl is not None:
             return self._test_dl
+        else: # None dataloader no longer supported in PTL2.0
+            return []
 
     def on_validation_epoch_end(self) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
         """

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -856,24 +856,11 @@ class ModelPT(LightningModule, Model):
             return self._train_dl
 
     def val_dataloader(self):
-<<<<<<< HEAD
         if self._validation_dl is None:
             # None dataloader no longer supported in PTL2.0
             self._validation_dl = []
 
         return self._validation_dl
-=======
-        if self._validation_dl is not None:
-            return self._validation_dl
-        else:  # None dataloader no longer supported in PTL2.0
-            return []
-
-    def test_dataloader(self):
-        if self._test_dl is not None:
-            return self._test_dl
-        else:  # None dataloader no longer supported in PTL2.0
-            return []
->>>>>>> 75269ded63752763de3887a0f1e0ba30a74a6fb8
 
     def test_dataloader(self):
         if self._test_dl is None:

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -856,17 +856,19 @@ class ModelPT(LightningModule, Model):
             return self._train_dl
 
     def val_dataloader(self):
-        if self._validation_dl is not None:
-            return self._validation_dl
-        else: # None dataloader no longer supported in PTL2.0
-            return []
+        if self._validation_dl is None:
+            # None dataloader no longer supported in PTL2.0
+            self._validation_dl = []
+
+        return self._validation_dl
 
     def test_dataloader(self):
-        if self._test_dl is not None:
-            return self._test_dl
-        else: # None dataloader no longer supported in PTL2.0
-            return []
-
+        if self._test_dl is None:
+            # None dataloader no longer supported in PTL2.0
+            self._test_dl = []
+            
+        return self._test_dl
+    
     def on_validation_epoch_end(self) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
         """
         Default DataLoader for Validation set which automatically supports multiple data loaders

--- a/tools/speech_data_simulator/README.md
+++ b/tools/speech_data_simulator/README.md
@@ -89,7 +89,7 @@ python scripts/dataset_processing/get_librispeech_data.py \
 python <NeMo base path>/scripts/speaker_tasks/create_alignment_manifest.py \
   --input_manifest_filepath <Path to train_clean_100.json manifest file> \
   --base_alignment_path <Path to LibriSpeech_Alignments directory> \
-  --output_path train-clean-100-align.json \
+  --output_manifest_filepath train-clean-100-align.json \
   --ctm_output_directory ./ctm_out \
   --libri_dataset_split train-clean-100
 ```


### PR DESCRIPTION
# What does this PR do ?

With PTL2.0, returning None from the *_dataloader methods is no longer supported (reference - https://github.com/Lightning-AI/lightning/issues/17154). This change causes an issue with ASR decoding when we don't provide a valid trainer.validation_ds.manifest_filepath or trainer.test_ds.manifest_filepath. For example running the following code:
`python NeMo/examples/asr/asr_ctc/speech_to_text_ctc_bpe.py --config-path=../conf/citrinet/ --config-name=citrinet_1024.yaml model.tokenizer.dir=data/tokenizer/tokenizer_bpe_v1024/ model.tokenizer.type="bpe" model.train_ds.manifest_filepath=data/LibriSpeech/train_clean_100.json model.validation_ds.manifest_filepath=data/LibriSpeech/dev_clean.json model.train_ds.batch_size=16 +accelerator="gpu" +strategy="ddp" +devices=1 trainer.max_epochs=1 exp_manager.checkpoint_callback_params.monitor="train_loss"`

throws the error - 
`TypeError: An invalid dataloader was returned from EncDecCTCModelBPE.val_dataloader(). Found None.`

The following PR fixes this issue by making the default return value of val_dataloader and test_dataloader as `[]`

**Collection**: All

# Changelog 

```
  def val_dataloader(self):
      if self._validation_dl is not None:
          return self._validation_dl
      else: # None dataloader no longer supported in PTL2.0
          return []

  def test_dataloader(self):
      if self._test_dl is not None:
          return self._test_dl
      else: # None dataloader no longer supported in PTL2.0
          return []
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

