### PR TITLE
Added knob fot user buffer/tensor parallel communication overlap for …

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1554,6 +1554,8 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         recompute_method = self.cfg.get('activations_checkpoint_method', None)
         recompute_num_layers = self.cfg.get('activations_checkpoint_num_layers', None)
 
+        ub_tp_comm_overlap = self.cfg.get('ub_tp_comm_overlap',False)
+
         if not self.cfg.get('fp8', False):
             fp8 = None
         elif self.cfg.get('fp8_e4m3', False):
@@ -1580,6 +1582,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             'recompute_method': recompute_method,
             'recompute_num_layers': recompute_num_layers,
             'distribute_saved_activations': False,  # not currently used in NeMo
+            'ub_tp_comm_overlap': ub_tp_comm_overlap,
             'fp8': fp8,
         }
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1554,7 +1554,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         recompute_method = self.cfg.get('activations_checkpoint_method', None)
         recompute_num_layers = self.cfg.get('activations_checkpoint_num_layers', None)
 
-        ub_tp_comm_overlap = self.cfg.get('ub_tp_comm_overlap',False)
+        ub_tp_comm_overlap = self.cfg.get('ub_tp_comm_overlap', False)
 
         if not self.cfg.get('fp8', False):
             fp8 = None


### PR DESCRIPTION
…MCORE pass

# What does this PR do ?

Added a knob to pass from the Nemo Launcher to the Mcore pass model for the ub_tp_comm_overlap switch.

Reference PR: https://github.com/NVIDIA/Megatron-LM/pull/532
This fix will be used by this PR in the Megatron-LM repository.