### PR TITLE
Fix import error of megatron.core for tests

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -75,8 +75,8 @@ except (ImportError, ModuleNotFoundError):
 
 try:
     from megatron.core import InferenceParams, parallel_state
-    from megatron.core.models.gpt import GPTModel as MCoreGPTModel
-    from megatron.core.models.gpt.gpt_layer_specs import get_gpt_layer_with_transformer_engine_spec
+    from megatron.model import GPTModel as MCoreGPTModel
+    from megatron.core.models.gpt.gpt_layer_specs import gpt_layer_with_transformer_engine_spec
     from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
     from megatron.core.transformer.module import Float16Module as MCoreFloat16Module
     from megatron.core.transformer.transformer_config import TransformerConfig
@@ -308,7 +308,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         if self.mcore_gpt:
             model = MCoreGPTModel(
                 config=self.transformer_config,
-                transformer_layer_spec=get_gpt_layer_with_transformer_engine_spec(),
+                transformer_layer_spec=gpt_layer_with_transformer_engine_spec(),
                 vocab_size=self.cfg.get('override_vocab_size', self.padded_vocab_size),
                 max_sequence_length=self.cfg.get('encoder_seq_length', 512),
                 pre_process=pre_process,

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -75,12 +75,12 @@ except (ImportError, ModuleNotFoundError):
 
 try:
     from megatron.core import InferenceParams, parallel_state
-    from megatron.model import GPTModel as MCoreGPTModel
     from megatron.core.models.gpt.gpt_layer_specs import gpt_layer_with_transformer_engine_spec
     from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
     from megatron.core.transformer.module import Float16Module as MCoreFloat16Module
     from megatron.core.transformer.transformer_config import TransformerConfig
     from megatron.core.utils import init_method_normal, scaled_init_method_normal
+    from megatron.model import GPTModel as MCoreGPTModel
 
     # TODO @tmoon: Use once available in Megatron-LM
     # from megatron.core.pipeline_parallel.schedules import DataIteratorList


### PR DESCRIPTION
# What does this PR do ?

Installing NeMo/TransformerEngine and checkout Megatron-LM code by using its `main` branch.
Then run pytest
```python
PYTHONPATH=/home/robin/Megatron-LM/ pytest --tb=native tests/
```
It directly reported error:
```
ImportError while loading conftest '/home/robin/try1/NeMo/tests/conftest.py'.                                                                                                                                                               
tests/conftest.py:28: in <module>                                                                                                                                                                                                           
    from tests.fixtures.tts import *                                                                                                                                                                                                        
tests/fixtures/tts.py:21: in <module>
    from nemo.collections.asr.parts.utils.manifest_utils import read_manifest
nemo/collections/asr/__init__.py:15: in <module>
    from nemo.collections.asr import data, losses, models, modules
nemo/collections/asr/models/__init__.py:36: in <module>
    from nemo.collections.asr.models.transformer_bpe_models import EncDecTransfModelBPE
nemo/collections/asr/models/transformer_bpe_models.py:52: in <module>
    from nemo.collections.nlp.modules.common import TokenClassifier
nemo/collections/nlp/__init__.py:15: in <module>
    from nemo.collections.nlp import data, losses, models, modules
nemo/collections/nlp/models/__init__.py:28: in <module>
    from nemo.collections.nlp.models.language_modeling import MegatronGPTPromptLearningModel
nemo/collections/nlp/models/language_modeling/__init__.py:16: in <module>
    from nemo.collections.nlp.models.language_modeling.megatron_gpt_prompt_learning_model import (
nemo/collections/nlp/models/language_modeling/megatron_gpt_prompt_learning_model.py:31: in <module>
    from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel
nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py:78: in <module>
    from megatron.core.models.gpt import GPTModel as MCoreGPTModel
../../Megatron-LM/megatron/core/models/gpt/__init__.py:1: in <module>
    from .gpt_model import GPTModel
../../Megatron-LM/megatron/core/models/gpt/gpt_model.py:15: in <module>
    from megatron.core.transformer.transformer_block import TransformerBlock
../../Megatron-LM/megatron/core/transformer/transformer_block.py:10: in <module>
    from megatron.core.transformer.custom_layers.transformer_engine import TENorm
../../Megatron-LM/megatron/core/transformer/custom_layers/transformer_engine.py:67: in <module>
    class TELinear(te.pytorch.Linear):
E   AttributeError: module 'transformer_engine' has no attribute 'pytorch'
```
The reason for this error is that GPTModel hasn't been import correctly.

# Changelog 
- Fix import error of megatron.core for tests

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

@XuesongYang @MaximumEntropy, @ericharper, @ekmb, @yzhang123, @VahidooX, @vladgets, or @okuchaiev
