### PR TITLE
Fix typo in audio codec config, encoder target

### DIFF
--- a/examples/tts/conf/audio_codec/audio_codec_24000.yaml
+++ b/examples/tts/conf/audio_codec/audio_codec_24000.yaml
@@ -112,7 +112,7 @@ model:
       num_workers: 2
 
   audio_encoder:
-    _target_: nemo.collections.tts.modules.encodec_modules.HifiGanEncoder
+    _target_: nemo.collections.tts.modules.encodec_modules.SEANetEncoder
     down_sample_rates: ${down_sample_rates}
 
   audio_decoder:


### PR DESCRIPTION
# What does this PR do ?

This PR fixes a typo in encoder target in `audio_codec_24000.yaml`.

**Collection**: TTS

# Changelog 
- Changed encoder target in the config file

# Usage

N/A

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
