### PR TITLE
[TTS] Add STFT and SI-SDR loss to audio codec recipe

### DIFF
--- a/examples/tts/conf/audio_codec/audio_codec_24000.yaml
+++ b/examples/tts/conf/audio_codec/audio_codec_24000.yaml
@@ -1,4 +1,4 @@
-# This config contains the default values for training 24khz EnCodec model
+# This config contains the default values for training 24khz audio codec model
 # If you want to train model on other dataset, you can change config values according to your dataset.
 # Most dataset-specific arguments are in the head of the config file, see below.
 
@@ -36,17 +36,23 @@ model:
   sample_rate: ${sample_rate}
   samples_per_frame: ${samples_per_frame}
 
-  mel_loss_scale: 5.0
-  time_domain_loss_scale: 0.1
+  mel_loss_l1_scale: 15.0
+  mel_loss_l2_scale: 0.0
+  stft_loss_scale: 15.0
+  time_domain_loss_scale: 0.0
+
   # Probability of updating the discriminator during each training step
   # For example, update the discriminator 2/3 times (2 updates for every 3 batches)
   disc_updates_per_period: 2
   disc_update_period: 3
 
-  # All resolutions for mel reconstruction loss, ordered [num_fft, hop_length, window_length]
-  mel_loss_resolutions: [
+  # All resolutions for reconstruction loss, ordered [num_fft, hop_length, window_length]
+  loss_resolutions: [
     [32, 8, 32], [64, 16, 64], [128, 32, 128], [256, 64, 256], [512, 128, 512], [1024, 256, 1024], [2048, 512, 2048]
   ]
+  mel_loss_dims: [5, 10, 20, 40, 80, 160, 320]
+  mel_loss_log_guard: 1.0
+  stft_loss_log_guard: 1.0
 
   train_ds:
     dataset:
@@ -106,7 +112,7 @@ model:
       num_workers: 2
 
   audio_encoder:
-    _target_: nemo.collections.tts.modules.encodec_modules.SEANetEncoder
+    _target_: nemo.collections.tts.modules.encodec_modules.HifiGanEncoder
     down_sample_rates: ${down_sample_rates}
 
   audio_decoder:
@@ -136,7 +142,7 @@ model:
 
     sched:
       name: ExponentialLR
-      gamma: 0.999
+      gamma: 0.998
 
 trainer:
   num_nodes: 1
@@ -149,7 +155,7 @@ trainer:
   enable_checkpointing: False # Provided by exp_manager
   logger: false # Provided by exp_manager
   log_every_n_steps: 100
-  check_val_every_n_epoch: 5
+  check_val_every_n_epoch: 10
   benchmark: false
 
 exp_manager:

--- a/examples/tts/conf/audio_codec/encodec_24000.yaml
+++ b/examples/tts/conf/audio_codec/encodec_24000.yaml
@@ -1,0 +1,170 @@
+# This config contains the default values for training 24khz EnCodec model
+# If you want to train model on other dataset, you can change config values according to your dataset.
+# Most dataset-specific arguments are in the head of the config file, see below.
+
+name: EnCodec
+
+max_epochs: ???
+# Adjust batch size based on GPU memory
+batch_size: 16
+# When doing weighted sampling with multiple manifests, this defines how many training steps are in an epoch.
+# If null, then weighted sampling is disabled.
+weighted_sampling_steps_per_epoch: null
+
+# Dataset metadata for each manifest
+# https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/tts/data/vocoder_dataset.py#L39-L41
+train_ds_meta: ???
+val_ds_meta: ???
+
+log_ds_meta: ???
+log_dir: ???
+
+# Modify these values based on your sample rate
+sample_rate: 24000
+train_n_samples: 24000
+down_sample_rates: [2, 4, 5, 8]
+up_sample_rates: [8, 5, 4, 2]
+# The number of samples per encoded audio frame. Should be the product of the down_sample_rates.
+# For example 2 * 4 * 5 * 8 = 320.
+samples_per_frame: 320
+
+model:
+
+  max_epochs: ${max_epochs}
+  steps_per_epoch: ${weighted_sampling_steps_per_epoch}
+
+  sample_rate: ${sample_rate}
+  samples_per_frame: ${samples_per_frame}
+
+  mel_loss_l1_scale: 1.0
+  mel_loss_l2_scale: 1.0
+  stft_loss_scale: 0.0
+  time_domain_loss_scale: 0.1
+
+  # Probability of updating the discriminator during each training step
+  # For example, update the discriminator 2/3 times (2 updates for every 3 batches)
+  disc_updates_per_period: 2
+  disc_update_period: 3
+
+  # All resolutions for reconstruction loss, ordered [num_fft, hop_length, window_length]
+  loss_resolutions: [
+    [32, 8, 32], [64, 16, 64], [128, 32, 128], [256, 64, 256], [512, 128, 512], [1024, 256, 1024], [2048, 512, 2048]
+  ]
+  mel_loss_dims: [64, 64, 64, 64, 64, 64, 64]
+  mel_loss_log_guard: 1E-5
+  stft_loss_log_guard: 1.0
+
+  train_ds:
+    dataset:
+      _target_: nemo.collections.tts.data.vocoder_dataset.VocoderDataset
+      weighted_sampling_steps_per_epoch: ${weighted_sampling_steps_per_epoch}
+      sample_rate: ${sample_rate}
+      n_samples: ${train_n_samples}
+      min_duration: 1.01
+      max_duration: null
+      dataset_meta: ${train_ds_meta}
+
+    dataloader_params:
+      batch_size: ${batch_size}
+      drop_last: true
+      num_workers: 4
+
+  validation_ds:
+    dataset:
+      _target_: nemo.collections.tts.data.vocoder_dataset.VocoderDataset
+      sample_rate: ${sample_rate}
+      n_samples: null
+      min_duration: null
+      max_duration: null
+      trunc_duration: 10.0 # Only use the first 10 seconds of audio for computing validation loss
+      dataset_meta: ${val_ds_meta}
+
+    dataloader_params:
+      batch_size: 8
+      num_workers: 2
+
+  # Configures how audio samples are generated and saved during training.
+  # Remove this section to disable logging.
+  log_config:
+    log_dir: ${log_dir}
+    log_epochs: [10, 50]
+    epoch_frequency: 100
+    log_tensorboard: false
+    log_wandb: false
+
+    generators:
+      - _target_: nemo.collections.tts.parts.utils.callbacks.AudioCodecArtifactGenerator
+        log_audio: true
+        log_encoding: true
+        log_dequantized: true
+
+    dataset:
+      _target_: nemo.collections.tts.data.vocoder_dataset.VocoderDataset
+      sample_rate: ${sample_rate}
+      n_samples: null
+      min_duration: null
+      max_duration: null
+      trunc_duration: 15.0 # Only log the first 15 seconds of generated audio.
+      dataset_meta: ${log_ds_meta}
+
+    dataloader_params:
+      batch_size: 4
+      num_workers: 2
+
+  audio_encoder:
+    _target_: nemo.collections.tts.modules.encodec_modules.SEANetEncoder
+    down_sample_rates: ${down_sample_rates}
+
+  audio_decoder:
+    _target_: nemo.collections.tts.modules.encodec_modules.SEANetDecoder
+    up_sample_rates: ${up_sample_rates}
+
+  vector_quantizer:
+    _target_: nemo.collections.tts.modules.encodec_modules.ResidualVectorQuantizer
+    num_codebooks: 8
+
+  discriminator:
+    _target_: nemo.collections.tts.modules.encodec_modules.MultiResolutionDiscriminatorSTFT
+    resolutions: [[128, 32, 128], [256, 64, 256], [512, 128, 512], [1024, 256, 1024], [2048, 512, 2048]]
+
+  # The original EnCodec uses hinged loss, but squared-GAN loss is more stable
+  # and reduces the need to tune the loss weights or use a gradient balancer.
+  generator_loss:
+    _target_: nemo.collections.tts.losses.audio_codec_loss.GeneratorSquaredLoss
+
+  discriminator_loss:
+    _target_: nemo.collections.tts.losses.audio_codec_loss.DiscriminatorSquaredLoss
+
+  optim:
+    _target_: torch.optim.Adam
+    lr: 3e-4
+    betas: [0.5, 0.9]
+
+    sched:
+      name: ExponentialLR
+      gamma: 0.999
+
+trainer:
+  num_nodes: 1
+  devices: 1
+  accelerator: gpu
+  strategy: ddp_find_unused_parameters_true
+  precision: 32 # Vector quantization only works with 32-bit precision.
+  max_epochs: ${max_epochs}
+  accumulate_grad_batches: 1
+  enable_checkpointing: False # Provided by exp_manager
+  logger: false # Provided by exp_manager
+  log_every_n_steps: 100
+  check_val_every_n_epoch: 5
+  benchmark: false
+
+exp_manager:
+  exp_dir: null
+  name: ${name}
+  create_tensorboard_logger: true
+  create_checkpoint_callback: true
+  create_wandb_logger: false
+  checkpoint_callback_params:
+    monitor: val_loss
+  resume_if_exists: false
+  resume_ignore_no_checkpoint: false

--- a/nemo/collections/tts/losses/audio_codec_loss.py
+++ b/nemo/collections/tts/losses/audio_codec_loss.py
@@ -171,7 +171,7 @@ class STFTLoss(Loss):
     def __init__(self, resolution: List[int], log_guard: float = 1.0, sqrt_guard: float = 1e-5):
         super(STFTLoss, self).__init__()
         self.loss_fn = MaskedMAELoss()
-        self.n_fft, self.win_length, self.hop_length = resolution
+        self.n_fft, self.hop_length, self.win_length = resolution
         self.register_buffer("window", torch.hann_window(self.win_length, periodic=False))
         self.log_guard = log_guard
         self.sqrt_guard = sqrt_guard

--- a/nemo/collections/tts/losses/audio_codec_loss.py
+++ b/nemo/collections/tts/losses/audio_codec_loss.py
@@ -119,6 +119,7 @@ class MultiResolutionMelLoss(Loss):
         mel_dims: Dimension of mel spectrogram to compute for each resolution. Should be same length as 'resolutions'.
         log_guard: Value to add to mel spectrogram to avoid taking log of 0.
     """
+
     def __init__(self, sample_rate: int, resolutions: List[List], mel_dims: List[int], log_guard: float = 1.0):
         super(MultiResolutionMelLoss, self).__init__()
         assert len(resolutions) == len(mel_dims)
@@ -186,6 +187,7 @@ class STFTLoss(Loss):
         log_guard: Value to add to magnitude spectrogram to avoid taking log of 0.
         sqrt_guard: Value to add to when computing absolute value of STFT to avoid NaN loss.
     """
+
     def __init__(self, resolution: List[int], log_guard: float = 1.0, sqrt_guard: float = 1e-5):
         super(STFTLoss, self).__init__()
         self.loss_fn = MaskedMAELoss()
@@ -242,6 +244,7 @@ class MultiResolutionSTFTLoss(Loss):
         log_guard: Value to add to magnitude spectrogram to avoid taking log of 0.
         sqrt_guard: Value to add to when computing absolute value of STFT to avoid NaN loss.
     """
+
     def __init__(self, resolutions: List[List], log_guard: float = 1.0, sqrt_guard: float = 1e-5):
         super(MultiResolutionSTFTLoss, self).__init__()
         self.loss_fns = torch.nn.ModuleList(

--- a/nemo/collections/tts/models/audio_codec.py
+++ b/nemo/collections/tts/models/audio_codec.py
@@ -401,42 +401,42 @@ class AudioCodecModel(ModelPT):
 
         loss_mel_l1, loss_mel_l2 = self.mel_loss_fn(audio_real=audio, audio_gen=audio_gen, audio_len=audio_len)
         if self.mel_loss_l1_scale:
-            generator_losses.append(self.mel_loss_l1_scale * loss_mel_l1)
             metrics["g_loss_mel_l1"] = loss_mel_l1
+            generator_losses.append(self.mel_loss_l1_scale * loss_mel_l1)
         if self.mel_loss_l2_scale:
-            generator_losses.append(self.mel_loss_l2_scale * loss_mel_l2)
             metrics["g_loss_mel_l2"] = loss_mel_l2
+            generator_losses.append(self.mel_loss_l2_scale * loss_mel_l2)
 
         if self.stft_loss_scale:
             loss_stft = self.stft_loss_fn(audio_real=audio, audio_gen=audio_gen, audio_len=audio_len)
-            generator_losses.append(self.stft_loss_scale * loss_stft)
             metrics["g_loss_stft"] = loss_stft
+            generator_losses.append(self.stft_loss_scale * loss_stft)
 
         if self.time_domain_loss_scale:
             loss_time_domain = self.time_domain_loss_fn(audio_real=audio, audio_gen=audio_gen, audio_len=audio_len)
-            generator_losses.append(self.time_domain_loss_scale * loss_time_domain)
             metrics["g_loss_time_domain"] = loss_time_domain
+            generator_losses.append(self.time_domain_loss_scale * loss_time_domain)
 
         if self.si_sdr_loss_scale:
             loss_si_sdr = self.si_sdr_loss_fn(audio_real=audio, audio_gen=audio_gen, audio_len=audio_len)
+            metrics["g_loss_si_sdr"] = loss_si_sdr
             generator_losses.append(self.si_sdr_loss_scale * loss_si_sdr)
-            metrics["g_loss_si_sdr"] = commit_loss
 
         _, disc_scores_gen, fmaps_real, fmaps_gen = self.discriminator(audio_real=audio, audio_gen=audio_gen)
 
         if self.gen_loss_scale:
             loss_gen = self.gen_loss_fn(disc_scores_gen=disc_scores_gen)
+            metrics["g_loss_gen"] = loss_gen
             generator_losses.append(self.gen_loss_scale * loss_gen)
-            metrics["g_loss_gen"] = commit_loss
 
         if self.feature_loss_scale:
             loss_feature = self.feature_loss_fn(fmaps_real=fmaps_real, fmaps_gen=fmaps_gen)
+            metrics["g_loss_feature"] = loss_feature
             generator_losses.append(self.feature_loss_scale * loss_feature)
-            metrics["g_loss_feature"] = commit_loss
 
         if self.commit_loss_scale:
-            generator_losses.append(self.commit_loss_scale * commit_loss)
             metrics["g_loss_commit"] = commit_loss
+            generator_losses.append(self.commit_loss_scale * commit_loss)
 
         loss_gen_all = sum(generator_losses)
 

--- a/nemo/collections/tts/parts/utils/helpers.py
+++ b/nemo/collections/tts/parts/utils/helpers.py
@@ -141,7 +141,7 @@ def get_mask_from_lengths(lengths: Optional[torch.Tensor] = None, x: Optional[to
         lengths: Optional[torch.tensor] (torch.tensor): 1D tensor with lengths
         x: Optional[torch.tensor] = tensor to be used on, last dimension is for mask 
     Returns:
-        mask (torch.tensor): num_sequences x max_length x 1 binary tensor
+        mask (torch.tensor): num_sequences x max_length binary tensor
     """
     if lengths is None:
         assert x is not None

--- a/tests/collections/tts/modules/test_audio_codec_modules.py
+++ b/tests/collections/tts/modules/test_audio_codec_modules.py
@@ -15,12 +15,7 @@
 import pytest
 import torch
 
-from nemo.collections.tts.modules.audio_codec_modules import (
-    Conv1dNorm,
-    ConvTranspose1dNorm,
-    get_down_sample_padding,
-    get_up_sample_padding,
-)
+from nemo.collections.tts.modules.audio_codec_modules import Conv1dNorm, ConvTranspose1dNorm, get_down_sample_padding
 
 
 class TestAudioCodecModules:


### PR DESCRIPTION
# What does this PR do ?

Make audio codec losses more configurable, and add STFT and SI-SDR loss definitions.

**Collection**: [TTS]

# Changelog 
- Rename encodec.yaml to encodec_24000.yaml to include sampling rate, and modify parameters to better match the original paper.
- Add audio_codec_24000.yaml where we can start creating config for optimized NeMo audio codec recipe. 
- Separate out aggregate mel loss into separate L1 and L2 losses.
- Add parameter to control mel dimension for different resolutions.
- Implement multi-resolution log STFT loss.
- Implement SI-SDR loss, being a slightly modified version of the torchmetrics implementation but with masking support.
- Make all losses optional during train_step, only computing and optimizing on them if their loss_scale is non-zero. Except L1 mel loss which I expect will always be used, so I can use it as the logged "t_loss" value.
- Compute all losses during validation step for monitoring and validation.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

# Additional Information
The new configuration places no weight on time domain loss, scales the mel dimension proportional to the resolution (like DAC), and adds STFT loss (like univnet) to further improve accuracy. 

These are what the validation losses look like when training with different losses: mel fixed dimension, mel scaled dimension, STFT, and (mel scaled & STFT).

![loss_mel](https://github.com/NVIDIA/NeMo/assets/9942053/3f1e4db6-ec3f-4359-8789-86506227315e)

![loss_si_sdr](https://github.com/NVIDIA/NeMo/assets/9942053/1613c838-56c9-41aa-a2a6-8cd8bffa1b3a)

![loss_time_domain](https://github.com/NVIDIA/NeMo/assets/9942053/4339cd9f-beca-4007-b0ed-032fb1e8585f)

![loss_stft](https://github.com/NVIDIA/NeMo/assets/9942053/35d16738-82c7-41a1-bb36-70313a03dde7)
