### PR TITLE
fix llama2 70b lora tuning bug

### DIFF
--- a/nemo/collections/nlp/parts/peft_config.py
+++ b/nemo/collections/nlp/parts/peft_config.py
@@ -63,7 +63,7 @@ class LoraPEFTConfig(PEFTConfig):
         num_query_groups = cfg.get("num_query_groups", None)
         if num_query_groups is None:
             num_query_groups = cfg.num_attention_heads
-        qkv_projection_size = projection_size + 2 * kv_channels * num_query_groups
+        qkv_projection_size = projection_size + (2 * kv_channels * num_query_groups)
 
         config_args = {
             "in_features": cfg.hidden_size,

--- a/nemo/collections/nlp/parts/peft_config.py
+++ b/nemo/collections/nlp/parts/peft_config.py
@@ -60,10 +60,14 @@ class LoraPEFTConfig(PEFTConfig):
         else:
             kv_channels = cfg.kv_channels
         projection_size = kv_channels * cfg.num_attention_heads
+        num_query_groups = cfg.get("num_query_groups", None)
+        if num_query_groups is None:
+            num_query_groups = cfg.num_attention_heads
+        qkv_projection_size = projection_size + 2 * kv_channels * num_query_groups
 
         config_args = {
             "in_features": cfg.hidden_size,
-            "out_features": 3 * projection_size,
+            "out_features": qkv_projection_size,
             "dim": lora_cfg.adapter_dim,
             "norm_position": None,
             "norm_type": None,


### PR DESCRIPTION
# What does this PR do ?

Fixes a bug in LLaMa2 70b LoRA tuning. There was a modification to specifically deal with LLaMa2 70b (which uses GQA) in the old API that was not propagated during the refactor.

**Collection**: NLP

# Changelog 
- Modified LoraPEFTConfig to exactly follow the logic in the old MegatronGPTLoRAModel

# Usage

```python
python megatron_gpt_peft_tuning.py <...> model.restore_from_path=<a llama2 70b checkpoint>
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #7299 and #7308
