### PR TITLE
Append val output to self.validation_step_outputs in GLUEModel

### DIFF
--- a/nemo/collections/nlp/models/glue_benchmark/glue_benchmark_model.py
+++ b/nemo/collections/nlp/models/glue_benchmark/glue_benchmark_model.py
@@ -173,16 +173,18 @@ class GLUEModel(NLPModel):
             model_output = torch.argmax(model_output, 1)
 
         eval_tensors = {'preds': model_output, 'labels': labels}
-        return {'val_loss': val_loss, 'eval_tensors': eval_tensors}
+        output = {'val_loss': val_loss, 'eval_tensors': eval_tensors}
+        self.validation_step_outputs.append(output)
+        return output
 
     def multi_validation_epoch_end(self, outputs, dataloader_idx: int = 0):
         """
         Called at the end of validation to aggregate outputs.
         outputs: list of individual outputs of each validation step.
         """
-        avg_loss = torch.stack([x['val_loss'] for x in outputs]).mean()
-        preds = torch.cat([x['eval_tensors']['preds'] for x in outputs])
-        labels = torch.cat([x['eval_tensors']['labels'] for x in outputs])
+        avg_loss = torch.stack([x['val_loss'] for x in self.validation_step_outputs]).mean()
+        preds = torch.cat([x['eval_tensors']['preds'] for x in self.validation_step_outputs])
+        labels = torch.cat([x['eval_tensors']['labels'] for x in self.validation_step_outputs])
 
         all_preds = []
         all_labels = []


### PR DESCRIPTION
# What does this PR do ?

Appends the output of `validation_step` in `GLUEModel` to the instance variable `self.validation_step_outputs` as expected by PTL 2.0.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
