### PR TITLE
Distributed optimizer support for experimental FP8 tensors

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -532,9 +532,11 @@ class MegatronBaseModel(NLPModel):
         if self.with_distributed_adam:
 
             # Initialize param buckets if explicitly provided
-            if hasattr(self, 'distributed_adam_buckets'):
+            if getattr(self, 'distributed_adam_buckets', None):
                 for bucket in self.distributed_adam_buckets:
                     self._optimizer.init_params_bucket(bucket)
+                self._optimizer.init_params_bucket(self.parameters())
+            if hasattr(self, 'distributed_adam_buckets'):
                 del self.distributed_adam_buckets
 
             # Make sure all params are initialized so main grads are

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -469,12 +469,6 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                             [p for p in layer.parameters() if not getattr(p, '_disable_overlap_grad_sync', False)]
                         )
             buckets.reverse()
-            used_params = set()
-            for bucket in buckets:
-                used_params.update(bucket)
-            remaining_params = [p for p in self.parameters() if p not in used_params]
-            if remaining_params:
-                buckets.append(remaining_params)
             self.distributed_adam_buckets = buckets
 
         return super().configure_optimizers()

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -237,9 +237,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                 fp8_recipe = transformer_engine.common.recipe.DelayedScaling(
                     margin=0, interval=1, fp8_format=transformer_engine.common.recipe.Format.E4M3
                 )
-            with transformer_engine.pytorch.fp8_autocast(
-                enabled=fp8_enabled, fp8_recipe=fp8_recipe
-            ):
+            with transformer_engine.pytorch.fp8_autocast(enabled=fp8_enabled, fp8_recipe=fp8_recipe):
                 self.model = build_model(
                     model_provider_func=self.model_provider_func,
                     wrap_with_ddp=False,
@@ -305,6 +303,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         """Model depends on pipeline paralellism."""
         if self.mcore_gpt:
             from megatron.core.models.gpt.gpt_decoder_spec import get_gpt_decoder_spec
+
             model = MCoreGPTModel(
                 config=self.transformer_config,
                 spec=get_gpt_decoder_spec(),

--- a/nemo/core/optim/optimizer_with_main_params.py
+++ b/nemo/core/optim/optimizer_with_main_params.py
@@ -162,7 +162,7 @@ class MainParamsOptimizerWrapper(torch.optim.Optimizer):
     Arguments:
         optimizer: base optimizer such as Adam or SGD.
         fp32_grad_accum: to enable the use of fp32 in gradient accumulation and allreduce.
-        contiguous_grad_bucket: to enable allocating the master gradients in the 
+        contiguous_grad_bucket: to enable allocating the master gradients in the
             contiguous memory space to reduce memory fragmentation.
         async_grad_allreduce: enable asynchronous gradient allreduce that is executed
             along with the training step backprop.


### PR DESCRIPTION
# What does this PR do ?

This PR integrates with experimental `Float8Tensor`s from the [Transformer Engine float8tensor_experiments branch](https://github.com/sudhakarsingh27/transformerengine/tree/float8tensor_experiments). This allows the model to only store FP8 weight matrices. The distributed optimizer will store an FP32 master copy of the weights and will perform param all-gathers in FP8.

**Collection**: NLP

# Changelog 
- Add logic to initialize GPT with FP8 weight matrices
- Add distributed optimizer support for FP8 weight matrices, including FP8 param all-gathers

# Usage
Enable FP8 support:
https://github.com/NVIDIA/NeMo/blob/19a3b7015fe353199af97903df1814e3a470b503/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml#L169

Use Megatron-core model:
https://github.com/NVIDIA/NeMo/blob/19a3b7015fe353199af97903df1814e3a470b503/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml#L49

Set the optimizer to `distributed_fused_adam`:

https://github.com/NVIDIA/NeMo/blob/f8be40b75ee1f8437b56fcc9602dc2aaddfb0643/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml#L228

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

Pinging @sudhakarsingh27.

# Additional Information
* Depends on https://github.com/sudhakarsingh27/transformerengine/tree/float8tensor_experiments, but there are import guards to handle the case that it isn't available.
* Depends on https://github.com/NVIDIA/apex/pull/1723
* Depends on https://gitlab-master.nvidia.com/ADLR/megatron-lm/-/tree/run_fp8_poc_with_nemo/
* Behavior is unchanged for non-FP8 models.
* If any FP8 params are detected, overlapping is disabled for non-FP8 grad reductions and param all-gathers.