### PR TITLE
[TTS] Read audio as int32 to avoid flac read errors

### DIFF
--- a/nemo/collections/asr/parts/preprocessing/segment.py
+++ b/nemo/collections/asr/parts/preprocessing/segment.py
@@ -375,7 +375,15 @@ class AudioSegment(object):
 
     @classmethod
     def segment_from_file(
-        cls, audio_file, target_sr=None, n_segments=0, trim=False, orig_sr=None, channel_selector=None, offset=None
+        cls,
+        audio_file,
+        target_sr=None,
+        n_segments=0,
+        trim=False,
+        orig_sr=None,
+        channel_selector=None,
+        offset=None,
+        dtype='float32',
     ):
         """Grabs n_segments number of samples from audio_file.
         If offset is not provided, n_segments are selected randomly.
@@ -390,6 +398,7 @@ class AudioSegment(object):
         :param orig_sr: the original sample rate
         :param channel selector: select a subset of channels. If set to `None`, the original signal will be used.
         :param offset: fixed offset in seconds
+        :param dtype: data type to load audio as.
         :return: numpy array of samples
         """
         is_segmented = False
@@ -412,15 +421,15 @@ class AudioSegment(object):
                                 f'Provided audio start ({audio_start}) is larger than the maximum possible ({max_audio_start})'
                             )
                     f.seek(audio_start)
-                    samples = f.read(n_segments_at_original_sr, dtype='float32')
+                    samples = f.read(n_segments_at_original_sr, dtype=dtype)
                     is_segmented = True
                 elif n_segments_at_original_sr > len(f):
                     logging.warning(
                         f"Number of segments ({n_segments_at_original_sr}) is greater than the length ({len(f)}) of the audio file {audio_file}. This may lead to shape mismatch errors."
                     )
-                    samples = f.read(dtype='float32')
+                    samples = f.read(dtype=dtype)
                 else:
-                    samples = f.read(dtype='float32')
+                    samples = f.read(dtype=dtype)
         except RuntimeError as e:
             logging.error(f"Loading {audio_file} via SoundFile raised RuntimeError: `{e}`.")
             raise e

--- a/nemo/collections/tts/data/vocoder_dataset.py
+++ b/nemo/collections/tts/data/vocoder_dataset.py
@@ -126,7 +126,7 @@ class VocoderDataset(Dataset):
         for _ in range(self.num_audio_retries):
             try:
                 audio_segment = AudioSegment.segment_from_file(
-                    audio_filepath, target_sr=self.sample_rate, n_segments=self.n_samples,
+                    audio_filepath, target_sr=self.sample_rate, n_segments=self.n_samples, dtype="int32"
                 )
                 return audio_segment
             except Exception:

--- a/nemo/collections/tts/data/vocoder_dataset.py
+++ b/nemo/collections/tts/data/vocoder_dataset.py
@@ -122,7 +122,9 @@ class VocoderDataset(Dataset):
         return sampler
 
     def _segment_audio(self, audio_filepath: Path) -> AudioSegment:
-        # Retry file read multiple times as file seeking can produce random IO errors.
+        # File seeking sometimes fails when reading flac files with libsndfile < 1.0.30.
+        # Read audio as int32 to minimize issues, and retry read on a different segment in case of failure.
+        # https://github.com/bastibe/python-soundfile/issues/274
         for _ in range(self.num_audio_retries):
             try:
                 audio_segment = AudioSegment.segment_from_file(


### PR DESCRIPTION
# What does this PR do ?

As described here https://github.com/bastibe/python-soundfile/issues/274 when reading flac files there is bug in libsnd in which it sometimes warps the audio, and as a result sometimes causes an 'Internal psf_fseek() failed.' error when reading.

The only known solution is to read audio as int32 instead of float32. AudioSegment class already has the logic to convert the int32 to float32 [-1, 1] representation during initialization, we just need a flag in segment_from_file() to utilize it.

**Collection**: [TTS]

# Changelog
- Add flag to segment_from_file() to specify dtype to read audio as (the AudioSegment will automatically convert it to float32 afterwards)
- Read audio in VocoderDataset as int32.
- Remove retrial logic which should no longer be necessary.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
