### PR TITLE
Fix py3.11 dataclasses issue 

### DIFF
--- a/examples/asr/experimental/k2/align_speech_parallel.py
+++ b/examples/asr/experimental/k2/align_speech_parallel.py
@@ -74,7 +74,7 @@ You may control the aligner's config by setting the aligner_args:
 
 
 import os
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass, field, is_dataclass
 from typing import Optional
 
 import pytorch_lightning as ptl
@@ -94,12 +94,12 @@ from nemo.utils.get_rank import is_global_rank_zero
 @dataclass
 class ParallelAlignmentConfig:
     model: Optional[str] = None  # name
-    predict_ds: ASRDatasetConfig = ASRDatasetConfig(return_sample_id=True, num_workers=4)
-    aligner_args: K2AlignerWrapperModelConfig = K2AlignerWrapperModelConfig()
+    predict_ds: ASRDatasetConfig = field(default_factory=lambda: ASRDatasetConfig(return_sample_id=True, num_workers=4))
+    aligner_args: K2AlignerWrapperModelConfig = field(default_factory=lambda: K2AlignerWrapperModelConfig())
     output_path: str = MISSING
     model_stride: int = 8
 
-    trainer: TrainerConfig = TrainerConfig(gpus=-1, accelerator="ddp")
+    trainer: TrainerConfig = field(default_factory=lambda: TrainerConfig(gpus=-1, accelerator="ddp"))
 
     # there arguments will be ignored
     return_predictions: bool = False

--- a/examples/asr/experimental/k2/align_speech_parallel.py
+++ b/examples/asr/experimental/k2/align_speech_parallel.py
@@ -94,7 +94,9 @@ from nemo.utils.get_rank import is_global_rank_zero
 @dataclass
 class ParallelAlignmentConfig:
     model: Optional[str] = None  # name
-    predict_ds: ASRDatasetConfig = field(default_factory=lambda: ASRDatasetConfig(return_sample_id=True, num_workers=4))
+    predict_ds: ASRDatasetConfig = field(
+        default_factory=lambda: ASRDatasetConfig(return_sample_id=True, num_workers=4)
+    )
     aligner_args: K2AlignerWrapperModelConfig = field(default_factory=lambda: K2AlignerWrapperModelConfig())
     output_path: str = MISSING
     model_stride: int = 8

--- a/nemo/collections/asr/metrics/rnnt_wer.py
+++ b/nemo/collections/asr/metrics/rnnt_wer.py
@@ -15,7 +15,7 @@
 import copy
 import re
 from abc import abstractmethod
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass, field, is_dataclass
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import editdistance
@@ -1299,7 +1299,7 @@ class RNNTDecodingConfig:
     preserve_alignments: Optional[bool] = None
 
     #  confidence config
-    confidence_cfg: ConfidenceConfig = ConfidenceConfig()
+    confidence_cfg: ConfidenceConfig = field(default_factory=lambda: ConfidenceConfig())
 
     # RNNT Joint fused batch size
     fused_batch_size: Optional[int] = None
@@ -1317,10 +1317,10 @@ class RNNTDecodingConfig:
     rnnt_timestamp_type: str = "all"  # can be char, word or all for both
 
     # greedy decoding config
-    greedy: greedy_decode.GreedyRNNTInferConfig = greedy_decode.GreedyRNNTInferConfig()
+    greedy: greedy_decode.GreedyRNNTInferConfig = field(default_factory=lambda: greedy_decode.GreedyRNNTInferConfig())
 
     # beam decoding config
-    beam: beam_decode.BeamRNNTInferConfig = beam_decode.BeamRNNTInferConfig(beam_size=4)
+    beam: beam_decode.BeamRNNTInferConfig = field(default_factory=lambda: beam_decode.BeamRNNTInferConfig(beam_size=4))
 
     # can be used to change temperature for decoding
     temperature: float = 1.0

--- a/nemo/collections/asr/metrics/wer.py
+++ b/nemo/collections/asr/metrics/wer.py
@@ -14,7 +14,7 @@
 
 import re
 from abc import abstractmethod
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass, field, is_dataclass
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import editdistance
@@ -1297,13 +1297,17 @@ class CTCDecodingConfig:
     batch_dim_index: int = 0
 
     # greedy decoding config
-    greedy: ctc_greedy_decoding.GreedyCTCInferConfig = ctc_greedy_decoding.GreedyCTCInferConfig()
+    greedy: ctc_greedy_decoding.GreedyCTCInferConfig = field(
+        default_factory=lambda: ctc_greedy_decoding.GreedyCTCInferConfig()
+    )
 
     # beam decoding config
-    beam: ctc_beam_decoding.BeamCTCInferConfig = ctc_beam_decoding.BeamCTCInferConfig(beam_size=4)
+    beam: ctc_beam_decoding.BeamCTCInferConfig = field(
+        default_factory=lambda: ctc_beam_decoding.BeamCTCInferConfig(beam_size=4)
+    )
 
     # confidence config
-    confidence_cfg: ConfidenceConfig = ConfidenceConfig()
+    confidence_cfg: ConfidenceConfig = field(default_factory=lambda: ConfidenceConfig())
 
     # can be used to change temperature for decoding
     temperature: float = 1.0

--- a/nemo/collections/asr/models/configs/aligner_config.py
+++ b/nemo/collections/asr/models/configs/aligner_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from nemo.collections.asr.parts.k2.classes import GraphModuleConfig
 
@@ -35,10 +35,10 @@ class AlignerWrapperModelConfig:
     word_output: bool = True
     cpu_decoding: bool = False
     decode_batch_size: int = 0
-    ctc_cfg: AlignerCTCConfig = AlignerCTCConfig()
-    rnnt_cfg: AlignerRNNTConfig = AlignerRNNTConfig()
+    ctc_cfg: AlignerCTCConfig = field(default_factory=lambda: AlignerCTCConfig())
+    rnnt_cfg: AlignerRNNTConfig = field(default_factory=lambda: AlignerRNNTConfig())
 
 
 @dataclass
 class K2AlignerWrapperModelConfig(AlignerWrapperModelConfig):
-    decoder_module_cfg: GraphModuleConfig = GraphModuleConfig()
+    decoder_module_cfg: GraphModuleConfig = field(default_factory=lambda: GraphModuleConfig())

--- a/nemo/collections/asr/models/configs/asr_models_config.py
+++ b/nemo/collections/asr/models/configs/asr_models_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from omegaconf import MISSING
@@ -74,24 +74,24 @@ class EncDecCTCConfig(model_cfg.ModelConfig):
     labels: List[str] = MISSING
 
     # Dataset configs
-    train_ds: ASRDatasetConfig = ASRDatasetConfig(manifest_filepath=None, shuffle=True)
-    validation_ds: ASRDatasetConfig = ASRDatasetConfig(manifest_filepath=None, shuffle=False)
-    test_ds: ASRDatasetConfig = ASRDatasetConfig(manifest_filepath=None, shuffle=False)
+    train_ds: ASRDatasetConfig = field(default_factory=lambda: ASRDatasetConfig(manifest_filepath=None, shuffle=True))
+    validation_ds: ASRDatasetConfig = field(default_factory=lambda: ASRDatasetConfig(manifest_filepath=None, shuffle=False))
+    test_ds: ASRDatasetConfig = field(default_factory=lambda: ASRDatasetConfig(manifest_filepath=None, shuffle=False))
 
     # Optimizer / Scheduler config
-    optim: Optional[model_cfg.OptimConfig] = model_cfg.OptimConfig(sched=model_cfg.SchedConfig())
+    optim: Optional[model_cfg.OptimConfig] = field(default_factory=lambda: model_cfg.OptimConfig(sched=model_cfg.SchedConfig()))
 
     # Model component configs
-    preprocessor: AudioToMelSpectrogramPreprocessorConfig = AudioToMelSpectrogramPreprocessorConfig()
-    spec_augment: Optional[SpectrogramAugmentationConfig] = SpectrogramAugmentationConfig()
-    encoder: ConvASREncoderConfig = ConvASREncoderConfig()
-    decoder: ConvASRDecoderConfig = ConvASRDecoderConfig()
-    decoding: CTCDecodingConfig = CTCDecodingConfig()
+    preprocessor: AudioToMelSpectrogramPreprocessorConfig = field(default_factory=lambda: AudioToMelSpectrogramPreprocessorConfig())
+    spec_augment: Optional[SpectrogramAugmentationConfig] = field(default_factory=lambda: SpectrogramAugmentationConfig())
+    encoder: ConvASREncoderConfig = field(default_factory=lambda: ConvASREncoderConfig())
+    decoder: ConvASRDecoderConfig = field(default_factory=lambda: ConvASRDecoderConfig())
+    decoding: CTCDecodingConfig = field(default_factory=lambda: CTCDecodingConfig())
 
 
 @dataclass
 class EncDecCTCModelConfig(model_cfg.NemoConfig):
-    model: EncDecCTCConfig = EncDecCTCConfig()
+    model: EncDecCTCConfig = field(default_factory=lambda: EncDecCTCConfig())
 
 
 @dataclass

--- a/nemo/collections/asr/models/configs/asr_models_config.py
+++ b/nemo/collections/asr/models/configs/asr_models_config.py
@@ -75,15 +75,23 @@ class EncDecCTCConfig(model_cfg.ModelConfig):
 
     # Dataset configs
     train_ds: ASRDatasetConfig = field(default_factory=lambda: ASRDatasetConfig(manifest_filepath=None, shuffle=True))
-    validation_ds: ASRDatasetConfig = field(default_factory=lambda: ASRDatasetConfig(manifest_filepath=None, shuffle=False))
+    validation_ds: ASRDatasetConfig = field(
+        default_factory=lambda: ASRDatasetConfig(manifest_filepath=None, shuffle=False)
+    )
     test_ds: ASRDatasetConfig = field(default_factory=lambda: ASRDatasetConfig(manifest_filepath=None, shuffle=False))
 
     # Optimizer / Scheduler config
-    optim: Optional[model_cfg.OptimConfig] = field(default_factory=lambda: model_cfg.OptimConfig(sched=model_cfg.SchedConfig()))
+    optim: Optional[model_cfg.OptimConfig] = field(
+        default_factory=lambda: model_cfg.OptimConfig(sched=model_cfg.SchedConfig())
+    )
 
     # Model component configs
-    preprocessor: AudioToMelSpectrogramPreprocessorConfig = field(default_factory=lambda: AudioToMelSpectrogramPreprocessorConfig())
-    spec_augment: Optional[SpectrogramAugmentationConfig] = field(default_factory=lambda: SpectrogramAugmentationConfig())
+    preprocessor: AudioToMelSpectrogramPreprocessorConfig = field(
+        default_factory=lambda: AudioToMelSpectrogramPreprocessorConfig()
+    )
+    spec_augment: Optional[SpectrogramAugmentationConfig] = field(
+        default_factory=lambda: SpectrogramAugmentationConfig()
+    )
     encoder: ConvASREncoderConfig = field(default_factory=lambda: ConvASREncoderConfig())
     decoder: ConvASRDecoderConfig = field(default_factory=lambda: ConvASRDecoderConfig())
     decoding: CTCDecodingConfig = field(default_factory=lambda: CTCDecodingConfig())

--- a/nemo/collections/asr/models/configs/classification_models_config.py
+++ b/nemo/collections/asr/models/configs/classification_models_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 from omegaconf import MISSING
@@ -72,30 +72,34 @@ class EncDecClassificationConfig(model_cfg.ModelConfig):
     timesteps: int = MISSING
 
     # Dataset configs
-    train_ds: EncDecClassificationDatasetConfig = EncDecClassificationDatasetConfig(
+    train_ds: EncDecClassificationDatasetConfig = field(default_factory=lambda: EncDecClassificationDatasetConfig(
         manifest_filepath=None, shuffle=True, trim_silence=False
-    )
-    validation_ds: EncDecClassificationDatasetConfig = EncDecClassificationDatasetConfig(
+    ))
+    validation_ds: EncDecClassificationDatasetConfig = field(default_factory=lambda: EncDecClassificationDatasetConfig(
         manifest_filepath=None, shuffle=False
-    )
-    test_ds: EncDecClassificationDatasetConfig = EncDecClassificationDatasetConfig(
+    ))
+    test_ds: EncDecClassificationDatasetConfig = field(default_factory=lambda: EncDecClassificationDatasetConfig(
         manifest_filepath=None, shuffle=False
-    )
+    ))
 
     # Optimizer / Scheduler config
-    optim: Optional[model_cfg.OptimConfig] = model_cfg.OptimConfig(sched=model_cfg.SchedConfig())
+    optim: Optional[model_cfg.OptimConfig] = field(default_factory=lambda: model_cfg.OptimConfig(sched=model_cfg.SchedConfig()))
 
     # Model component configs
-    preprocessor: AudioToMFCCPreprocessorConfig = AudioToMFCCPreprocessorConfig()
-    spec_augment: Optional[SpectrogramAugmentationConfig] = SpectrogramAugmentationConfig()
-    crop_or_pad_augment: Optional[CropOrPadSpectrogramAugmentationConfig] = CropOrPadSpectrogramAugmentationConfig(
-        audio_length=timesteps
-    )
+    preprocessor: AudioToMFCCPreprocessorConfig = field(default_factory=lambda: AudioToMFCCPreprocessorConfig())
+    spec_augment: Optional[SpectrogramAugmentationConfig] = field(default_factory=lambda: SpectrogramAugmentationConfig())
+    crop_or_pad_augment: Optional[CropOrPadSpectrogramAugmentationConfig] = field(default_factory=lambda: CropOrPadSpectrogramAugmentationConfig(
+        audio_length=-1
+    ))
 
-    encoder: ConvASREncoderConfig = ConvASREncoderConfig()
-    decoder: ConvASRDecoderClassificationConfig = ConvASRDecoderClassificationConfig()
+    encoder: ConvASREncoderConfig = field(default_factory=lambda: ConvASREncoderConfig())
+    decoder: ConvASRDecoderClassificationConfig = field(default_factory=lambda: ConvASRDecoderClassificationConfig())
+
+    def __post_init__(self):
+        if self.crop_or_pad_augment is not None:
+            self.crop_or_pad_augment.audio_length = self.timesteps
 
 
 @dataclass
 class EncDecClassificationModelConfig(model_cfg.NemoConfig):
-    model: EncDecClassificationConfig = EncDecClassificationConfig()
+    model: EncDecClassificationConfig = field(default_factory=lambda: EncDecClassificationConfig())

--- a/nemo/collections/asr/models/configs/classification_models_config.py
+++ b/nemo/collections/asr/models/configs/classification_models_config.py
@@ -72,25 +72,31 @@ class EncDecClassificationConfig(model_cfg.ModelConfig):
     timesteps: int = MISSING
 
     # Dataset configs
-    train_ds: EncDecClassificationDatasetConfig = field(default_factory=lambda: EncDecClassificationDatasetConfig(
-        manifest_filepath=None, shuffle=True, trim_silence=False
-    ))
-    validation_ds: EncDecClassificationDatasetConfig = field(default_factory=lambda: EncDecClassificationDatasetConfig(
-        manifest_filepath=None, shuffle=False
-    ))
-    test_ds: EncDecClassificationDatasetConfig = field(default_factory=lambda: EncDecClassificationDatasetConfig(
-        manifest_filepath=None, shuffle=False
-    ))
+    train_ds: EncDecClassificationDatasetConfig = field(
+        default_factory=lambda: EncDecClassificationDatasetConfig(
+            manifest_filepath=None, shuffle=True, trim_silence=False
+        )
+    )
+    validation_ds: EncDecClassificationDatasetConfig = field(
+        default_factory=lambda: EncDecClassificationDatasetConfig(manifest_filepath=None, shuffle=False)
+    )
+    test_ds: EncDecClassificationDatasetConfig = field(
+        default_factory=lambda: EncDecClassificationDatasetConfig(manifest_filepath=None, shuffle=False)
+    )
 
     # Optimizer / Scheduler config
-    optim: Optional[model_cfg.OptimConfig] = field(default_factory=lambda: model_cfg.OptimConfig(sched=model_cfg.SchedConfig()))
+    optim: Optional[model_cfg.OptimConfig] = field(
+        default_factory=lambda: model_cfg.OptimConfig(sched=model_cfg.SchedConfig())
+    )
 
     # Model component configs
     preprocessor: AudioToMFCCPreprocessorConfig = field(default_factory=lambda: AudioToMFCCPreprocessorConfig())
-    spec_augment: Optional[SpectrogramAugmentationConfig] = field(default_factory=lambda: SpectrogramAugmentationConfig())
-    crop_or_pad_augment: Optional[CropOrPadSpectrogramAugmentationConfig] = field(default_factory=lambda: CropOrPadSpectrogramAugmentationConfig(
-        audio_length=-1
-    ))
+    spec_augment: Optional[SpectrogramAugmentationConfig] = field(
+        default_factory=lambda: SpectrogramAugmentationConfig()
+    )
+    crop_or_pad_augment: Optional[CropOrPadSpectrogramAugmentationConfig] = field(
+        default_factory=lambda: CropOrPadSpectrogramAugmentationConfig(audio_length=-1)
+    )
 
     encoder: ConvASREncoderConfig = field(default_factory=lambda: ConvASREncoderConfig())
     decoder: ConvASRDecoderClassificationConfig = field(default_factory=lambda: ConvASRDecoderClassificationConfig())

--- a/nemo/collections/asr/models/configs/diarizer_config.py
+++ b/nemo/collections/asr/models/configs/diarizer_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from typing import Any, Dict, Optional, Tuple, Union
 
 
@@ -78,9 +78,9 @@ class ASRDiarizerParams(DiarizerComponentConfig):
 @dataclass
 class ASRDiarizerConfig(DiarizerComponentConfig):
     model_path: Optional[str] = "stt_en_conformer_ctc_large"
-    parameters: ASRDiarizerParams = ASRDiarizerParams()
-    ctc_decoder_parameters: ASRDiarizerCTCDecoderParams = ASRDiarizerCTCDecoderParams()
-    realigning_lm_parameters: ASRRealigningLMParams = ASRRealigningLMParams()
+    parameters: ASRDiarizerParams = field(default_factory=lambda: ASRDiarizerParams())
+    ctc_decoder_parameters: ASRDiarizerCTCDecoderParams = field(default_factory=lambda: ASRDiarizerCTCDecoderParams())
+    realigning_lm_parameters: ASRRealigningLMParams = field(default_factory=lambda: ASRRealigningLMParams())
 
 
 @dataclass
@@ -102,7 +102,7 @@ class VADParams(DiarizerComponentConfig):
 class VADConfig(DiarizerComponentConfig):
     model_path: str = "vad_multilingual_marblenet"  # .nemo local model path or pretrained VAD model name
     external_vad_manifest: Optional[str] = None
-    parameters: VADParams = VADParams()
+    parameters: VADParams = field(default_factory=lambda: VADParams())
 
 
 @dataclass
@@ -121,7 +121,7 @@ class SpeakerEmbeddingsParams(DiarizerComponentConfig):
 class SpeakerEmbeddingsConfig(DiarizerComponentConfig):
     # .nemo local model path or pretrained model name (titanet_large, ecapa_tdnn or speakerverification_speakernet)
     model_path: Optional[str] = None
-    parameters: SpeakerEmbeddingsParams = SpeakerEmbeddingsParams()
+    parameters: SpeakerEmbeddingsParams = field(default_factory=lambda: SpeakerEmbeddingsParams())
 
 
 @dataclass
@@ -142,7 +142,7 @@ class ClusteringParams(DiarizerComponentConfig):
 
 @dataclass
 class ClusteringConfig(DiarizerComponentConfig):
-    parameters: ClusteringParams = ClusteringParams()
+    parameters: ClusteringParams = field(default_factory=lambda: ClusteringParams())
 
 
 @dataclass
@@ -166,7 +166,7 @@ class MSDDParams(DiarizerComponentConfig):
 @dataclass
 class MSDDConfig(DiarizerComponentConfig):
     model_path: Optional[str] = "diar_msdd_telephonic"
-    parameters: MSDDParams = MSDDParams()
+    parameters: MSDDParams = field(default_factory=lambda: MSDDParams())
 
 
 @dataclass
@@ -176,16 +176,16 @@ class DiarizerConfig(DiarizerComponentConfig):
     oracle_vad: bool = False  # If True, uses RTTM files provided in the manifest file to get VAD timestamps
     collar: float = 0.25  # Collar value for scoring
     ignore_overlap: bool = True  # Consider or ignore overlap segments while scoring
-    vad: VADConfig = VADConfig()
-    speaker_embeddings: SpeakerEmbeddingsConfig = SpeakerEmbeddingsConfig()
-    clustering: ClusteringConfig = ClusteringConfig()
-    msdd_model: MSDDConfig = MSDDConfig()
-    asr: ASRDiarizerConfig = ASRDiarizerConfig()
+    vad: VADConfig = field(default_factory=lambda: VADConfig())
+    speaker_embeddings: SpeakerEmbeddingsConfig = field(default_factory=lambda: SpeakerEmbeddingsConfig())
+    clustering: ClusteringConfig = field(default_factory=lambda: ClusteringConfig())
+    msdd_model: MSDDConfig = field(default_factory=lambda: MSDDConfig())
+    asr: ASRDiarizerConfig = field(default_factory=lambda: ASRDiarizerConfig())
 
 
 @dataclass
 class NeuralDiarizerInferenceConfig(DiarizerComponentConfig):
-    diarizer: DiarizerConfig = DiarizerConfig()
+    diarizer: DiarizerConfig = field(default_factory=lambda: DiarizerConfig())
     device: str = "cpu"
     verbose: bool = False
     batch_size: int = 64

--- a/nemo/collections/asr/models/configs/k2_sequence_models_config.py
+++ b/nemo/collections/asr/models/configs/k2_sequence_models_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from nemo.collections.asr.models.configs.asr_models_config import EncDecCTCConfig
 from nemo.collections.asr.parts.k2.classes import GraphModuleConfig as BackendConfig
@@ -26,14 +26,14 @@ class GraphModuleConfig:
     split_batch_size: int = 0
     dec_type: str = "topo"
     transcribe_training: bool = True
-    backend_cfg: BackendConfig = BackendConfig()
+    backend_cfg: BackendConfig = field(default_factory=lambda: BackendConfig())
 
 
 @dataclass
 class EncDecK2SeqConfig(EncDecCTCConfig):
-    graph_module_cfg: GraphModuleConfig = GraphModuleConfig()
+    graph_module_cfg: GraphModuleConfig = field(default_factory=lambda: GraphModuleConfig())
 
 
 @dataclass
 class EncDecK2SeqModelConfig(NemoConfig):
-    model: EncDecK2SeqConfig = EncDecK2SeqConfig()
+    model: EncDecK2SeqConfig = field(default_factory=lambda: EncDecK2SeqConfig())

--- a/nemo/collections/asr/models/configs/matchboxnet_config.py
+++ b/nemo/collections/asr/models/configs/matchboxnet_config.py
@@ -107,27 +107,35 @@ class MatchboxNetModelConfig(clf_cfg.EncDecClassificationConfig):
     labels: List[str] = MISSING
 
     # Dataset configs
-    train_ds: clf_cfg.EncDecClassificationDatasetConfig = field(default_factory=lambda: clf_cfg.EncDecClassificationDatasetConfig(
-        manifest_filepath=None, shuffle=True, trim_silence=False
-    ))
-    validation_ds: clf_cfg.EncDecClassificationDatasetConfig = field(default_factory=lambda: clf_cfg.EncDecClassificationDatasetConfig(
-        manifest_filepath=None, shuffle=False
-    ))
-    test_ds: clf_cfg.EncDecClassificationDatasetConfig = field(default_factory=lambda: clf_cfg.EncDecClassificationDatasetConfig(
-        manifest_filepath=None, shuffle=False
-    ))
+    train_ds: clf_cfg.EncDecClassificationDatasetConfig = field(
+        default_factory=lambda: clf_cfg.EncDecClassificationDatasetConfig(
+            manifest_filepath=None, shuffle=True, trim_silence=False
+        )
+    )
+    validation_ds: clf_cfg.EncDecClassificationDatasetConfig = field(
+        default_factory=lambda: clf_cfg.EncDecClassificationDatasetConfig(manifest_filepath=None, shuffle=False)
+    )
+    test_ds: clf_cfg.EncDecClassificationDatasetConfig = field(
+        default_factory=lambda: clf_cfg.EncDecClassificationDatasetConfig(manifest_filepath=None, shuffle=False)
+    )
 
     # Optimizer / Scheduler config
-    optim: Optional[model_cfg.OptimConfig] = field(default_factory=lambda: model_cfg.OptimConfig(sched=model_cfg.SchedConfig()))
+    optim: Optional[model_cfg.OptimConfig] = field(
+        default_factory=lambda: model_cfg.OptimConfig(sched=model_cfg.SchedConfig())
+    )
 
     # Model general component configs
-    preprocessor: AudioToMFCCPreprocessorConfig = field(default_factory=lambda: AudioToMFCCPreprocessorConfig(window_size=0.025))
-    spec_augment: Optional[SpectrogramAugmentationConfig] = field(default_factory=lambda: SpectrogramAugmentationConfig(
-        freq_masks=2, time_masks=2, freq_width=15, time_width=25, rect_masks=5, rect_time=25, rect_freq=15
-    ))
-    crop_or_pad_augment: Optional[CropOrPadSpectrogramAugmentationConfig] = field(default_factory=lambda: CropOrPadSpectrogramAugmentationConfig(
-        audio_length=128
-    ))
+    preprocessor: AudioToMFCCPreprocessorConfig = field(
+        default_factory=lambda: AudioToMFCCPreprocessorConfig(window_size=0.025)
+    )
+    spec_augment: Optional[SpectrogramAugmentationConfig] = field(
+        default_factory=lambda: SpectrogramAugmentationConfig(
+            freq_masks=2, time_masks=2, freq_width=15, time_width=25, rect_masks=5, rect_time=25, rect_freq=15
+        )
+    )
+    crop_or_pad_augment: Optional[CropOrPadSpectrogramAugmentationConfig] = field(
+        default_factory=lambda: CropOrPadSpectrogramAugmentationConfig(audio_length=128)
+    )
 
     encoder: ConvASREncoderConfig = field(default_factory=lambda: ConvASREncoderConfig(activation="relu"))
     decoder: ConvASRDecoderClassificationConfig = field(default_factory=lambda: ConvASRDecoderClassificationConfig())

--- a/nemo/collections/asr/models/configs/matchboxnet_config.py
+++ b/nemo/collections/asr/models/configs/matchboxnet_config.py
@@ -107,30 +107,30 @@ class MatchboxNetModelConfig(clf_cfg.EncDecClassificationConfig):
     labels: List[str] = MISSING
 
     # Dataset configs
-    train_ds: clf_cfg.EncDecClassificationDatasetConfig = clf_cfg.EncDecClassificationDatasetConfig(
+    train_ds: clf_cfg.EncDecClassificationDatasetConfig = field(default_factory=lambda: clf_cfg.EncDecClassificationDatasetConfig(
         manifest_filepath=None, shuffle=True, trim_silence=False
-    )
-    validation_ds: clf_cfg.EncDecClassificationDatasetConfig = clf_cfg.EncDecClassificationDatasetConfig(
+    ))
+    validation_ds: clf_cfg.EncDecClassificationDatasetConfig = field(default_factory=lambda: clf_cfg.EncDecClassificationDatasetConfig(
         manifest_filepath=None, shuffle=False
-    )
-    test_ds: clf_cfg.EncDecClassificationDatasetConfig = clf_cfg.EncDecClassificationDatasetConfig(
+    ))
+    test_ds: clf_cfg.EncDecClassificationDatasetConfig = field(default_factory=lambda: clf_cfg.EncDecClassificationDatasetConfig(
         manifest_filepath=None, shuffle=False
-    )
+    ))
 
     # Optimizer / Scheduler config
-    optim: Optional[model_cfg.OptimConfig] = model_cfg.OptimConfig(sched=model_cfg.SchedConfig())
+    optim: Optional[model_cfg.OptimConfig] = field(default_factory=lambda: model_cfg.OptimConfig(sched=model_cfg.SchedConfig()))
 
     # Model general component configs
-    preprocessor: AudioToMFCCPreprocessorConfig = AudioToMFCCPreprocessorConfig(window_size=0.025)
-    spec_augment: Optional[SpectrogramAugmentationConfig] = SpectrogramAugmentationConfig(
+    preprocessor: AudioToMFCCPreprocessorConfig = field(default_factory=lambda: AudioToMFCCPreprocessorConfig(window_size=0.025))
+    spec_augment: Optional[SpectrogramAugmentationConfig] = field(default_factory=lambda: SpectrogramAugmentationConfig(
         freq_masks=2, time_masks=2, freq_width=15, time_width=25, rect_masks=5, rect_time=25, rect_freq=15
-    )
-    crop_or_pad_augment: Optional[CropOrPadSpectrogramAugmentationConfig] = CropOrPadSpectrogramAugmentationConfig(
+    ))
+    crop_or_pad_augment: Optional[CropOrPadSpectrogramAugmentationConfig] = field(default_factory=lambda: CropOrPadSpectrogramAugmentationConfig(
         audio_length=128
-    )
+    ))
 
-    encoder: ConvASREncoderConfig = ConvASREncoderConfig(activation="relu")
-    decoder: ConvASRDecoderClassificationConfig = ConvASRDecoderClassificationConfig()
+    encoder: ConvASREncoderConfig = field(default_factory=lambda: ConvASREncoderConfig(activation="relu"))
+    decoder: ConvASRDecoderClassificationConfig = field(default_factory=lambda: ConvASRDecoderClassificationConfig())
 
 
 @dataclass

--- a/nemo/collections/asr/models/configs/quartznet_config.py
+++ b/nemo/collections/asr/models/configs/quartznet_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable, List, Optional
 
 from omegaconf import MISSING
@@ -174,20 +174,20 @@ class JasperModelConfig(ctc_cfg.EncDecCTCConfig):
     labels: List[str] = MISSING
 
     # Dataset configs
-    train_ds: ctc_cfg.ASRDatasetConfig = ctc_cfg.ASRDatasetConfig(
+    train_ds: ctc_cfg.ASRDatasetConfig = field(default_factory=lambda: ctc_cfg.ASRDatasetConfig(
         manifest_filepath=None, shuffle=True, trim_silence=True
-    )
-    validation_ds: ctc_cfg.ASRDatasetConfig = ctc_cfg.ASRDatasetConfig(manifest_filepath=None, shuffle=False)
-    test_ds: ctc_cfg.ASRDatasetConfig = ctc_cfg.ASRDatasetConfig(manifest_filepath=None, shuffle=False)
+    ))
+    validation_ds: ctc_cfg.ASRDatasetConfig = field(default_factory=lambda: ctc_cfg.ASRDatasetConfig(manifest_filepath=None, shuffle=False))
+    test_ds: ctc_cfg.ASRDatasetConfig = field(default_factory=lambda: ctc_cfg.ASRDatasetConfig(manifest_filepath=None, shuffle=False))
 
     # Optimizer / Scheduler config
-    optim: Optional[model_cfg.OptimConfig] = model_cfg.OptimConfig(sched=model_cfg.SchedConfig())
+    optim: Optional[model_cfg.OptimConfig] = field(default_factory=lambda: model_cfg.OptimConfig(sched=model_cfg.SchedConfig()))
 
     # Model general component configs
-    preprocessor: AudioToMelSpectrogramPreprocessorConfig = AudioToMelSpectrogramPreprocessorConfig()
-    spec_augment: Optional[SpectrogramAugmentationConfig] = SpectrogramAugmentationConfig()
-    encoder: ConvASREncoderConfig = ConvASREncoderConfig(activation="relu")
-    decoder: ConvASRDecoderConfig = ConvASRDecoderConfig()
+    preprocessor: AudioToMelSpectrogramPreprocessorConfig = field(default_factory=lambda: AudioToMelSpectrogramPreprocessorConfig())
+    spec_augment: Optional[SpectrogramAugmentationConfig] = field(default_factory=lambda: SpectrogramAugmentationConfig())
+    encoder: ConvASREncoderConfig = field(default_factory=lambda: ConvASREncoderConfig(activation="relu"))
+    decoder: ConvASRDecoderConfig = field(default_factory=lambda: ConvASRDecoderConfig())
 
 
 @dataclass

--- a/nemo/collections/asr/models/configs/quartznet_config.py
+++ b/nemo/collections/asr/models/configs/quartznet_config.py
@@ -174,18 +174,28 @@ class JasperModelConfig(ctc_cfg.EncDecCTCConfig):
     labels: List[str] = MISSING
 
     # Dataset configs
-    train_ds: ctc_cfg.ASRDatasetConfig = field(default_factory=lambda: ctc_cfg.ASRDatasetConfig(
-        manifest_filepath=None, shuffle=True, trim_silence=True
-    ))
-    validation_ds: ctc_cfg.ASRDatasetConfig = field(default_factory=lambda: ctc_cfg.ASRDatasetConfig(manifest_filepath=None, shuffle=False))
-    test_ds: ctc_cfg.ASRDatasetConfig = field(default_factory=lambda: ctc_cfg.ASRDatasetConfig(manifest_filepath=None, shuffle=False))
+    train_ds: ctc_cfg.ASRDatasetConfig = field(
+        default_factory=lambda: ctc_cfg.ASRDatasetConfig(manifest_filepath=None, shuffle=True, trim_silence=True)
+    )
+    validation_ds: ctc_cfg.ASRDatasetConfig = field(
+        default_factory=lambda: ctc_cfg.ASRDatasetConfig(manifest_filepath=None, shuffle=False)
+    )
+    test_ds: ctc_cfg.ASRDatasetConfig = field(
+        default_factory=lambda: ctc_cfg.ASRDatasetConfig(manifest_filepath=None, shuffle=False)
+    )
 
     # Optimizer / Scheduler config
-    optim: Optional[model_cfg.OptimConfig] = field(default_factory=lambda: model_cfg.OptimConfig(sched=model_cfg.SchedConfig()))
+    optim: Optional[model_cfg.OptimConfig] = field(
+        default_factory=lambda: model_cfg.OptimConfig(sched=model_cfg.SchedConfig())
+    )
 
     # Model general component configs
-    preprocessor: AudioToMelSpectrogramPreprocessorConfig = field(default_factory=lambda: AudioToMelSpectrogramPreprocessorConfig())
-    spec_augment: Optional[SpectrogramAugmentationConfig] = field(default_factory=lambda: SpectrogramAugmentationConfig())
+    preprocessor: AudioToMelSpectrogramPreprocessorConfig = field(
+        default_factory=lambda: AudioToMelSpectrogramPreprocessorConfig()
+    )
+    spec_augment: Optional[SpectrogramAugmentationConfig] = field(
+        default_factory=lambda: SpectrogramAugmentationConfig()
+    )
     encoder: ConvASREncoderConfig = field(default_factory=lambda: ConvASREncoderConfig(activation="relu"))
     decoder: ConvASRDecoderConfig = field(default_factory=lambda: ConvASRDecoderConfig())
 

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -635,8 +635,10 @@ class CropOrPadSpectrogramAugmentation(NeuralModule):
         self.audio_length = audio_length
 
         if self.audio_length < 0:
-            raise ValueError('audio_length must be non-negative. If using a dataclass with OmegaConf, '
-                             'please call OmegaConf.to_object(cfg) to call appropriate __post_init__ methods.')
+            raise ValueError(
+                'audio_length must be non-negative. If using a dataclass with OmegaConf, '
+                'please call OmegaConf.to_object(cfg) to call appropriate __post_init__ methods.'
+            )
 
     @typecheck()
     @torch.no_grad()

--- a/nemo/collections/asr/modules/audio_preprocessing.py
+++ b/nemo/collections/asr/modules/audio_preprocessing.py
@@ -634,6 +634,10 @@ class CropOrPadSpectrogramAugmentation(NeuralModule):
         super(CropOrPadSpectrogramAugmentation, self).__init__()
         self.audio_length = audio_length
 
+        if self.audio_length < 0:
+            raise ValueError('audio_length must be non-negative. If using a dataclass with OmegaConf, '
+                             'please call OmegaConf.to_object(cfg) to call appropriate __post_init__ methods.')
+
     @typecheck()
     @torch.no_grad()
     def forward(self, input_signal, length):

--- a/nemo/collections/asr/parts/k2/classes.py
+++ b/nemo/collections/asr/parts/k2/classes.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from abc import ABC
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional, Tuple
 
 import torch
@@ -43,7 +43,7 @@ class GraphModuleConfig:
     topo_with_self_loops: bool = True
     token_lm: Optional[Any] = None
     intersect_pruned: bool = False
-    intersect_conf: GraphIntersectDenseConfig = GraphIntersectDenseConfig()
+    intersect_conf: GraphIntersectDenseConfig = field(default_factory=lambda: GraphIntersectDenseConfig())
     boost_coeff: float = 0.0
     predictor_window_size: int = 0
     predictor_step_size: int = 1

--- a/nemo/collections/asr/parts/submodules/adapters/multi_head_attention_adapter_module.py
+++ b/nemo/collections/asr/parts/submodules/adapters/multi_head_attention_adapter_module.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional
 
 import torch
@@ -183,7 +183,7 @@ class MultiHeadAttentionAdapterConfig:
     n_feat: int
     dropout_rate: float = 0.0
     proj_dim: Optional[int] = None
-    adapter_strategy: Optional[Any] = MHAResidualAddAdapterStrategyConfig()
+    adapter_strategy: Optional[Any] = field(default_factory=lambda: MHAResidualAddAdapterStrategyConfig())
     _target_: str = "{0}.{1}".format(MultiHeadAttentionAdapter.__module__, MultiHeadAttentionAdapter.__name__)
 
 
@@ -287,7 +287,7 @@ class RelPositionMultiHeadAttentionAdapterConfig:
     n_feat: int
     dropout_rate: float = 0.0
     proj_dim: Optional[int] = None
-    adapter_strategy: Optional[Any] = MHAResidualAddAdapterStrategyConfig()
+    adapter_strategy: Optional[Any] = field(default_factory=lambda: MHAResidualAddAdapterStrategyConfig())
     _target_: str = "{0}.{1}".format(
         RelPositionMultiHeadAttentionAdapter.__module__, RelPositionMultiHeadAttentionAdapter.__name__
     )
@@ -336,7 +336,9 @@ class PositionalEncodingAdapterConfig:
     d_model: int
     max_len: int = 5000
     xscale: float = 1.0
-    adapter_strategy: Optional[Any] = adapter_mixin_strategies.ResidualAddAdapterStrategyConfig()
+    adapter_strategy: Optional[Any] = field(
+        default_factory=lambda: adapter_mixin_strategies.ResidualAddAdapterStrategyConfig()
+    )
     _target_: str = "{0}.{1}".format(PositionalEncodingAdapter.__module__, PositionalEncodingAdapter.__name__)
 
 
@@ -378,5 +380,7 @@ class RelPositionalEncodingAdapterConfig:
     d_model: int
     max_len: int = 5000
     xscale: float = 1.0
-    adapter_strategy: Optional[Any] = adapter_mixin_strategies.ResidualAddAdapterStrategyConfig()
+    adapter_strategy: Optional[Any] = field(
+        default_factory=lambda: adapter_mixin_strategies.ResidualAddAdapterStrategyConfig()
+    )
     _target_: str = "{0}.{1}".format(RelPositionalEncodingAdapter.__module__, RelPositionalEncodingAdapter.__name__)

--- a/nemo/collections/asr/parts/submodules/ctc_beam_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_beam_decoding.py
@@ -14,7 +14,7 @@
 
 import math
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional, Tuple, Union
 
 import torch
@@ -602,5 +602,5 @@ class BeamCTCInferConfig:
     beam_beta: float = 0.0
     kenlm_path: Optional[str] = None
 
-    flashlight_cfg: Optional[FlashlightConfig] = FlashlightConfig()
-    pyctcdecode_cfg: Optional[PyCTCDecodeConfig] = PyCTCDecodeConfig()
+    flashlight_cfg: Optional[FlashlightConfig] = field(default_factory=lambda: FlashlightConfig())
+    pyctcdecode_cfg: Optional[PyCTCDecodeConfig] = field(default_factory=lambda: PyCTCDecodeConfig())

--- a/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional
 
 import torch
@@ -253,7 +253,7 @@ class GreedyCTCInferConfig:
     preserve_alignments: bool = False
     compute_timestamps: bool = False
     preserve_frame_confidence: bool = False
-    confidence_measure_cfg: Optional[ConfidenceMeasureConfig] = ConfidenceMeasureConfig()
+    confidence_measure_cfg: Optional[ConfidenceMeasureConfig] = field(default_factory=lambda :ConfidenceMeasureConfig())
     confidence_method_cfg: str = "DEPRECATED"
 
     def __post_init__(self):

--- a/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
@@ -253,7 +253,9 @@ class GreedyCTCInferConfig:
     preserve_alignments: bool = False
     compute_timestamps: bool = False
     preserve_frame_confidence: bool = False
-    confidence_measure_cfg: Optional[ConfidenceMeasureConfig] = field(default_factory=lambda :ConfidenceMeasureConfig())
+    confidence_measure_cfg: Optional[ConfidenceMeasureConfig] = field(
+        default_factory=lambda: ConfidenceMeasureConfig()
+    )
     confidence_method_cfg: str = "DEPRECATED"
 
     def __post_init__(self):

--- a/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
@@ -2185,7 +2185,9 @@ class GreedyRNNTInferConfig:
     max_symbols_per_step: Optional[int] = 10
     preserve_alignments: bool = False
     preserve_frame_confidence: bool = False
-    confidence_measure_cfg: Optional[ConfidenceMeasureConfig] = field(default_factory=lambda: ConfidenceMeasureConfig())
+    confidence_measure_cfg: Optional[ConfidenceMeasureConfig] = field(
+        default_factory=lambda: ConfidenceMeasureConfig()
+    )
     confidence_method_cfg: str = "DEPRECATED"
 
     def __post_init__(self):
@@ -2217,7 +2219,9 @@ class GreedyBatchedRNNTInferConfig:
     max_symbols_per_step: Optional[int] = 10
     preserve_alignments: bool = False
     preserve_frame_confidence: bool = False
-    confidence_measure_cfg: Optional[ConfidenceMeasureConfig] = field(default_factory=lambda: ConfidenceMeasureConfig())
+    confidence_measure_cfg: Optional[ConfidenceMeasureConfig] = field(
+        default_factory=lambda: ConfidenceMeasureConfig()
+    )
     confidence_method_cfg: str = "DEPRECATED"
 
     def __post_init__(self):

--- a/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
@@ -26,7 +26,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional, Tuple, Union
 
 import numpy as np
@@ -2185,7 +2185,7 @@ class GreedyRNNTInferConfig:
     max_symbols_per_step: Optional[int] = 10
     preserve_alignments: bool = False
     preserve_frame_confidence: bool = False
-    confidence_measure_cfg: Optional[ConfidenceMeasureConfig] = ConfidenceMeasureConfig()
+    confidence_measure_cfg: Optional[ConfidenceMeasureConfig] = field(default_factory=lambda: ConfidenceMeasureConfig())
     confidence_method_cfg: str = "DEPRECATED"
 
     def __post_init__(self):
@@ -2217,7 +2217,7 @@ class GreedyBatchedRNNTInferConfig:
     max_symbols_per_step: Optional[int] = 10
     preserve_alignments: bool = False
     preserve_frame_confidence: bool = False
-    confidence_measure_cfg: Optional[ConfidenceMeasureConfig] = ConfidenceMeasureConfig()
+    confidence_measure_cfg: Optional[ConfidenceMeasureConfig] = field(default_factory=lambda: ConfidenceMeasureConfig())
     confidence_method_cfg: str = "DEPRECATED"
 
     def __post_init__(self):

--- a/nemo/collections/asr/parts/utils/asr_confidence_utils.py
+++ b/nemo/collections/asr/parts/utils/asr_confidence_utils.py
@@ -14,7 +14,7 @@
 
 import math
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from typing import List, Optional
 
@@ -181,7 +181,7 @@ class ConfidenceConfig:
     preserve_word_confidence: bool = False
     exclude_blank: bool = True
     aggregation: str = "min"
-    measure_cfg: ConfidenceMeasureConfig = ConfidenceMeasureConfig()
+    measure_cfg: ConfidenceMeasureConfig = field(default_factory=lambda: ConfidenceMeasureConfig())
     method_cfg: str = "DEPRECATED"
 
     def __post_init__(self):

--- a/nemo/collections/common/parts/adapter_modules.py
+++ b/nemo/collections/common/parts/adapter_modules.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass, field, is_dataclass
 from typing import Any, Optional
 
 from hydra.utils import instantiate
@@ -160,5 +160,7 @@ class LinearAdapterConfig:
     activation: str = 'swish'
     norm_position: str = 'pre'
     dropout: float = 0.0
-    adapter_strategy: Optional[Any] = adapter_mixin_strategies.ResidualAddAdapterStrategyConfig()
+    adapter_strategy: Optional[Any] = field(
+        default_factory=lambda: adapter_mixin_strategies.ResidualAddAdapterStrategyConfig()
+    )
     _target_: str = "{0}.{1}".format(LinearAdapter.__module__, LinearAdapter.__name__)

--- a/nemo/collections/common/tokenizers/en_ja_tokenizers.py
+++ b/nemo/collections/common/tokenizers/en_ja_tokenizers.py
@@ -14,11 +14,18 @@
 import re
 from typing import List
 
-import ipadic
-import MeCab
 from pangu import spacing
 from sacremoses import MosesDetokenizer, MosesPunctNormalizer, MosesTokenizer
 
+try:
+    import ipadic
+    import MeCab
+
+    HAVE_MECAB = True
+    HAVE_IPADIC = True
+except (ImportError, ModuleNotFoundError):
+    HAVE_MECAB = False
+    HAVE_IPADIC = False
 
 class EnJaProcessor:
     """
@@ -67,6 +74,9 @@ class JaMecabProcessor:
     """
 
     def __init__(self):
+        if not HAVE_MECAB or not HAVE_IPADIC:
+            raise ImportError("Please ensure that you have installed `MeCab` and `ipadic` to use JaMecabProcessor")
+
         self.mecab_tokenizer = MeCab.Tagger(ipadic.MECAB_ARGS + " -Owakati")
 
     def detokenize(self, text: List[str]) -> str:

--- a/nemo/collections/common/tokenizers/en_ja_tokenizers.py
+++ b/nemo/collections/common/tokenizers/en_ja_tokenizers.py
@@ -27,6 +27,7 @@ except (ImportError, ModuleNotFoundError):
     HAVE_MECAB = False
     HAVE_IPADIC = False
 
+
 class EnJaProcessor:
     """
     Tokenizer, Detokenizer and Normalizer utilities for Japanese & English

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -77,33 +77,39 @@ class MTEncDecModelConfig(EncDecNLPModelConfig):
     head: TokenClassifierConfig = field(default_factory=lambda: TokenClassifierConfig(log_softmax=True))
 
     # dataset configurations
-    train_ds: Optional[TranslationDataConfig] = field(default_factory=lambda: TranslationDataConfig(
-        src_file_name=MISSING,
-        tgt_file_name=MISSING,
-        tokens_in_batch=512,
-        clean=True,
-        shuffle=True,
-        cache_ids=False,
-        use_cache=False,
-    ))
-    validation_ds: Optional[TranslationDataConfig] = field(default_factory=lambda: TranslationDataConfig(
-        src_file_name=MISSING,
-        tgt_file_name=MISSING,
-        tokens_in_batch=512,
-        clean=False,
-        shuffle=False,
-        cache_ids=False,
-        use_cache=False,
-    ))
-    test_ds: Optional[TranslationDataConfig] = field(default_factory=lambda: TranslationDataConfig(
-        src_file_name=MISSING,
-        tgt_file_name=MISSING,
-        tokens_in_batch=512,
-        clean=False,
-        shuffle=False,
-        cache_ids=False,
-        use_cache=False,
-    ))
+    train_ds: Optional[TranslationDataConfig] = field(
+        default_factory=lambda: TranslationDataConfig(
+            src_file_name=MISSING,
+            tgt_file_name=MISSING,
+            tokens_in_batch=512,
+            clean=True,
+            shuffle=True,
+            cache_ids=False,
+            use_cache=False,
+        )
+    )
+    validation_ds: Optional[TranslationDataConfig] = field(
+        default_factory=lambda: TranslationDataConfig(
+            src_file_name=MISSING,
+            tgt_file_name=MISSING,
+            tokens_in_batch=512,
+            clean=False,
+            shuffle=False,
+            cache_ids=False,
+            use_cache=False,
+        )
+    )
+    test_ds: Optional[TranslationDataConfig] = field(
+        default_factory=lambda: TranslationDataConfig(
+            src_file_name=MISSING,
+            tgt_file_name=MISSING,
+            tokens_in_batch=512,
+            clean=False,
+            shuffle=False,
+            cache_ids=False,
+            use_cache=False,
+        )
+    )
     optim: Optional[OptimConfig] = field(default_factory=lambda: MTOptimConfig())
 
 
@@ -114,31 +120,35 @@ class AAYNBaseConfig(MTEncDecModelConfig):
     encoder_tokenizer: TokenizerConfig = field(default_factory=lambda: TokenizerConfig(library='yttm'))
     decoder_tokenizer: TokenizerConfig = field(default_factory=lambda: TokenizerConfig(library='yttm'))
 
-    encoder: NeMoTransformerEncoderConfig = field(default_factory=lambda: NeMoTransformerEncoderConfig(
-        library='nemo',
-        model_name=None,
-        pretrained=False,
-        hidden_size=512,
-        inner_size=2048,
-        num_layers=6,
-        num_attention_heads=8,
-        ffn_dropout=0.1,
-        attn_score_dropout=0.1,
-        attn_layer_dropout=0.1,
-    ))
+    encoder: NeMoTransformerEncoderConfig = field(
+        default_factory=lambda: NeMoTransformerEncoderConfig(
+            library='nemo',
+            model_name=None,
+            pretrained=False,
+            hidden_size=512,
+            inner_size=2048,
+            num_layers=6,
+            num_attention_heads=8,
+            ffn_dropout=0.1,
+            attn_score_dropout=0.1,
+            attn_layer_dropout=0.1,
+        )
+    )
 
-    decoder: NeMoTransformerConfig = field(default_factory=lambda: NeMoTransformerConfig(
-        library='nemo',
-        model_name=None,
-        pretrained=False,
-        hidden_size=512,
-        inner_size=2048,
-        num_layers=6,
-        num_attention_heads=8,
-        ffn_dropout=0.1,
-        attn_score_dropout=0.1,
-        attn_layer_dropout=0.1,
-    ))
+    decoder: NeMoTransformerConfig = field(
+        default_factory=lambda: NeMoTransformerConfig(
+            library='nemo',
+            model_name=None,
+            pretrained=False,
+            hidden_size=512,
+            inner_size=2048,
+            num_layers=6,
+            num_attention_heads=8,
+            ffn_dropout=0.1,
+            attn_score_dropout=0.1,
+            attn_layer_dropout=0.1,
+        )
+    )
 
 
 @dataclass
@@ -150,32 +160,36 @@ class MTBottleneckModelConfig(AAYNBaseConfig):
     recon_per_token: bool = True
     log_timing: bool = True
 
-    encoder: NeMoTransformerBottleneckEncoderConfig = field(default_factory=lambda: NeMoTransformerBottleneckEncoderConfig(
-        library='nemo',
-        model_name=None,
-        pretrained=False,
-        hidden_size=512,
-        inner_size=2048,
-        num_layers=6,
-        num_attention_heads=8,
-        ffn_dropout=0.1,
-        attn_score_dropout=0.1,
-        attn_layer_dropout=0.1,
-        arch='seq2seq',
-        hidden_steps=32,
-        hidden_blocks=1,
-        hidden_init_method='params',
-    ))
+    encoder: NeMoTransformerBottleneckEncoderConfig = field(
+        default_factory=lambda: NeMoTransformerBottleneckEncoderConfig(
+            library='nemo',
+            model_name=None,
+            pretrained=False,
+            hidden_size=512,
+            inner_size=2048,
+            num_layers=6,
+            num_attention_heads=8,
+            ffn_dropout=0.1,
+            attn_score_dropout=0.1,
+            attn_layer_dropout=0.1,
+            arch='seq2seq',
+            hidden_steps=32,
+            hidden_blocks=1,
+            hidden_init_method='params',
+        )
+    )
 
-    decoder: NeMoTransformerBottleneckDecoderConfig = field(default_factory=lambda: NeMoTransformerBottleneckDecoderConfig(
-        library='nemo',
-        model_name=None,
-        pretrained=False,
-        inner_size=2048,
-        num_layers=6,
-        num_attention_heads=8,
-        ffn_dropout=0.1,
-        attn_score_dropout=0.1,
-        attn_layer_dropout=0.1,
-        arch='seq2seq',
-    ))
+    decoder: NeMoTransformerBottleneckDecoderConfig = field(
+        default_factory=lambda: NeMoTransformerBottleneckDecoderConfig(
+            library='nemo',
+            model_name=None,
+            pretrained=False,
+            inner_size=2048,
+            num_layers=6,
+            num_attention_heads=8,
+            ffn_dropout=0.1,
+            attn_score_dropout=0.1,
+            attn_layer_dropout=0.1,
+            arch='seq2seq',
+        )
+    )

--- a/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
+++ b/nemo/collections/nlp/models/machine_translation/mt_enc_dec_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Optional, Tuple
 
 from omegaconf.omegaconf import MISSING
@@ -46,7 +46,7 @@ class MTOptimConfig(OptimConfig):
     lr: float = 1e-3
     betas: Tuple[float, float] = (0.9, 0.98)
     weight_decay: float = 0.0
-    sched: Optional[MTSchedConfig] = MTSchedConfig()
+    sched: Optional[MTSchedConfig] = field(default_factory=lambda: MTSchedConfig())
 
 
 @dataclass
@@ -74,10 +74,10 @@ class MTEncDecModelConfig(EncDecNLPModelConfig):
     decoder_tokenizer: Any = MISSING
     decoder: Any = MISSING
 
-    head: TokenClassifierConfig = TokenClassifierConfig(log_softmax=True)
+    head: TokenClassifierConfig = field(default_factory=lambda: TokenClassifierConfig(log_softmax=True))
 
     # dataset configurations
-    train_ds: Optional[TranslationDataConfig] = TranslationDataConfig(
+    train_ds: Optional[TranslationDataConfig] = field(default_factory=lambda: TranslationDataConfig(
         src_file_name=MISSING,
         tgt_file_name=MISSING,
         tokens_in_batch=512,
@@ -85,8 +85,8 @@ class MTEncDecModelConfig(EncDecNLPModelConfig):
         shuffle=True,
         cache_ids=False,
         use_cache=False,
-    )
-    validation_ds: Optional[TranslationDataConfig] = TranslationDataConfig(
+    ))
+    validation_ds: Optional[TranslationDataConfig] = field(default_factory=lambda: TranslationDataConfig(
         src_file_name=MISSING,
         tgt_file_name=MISSING,
         tokens_in_batch=512,
@@ -94,8 +94,8 @@ class MTEncDecModelConfig(EncDecNLPModelConfig):
         shuffle=False,
         cache_ids=False,
         use_cache=False,
-    )
-    test_ds: Optional[TranslationDataConfig] = TranslationDataConfig(
+    ))
+    test_ds: Optional[TranslationDataConfig] = field(default_factory=lambda: TranslationDataConfig(
         src_file_name=MISSING,
         tgt_file_name=MISSING,
         tokens_in_batch=512,
@@ -103,18 +103,18 @@ class MTEncDecModelConfig(EncDecNLPModelConfig):
         shuffle=False,
         cache_ids=False,
         use_cache=False,
-    )
-    optim: Optional[OptimConfig] = MTOptimConfig()
+    ))
+    optim: Optional[OptimConfig] = field(default_factory=lambda: MTOptimConfig())
 
 
 @dataclass
 class AAYNBaseConfig(MTEncDecModelConfig):
 
     # Attention is All You Need Base Configuration
-    encoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
-    decoder_tokenizer: TokenizerConfig = TokenizerConfig(library='yttm')
+    encoder_tokenizer: TokenizerConfig = field(default_factory=lambda: TokenizerConfig(library='yttm'))
+    decoder_tokenizer: TokenizerConfig = field(default_factory=lambda: TokenizerConfig(library='yttm'))
 
-    encoder: NeMoTransformerEncoderConfig = NeMoTransformerEncoderConfig(
+    encoder: NeMoTransformerEncoderConfig = field(default_factory=lambda: NeMoTransformerEncoderConfig(
         library='nemo',
         model_name=None,
         pretrained=False,
@@ -125,9 +125,9 @@ class AAYNBaseConfig(MTEncDecModelConfig):
         ffn_dropout=0.1,
         attn_score_dropout=0.1,
         attn_layer_dropout=0.1,
-    )
+    ))
 
-    decoder: NeMoTransformerConfig = NeMoTransformerConfig(
+    decoder: NeMoTransformerConfig = field(default_factory=lambda: NeMoTransformerConfig(
         library='nemo',
         model_name=None,
         pretrained=False,
@@ -138,7 +138,7 @@ class AAYNBaseConfig(MTEncDecModelConfig):
         ffn_dropout=0.1,
         attn_score_dropout=0.1,
         attn_layer_dropout=0.1,
-    )
+    ))
 
 
 @dataclass
@@ -150,7 +150,7 @@ class MTBottleneckModelConfig(AAYNBaseConfig):
     recon_per_token: bool = True
     log_timing: bool = True
 
-    encoder: NeMoTransformerBottleneckEncoderConfig = NeMoTransformerBottleneckEncoderConfig(
+    encoder: NeMoTransformerBottleneckEncoderConfig = field(default_factory=lambda: NeMoTransformerBottleneckEncoderConfig(
         library='nemo',
         model_name=None,
         pretrained=False,
@@ -165,9 +165,9 @@ class MTBottleneckModelConfig(AAYNBaseConfig):
         hidden_steps=32,
         hidden_blocks=1,
         hidden_init_method='params',
-    )
+    ))
 
-    decoder: NeMoTransformerBottleneckDecoderConfig = NeMoTransformerBottleneckDecoderConfig(
+    decoder: NeMoTransformerBottleneckDecoderConfig = field(default_factory=lambda: NeMoTransformerBottleneckDecoderConfig(
         library='nemo',
         model_name=None,
         pretrained=False,
@@ -178,4 +178,4 @@ class MTBottleneckModelConfig(AAYNBaseConfig):
         attn_score_dropout=0.1,
         attn_layer_dropout=0.1,
         arch='seq2seq',
-    )
+    ))

--- a/nemo/collections/nlp/models/token_classification/punctuation_capitalization_config.py
+++ b/nemo/collections/nlp/models/token_classification/punctuation_capitalization_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
 from omegaconf.omegaconf import MISSING, DictConfig, OmegaConf, open_dict
@@ -215,13 +215,15 @@ class PunctuationCapitalizationModelConfig:
     This config is a part of :class:`~PunctuationCapitalizationConfig`.
     """
 
-    class_labels: ClassLabelsConfig = ClassLabelsConfig()
+    class_labels: ClassLabelsConfig = field(default_factory=lambda: ClassLabelsConfig())
     """A mandatory parameter containing a dictionary with names of label id files used in .nemo checkpoints.
     These file names can also be used for passing label vocabularies to the model. If you wish to use ``class_labels``
     for passing vocabularies, please provide path to vocabulary files in
     ``model.common_dataset_parameters.label_vocab_dir`` parameter."""
 
-    common_dataset_parameters: Optional[CommonDatasetParametersConfig] = CommonDatasetParametersConfig()
+    common_dataset_parameters: Optional[CommonDatasetParametersConfig] = field(
+        default_factory=lambda: CommonDatasetParametersConfig()
+    )
     """Label ids and loss mask information information."""
 
     train_ds: Optional[PunctuationCapitalizationTrainDataConfig] = None
@@ -233,16 +235,16 @@ class PunctuationCapitalizationModelConfig:
     test_ds: Optional[PunctuationCapitalizationEvalDataConfig] = None
     """A configuration for creating test datasets and data loaders."""
 
-    punct_head: HeadConfig = HeadConfig()
+    punct_head: HeadConfig = field(default_factory=lambda: HeadConfig())
     """A configuration for creating punctuation MLP head that is applied to a language model outputs."""
 
-    capit_head: HeadConfig = HeadConfig()
+    capit_head: HeadConfig = field(default_factory=lambda: HeadConfig())
     """A configuration for creating capitalization MLP head that is applied to a language model outputs."""
 
-    tokenizer: Any = TokenizerConfig()
+    tokenizer: Any = field(default_factory=lambda: TokenizerConfig())
     """A configuration for source text tokenizer."""
 
-    language_model: LanguageModelConfig = LanguageModelConfig()
+    language_model: LanguageModelConfig = field(default_factory=lambda: LanguageModelConfig())
     """A configuration of a BERT-like language model which serves as a model body."""
 
     optim: Optional[Any] = None
@@ -311,22 +313,30 @@ class PunctuationCapitalizationConfig(NemoConfig):
     do_testing: bool = False
     """Whether ot perform testing of the model."""
 
-    model: PunctuationCapitalizationModelConfig = PunctuationCapitalizationModelConfig()
+    model: PunctuationCapitalizationModelConfig = field(default_factory=lambda: PunctuationCapitalizationModelConfig())
     """A configuration for the
     :class:`~nemo.collections.nlp.models.token_classification.punctuation_capitalization_model.PunctuationCapitalizationModel`
     model."""
 
-    trainer: Optional[TrainerConfig] = TrainerConfig()
+    trainer: Optional[TrainerConfig] = field(default_factory=lambda: TrainerConfig())
     """Contains ``Trainer`` Lightning class constructor parameters."""
 
-    exp_manager: Optional[ExpManagerConfig] = ExpManagerConfig(name=name, files_to_copy=[])
+    exp_manager: Optional[ExpManagerConfig] = field(
+        default_factory=lambda: ExpManagerConfig(name=None, files_to_copy=[])
+    )
     """A configuration with various NeMo training options such as output directories, resuming from checkpoint,
     tensorboard and W&B logging, and so on. For possible options see :ref:`exp-manager-label`."""
+
+    def __post_init__(self):
+        if self.exp_manager is not None:
+            self.exp_manager.name = self.name
 
 
 @dataclass
 class PunctuationCapitalizationLexicalAudioConfig(PunctuationCapitalizationConfig):
-    model: PunctuationCapitalizationLexicalAudioModelConfig = PunctuationCapitalizationLexicalAudioModelConfig()
+    model: PunctuationCapitalizationLexicalAudioModelConfig = field(
+        default_factory=lambda: PunctuationCapitalizationLexicalAudioModelConfig()
+    )
 
 
 def is_legacy_model_config(model_cfg: DictConfig) -> bool:

--- a/nemo/collections/nlp/modules/common/megatron/megatron_encoders.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_encoders.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 """Transformer based language model."""
-from MeCab import Model
 from nemo.collections.nlp.modules.common.megatron.megatron_perceiver_encoders import MegatronPerceiverEncoderModule
 from nemo.collections.nlp.modules.common.megatron.megatron_transformer_encoder import MegatronTransformerEncoderModule
 from nemo.collections.nlp.modules.common.megatron.retrieval_transformer import (
@@ -24,6 +23,13 @@ from nemo.collections.nlp.modules.common.megatron.utils import (
     init_method_normal,
     scaled_init_method_normal,
 )
+
+try:
+    from MeCab import Model
+
+    HAVE_MECAB = True
+except (ImportError, ModuleNotFoundError):
+    HAVE_MECAB = False
 
 try:
     from apex.transformer.enums import AttnMaskType, ModelType

--- a/nemo/collections/tts/models/fastpitch.py
+++ b/nemo/collections/tts/models/fastpitch.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import List, Optional
 
@@ -70,12 +70,12 @@ class TextTokenizer:
     apostrophe: bool = True
     pad_with_space: bool = True
     add_blank_at: bool = True
-    g2p: G2PConfig = G2PConfig()
+    g2p: G2PConfig = field(default_factory=lambda: G2PConfig())
 
 
 @dataclass
 class TextTokenizerConfig:
-    text_tokenizer: TextTokenizer = TextTokenizer()
+    text_tokenizer: TextTokenizer = field(default_factory=lambda: TextTokenizer())
 
 
 class FastPitchModel(SpectrogramGenerator, Exportable, FastPitchAdapterModelMixin):

--- a/nemo/collections/tts/models/tacotron2.py
+++ b/nemo/collections/tts/models/tacotron2.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import contextlib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 import torch
@@ -53,7 +53,7 @@ class Preprocessor:
 
 @dataclass
 class Tacotron2Config:
-    preprocessor: Preprocessor = Preprocessor()
+    preprocessor: Preprocessor = field(default_factory=lambda: Preprocessor())
     encoder: Dict[Any, Any] = MISSING
     decoder: Dict[Any, Any] = MISSING
     postnet: Dict[Any, Any] = MISSING

--- a/nemo/core/config/modelPT.py
+++ b/nemo/core/config/modelPT.py
@@ -58,11 +58,11 @@ class HydraConfig:
 class NemoConfig:
     name: str = MISSING
     model: ModelConfig = MISSING
-    trainer: config.TrainerConfig = config.TrainerConfig(
+    trainer: config.TrainerConfig = field(default_factory=lambda: config.TrainerConfig(
         strategy="ddp", enable_checkpointing=False, logger=False, log_every_n_steps=1, accelerator='gpu'
-    )
-    exp_manager: Optional[Any] = exp_manager.ExpManagerConfig()
-    hydra: HydraConfig = HydraConfig()
+    ))
+    exp_manager: Optional[Any] = field(default_factory=lambda: exp_manager.ExpManagerConfig())
+    hydra: HydraConfig = field(default_factory=lambda: HydraConfig())
 
 
 class ModelConfigBuilder:

--- a/nemo/core/config/modelPT.py
+++ b/nemo/core/config/modelPT.py
@@ -58,9 +58,11 @@ class HydraConfig:
 class NemoConfig:
     name: str = MISSING
     model: ModelConfig = MISSING
-    trainer: config.TrainerConfig = field(default_factory=lambda: config.TrainerConfig(
-        strategy="ddp", enable_checkpointing=False, logger=False, log_every_n_steps=1, accelerator='gpu'
-    ))
+    trainer: config.TrainerConfig = field(
+        default_factory=lambda: config.TrainerConfig(
+            strategy="ddp", enable_checkpointing=False, logger=False, log_every_n_steps=1, accelerator='gpu'
+        )
+    )
     exp_manager: Optional[Any] = field(default_factory=lambda: exp_manager.ExpManagerConfig())
     hydra: HydraConfig = field(default_factory=lambda: HydraConfig())
 

--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -18,7 +18,7 @@ import subprocess
 import sys
 import time
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import timedelta
 from pathlib import Path
 from shutil import copy, move
@@ -146,28 +146,28 @@ class ExpManagerConfig:
     create_wandb_logger: Optional[bool] = False
     wandb_logger_kwargs: Optional[Dict[Any, Any]] = None
     create_mlflow_logger: Optional[bool] = False
-    mlflow_logger_kwargs: Optional[MLFlowParams] = MLFlowParams()
+    mlflow_logger_kwargs: Optional[MLFlowParams] = field(default_factory=lambda: MLFlowParams())
     create_dllogger_logger: Optional[bool] = False
-    dllogger_logger_kwargs: Optional[DLLoggerParams] = DLLoggerParams()
+    dllogger_logger_kwargs: Optional[DLLoggerParams] = field(default_factory=lambda: DLLoggerParams())
     create_clearml_logger: Optional[bool] = False
-    clearml_logger_kwargs: Optional[ClearMLParams] = ClearMLParams()
+    clearml_logger_kwargs: Optional[ClearMLParams] = field(default_factory=lambda: ClearMLParams())
     # Checkpointing parameters
     create_checkpoint_callback: Optional[bool] = True
-    checkpoint_callback_params: Optional[CallbackParams] = CallbackParams()
+    checkpoint_callback_params: Optional[CallbackParams] = field(default_factory=lambda: CallbackParams())
     create_early_stopping_callback: Optional[bool] = False
-    early_stopping_callback_params: Optional[EarlyStoppingParams] = EarlyStoppingParams()
+    early_stopping_callback_params: Optional[EarlyStoppingParams] = field(default_factory=lambda: EarlyStoppingParams())
     create_preemption_callback: Optional[bool] = True
     # Additional exp_manager arguments
     files_to_copy: Optional[List[str]] = None
     # logs timing of train/val/test steps
     log_step_timing: Optional[bool] = True
-    step_timing_kwargs: Optional[StepTimingParams] = StepTimingParams()
+    step_timing_kwargs: Optional[StepTimingParams] = field(default_factory=lambda: StepTimingParams())
     # Configures creation of log files for different ranks
     log_local_rank_0_only: Optional[bool] = False
     log_global_rank_0_only: Optional[bool] = False
     # disable initial validation when resuming from a checkpoint saved during validation
     disable_validation_on_resume: Optional[bool] = True
-    ema: Optional[EMAParams] = EMAParams()
+    ema: Optional[EMAParams] = field(default_factory=lambda: EMAParams())
     # Wall clock time limit
     max_time_per_run: Optional[str] = None
     # time to sleep non 0 ranks during initialization

--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -155,7 +155,9 @@ class ExpManagerConfig:
     create_checkpoint_callback: Optional[bool] = True
     checkpoint_callback_params: Optional[CallbackParams] = field(default_factory=lambda: CallbackParams())
     create_early_stopping_callback: Optional[bool] = False
-    early_stopping_callback_params: Optional[EarlyStoppingParams] = field(default_factory=lambda: EarlyStoppingParams())
+    early_stopping_callback_params: Optional[EarlyStoppingParams] = field(
+        default_factory=lambda: EarlyStoppingParams()
+    )
     create_preemption_callback: Optional[bool] = True
     # Additional exp_manager arguments
     files_to_copy: Optional[List[str]] = None

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -17,7 +17,7 @@ opencc
 pangu
 rapidfuzz
 rouge_score
-sacrebleu[ja]
+sacrebleu  # manually install sacrebleu[ja] for Japanese support; MeCab is unsupported in Python 3.11+
 sentence_transformers
 tensorstore
 zarr

--- a/scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram.py
+++ b/scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram.py
@@ -112,14 +112,14 @@ class EvalBeamSearchNGramConfig:
     beam_beta: List[float] = field(default_factory=lambda: [0.0])  # The beta parameter or list of the betas for the beam search decoding
 
     decoding_strategy: str = "beam"
-    decoding: ctc_beam_decoding.BeamCTCInferConfig = ctc_beam_decoding.BeamCTCInferConfig(beam_size=128)
+    decoding: ctc_beam_decoding.BeamCTCInferConfig = field(default_factory=lambda: ctc_beam_decoding.BeamCTCInferConfig(beam_size=128))
     
-    text_processing: Optional[TextProcessingConfig] = TextProcessingConfig(
+    text_processing: Optional[TextProcessingConfig] = field(default_factory=lambda: TextProcessingConfig(
         punctuation_marks = ".,?",
         separate_punctuation = False,
         do_lowercase = False,
         rm_punctuation = False,
-    )
+    ))
 # fmt: on
 
 

--- a/scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram_transducer.py
+++ b/scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram_transducer.py
@@ -115,7 +115,7 @@ class EvalBeamSearchNGramConfig:
     hat_subtract_ilm: bool = False
     hat_ilm_weight: List[float] = field(default_factory=lambda: [0.0])
 
-    decoding: rnnt_beam_decoding.BeamRNNTInferConfig = rnnt_beam_decoding.BeamRNNTInferConfig(beam_size=128)
+    decoding: rnnt_beam_decoding.BeamRNNTInferConfig = field(default_factory=lambda: rnnt_beam_decoding.BeamRNNTInferConfig(beam_size=128))
 
 
 # fmt: on

--- a/scripts/confidence_ensembles/build_ensemble.py
+++ b/scripts/confidence_ensembles/build_ensemble.py
@@ -209,19 +209,23 @@ class BuildEnsembleConfig:
     random_seed: int = 0  # for reproducibility
 
     # default confidence, can override
-    confidence: ConfidenceConfig = field(default_factory=lambda: ConfidenceConfig(
-        # we keep frame confidences and apply aggregation manually to get full-utterance confidence
-        preserve_frame_confidence=True,
-        exclude_blank=True,
-        aggregation="mean",
-        measure_cfg=ConfidenceMeasureConfig(name="entropy", entropy_type="renyi", alpha=0.25, entropy_norm="lin",),
-    ))
+    confidence: ConfidenceConfig = field(
+        default_factory=lambda: ConfidenceConfig(
+            # we keep frame confidences and apply aggregation manually to get full-utterance confidence
+            preserve_frame_confidence=True,
+            exclude_blank=True,
+            aggregation="mean",
+            measure_cfg=ConfidenceMeasureConfig(name="entropy", entropy_type="renyi", alpha=0.25, entropy_norm="lin",),
+        )
+    )
     temperature: float = 1.0
 
     # this is optional, but can be used to change any aspect of the transcription
     # config, such as batch size or amp usage. Note that model, data and confidence
     # will be overriden by this script
-    transcription: transcribe_speech.TranscriptionConfig = field(default_factory=lambda: transcribe_speech.TranscriptionConfig())
+    transcription: transcribe_speech.TranscriptionConfig = field(
+        default_factory=lambda: transcribe_speech.TranscriptionConfig()
+    )
 
     # set to True to tune the confidence.
     # requires dev manifests to be specified for each model
@@ -234,7 +238,9 @@ class BuildEnsembleConfig:
     # very fast to tune and can be important in case of imbalanced datasets
     # will automatically set to False if dev data is not available
     tune_logistic_regression: bool = True
-    tune_logistic_regression_config: TuneLogisticRegressionConfig = field(default_factory=lambda: TuneLogisticRegressionConfig())
+    tune_logistic_regression_config: TuneLogisticRegressionConfig = field(
+        default_factory=lambda: TuneLogisticRegressionConfig()
+    )
 
     def __post_init__(self):
         """Checking that if any dev data is provided, all are provided.

--- a/scripts/confidence_ensembles/build_ensemble.py
+++ b/scripts/confidence_ensembles/build_ensemble.py
@@ -75,7 +75,7 @@ import random
 import sys
 import tempfile
 from copy import deepcopy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -209,19 +209,19 @@ class BuildEnsembleConfig:
     random_seed: int = 0  # for reproducibility
 
     # default confidence, can override
-    confidence: ConfidenceConfig = ConfidenceConfig(
+    confidence: ConfidenceConfig = field(default_factory=lambda: ConfidenceConfig(
         # we keep frame confidences and apply aggregation manually to get full-utterance confidence
         preserve_frame_confidence=True,
         exclude_blank=True,
         aggregation="mean",
         measure_cfg=ConfidenceMeasureConfig(name="entropy", entropy_type="renyi", alpha=0.25, entropy_norm="lin",),
-    )
+    ))
     temperature: float = 1.0
 
     # this is optional, but can be used to change any aspect of the transcription
     # config, such as batch size or amp usage. Note that model, data and confidence
     # will be overriden by this script
-    transcription: transcribe_speech.TranscriptionConfig = transcribe_speech.TranscriptionConfig()
+    transcription: transcribe_speech.TranscriptionConfig = field(default_factory=lambda: transcribe_speech.TranscriptionConfig())
 
     # set to True to tune the confidence.
     # requires dev manifests to be specified for each model
@@ -229,12 +229,12 @@ class BuildEnsembleConfig:
     # used to specify what to tune over. By default runs tuning over some
     # reasonalbe grid, so that it does not take forever.
     # Can be changed as needed
-    tune_confidence_config: TuneConfidenceConfig = TuneConfidenceConfig()
+    tune_confidence_config: TuneConfidenceConfig = field(default_factory=lambda: TuneConfidenceConfig())
 
     # very fast to tune and can be important in case of imbalanced datasets
     # will automatically set to False if dev data is not available
     tune_logistic_regression: bool = True
-    tune_logistic_regression_config: TuneLogisticRegressionConfig = TuneLogisticRegressionConfig()
+    tune_logistic_regression_config: TuneLogisticRegressionConfig = field(default_factory=lambda: TuneLogisticRegressionConfig())
 
     def __post_init__(self):
         """Checking that if any dev data is provided, all are provided.

--- a/scripts/speech_recognition/confidence/benchmark_asr_confidence.py
+++ b/scripts/speech_recognition/confidence/benchmark_asr_confidence.py
@@ -14,7 +14,7 @@
 
 import json
 import os
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass, field, is_dataclass
 from pathlib import Path
 from typing import Optional
 
@@ -124,7 +124,9 @@ class ConfidenceBenchmarkingConfig:
 
     # Confidence configs
     target_level: str = "auto"  # Choices: "word", "token", "auto" (for both word- and token-level confidence)
-    confidence_cfg: ConfidenceConfig = ConfidenceConfig(preserve_word_confidence=True, preserve_token_confidence=True)
+    confidence_cfg: ConfidenceConfig = field(
+        default_factory=lambda: ConfidenceConfig(preserve_word_confidence=True, preserve_token_confidence=True)
+    )
     grid_params: Optional[str] = None  # a dictionary with lists of parameters to iteratively benchmark on
 
 

--- a/scripts/speech_recognition/convert_to_tarred_audio_dataset.py
+++ b/scripts/speech_recognition/convert_to_tarred_audio_dataset.py
@@ -202,7 +202,7 @@ class ASRTarredDatasetMetadata:
     num_samples_per_shard: Optional[int] = None
     is_concatenated_manifest: bool = False
 
-    dataset_config: Optional[ASRTarredDatasetConfig] = ASRTarredDatasetConfig()
+    dataset_config: Optional[ASRTarredDatasetConfig] = field(default_factory=lambda: ASRTarredDatasetConfig())
     history: Optional[List[Any]] = field(default_factory=lambda: [])
 
     def __post_init__(self):

--- a/tests/collections/asr/test_text_to_text_dataset.py
+++ b/tests/collections/asr/test_text_to_text_dataset.py
@@ -15,7 +15,7 @@
 import json
 import multiprocessing
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
@@ -110,7 +110,7 @@ def tts_tokenizer():
         apostrophe: bool = True
         pad_with_space: bool = True
         add_blank_at: bool = True
-        g2p: G2PConfig = G2PConfig()
+        g2p: G2PConfig = field(default_factory=lambda: G2PConfig())
 
     config = OmegaConf.create(OmegaConf.to_yaml(TextTokenizerCfg()))
     return instantiate(config)

--- a/tools/nemo_forced_aligner/align.py
+++ b/tools/nemo_forced_aligner/align.py
@@ -149,8 +149,8 @@ class AlignmentConfig:
 
     # Output file configs
     save_output_file_formats: List[str] = field(default_factory=lambda: ["ctm", "ass"])
-    ctm_file_config: CTMFileConfig = CTMFileConfig()
-    ass_file_config: ASSFileConfig = ASSFileConfig()
+    ctm_file_config: CTMFileConfig = field(default_factory=lambda: CTMFileConfig())
+    ass_file_config: ASSFileConfig = field(default_factory=lambda: ASSFileConfig())
 
 
 @hydra_runner(config_name="AlignmentConfig", schema=AlignmentConfig)


### PR DESCRIPTION
# What does this PR do ?

Fixes an issue with mutable defaults inside dataclasses across NeMo configs

Fixes #7166 

**Collection**: [Core, ASR, NLP, TTS, Tools]

# Changelog 
- Guard mecab and ipadic
- Remove dependence on mecab and ipadic from sacrebleu
- Fix dataclasses across domains and tools

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
