### PR TITLE
PEFT eval fix

### DIFF
--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -814,8 +814,9 @@ class PEFTSaveRestoreConnector(NLPSaveRestoreConnector):
                     # we need to untar the .nemo if its still tarred
                     with tempfile.TemporaryDirectory() as tmpdir2:
                         self._unpack_nemo_file(self.peft_model_nemo_path, tmpdir2)
-                        model_weights_path = self._inject_model_parallel_rank_for_ckpt(tmpdir2,
-                                                                                       self.peft_model_ckpt_name)
+                        model_weights_path = self._inject_model_parallel_rank_for_ckpt(
+                            tmpdir2, self.peft_model_ckpt_name
+                        )
                         peft_state_dict = torch.load(model_weights_path, map_location)
                 elif self.peft_model_ckpt_dir:
                     # if the PEFT weights are provided in a ckpt path file


### PR DESCRIPTION
# What does this PR do ?

Fix issue where peft weights are not loaded for distributed checkpoints

**Collection**: NLP

# Changelog 
- Load peft weights in restore_from instead of _load_state_dict_from_disk if distributed checkpoint is used

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
