### PR TITLE
Fix PTL2.0 related ASR bugs in r1.21.0: Val metrics logging, None dataloader issue

### DIFF
--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -601,9 +601,8 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         if AccessMixin.is_access_enabled():
             AccessMixin.reset_registry(self)
 
-        #adding this as return values are no longer logger automatically in PTL2.0
+        # adding this as return values are no longer logger automatically in PTL2.0
         self.log_dict(tensorboard_logs)
-
 
         return tensorboard_logs
 

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -601,7 +601,6 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         if AccessMixin.is_access_enabled():
             AccessMixin.reset_registry(self)
 
-        # adding this as return values are no longer logger automatically in PTL2.0
         self.log_dict(tensorboard_logs)
 
         return tensorboard_logs

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -601,6 +601,10 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         if AccessMixin.is_access_enabled():
             AccessMixin.reset_registry(self)
 
+        #adding this as return values are no longer logger automatically in PTL2.0
+        self.log_dict(tensorboard_logs)
+
+
         return tensorboard_logs
 
     def validation_step(self, batch, batch_idx, dataloader_idx=0):

--- a/nemo/collections/asr/models/label_models.py
+++ b/nemo/collections/asr/models/label_models.py
@@ -373,13 +373,16 @@ class EncDecSpeakerLabelModel(ModelPT, ExportableEncDecModel):
         self._macro_accuracy.update(preds=logits, target=labels)
         stats = self._macro_accuracy._final_state()
 
-        return {
+        eval_dict = {
             f'{tag}_loss': loss_value,
             f'{tag}_correct_counts': correct_counts,
             f'{tag}_total_counts': total_counts,
             f'{tag}_acc_micro_top_k': acc_top_k,
             f'{tag}_acc_macro_stats': stats,
         }
+
+        self.log_dict(eval_dict)
+        return eval_dict
 
     def multi_evaluation_epoch_end(self, outputs, dataloader_idx: int = 0, tag: str = 'val'):
         loss_mean = torch.stack([x[f'{tag}_loss'] for x in outputs]).mean()

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -833,7 +833,6 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel):
 
         self.log('global_step', torch.tensor(self.trainer.global_step, dtype=torch.float32))
 
-        # adding this as return values are no longer logger automatically in PTL2.0
         self.log_dict(tensorboard_logs)
 
         return tensorboard_logs

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -833,6 +833,9 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel):
 
         self.log('global_step', torch.tensor(self.trainer.global_step, dtype=torch.float32))
 
+        #adding this as return values are no longer logger automatically in PTL2.0
+        self.log_dict(tensorboard_logs)
+
         return tensorboard_logs
 
     def test_step(self, batch, batch_idx, dataloader_idx=0):

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -833,7 +833,7 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel):
 
         self.log('global_step', torch.tensor(self.trainer.global_step, dtype=torch.float32))
 
-        #adding this as return values are no longer logger automatically in PTL2.0
+        # adding this as return values are no longer logger automatically in PTL2.0
         self.log_dict(tensorboard_logs)
 
         return tensorboard_logs

--- a/nemo/collections/asr/models/slu_models.py
+++ b/nemo/collections/asr/models/slu_models.py
@@ -320,12 +320,16 @@ class SLUIntentSlotBPEModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, ASR
         wer, wer_num, wer_denom = self._wer.compute()
         self._wer.reset()
 
-        return {
+        val_logs_dict = {
             'val_loss': loss_value,
             'val_wer_num': wer_num,
             'val_wer_denom': wer_denom,
             'val_wer': wer,
         }
+
+        self.log_dict(val_logs_dict)
+
+        return val_logs_dict
 
     def test_step(self, batch, batch_idx, dataloader_idx=0):
         logs = self.validation_step(batch, batch_idx, dataloader_idx=dataloader_idx)
@@ -335,6 +339,9 @@ class SLUIntentSlotBPEModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, ASR
             'test_wer_denom': logs['val_wer_denom'],
             'test_wer': logs['val_wer'],
         }
+
+        self.log_dict(test_logs)
+
         return test_logs
 
     def test_dataloader(self):

--- a/nemo/collections/asr/models/ssl_models.py
+++ b/nemo/collections/asr/models/ssl_models.py
@@ -554,9 +554,11 @@ class SpeechEncDecSelfSupervisedModel(ModelPT, ASRModuleMixin, AccessMixin):
         self.reset_registry()
         del self._in_validation_step
 
-        return {
-            'val_loss': loss_value,
-        }
+        val_log_dict = {'val_loss': loss_value}
+
+        self.log_dict(val_log_dict)
+
+        return val_log_dict
 
     def multi_validation_epoch_end(self, outputs, dataloader_idx: int = 0):
         val_loss_mean = torch.stack([x['val_loss'] for x in outputs]).mean()

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -869,7 +869,6 @@ class ModelPT(LightningModule, Model):
 
         return self._test_dl
 
-
     def on_validation_epoch_end(self) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
         """
         Default DataLoader for Validation set which automatically supports multiple data loaders

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -856,12 +856,19 @@ class ModelPT(LightningModule, Model):
             return self._train_dl
 
     def val_dataloader(self):
-        if self._validation_dl is not None:
-            return self._validation_dl
+        if self._validation_dl is None:
+            # None dataloader no longer supported in PTL2.0
+            self._validation_dl = []
+
+        return self._validation_dl
 
     def test_dataloader(self):
-        if self._test_dl is not None:
-            return self._test_dl
+        if self._test_dl is None:
+            # None dataloader no longer supported in PTL2.0
+            self._test_dl = []
+
+        return self._test_dl
+
 
     def on_validation_epoch_end(self) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
         """


### PR DESCRIPTION
# What does this PR do ?

This PR added fixes for PTL2.0 related ASR bugs in r1.21.0: Val metrics logging, None dataloader issue

**Collection**: 
ASR, Core

# Changelog 
- val_dataloader() and test_dataloader() functions in nemo/core/classes/modelPT.py updated to handle cases where dataloader is None
- correct logging of validation metrics in nemo/collections/asr/models/rnnt_models.py and nemo/collections/asr/models/hybrid_rnnt_ctc_models.py


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Additional Information
* Related to [Bug4296343](https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=4296343&cmtNo=), [Bug4296057](https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=4296057&cmtNo=), [Bug4246804](https://nvbugswb.nvidia.com/NvBugs5/SWBug.aspx?bugid=4246804&cmtNo=)
* Fixes issues raised in #7450, #7507
