### PR TITLE
Clarify that `length_params.max_length` is not a hard constraint

### DIFF
--- a/nemo/collections/nlp/modules/common/transformer/text_generation.py
+++ b/nemo/collections/nlp/modules/common/transformer/text_generation.py
@@ -77,7 +77,9 @@ class TextGeneration:
                           where 'prompt-tag' is used to identify the type of NLP task to solve.
             length_params (LengthParam):
                 a dictionary type which controls the sampling length.
-                    max_length: int, The maximum length of the sequence to be generated.
+                    max_length: int, The maximum length of the sequence to be generated. Note that this is a "soft"
+                        contraint: only the generated sequence with the longest context in the batch is guaranteed not
+                        to exceed this length (those generated from shorter contexts in the same batch may exceed it).
                     min_length: int,  The minimum length of the sequence to be generated.
                 If None, max_length is set to 30, and min_length is set to None
             sampling_params (SamplingParam):


### PR DESCRIPTION
# What does this PR do ?

Update docstring describing `length_params.max_length` to say that generated sequences may actually exceed this length, since this can be surprising.

**Collection**: nlp

# Changelog 
- Clarify that `length_params.max_length` is not a hard constraint

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [X] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [X] Documentation


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

I need someone to confirm whether the same doc change should be applied to this `asr` file, that seems to be copied from `nlp`:
https://github.com/NVIDIA/NeMo/blob/82e1f4f9f1a280edb70088bf30bf0a099152e185/nemo/collections/asr/modules/transformer/text_generation.py#L79

@stevehuang52 would you be able to confirm by any chance?