### PR TITLE
Add onnx export for Tacotron2 model

### DIFF
--- a/examples/tts/export/infer_tacotron2_onnx.py
+++ b/examples/tts/export/infer_tacotron2_onnx.py
@@ -1,12 +1,10 @@
-import soundfile as sf
 import numpy as np
 import onnxruntime as ort
-
-# Load Tacotron2
-from nemo.collections.tts.models import Tacotron2Model
+import soundfile as sf
 
 # Load HifiGanModel
-from nemo.collections.tts.models import HifiGanModel
+# Load Tacotron2
+from nemo.collections.tts.models import HifiGanModel, Tacotron2Model
 
 
 def initialize_decoder_states(self, memory):

--- a/examples/tts/export/infer_tacotron2_onnx.py
+++ b/examples/tts/export/infer_tacotron2_onnx.py
@@ -1,0 +1,172 @@
+import soundfile as sf
+import numpy as np
+import onnxruntime as ort
+
+# Load Tacotron2
+from nemo.collections.tts.models import Tacotron2Model
+
+# Load HifiGanModel
+from nemo.collections.tts.models import HifiGanModel
+
+
+def initialize_decoder_states(self, memory):
+    B = memory.shape[0]
+    MAX_TIME = memory.shape[1]
+
+    attention_hidden = np.zeros((B, self.attention_rnn_dim), dtype=np.float32)
+    attention_cell = np.zeros((B, self.attention_rnn_dim), dtype=np.float32)
+
+    decoder_hidden = np.zeros((B, self.decoder_rnn_dim), dtype=np.float32)
+    decoder_cell = np.zeros((B, self.decoder_rnn_dim), dtype=np.float32)
+
+    attention_weights = np.zeros((B, MAX_TIME), dtype=np.float32)
+    attention_weights_cum = np.zeros((B, MAX_TIME), dtype=np.float32)
+    attention_context = np.zeros((B, self.encoder_embedding_dim), dtype=np.float32)
+
+    return (
+        attention_hidden,
+        attention_cell,
+        decoder_hidden,
+        decoder_cell,
+        attention_weights,
+        attention_weights_cum,
+        attention_context,
+    )
+
+
+def get_go_frame(self, memory):
+    B = memory.shape[0]
+    decoder_input = np.zeros((B, self.n_mel_channels * self.n_frames_per_step), dtype=np.float32)
+    return decoder_input
+
+
+def sigmoid(x):
+    return np.exp(-np.logaddexp(0, -x))
+
+
+def parse_decoder_outputs(self, mel_outputs, gate_outputs, alignments):
+    # (T_out, B) -> (B, T_out)
+    alignments = np.stack(alignments).transpose((1, 0, 2, 3))
+    # (T_out, B) -> (B, T_out)
+    # Add a -1 to prevent squeezing the batch dimension in case
+    # batch is 1
+    gate_outputs = np.stack(gate_outputs).squeeze(-1).transpose((1, 0, 2))
+    # (T_out, B, n_mel_channels) -> (B, T_out, n_mel_channels)
+    mel_outputs = np.stack(mel_outputs).transpose((1, 0, 2, 3))
+    # decouple frames per step
+    mel_outputs = mel_outputs.reshape(mel_outputs.shape[0], -1, self.n_mel_channels)
+    # (B, T_out, n_mel_channels) -> (B, n_mel_channels, T_out)
+    mel_outputs = mel_outputs.transpose((0, 2, 1))
+
+    return mel_outputs, gate_outputs, alignments
+
+
+# only numpy operations
+def test_inference(encoder, decoder_iter, postnet):
+    parsed = spec_generator.parse("You can type your sentence here to get nemo to produce speech.").to("cpu")
+    sequences, sequence_lengths = parsed, np.array([parsed.size(1)])
+
+    print("Running Tacotron2 Encoder")
+    inputs = {"seq": sequences.numpy(), "seq_len": sequence_lengths}
+    memory, processed_memory, _ = encoder.run(None, inputs)
+
+    print("Running Tacotron2 Decoder")
+    mel_lengths = np.zeros([memory.shape[0]], dtype=np.int32)
+    not_finished = np.ones([memory.shape[0]], dtype=np.int32)
+    mel_outputs, gate_outputs, alignments = [], [], []
+    gate_threshold = 0.5
+    max_decoder_steps = 1000
+    first_iter = True
+
+    (
+        attention_hidden,
+        attention_cell,
+        decoder_hidden,
+        decoder_cell,
+        attention_weights,
+        attention_weights_cum,
+        attention_context,
+    ) = initialize_decoder_states(spec_generator.decoder, memory)
+
+    decoder_input = get_go_frame(spec_generator.decoder, memory)
+
+    while True:
+        inputs = {
+            "decoder_input": decoder_input,
+            "attention_hidden": attention_hidden,
+            "attention_cell": attention_cell,
+            "decoder_hidden": decoder_hidden,
+            "decoder_cell": decoder_cell,
+            "attention_weights": attention_weights,
+            "attention_weights_cum": attention_weights_cum,
+            "attention_context": attention_context,
+            "memory": memory,
+            "processed_memory": processed_memory,
+        }
+        (
+            mel_output,
+            gate_output,
+            attention_hidden,
+            attention_cell,
+            decoder_hidden,
+            decoder_cell,
+            attention_weights,
+            attention_weights_cum,
+            attention_context,
+        ) = decoder_iter.run(None, inputs)
+
+        if first_iter:
+            mel_outputs = [np.expand_dims(mel_output, 2)]
+            gate_outputs = [np.expand_dims(gate_output, 2)]
+            alignments = [np.expand_dims(attention_weights, 2)]
+            first_iter = False
+        else:
+            mel_outputs += [np.expand_dims(mel_output, 2)]
+            gate_outputs += [np.expand_dims(gate_output, 2)]
+            alignments += [np.expand_dims(attention_weights, 2)]
+
+        dec = np.less(sigmoid(gate_output), gate_threshold)
+        dec = np.squeeze(dec, axis=1)
+        not_finished = not_finished * dec
+        mel_lengths += not_finished
+
+        if not_finished.sum() == 0:
+            print("Stopping after ", len(mel_outputs), " decoder steps")
+            break
+        if len(mel_outputs) == max_decoder_steps:
+            print("Warning! Reached max decoder steps")
+            break
+
+        decoder_input = mel_output
+
+    mel_outputs, gate_outputs, alignments = parse_decoder_outputs(
+        spec_generator.decoder, mel_outputs, gate_outputs, alignments
+    )
+
+    print("Running Tacotron2 PostNet")
+    inputs = {"mel_spec": mel_outputs}
+    mel_outputs_postnet = postnet.run(None, inputs)
+
+    return mel_outputs_postnet
+
+
+vocoder = HifiGanModel.from_pretrained(model_name="tts_en_hifigan").to("cpu")
+vocoder.eval()
+vocoder.export("vocoder.onnx")
+
+spec_generator = Tacotron2Model.from_pretrained("tts_en_tacotron2").to("cpu")
+spec_generator.eval()
+spec_generator.export("en.onnx")
+
+# Load encoder/decoder/postnet from onnx files
+encoder = ort.InferenceSession("tacotron2encoder-en.onnx")
+decoder = ort.InferenceSession("tacotron2decoder-en.onnx")
+postnet = ort.InferenceSession("tacotron2postnet-en.onnx")
+
+mel = test_inference(encoder, decoder, postnet)
+
+# Use vocoder to get raw audio from spectrogram
+hifi = ort.InferenceSession("vocoder.onnx")
+audio = hifi.run(None, {"spec": mel[0]})
+audio = audio[0][0, 0, :]
+sf.write("speech.wav", audio, 22050, format="WAV")

--- a/examples/tts/export/infer_tacotron2_onnx.py
+++ b/examples/tts/export/infer_tacotron2_onnx.py
@@ -16,8 +16,6 @@ import numpy as np
 import onnxruntime as ort
 import soundfile as sf
 
-# Load HifiGanModel
-# Load Tacotron2
 from nemo.collections.tts.models import HifiGanModel, Tacotron2Model
 
 

--- a/examples/tts/export/infer_tacotron2_onnx.py
+++ b/examples/tts/export/infer_tacotron2_onnx.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import numpy as np
 import onnxruntime as ort
 import soundfile as sf

--- a/nemo/collections/tts/models/tacotron2.py
+++ b/nemo/collections/tts/models/tacotron2.py
@@ -15,7 +15,6 @@
 import contextlib
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
-from torch.nn import functional as F
 
 import torch
 from hydra.utils import instantiate
@@ -23,6 +22,7 @@ from omegaconf import MISSING, DictConfig, OmegaConf, open_dict
 from omegaconf.errors import ConfigAttributeError
 from pytorch_lightning.loggers import TensorBoardLogger, WandbLogger
 from torch import nn
+from torch.nn import functional as F
 
 from nemo.collections.common.parts.preprocessing import parsers
 from nemo.collections.tts.losses.tacotron2loss import Tacotron2Loss
@@ -37,10 +37,10 @@ from nemo.core.classes import Exportable
 from nemo.core.classes.common import PretrainedModelInfo, typecheck
 from nemo.core.neural_types.elements import (
     AudioSignal,
+    ChannelType,
     EmbeddedTextType,
     LengthsType,
     LogitsType,
-    ChannelType,
     MelSpectrogramType,
     SequenceToSequenceAlignmentType,
 )
@@ -72,15 +72,13 @@ def encoder_infer(self, x, input_lengths):
 
     x = x.transpose(1, 2)
 
-    x = torch.nn.utils.rnn.pack_padded_sequence(
-        x, input_lengths, batch_first=True, enforce_sorted=False
-    )
+    x = torch.nn.utils.rnn.pack_padded_sequence(x, input_lengths, batch_first=True, enforce_sorted=False)
 
     outputs, _ = self.lstm(x)
 
     outputs, _ = torch.nn.utils.rnn.pad_packed_sequence(outputs, batch_first=True)
 
-    return outputs, input_lengths*2
+    return outputs, input_lengths * 2
 
 
 class EncoderIter(torch.nn.Module, Exportable):
@@ -130,7 +128,7 @@ def prenet_infer(self, x):
         x = F.relu(linear(x))
         mask = torch.le(torch.rand(256).to(x.dtype), 0.5).to(x.dtype)
         mask = mask.expand(x.size(0), x.size(1))
-        x = x*mask*2.0
+        x = x * mask * 2.0
 
     return x
 
@@ -148,92 +146,105 @@ class DecoderIter(torch.nn.Module, Exportable):
 
         self.prenet.infer = prenet_infer
 
-        self.attention_rnn = nn.LSTM(dec.prenet_dim + dec.encoder_embedding_dim,
-                                     dec.attention_rnn_dim, 1)
+        self.attention_rnn = nn.LSTM(dec.prenet_dim + dec.encoder_embedding_dim, dec.attention_rnn_dim, 1)
         lstmcell2lstm_params(self.attention_rnn, dec.attention_rnn)
         self.attention_rnn.flatten_parameters()
 
         self.attention_layer = dec.attention_layer
 
-        self.decoder_rnn = nn.LSTM(dec.attention_rnn_dim + dec.encoder_embedding_dim,
-                                   dec.decoder_rnn_dim, 1)
+        self.decoder_rnn = nn.LSTM(dec.attention_rnn_dim + dec.encoder_embedding_dim, dec.decoder_rnn_dim, 1)
         lstmcell2lstm_params(self.decoder_rnn, dec.decoder_rnn)
         self.decoder_rnn.flatten_parameters()
 
         self.linear_projection = dec.linear_projection
         self.gate_layer = dec.gate_layer
 
-
-    def decode(self, decoder_input, in_attention_hidden, in_attention_cell,
-               in_decoder_hidden, in_decoder_cell, in_attention_weights,
-               in_attention_weights_cum, in_attention_context, memory,
-               processed_memory):
+    def decode(
+        self,
+        decoder_input,
+        in_attention_hidden,
+        in_attention_cell,
+        in_decoder_hidden,
+        in_decoder_cell,
+        in_attention_weights,
+        in_attention_weights_cum,
+        in_attention_context,
+        memory,
+        processed_memory,
+    ):
 
         cell_input = torch.cat((decoder_input, in_attention_context), -1)
 
         _, (out_attention_hidden, out_attention_cell) = self.attention_rnn(
-            cell_input.unsqueeze(0), (in_attention_hidden.unsqueeze(0),
-                                      in_attention_cell.unsqueeze(0)))
+            cell_input.unsqueeze(0), (in_attention_hidden.unsqueeze(0), in_attention_cell.unsqueeze(0))
+        )
         out_attention_hidden = out_attention_hidden.squeeze(0)
         out_attention_cell = out_attention_cell.squeeze(0)
 
-        out_attention_hidden = F.dropout(
-            out_attention_hidden, self.p_attention_dropout, False)
+        out_attention_hidden = F.dropout(out_attention_hidden, self.p_attention_dropout, False)
 
         attention_weights_cat = torch.cat(
-            (in_attention_weights.unsqueeze(1),
-             in_attention_weights_cum.unsqueeze(1)), dim=1)
+            (in_attention_weights.unsqueeze(1), in_attention_weights_cum.unsqueeze(1)), dim=1
+        )
         out_attention_context, out_attention_weights = self.attention_layer(
-            out_attention_hidden, memory, processed_memory,
-            attention_weights_cat, None)
+            out_attention_hidden, memory, processed_memory, attention_weights_cat, None
+        )
 
         out_attention_weights_cum = in_attention_weights_cum + out_attention_weights
-        decoder_input_tmp = torch.cat(
-            (out_attention_hidden, out_attention_context), -1)
+        decoder_input_tmp = torch.cat((out_attention_hidden, out_attention_context), -1)
 
         _, (out_decoder_hidden, out_decoder_cell) = self.decoder_rnn(
-            decoder_input_tmp.unsqueeze(0), (in_decoder_hidden.unsqueeze(0),
-                                             in_decoder_cell.unsqueeze(0)))
+            decoder_input_tmp.unsqueeze(0), (in_decoder_hidden.unsqueeze(0), in_decoder_cell.unsqueeze(0))
+        )
         out_decoder_hidden = out_decoder_hidden.squeeze(0)
         out_decoder_cell = out_decoder_cell.squeeze(0)
 
-        out_decoder_hidden = F.dropout(
-            out_decoder_hidden, self.p_decoder_dropout, False)
+        out_decoder_hidden = F.dropout(out_decoder_hidden, self.p_decoder_dropout, False)
 
-        decoder_hidden_attention_context = torch.cat(
-            (out_decoder_hidden, out_attention_context), 1)
+        decoder_hidden_attention_context = torch.cat((out_decoder_hidden, out_attention_context), 1)
 
-        decoder_output = self.linear_projection(
-            decoder_hidden_attention_context)
+        decoder_output = self.linear_projection(decoder_hidden_attention_context)
 
         gate_prediction = self.gate_layer(decoder_hidden_attention_context)
 
-        return (decoder_output, gate_prediction, out_attention_hidden,
-                out_attention_cell, out_decoder_hidden, out_decoder_cell,
-                out_attention_weights, out_attention_weights_cum, out_attention_context)
+        return (
+            decoder_output,
+            gate_prediction,
+            out_attention_hidden,
+            out_attention_cell,
+            out_decoder_hidden,
+            out_decoder_cell,
+            out_attention_weights,
+            out_attention_weights_cum,
+            out_attention_context,
+        )
 
-    def forward(self,
-                decoder_input,
-                attention_hidden,
-                attention_cell,
-                decoder_hidden,
-                decoder_cell,
-                attention_weights,
-                attention_weights_cum,
-                attention_context,
-                memory,
-                processed_memory):
+    def forward(
+        self,
+        decoder_input,
+        attention_hidden,
+        attention_cell,
+        decoder_hidden,
+        decoder_cell,
+        attention_weights,
+        attention_weights_cum,
+        attention_context,
+        memory,
+        processed_memory,
+    ):
         decoder_input1 = self.prenet.infer(self.prenet, decoder_input)
-        outputs = self.decode(decoder_input1,
-                              attention_hidden,
-                              attention_cell,
-                              decoder_hidden,
-                              decoder_cell,
-                              attention_weights,
-                              attention_weights_cum,
-                              attention_context,
-                              memory,
-                              processed_memory)
+        outputs = self.decode(
+            decoder_input1,
+            attention_hidden,
+            attention_cell,
+            decoder_hidden,
+            decoder_cell,
+            attention_weights,
+            attention_weights_cum,
+            attention_context,
+            memory,
+            processed_memory,
+        )
         return outputs
 
     def input_example(self, max_batch=1, max_dim=512):
@@ -295,7 +306,9 @@ class PostnetIter(torch.nn.Module, Exportable):
         return mel_outputs_postnet
 
     def input_example(self, max_batch=1, max_dim=80):
-        mel_spec = torch.randn((max_batch, self.tacotron2.decoder.n_mel_channels, self.tacotron2.decoder.max_decoder_steps))
+        mel_spec = torch.randn(
+            (max_batch, self.tacotron2.decoder.n_mel_channels, self.tacotron2.decoder.max_decoder_steps)
+        )
         inputs = {"mel_spec": mel_spec}
         return (inputs,)
 

--- a/nemo/collections/tts/models/tacotron2.py
+++ b/nemo/collections/tts/models/tacotron2.py
@@ -15,6 +15,7 @@
 import contextlib
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
+from torch.nn import functional as F
 
 import torch
 from hydra.utils import instantiate
@@ -32,12 +33,14 @@ from nemo.collections.tts.parts.utils.helpers import (
     tacotron2_log_to_tb_func,
     tacotron2_log_to_wandb_func,
 )
+from nemo.core.classes import Exportable
 from nemo.core.classes.common import PretrainedModelInfo, typecheck
 from nemo.core.neural_types.elements import (
     AudioSignal,
     EmbeddedTextType,
     LengthsType,
     LogitsType,
+    ChannelType,
     MelSpectrogramType,
     SequenceToSequenceAlignmentType,
 )
@@ -62,7 +65,254 @@ class Tacotron2Config:
     validation_ds: Optional[Dict[Any, Any]] = None
 
 
-class Tacotron2Model(SpectrogramGenerator):
+def encoder_infer(self, x, input_lengths):
+    device = x.device
+    for conv in self.convolutions:
+        x = F.dropout(F.relu(conv(x.to(device))), 0.5, False)
+
+    x = x.transpose(1, 2)
+
+    x = torch.nn.utils.rnn.pack_padded_sequence(
+        x, input_lengths, batch_first=True, enforce_sorted=False
+    )
+
+    outputs, _ = self.lstm(x)
+
+    outputs, _ = torch.nn.utils.rnn.pad_packed_sequence(outputs, batch_first=True)
+
+    return outputs, input_lengths*2
+
+
+class EncoderIter(torch.nn.Module, Exportable):
+    def __init__(self, tacotron2):
+        super(EncoderIter, self).__init__()
+        self.tacotron2 = tacotron2
+        self.tacotron2.encoder.lstm.flatten_parameters()
+        self.infer = encoder_infer
+
+    def forward(self, seq, seq_len):
+        embedded_inputs = self.tacotron2.text_embedding(seq).transpose(1, 2)
+        memory, lens = self.infer(self.tacotron2.encoder, embedded_inputs, seq_len)
+        processed_memory = self.tacotron2.decoder.attention_layer.memory_layer(memory)
+        return memory, processed_memory, lens
+
+    def input_example(self, max_batch=1, max_dim=512):
+        seq = torch.randint(low=0, high=114, size=(1, max_dim), dtype=torch.long)
+        seq_len = torch.IntTensor([seq.size(1)]).long()
+        inputs = {"seq": seq, "seq_len": seq_len}
+        return (inputs,)
+
+    @property
+    def input_types(self):
+        return {
+            "seq": NeuralType(('B', 'T'), EmbeddedTextType()),
+            "seq_len": NeuralType(('B'), LengthsType()),
+        }
+
+    @property
+    def output_types(self):
+        return {
+            "memory": NeuralType(('B', 'T', 'D'), EmbeddedTextType()),
+            "processed_memory": NeuralType(('B', 'T', 'D'), EmbeddedTextType()),
+            "lens": NeuralType(('B'), LengthsType()),
+        }
+
+
+def lstmcell2lstm_params(lstm_mod, lstmcell_mod):
+    lstm_mod.weight_ih_l0 = torch.nn.Parameter(lstmcell_mod.weight_ih)
+    lstm_mod.weight_hh_l0 = torch.nn.Parameter(lstmcell_mod.weight_hh)
+    lstm_mod.bias_ih_l0 = torch.nn.Parameter(lstmcell_mod.bias_ih)
+    lstm_mod.bias_hh_l0 = torch.nn.Parameter(lstmcell_mod.bias_hh)
+
+
+def prenet_infer(self, x):
+    for linear in self.layers:
+        x = F.relu(linear(x))
+        mask = torch.le(torch.rand(256).to(x.dtype), 0.5).to(x.dtype)
+        mask = mask.expand(x.size(0), x.size(1))
+        x = x*mask*2.0
+
+    return x
+
+
+class DecoderIter(torch.nn.Module, Exportable):
+    def __init__(self, tacotron2):
+        super(DecoderIter, self).__init__()
+
+        self.tacotron2 = tacotron2
+        dec = tacotron2.decoder
+
+        self.p_attention_dropout = dec.p_attention_dropout
+        self.p_decoder_dropout = dec.p_decoder_dropout
+        self.prenet = dec.prenet
+
+        self.prenet.infer = prenet_infer
+
+        self.attention_rnn = nn.LSTM(dec.prenet_dim + dec.encoder_embedding_dim,
+                                     dec.attention_rnn_dim, 1)
+        lstmcell2lstm_params(self.attention_rnn, dec.attention_rnn)
+        self.attention_rnn.flatten_parameters()
+
+        self.attention_layer = dec.attention_layer
+
+        self.decoder_rnn = nn.LSTM(dec.attention_rnn_dim + dec.encoder_embedding_dim,
+                                   dec.decoder_rnn_dim, 1)
+        lstmcell2lstm_params(self.decoder_rnn, dec.decoder_rnn)
+        self.decoder_rnn.flatten_parameters()
+
+        self.linear_projection = dec.linear_projection
+        self.gate_layer = dec.gate_layer
+
+
+    def decode(self, decoder_input, in_attention_hidden, in_attention_cell,
+               in_decoder_hidden, in_decoder_cell, in_attention_weights,
+               in_attention_weights_cum, in_attention_context, memory,
+               processed_memory):
+
+        cell_input = torch.cat((decoder_input, in_attention_context), -1)
+
+        _, (out_attention_hidden, out_attention_cell) = self.attention_rnn(
+            cell_input.unsqueeze(0), (in_attention_hidden.unsqueeze(0),
+                                      in_attention_cell.unsqueeze(0)))
+        out_attention_hidden = out_attention_hidden.squeeze(0)
+        out_attention_cell = out_attention_cell.squeeze(0)
+
+        out_attention_hidden = F.dropout(
+            out_attention_hidden, self.p_attention_dropout, False)
+
+        attention_weights_cat = torch.cat(
+            (in_attention_weights.unsqueeze(1),
+             in_attention_weights_cum.unsqueeze(1)), dim=1)
+        out_attention_context, out_attention_weights = self.attention_layer(
+            out_attention_hidden, memory, processed_memory,
+            attention_weights_cat, None)
+
+        out_attention_weights_cum = in_attention_weights_cum + out_attention_weights
+        decoder_input_tmp = torch.cat(
+            (out_attention_hidden, out_attention_context), -1)
+
+        _, (out_decoder_hidden, out_decoder_cell) = self.decoder_rnn(
+            decoder_input_tmp.unsqueeze(0), (in_decoder_hidden.unsqueeze(0),
+                                             in_decoder_cell.unsqueeze(0)))
+        out_decoder_hidden = out_decoder_hidden.squeeze(0)
+        out_decoder_cell = out_decoder_cell.squeeze(0)
+
+        out_decoder_hidden = F.dropout(
+            out_decoder_hidden, self.p_decoder_dropout, False)
+
+        decoder_hidden_attention_context = torch.cat(
+            (out_decoder_hidden, out_attention_context), 1)
+
+        decoder_output = self.linear_projection(
+            decoder_hidden_attention_context)
+
+        gate_prediction = self.gate_layer(decoder_hidden_attention_context)
+
+        return (decoder_output, gate_prediction, out_attention_hidden,
+                out_attention_cell, out_decoder_hidden, out_decoder_cell,
+                out_attention_weights, out_attention_weights_cum, out_attention_context)
+
+    def forward(self,
+                decoder_input,
+                attention_hidden,
+                attention_cell,
+                decoder_hidden,
+                decoder_cell,
+                attention_weights,
+                attention_weights_cum,
+                attention_context,
+                memory,
+                processed_memory):
+        decoder_input1 = self.prenet.infer(self.prenet, decoder_input)
+        outputs = self.decode(decoder_input1,
+                              attention_hidden,
+                              attention_cell,
+                              decoder_hidden,
+                              decoder_cell,
+                              attention_weights,
+                              attention_weights_cum,
+                              attention_context,
+                              memory,
+                              processed_memory)
+        return outputs
+
+    def input_example(self, max_batch=1, max_dim=512):
+        memory = torch.randn((1, max_dim, max_dim))
+        memory_lengths = torch.tensor([max_dim])
+        self.tacotron2.decoder.initialize_decoder_states(memory, None)
+        decoder_input = self.tacotron2.decoder.get_go_frame(memory)
+        inputs = {
+            "decoder_input": decoder_input,
+            "attention_hidden": self.tacotron2.decoder.attention_hidden,
+            "attention_cell": self.tacotron2.decoder.attention_cell,
+            "decoder_hidden": self.tacotron2.decoder.decoder_hidden,
+            "decoder_cell": self.tacotron2.decoder.decoder_cell,
+            "attention_weights": self.tacotron2.decoder.attention_weights,
+            "attention_weights_cum": self.tacotron2.decoder.attention_weights_cum,
+            "attention_context": self.tacotron2.decoder.attention_context,
+            "memory": memory,
+            "processed_memory": self.tacotron2.decoder.processed_memory,
+        }
+        return (inputs,)
+
+    @property
+    def input_types(self):
+        return {
+            "decoder_input": NeuralType(('B', 'T', 'D'), ChannelType()),
+            "attention_hidden": NeuralType(('B', 'T', 'D'), ChannelType()),
+            "attention_cell": NeuralType(('B', 'T', 'D'), ChannelType()),
+            "decoder_hidden": NeuralType(('B', 'T', 'D'), ChannelType()),
+            "decoder_cell": NeuralType(('B', 'T', 'D'), ChannelType()),
+            "attention_weights": NeuralType(('B', 'T'), ChannelType()),
+            "attention_weights_cum": NeuralType(('B', 'T'), ChannelType()),
+            "attention_context": NeuralType(('B', 'D'), ChannelType()),
+            "memory": NeuralType(('B', 'T', 'D'), EmbeddedTextType()),
+            "processed_memory": NeuralType(('B', 'T', 'D'), EmbeddedTextType()),
+        }
+
+    @property
+    def output_types(self):
+        return {
+            "decoder_output": NeuralType(('B', 'D', 'T'), EmbeddedTextType()),
+            "gate_prediction": NeuralType(('B', 'T'), LogitsType()),
+            "out_attention_hidden": NeuralType(('B', 'T', 'D'), ChannelType()),
+            "out_attention_cell": NeuralType(('B', 'T', 'D'), ChannelType()),
+            "out_decoder_hidden": NeuralType(('B', 'T', 'D'), ChannelType()),
+            "out_decoder_cell": NeuralType(('B', 'T', 'D'), ChannelType()),
+            "out_attention_weights": NeuralType(('B', 'T'), ChannelType()),
+            "out_attention_weights_cum": NeuralType(('B', 'T'), ChannelType()),
+            "out_attention_context": NeuralType(('B', 'D'), ChannelType()),
+        }
+
+
+class PostnetIter(torch.nn.Module, Exportable):
+    def __init__(self, tacotron2):
+        super(PostnetIter, self).__init__()
+        self.tacotron2 = tacotron2
+
+    def forward(self, mel_spec):
+        mel_outputs_postnet = self.tacotron2.postnet(mel_spec=mel_spec)
+        return mel_outputs_postnet
+
+    def input_example(self, max_batch=1, max_dim=80):
+        mel_spec = torch.randn((max_batch, self.tacotron2.decoder.n_mel_channels, self.tacotron2.decoder.max_decoder_steps))
+        inputs = {"mel_spec": mel_spec}
+        return (inputs,)
+
+    @property
+    def input_types(self):
+        return {
+            "mel_spec": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
+        }
+
+    @property
+    def output_types(self):
+        return {
+            "output": NeuralType(('B', 'D', 'T'), MelSpectrogramType()),
+        }
+
+
+class Tacotron2Model(SpectrogramGenerator, Exportable):
     """Tacotron 2 Model that is used to generate mel spectrograms from text"""
 
     def __init__(self, cfg: DictConfig, trainer: 'Trainer' = None):
@@ -424,3 +674,18 @@ class Tacotron2Model(SpectrogramGenerator):
         )
         list_of_models.append(model)
         return list_of_models
+
+    @property
+    def tacotron2encoder(self):
+        return EncoderIter(self)
+
+    @property
+    def tacotron2decoder(self):
+        return DecoderIter(self)
+
+    @property
+    def tacotron2postnet(self):
+        return PostnetIter(self)
+
+    def list_export_subnets(self):
+        return ['tacotron2encoder', "tacotron2decoder", "tacotron2postnet"]

--- a/nemo/collections/tts/models/tacotron2.py
+++ b/nemo/collections/tts/models/tacotron2.py
@@ -249,7 +249,6 @@ class DecoderIter(torch.nn.Module, Exportable):
 
     def input_example(self, max_batch=1, max_dim=512):
         memory = torch.randn((1, max_dim, max_dim))
-        memory_lengths = torch.tensor([max_dim])
         self.tacotron2.decoder.initialize_decoder_states(memory, None)
         decoder_input = self.tacotron2.decoder.get_go_frame(memory)
         inputs = {


### PR DESCRIPTION
# What does this PR do ?

1. Make Tacotron2 able to be exported to ONNX format files.
2. Create an example of how to use these ONNX files to do inference

The code is mainly learned from [NVIDIA/DeepLearningExamples](https://github.com/NVIDIA/DeepLearningExamples/blob/master/PyTorch/SpeechSynthesis/Tacotron2/exports/export_tacotron2_onnx.py)

# Changelog 
- Add support for Tacotron2 model to export to onnx format

# Usage
For testing, we could install necessary packages, check out this PR and run the example script:
```bash
pip install onnxruntime

cd NeMo
PYTHONPATH=. python3 examples/tts/export/infer_tacotron2_onnx.py 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

@blisc @XuesongYang 

# Additional Information
* Related to #6999 
