### PR TITLE
Remove incorrect extra argument of load_from_checkpoint_dir()

### DIFF
--- a/examples/nlp/language_modeling/megatron_gpt_continue_training.py
+++ b/examples/nlp/language_modeling/megatron_gpt_continue_training.py
@@ -183,7 +183,7 @@ def main(cfg) -> None:
         model = load_from_nemo(MegatronGPTModel, cfg, trainer, gpt_cfg, modify_confg_fn=_modify_config)
     elif cfg.model.get("pretrained_checkpoint", None) is not None:
         validate_checkpoint_loading_args(cfg.model.pretrained_checkpoint)
-        model = load_from_checkpoint_dir(MegatronGPTModel, cfg, trainer, gpt_cfg, modify_confg_fn=_modify_config)
+        model = load_from_checkpoint_dir(MegatronGPTModel, cfg, trainer, modify_confg_fn=_modify_config)
     else:
         print(' > WARNING: No checkpoint provided. Starting from scratch.')
         model = MegatronGPTModel(cfg.model, trainer)


### PR DESCRIPTION
# What does this PR do ?

The function load_from_checkpoint_dir() in `examples/nlp/language_modeling/megatron_gpt_continue_training.py` has four arguments:
```python
def load_from_checkpoint_dir(cls, cfg, trainer, modify_confg_fn):
```
But the calling side is:
```python
model = load_from_checkpoint_dir(MegatronGPTModel, cfg, trainer, gpt_cfg, modify_confg_fn=_modify_config)
```
The argument `gpt_cfg` is extraneous.

# Changelog 
- Remove extraneous argument of load_from_checkpoint_dir()

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

@MaximumEntropy @ericharper @ekmb @yzhang123 @VahidooX @vladgets @titu1994 @XuesongYang 

# Additional Information
* Related to #7480 
