### PR TITLE
bugfix: specify trainer.strategy=auto when devices=1

### DIFF
--- a/tutorials/tts/Vits_Training.ipynb
+++ b/tutorials/tts/Vits_Training.ipynb
@@ -309,6 +309,7 @@
     "  heteronyms_path=tts_dataset_files/heteronyms-052722 \\\n",
     "  trainer.max_epochs=3 \\\n",
     "  trainer.accelerator=auto \\\n",
+    "  trainer.strategy=auto \\\n",
     "  trainer.check_val_every_n_epoch=1 \\\n",
     "  trainer.devices=1)"
    ]


### PR DESCRIPTION
# What does this PR do ?

the script called default `conf/vits.yaml` config: https://github.com/NVIDIA/NeMo/blob/main/examples/tts/conf/vits.yaml#L192, which applied `strategy=ddp` by default. When `devices=1` in this tutorial, we should specify `auto` to override `ddp`.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
