### PR TITLE
dllogger - log on rank 0 only

### DIFF
--- a/nemo/utils/loggers/dllogger.py
+++ b/nemo/utils/loggers/dllogger.py
@@ -20,6 +20,7 @@ from typing import Optional
 from lightning_utilities.core.apply_func import apply_to_collection
 from omegaconf import DictConfig, ListConfig, OmegaConf
 from pytorch_lightning.loggers import Logger
+from pytorch_lightning.utilities import rank_zero_only
 from pytorch_lightning.utilities.parsing import AttributeDict
 
 from nemo.utils import logging
@@ -81,6 +82,7 @@ class DLLogger(Logger):
             )
         dllogger.init(backends=backends)
 
+    @rank_zero_only
     def log_hyperparams(self, params, *args, **kwargs):
         if isinstance(params, Namespace):
             params = vars(params)
@@ -91,6 +93,7 @@ class DLLogger(Logger):
         params = _sanitize_callable_params(_flatten_dict(_convert_params(params)))
         dllogger.log(step="PARAMETER", data=params)
 
+    @rank_zero_only
     def log_metrics(self, metrics, step=None):
         if step is None:
             step = tuple()


### PR DESCRIPTION
# What does this PR do ?

As discussed in https://github.com/NVIDIA/NeMo/issues/7495 @titu1994 helped me to make Dllogger to log on rank0 as otherwise the metrics log happens 512 times per step on 512 gpus.

Fixes: https://github.com/NVIDIA/NeMo/issues/7495

**Collection**: [Note which collection this PR will affect]

# Changelog 
- make Dllogger to log on rank0 as otherwise the metrics log happens 512 times per step on 512 gpus.


# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to https://github.com/NVIDIA/NeMo/issues/7495
