### PR TITLE
Broadcast loss only when using pipeline parallelism and within the pipeline parallel domain

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
 import itertools
+import os
 import queue
 import warnings
 from functools import partial
@@ -611,9 +611,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                     last_pipeline_stage_offset = (tp_size * dp_size) * (pp_size - 1)
                     self.loss_broadcast_src_rank = last_pipeline_stage_offset + rank_in_dp_tp_group
                 torch.distributed.broadcast(
-                    loss_mean,
-                    self.loss_broadcast_src_rank,
-                    group=parallel_state.get_pipeline_model_parallel_group(),
+                    loss_mean, self.loss_broadcast_src_rank, group=parallel_state.get_pipeline_model_parallel_group(),
                 )
             self.log('reduced_train_loss', loss_mean, prog_bar=True, rank_zero_only=True, batch_size=1)
 
@@ -925,9 +923,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                 last_pipeline_stage_offset = (tp_size * dp_size) * (pp_size - 1)
                 self.loss_broadcast_src_rank = last_pipeline_stage_offset + rank_in_dp_tp_group
             torch.distributed.broadcast(
-                averaged_loss,
-                self.loss_broadcast_src_rank,
-                group=parallel_state.get_pipeline_model_parallel_group(),
+                averaged_loss, self.loss_broadcast_src_rank, group=parallel_state.get_pipeline_model_parallel_group(),
             )
 
         self.log('val_loss', averaged_loss, prog_bar=True, rank_zero_only=True, batch_size=1)


### PR DESCRIPTION
Broadcast train and validation loss only when pipeline parallel size is larger than 1.
Also, the loss broadcasting only within the pipeline parallel domain.

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
