### PR TITLE
[ASR] Fix type error in jasper

### DIFF
--- a/nemo/collections/asr/parts/submodules/jasper.py
+++ b/nemo/collections/asr/parts/submodules/jasper.py
@@ -375,7 +375,7 @@ class MaskedConv1d(nn.Module):
             self.lens = self.lens.to(device)
         else:
             self.lens = seq_range
-            self.max_len = max_len
+            self.max_len = torch.tensor(max_len)
 
     def mask_input(self, x, lens):
         max_len = x.size(2)


### PR DESCRIPTION
# What does this PR do ?

Currently when running VAD marblenet you sometimes randomly get the error:

```
  File "/usr/local/lib/python3.10/dist-packages/torch/nn/modules/module.py", line 1514, in _call_impl
    return forward_call(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/nemo/collections/asr/parts/submodules/jasper.py", line 351, in forward
    self.update_masked_length(x.size(2), device=lens.device)
  File "/usr/local/lib/python3.10/dist-packages/nemo/collections/asr/parts/submodules/jasper.py", line 374, in update_masked_length
    self.lens, self.max_len = _masked_conv_init_lens(self.lens, max_len, self.max_len)
RuntimeError: _masked_conv_init_lens() Expected a value of type 'Tensor' for argument 'original_maxlen' but instead found type 'int'.
; ((Tensor, Tensor))
Cast error details: Unable to cast 64 to Tensor
terminate called without an active exception
```

This happens because in this line of code, it assigns self.max_len to an integer value:

https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/asr/parts/submodules/jasper.py#L378

Whereas in all other code paths it assigns it to a tensor:

https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/asr/parts/submodules/jasper.py#L321

https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/asr/parts/submodules/jasper.py#L374
https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/asr/parts/submodules/jasper.py#L231
https://github.com/NVIDIA/NeMo/blob/main/nemo/collections/asr/parts/submodules/jasper.py#L234

**Collection**: [ASR]

# Changelog 
- Convert max_len to tensor.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation