### PR TITLE
Fix dimensionality in get_dist function

### DIFF
--- a/nemo/collections/tts/modules/aligner.py
+++ b/nemo/collections/tts/modules/aligner.py
@@ -98,7 +98,7 @@ class AlignmentEncoder(torch.nn.Module):
 
         self._apply_mask(dist, mask, float("inf"))
 
-        return dist
+        return dist.squeeze(1)
 
     @staticmethod
     def get_euclidean_dist(queries_enc, keys_enc):


### PR DESCRIPTION
# What does this PR do ?

Adds back a `squeeze(1)` to the Aligner `get_dist()` function.

This should fix a few cells erroring out in the Aligner inference notebook.

See #7490 for more info.

**Collection**:TTS

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation