### PR TITLE
Add few-shot in-context learning and MLP modality adapter

### DIFF
--- a/examples/multimodel/conf/speechllm/modularized_speech_gpt_config_eval.yaml
+++ b/examples/multimodel/conf/speechllm/modularized_speech_gpt_config_eval.yaml
@@ -118,7 +118,7 @@ model:
       tokens_to_generate: 512
       log_every_n_steps: 1
       sample_rate: ${data.train_ds.sample_rate}
-      audio_locator: null # set it to allow multiple audios in a sample, e.g. '||audio||', and use it in the context field of manifest to specify the locations of audios (`audio_filepath` is a list of audios).
+      audio_locator: null # set it to allow multiple audios in a sample, e.g. '|audio|', and use it in the context field of manifest to specify the locations of audios (`audio_filepath` is a list of audios).
 
       metric:
         name: "wer" # Name of the evaluation metric to use. Options: ['exact_string_match', 'loss']

--- a/examples/multimodel/conf/speechllm/modularized_speech_gpt_config_eval.yaml
+++ b/examples/multimodel/conf/speechllm/modularized_speech_gpt_config_eval.yaml
@@ -118,6 +118,7 @@ model:
       tokens_to_generate: 512
       log_every_n_steps: 1
       sample_rate: ${data.train_ds.sample_rate}
+      audio_locator: null # set it to allow multiple audios in a sample, e.g. '||audio||', and use it in the context field of manifest to specify the locations of audios (`audio_filepath` is a list of audios).
 
       metric:
         name: "wer" # Name of the evaluation metric to use. Options: ['exact_string_match', 'loss']

--- a/nemo/collections/common/parts/preprocessing/collections.py
+++ b/nemo/collections/common/parts/preprocessing/collections.py
@@ -294,19 +294,22 @@ class ALMAudioText(_Collection):
         ):
             # Duration filters.
             if duration is not None:
-                if min_duration is not None and duration < min_duration:
-                    duration_filtered += duration
+                curr_min_dur = min(duration) if isinstance(duration, list) else duration
+                curr_max_dur = max(duration) if isinstance(duration, list) else duration
+                curr_sum_dur = sum(duration) if isinstance(duration, list) else duration
+                if min_duration is not None and curr_min_dur < min_duration:
+                    duration_filtered += curr_sum_dur
                     num_filtered += 1
                     continue
 
-                if max_duration is not None and duration > max_duration:
-                    duration_filtered += duration
+                if max_duration is not None and curr_max_dur > max_duration:
+                    duration_filtered += curr_sum_dur
                     num_filtered += 1
                     continue
-                total_duration += duration
+                total_duration += curr_sum_dur
 
             if answer is None:
-                duration_filtered += duration
+                duration_filtered += curr_sum_dur
                 num_filtered += 1
                 continue
 

--- a/nemo/collections/multimodal/speechllm/data/audio_text_qa_dataset.py
+++ b/nemo/collections/multimodal/speechllm/data/audio_text_qa_dataset.py
@@ -171,6 +171,69 @@ def _audio_text_collate_fn(
     return batch
 
 
+def _multi_audio_text_collate_fn(
+    batch: Dict, tokens_to_generate: int, pad_to_max_length: bool, max_seq_length: int, text_pad_id: int,
+):
+    sample_ids = [x["idx"] for x in batch]
+    sample_ids = torch.tensor(sample_ids, dtype=torch.int32)
+
+    audio_signals = [x["audio_signal"] for x in batch]
+    audio_lengths = [x["audio_length"] for x in batch]
+    num_audios = [len(x) for x in audio_signals]
+
+    # put all audios from all samples in one batch
+    audio_signals = [item for audio_list in audio_signals for item in audio_list]
+    audio_lengths = [item for length_list in audio_lengths for item in length_list]
+    audio_signals, audio_lengths = _audio_collate_fn(audio_signals, audio_lengths)
+
+    input_ids = [item['input_ids'][:-1] for item in batch]
+    labels = [item['input_ids'][1:] for item in batch]
+    contexts = [item['context_ids'] for item in batch]
+    context_lengths = torch.LongTensor([item['context_length'] for item in batch])
+    context_start_idx = [item['context_start_idx'] for item in batch]
+
+    answers = [item['answer_ids'] for item in batch]
+
+    loss_mask = [_build_loss_mask(item)[1:] for item in batch]
+
+    max_length = max([len(x) for x in input_ids]) + tokens_to_generate
+    # increase max length to nearest multiple of 4 or 8
+    if pad_to_max_length:
+        max_length = max_seq_length
+    else:
+        max_length = min(max_seq_length, ceil_to_nearest(max_length, 8))
+    assert max_length <= max_seq_length
+
+    position_ids = [list(range(max_length)) for _ in batch]
+    position_ids = torch.LongTensor(position_ids)
+    input_ids = torch.LongTensor(_collate_item(input_ids, max_length=max_length, pad_id=text_pad_id))
+    input_length = torch.LongTensor([len(x) for x in input_ids])
+    labels = torch.LongTensor(_collate_item(labels, max_length=max_length, pad_id=text_pad_id))
+    loss_mask = torch.LongTensor(_collate_item(loss_mask, max_length=max_length, pad_id=0))
+    contexts = torch.LongTensor(_collate_item(contexts, max_length=max_length, pad_id=text_pad_id))
+    answers = torch.LongTensor(_collate_item(answers, max_length=max_length, pad_id=text_pad_id))
+
+    batch = {
+        'sample_ids': sample_ids,
+        'audio_signal': audio_signals,
+        'audio_signal_length': audio_lengths,
+        'tokens': input_ids,
+        'tokens_length': input_length,
+        'labels': labels,
+        'loss_mask': loss_mask,
+        'position_ids': position_ids,
+        'contexts': contexts,
+        'context_lengths': context_lengths,
+        'answers': answers,
+        'max_length': torch.LongTensor(max_length),
+        'metadata': [x['metadata'] for x in batch],
+        'context_start_idx': context_start_idx,  # List[List[int]]
+        'num_audios': torch.LongTensor(num_audios),
+    }
+
+    return batch
+
+
 class TextProcessing:
     """
     Text processing pipeline for AudioQuestionAnswerDataset and TarredAudioQuestionAnswerDataset.
@@ -197,6 +260,7 @@ class TextProcessing:
         output_key: str = 'output',
         end_string: Optional[str] = None,
         sample_alpha: Optional[float] = None,
+        audio_locator: Optional[str] = None,
     ):
         self.input_key = input_key
         self.output_key = output_key
@@ -216,6 +280,7 @@ class TextProcessing:
         self.add_sep = add_sep
         self.end_string = end_string
         self.sample_alpha = sample_alpha
+        self.audio_locator = audio_locator
 
         if add_bos and hasattr(tokenizer, "bos_id") and tokenizer.bos_id > 0:
             self.bos_id = tokenizer.bos_id
@@ -286,7 +351,18 @@ class TextProcessing:
         answer_ids = pre_pad + self.tokenizer.text_to_ids(answer_text, self.sample_alpha)
         if self.end_string:
             answer_ids += self.tokenizer.text_to_ids(self.end_string)
-        context_ids = pre_pad + self.tokenizer.text_to_ids(context)
+
+        if self.audio_locator is None:
+            context_ids = self.tokenizer.text_to_ids(context)
+            context_start_idx = [0]
+        else:
+            context_ids = []
+            context_start_idx = []
+            for context_seg in context.split(self.audio_locator):
+                context_start_idx.append(len(context_ids))
+                context_ids.extend(self.tokenizer.text_to_ids(context_seg))
+        context_ids = pre_pad + context_ids
+        context_start_idx = [x + len(pre_pad) for x in context_start_idx]
 
         # for the long context cases, collate_fn includes self.tokens_to_generate for padding
         total_ids = len(context_ids) + max(len(answer_ids), self.tokens_to_generate)
@@ -337,6 +413,7 @@ class TextProcessing:
             'context_ids': context_ids,
             'context_length': len(context_ids),
             'answer_ids': answer_ids,
+            'context_start_idx': context_start_idx,
         }
 
         return processed_example
@@ -417,6 +494,7 @@ class AudioQuestionAnswerDataset(TextProcessing, Dataset):
         random_context_num: Optional[int] = 3,
         random_context_positive_percent: Optional[float] = 0.1,
         sample_alpha: Optional[float] = None,
+        audio_locator: Optional[str] = None,
     ):
         super().__init__(
             tokenizer=tokenizer,
@@ -438,6 +516,7 @@ class AudioQuestionAnswerDataset(TextProcessing, Dataset):
             output_key=output_key,
             end_string=end_string,
             sample_alpha=sample_alpha,
+            audio_locator=audio_locator,
         )
 
         if isinstance(manifest_filepath, str):
@@ -513,6 +592,86 @@ class AudioQuestionAnswerDataset(TextProcessing, Dataset):
             max_seq_length=self.max_seq_length,
             text_pad_id=self.pad_id,
         )
+
+
+class MultiAudioQuestionAnswerDataset(AudioQuestionAnswerDataset):
+    def __init__(
+        self, *args, **kwargs,
+    ):
+        super().__init__(*args, **kwargs)
+
+    def _collate_fn(self, batch):
+        return _multi_audio_text_collate_fn(
+            batch=batch,
+            tokens_to_generate=self.tokens_to_generate,
+            pad_to_max_length=self.pad_to_max_length,
+            max_seq_length=self.max_seq_length,
+            text_pad_id=self.pad_id,
+        )
+
+    def __getitem__(self, index):
+        output = {"idx": index}
+        sample = self.collection[index]
+        offsets = sample.offset if sample.offset else 0.0
+        durations = sample.duration if sample.duration else 0.0
+        num_audios = 0
+        output["audio_signal"] = []
+        output["audio_length"] = []
+        if sample.audio_file is not None:
+            audio_list = sample.audio_file
+            if isinstance(sample.audio_file, str):
+                audio_list = [sample.audio_file]
+            if not isinstance(audio_list, list):
+                raise ValueError(
+                    f"The field `audio_file` must be either a str or a list of str, but got type {type(sample.audio_file)} instead"
+                )
+
+            num_audios = len(audio_list)
+            if isinstance(durations, list) and len(durations) != num_audios:
+                raise ValueError(
+                    f"The number of durations ({len(durations)}) must match the number of audio clips ({num_audios})"
+                )
+            if isinstance(offsets, list) and len(offsets) != num_audios:
+                raise ValueError(
+                    f"The number of offsets ({len(offsets)}) must match the number of audio clips ({num_audios})"
+                )
+
+            for i, audio_file in enumerate(audio_list):
+                duration = durations[i] if isinstance(durations, list) else 0
+                offset = offsets[i] if isinstance(offsets, list) else 0
+                features = self.featurizer.process(
+                    audio_file,
+                    offset=offset,
+                    duration=duration,
+                    trim=self.trim,
+                    orig_sr=sample.orig_sr,
+                    channel_selector=self.channel_selector,
+                )
+                f, fl = features, torch.tensor(features.shape[0]).long()
+                output["audio_signal"].append(f)
+                output["audio_length"].append(fl)
+        else:
+            # dummy features
+            output["audio_signal"] = [torch.zeros([8])]
+            # accomodates normalize_batch
+            output["audio_length"] = [torch.tensor(8)]
+
+        text_data = self._process_example(context=sample.question, output=sample.answer)
+
+        if isinstance(output["audio_signal"], list) and len(output["audio_signal"]) + 1 != len(
+            text_data['context_start_idx']
+        ):
+            raise ValueError(
+                f"The number of text segments ({len(text_data['context_start_idx'])}) must be one more than number of audios ({len(output['audio_signal'])})"
+            )
+
+        output.update(text_data)
+        output['metadata'] = {
+            'audio_filepath': sample.audio_file,
+            'offset': offset,
+            'duration': sample.duration,
+        }
+        return output
 
 
 class TarredAudioFilter:
@@ -1092,6 +1251,7 @@ def get_aqa_dataset_from_config(
     else:
         manifest_filepath = config.manifest_filepath
 
+    data_cls = MultiAudioQuestionAnswerDataset if config.get('audio_locator', None) else AudioQuestionAnswerDataset
     datasets = []
     if is_train:
         # Construct the data prefix list for `get_datasets_weights_and_num_samples()`
@@ -1125,7 +1285,7 @@ def get_aqa_dataset_from_config(
             question_file = question_file_set[dataset_idx]
         else:
             question_file = None
-        dataset = AudioQuestionAnswerDataset(
+        dataset = data_cls(
             manifest_filepath=file_path,
             tokenizer=tokenizer,
             sample_rate=config.sample_rate,
@@ -1161,6 +1321,7 @@ def get_aqa_dataset_from_config(
             random_context_num=config.get('random_context_num', 3),
             random_context_positive_percent=config.get('random_context_positive_percent', 0.1),
             question_file=question_file,
+            audio_locator=config.get('audio_locator', None),
         )
         datasets.append(dataset)
 

--- a/nemo/collections/multimodal/speechllm/data/audio_text_qa_dataset.py
+++ b/nemo/collections/multimodal/speechllm/data/audio_text_qa_dataset.py
@@ -565,6 +565,26 @@ class AudioQuestionAnswerDataset(TextProcessing, Dataset):
 
 
 class MultiAudioQuestionAnswerDataset(AudioQuestionAnswerDataset):
+    """
+    Dataset for having multi audios per sample, for example in few-shot in-context learning.
+    To use this dataset, you need to specify the `audio_locator` field in the dataset config,
+    and use that to specify the locations of the audio files in your manifest. In this case, 
+    the `audio_filepath` field in the manifest is a list of audio filepaths, and the `duration`
+    field is a list of durations, one for each audio file. The `offset` field is optional, and
+    if not specified, it is assumed to be 0.0. The `offset` field is also a list of offsets if specified.
+
+    Example manifest item for audio_locator='|audio|':
+    {
+    "audio_filepath": ["1.wav","2.wav","3.wav"], 
+    "duration": [1.05,1.05,2.0],
+    "answer": "this was her dream as nearly as she could recall it", 
+    "question": "Following are examples of speech audios and their transcriptions. 
+        Example 1: audio is |audio|, transcription is 'I have a dream'. 
+        Example 2: audio is |audio|, transcription is ' I don't have a dream'. 
+        Given the following audio |audio|, transcribe the audio into words."
+    }
+    """
+
     def __init__(
         self, *args, **kwargs,
     ):

--- a/nemo/collections/multimodal/speechllm/models/speechllm_models.py
+++ b/nemo/collections/multimodal/speechllm/models/speechllm_models.py
@@ -15,8 +15,7 @@
 import itertools
 import json
 import os
-from functools import partial
-from typing import Dict, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import sacrebleu
 import torch
@@ -25,8 +24,6 @@ from omegaconf.dictconfig import DictConfig
 from omegaconf.omegaconf import OmegaConf, open_dict
 from pytorch_lightning.trainer.trainer import Trainer
 
-from nemo.collections.asr.data import audio_to_text_dataset
-from nemo.collections.asr.data.audio_to_text_dali import AudioToBPEDALIDataset, DALIOutputs
 from nemo.collections.asr.models import ASRModel, SpeechEncDecSelfSupervisedModel
 from nemo.collections.asr.parts.preprocessing.perturb import process_augmentations
 from nemo.collections.common.metrics import MetricStringToTorchMetric, TextMetricsSet
@@ -36,6 +33,7 @@ from nemo.collections.multimodal.speechllm.data.audio_text_qa_dataset import (
 )
 from nemo.collections.multimodal.speechllm.modules.common.audio_text_generation_utils import generate
 from nemo.collections.multimodal.speechllm.modules.speechllm_perception import AudioPerceptionModel
+from nemo.collections.multimodal.speechllm.parts.utils.data_utils import to_cuda
 from nemo.collections.nlp.data.language_modeling.megatron.blendable_dataset import BlendableDataset
 from nemo.collections.nlp.data.language_modeling.megatron.megatron_batch_samplers import (
     MegatronPretrainingBatchSampler,
@@ -44,20 +42,15 @@ from nemo.collections.nlp.models.language_modeling.megatron_gpt_peft_models impo
     MegatronGPTLoRAModel,
     MegatronGPTPEFTModel,
 )
-from nemo.collections.nlp.models.language_modeling.megatron_gpt_prompt_learning_model import (
-    MegatronGPTPromptLearningModel,
-)
 from nemo.collections.nlp.models.language_modeling.megatron_gpt_sft_model import MegatronGPTSFTModel
 from nemo.collections.nlp.modules.common.megatron.utils import (
     average_losses_across_data_parallel_group,
     build_position_ids,
 )
 from nemo.collections.nlp.modules.common.text_generation_utils import get_computeprob_response
-from nemo.collections.nlp.modules.common.transformer.text_generation import LengthParam, SamplingParam
 from nemo.collections.nlp.parts.nlp_overrides import NLPSaveRestoreConnector, PEFTSaveRestoreConnector
 from nemo.collections.nlp.parts.utils_funcs import get_last_rank
 from nemo.core.classes.mixins import AccessMixin, adapter_mixins
-from nemo.core.neural_types import AcousticEncodedRepresentation, AudioSignal, LengthsType, NeuralType, SpectrogramType
 from nemo.utils import AppState, logging, model_utils
 
 try:
@@ -182,36 +175,72 @@ class ModularAudioGPTLoRAModel(MegatronGPTLoRAModel):
         self._optimizer_param_groups = param_groups
         logging.info(f"Optimizer groups set:\n{self.summarize(max_depth=2)}")
 
-    def inject_perception_input(self, encoded, encoded_len, input_ids, input_length):
-        def _concat_embs(embs1, emb1_lens, embs2, emb2_lens):
-            concat_emb = []
-            concat_len = []
-            for emb1, emb1_len, emb2, emb2_len in zip(embs1, emb1_lens, embs2, emb2_lens):
-                new_len = emb1_len + emb2_len
-                new_emb = torch.concat([emb1[:emb1_len], emb2[:emb2_len]], axis=0)
-                padded_new_emb = torch.zeros(emb1.shape[0] + emb2.shape[0], emb1.shape[-1], device=emb1.device)
-                padded_new_emb[:new_len, ...] = new_emb
-                concat_emb.append(padded_new_emb)
-                concat_len.append(new_len)
-            concat_emb = torch.stack(concat_emb, dim=0)
-            concat_len = torch.stack(concat_len, dim=0)
-            return concat_emb, concat_len
-
-        # [b, t, c]
-        lm_embedding = self.model.language_model.embedding
-        input_embeds = lm_embedding.word_embeddings(input_ids)
-        encoder_input, encoder_length = _concat_embs(encoded, encoded_len, input_embeds, input_length)
-
-        b = encoder_input.shape[0]
+    def _create_attention_mask(self, encoder_input: torch.Tensor):
+        batch_size = encoder_input.shape[0]
         max_len = encoder_input.shape[1]
-
-        # Using causal attention mask for whole input
         # TODO(zhehuai): use prefixlm instead for the audio embeddings
-        attention_mask = torch.tril(torch.ones((b, max_len, max_len), device=encoder_input.device)).view(
-            b, 1, max_len, max_len
+        # Using causal attention mask for whole input
+        attention_mask = torch.tril(torch.ones((batch_size, max_len, max_len), device=encoder_input.device)).view(
+            batch_size, 1, max_len, max_len
         )
         # Convert attention mask from float to bool
         attention_mask = attention_mask < 0.5
+        return attention_mask
+
+    def _concat_features(self, embs1, emb1_lens, embs2, emb2_lens):
+        concat_emb = []
+        concat_len = []
+        for emb1, emb1_len, emb2, emb2_len in zip(embs1, emb1_lens, embs2, emb2_lens):
+            new_len = emb1_len + emb2_len
+            new_emb = torch.concat([emb1[:emb1_len], emb2[:emb2_len]], axis=0)
+            padded_new_emb = torch.zeros(emb1.shape[0] + emb2.shape[0], emb1.shape[-1], device=emb1.device)
+            padded_new_emb[:new_len, ...] = new_emb
+            concat_emb.append(padded_new_emb)
+            concat_len.append(new_len)
+        concat_emb = torch.stack(concat_emb, dim=0)
+        concat_len = torch.stack(concat_len, dim=0)
+        return concat_emb, concat_len
+
+    def _concat_multi_features(self, encoded, encoded_len, input_embeds, input_length, context_start_idx):
+        encoder_input_list, encoder_length_list = [], []
+        batch_size = input_embeds.size(0)
+        max_length = 0
+        for i in range(batch_size):
+            start_idx_list_i = context_start_idx[i] + [input_embeds.size(1)]
+            input_len_list = [start_idx_list_i[j + 1] - start_idx_list_i[j] for j in range(len(start_idx_list_i) - 1)]
+            input_emb_list = input_embeds[i].split(input_len_list)
+            encoder_input_i = [input_emb_list[0]]
+            for j in range(1, len(input_emb_list)):
+                encoder_input_i.append(encoded[i][j - 1][: encoded_len[i][j - 1]])
+                encoder_input_i.append(input_emb_list[j])
+            encoder_input_i = torch.cat(encoder_input_i)  # T, C
+            encoder_length_i = encoder_input_i.size(0)
+            max_length = max(max_length, encoder_length_i)
+            encoder_input_list.append(encoder_input_i)
+            encoder_length_list.append(encoder_length_i)
+
+        encoder_input = torch.stack(
+            [torch.nn.functional.pad(f, (0, 0, 0, max_length - f.size(0))) for f in encoder_input_list]
+        )
+        encoder_length = torch.LongTensor(encoder_length_list).to(encoder_input.device)
+        return encoder_input, encoder_length
+
+    def inject_perception_input(
+        self, encoded, encoded_len, input_ids, input_length, context_start_idx: Optional[List[List[int]]] = None
+    ):
+        # [b, t, c]
+        lm_embedding = self.model.language_model.embedding
+        input_embeds = lm_embedding.word_embeddings(input_ids)
+        if isinstance(encoded, torch.Tensor):
+            # single audio
+            encoder_input, encoder_length = self._concat_features(encoded, encoded_len, input_embeds, input_length)
+        else:
+            # concat multiple audios with text segments
+            encoder_input, encoder_length = self._concat_multi_features(
+                encoded, encoded_len, input_embeds, input_length, context_start_idx
+            )
+
+        attention_mask = self._create_attention_mask(encoder_input)
         position_ids = build_position_ids(encoder_input[:, :, 0])
 
         # Add position embeddings
@@ -256,6 +285,9 @@ class ModularAudioGPTLoRAModel(MegatronGPTLoRAModel):
             audio_batch['loss_mask'],
         )
 
+        num_audios = audio_batch.get("num_audios", None)
+        context_start_idx = audio_batch.get("context_start_idx", None)
+
         # [b, t, c]
         encoded, encoded_len = self.perception(
             input_signal=input_signal,
@@ -263,9 +295,19 @@ class ModularAudioGPTLoRAModel(MegatronGPTLoRAModel):
             processed_signal=None,
             processed_signal_length=None,
         )
+
+        if num_audios is not None:
+            # split the encoded and encoded_len by num_audios
+            encoded = encoded.split(num_audios)
+            encoded_len = encoded_len.split(num_audios)
         encoder_input, attention_mask, encoder_length, _, encoder_max_length = self.inject_perception_input(
-            encoded, encoded_len, input_ids, input_length
+            encoded, encoded_len, input_ids, input_length, context_start_idx
         )
+        if num_audios is not None:
+            # sum up the audio_feat_lens for each sample in the batch
+            encoded_len = torch.stack([torch.sum(lens) for lens in encoded_len])
+
+        # Shift labels to the right
         labels = self._shift_labels_by_emb_len(labels, input_length, encoded_len, encoder_max_length, pad_token=0)
         # Loss mask where answer tokens are 1.0 and all other tokens are 0.0
         loss_mask = self._shift_labels_by_emb_len(
@@ -335,7 +377,7 @@ class ModularAudioGPTLoRAModel(MegatronGPTLoRAModel):
     def get_forward_output_and_loss_func(self, validation_step=False):
         def fwd_output_and_loss_func(dataloader_iter, model, checkpoint_activations_all_layers=None):
             batch = next(dataloader_iter)
-            batch = {key: val.cuda(non_blocking=True) for key, val in batch.items()}
+            batch = to_cuda(batch, non_blocking=True)
             output_tensor, loss_mask = self.forward(
                 batch, checkpoint_activations_all_layers=checkpoint_activations_all_layers
             )
@@ -616,7 +658,6 @@ class ModularAudioGPTLoRAModel(MegatronGPTLoRAModel):
 
     def load_state_dict(self, state_dict, strict: bool = True):
         if self.setup_complete:
-            print(f"loading state_dict: {state_dict.keys()}")
             super(MegatronGPTPEFTModel, self).load_state_dict(state_dict, strict=False)
         else:
             if self.cfg.get('override_vocab_size', False):
@@ -733,8 +774,9 @@ class ModularAudioGPTLoRAModel(MegatronGPTLoRAModel):
             for t, l in zip(output['token_ids'], batch['context_lengths'])
         ]
 
-        preds_text = [p.replace(data_cfg.end_string, '') for p in preds_text]
-        labels_text = [p.replace(data_cfg.end_string, '') for p in labels_text]
+        if data_cfg.get("end_string", None):
+            preds_text = [p.replace(data_cfg.end_string, '') for p in preds_text]
+            labels_text = [p.replace(data_cfg.end_string, '') for p in labels_text]
         if data_cfg.get("log_every_n_steps", None) is not None:
             if batch_idx % data_cfg.log_every_n_steps == 0:
                 logging.info(f"Input: `{inputs_text[0]}`")
@@ -781,6 +823,16 @@ class ModularAudioGPTLoRAModel(MegatronGPTLoRAModel):
             # for megatron_gpt_eval.py
             if isinstance(batch, list):
                 inference_config['inputs'] = batch
+            elif 'num_audios' in batch:
+                # peft_eval.py
+                inference_config['inputs'] = (
+                    batch['contexts'].cuda(),
+                    batch['context_lengths'].cuda(),
+                    batch['audio_signal'].cuda(),
+                    batch['audio_signal_length'].cuda(),
+                    batch['num_audios'].cuda(),
+                    batch['context_start_idx'],
+                )
             else:
                 # peft_eval.py
                 inference_config['inputs'] = (

--- a/nemo/collections/multimodal/speechllm/modules/common/audio_text_generation_strategy.py
+++ b/nemo/collections/multimodal/speechllm/modules/common/audio_text_generation_strategy.py
@@ -13,13 +13,13 @@
 # limitations under the License.
 
 import abc
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 
 import nemo.collections.nlp.modules.common.text_generation_strategy as text_generation_strategy
-from nemo.collections.nlp.modules.common.lm_utils import pad_batch
-from nemo.collections.nlp.modules.common.megatron.utils import get_ltor_masks_and_position_ids
+from nemo.collections.multimodal.speechllm.parts.utils.data_utils import shift_tokens_by_multi_audios
+
 
 try:
     from apex.transformer.pipeline_parallel.utils import get_num_microbatches
@@ -57,6 +57,8 @@ class AudioToTextGenerationStrategy(text_generation_strategy.GPTModelTextGenerat
         audio_signal: torch.Tensor,
         audio_length: torch.Tensor,
         compute_attention_mask: bool,
+        num_audios: Optional[torch.Tensor] = None,
+        context_start_idx: Optional[List[List[int]]] = None,
     ):
         """initialize the batch data before the inference steps."""
         # Move to GPU.
@@ -69,15 +71,27 @@ class AudioToTextGenerationStrategy(text_generation_strategy.GPTModelTextGenerat
             processed_signal_length=None,
         )
 
+        if num_audios is not None:
+            audio_feats = audio_feats.split(num_audios)
+            audio_feat_lens = audio_feat_lens.split(num_audios)
+
         encoder_input, attention_mask, _, position_ids, encoder_max_length = self.model.inject_perception_input(
-            audio_feats, audio_feat_lens, context_tokens, context_lengths
+            audio_feats, audio_feat_lens, context_tokens, context_lengths, context_start_idx
         )
+
         self.attention_mask = attention_mask
         self.position_ids = position_ids
 
-        new_context_tokens = self.model._shift_labels_by_emb_len(
-            context_tokens, context_lengths, audio_feat_lens, encoder_max_length, pad_token=0
-        )
+        if num_audios is not None:
+            # sum up the audio_feat_lens for each sample in the batch
+            new_context_tokens = shift_tokens_by_multi_audios(
+                context_tokens, context_lengths, audio_feat_lens, context_start_idx, encoder_max_length
+            )
+            audio_feat_lens = torch.stack([torch.sum(lens) for lens in audio_feat_lens])  # [batch,]
+        else:
+            new_context_tokens = self.model._shift_labels_by_emb_len(
+                context_tokens, context_lengths, audio_feat_lens, encoder_max_length, pad_token=0
+            )
 
         return new_context_tokens, encoder_input, audio_feat_lens
 
@@ -96,25 +110,25 @@ class AudioToTextGenerationStrategy(text_generation_strategy.GPTModelTextGenerat
         maxlen: int,
         micro_batch_size: int,
         step: int,
-        context_lengths: int,
-        context_length: int,
+        context_lengths: torch.Tensor,
+        curr_context_length: int,
         compute_attention_mask: bool,
     ) -> Tuple[List[torch.Tensor], List[int]]:
         # types2use = None
         if step == 0:
             # Allocate memory for the entire context.
             set_inference_key_value_memory = True
-            tokens2use = tokens[:, :context_length]
-            positions2use = self.position_ids[:, :context_length]
-            embeddings2use = input_embeddings[:context_length]
+            tokens2use = tokens[:, :curr_context_length]
+            positions2use = self.position_ids[:, :curr_context_length]
+            embeddings2use = input_embeddings[:curr_context_length]
         else:
             # Set this to false so the memory is not reallocated.
             set_inference_key_value_memory = False
-            tokens2use = tokens[:, context_length - 1].view(micro_batch_size, -1)
-            positions2use = self.position_ids[:, context_length - 1].view(micro_batch_size, -1)
+            tokens2use = tokens[:, curr_context_length - 1].view(micro_batch_size, -1)
+            positions2use = self.position_ids[:, curr_context_length - 1].view(micro_batch_size, -1)
             embeddings2use = self.model._get_text_embeddings(tokens2use, positions2use)
-            started = context_lengths <= context_length
-            embeddings2use = switch(input_embeddings[context_length - 1].unsqueeze(0), embeddings2use, started)
+            started = context_lengths <= curr_context_length
+            embeddings2use = switch(input_embeddings[curr_context_length - 1].unsqueeze(0), embeddings2use, started)
 
         """Prepare batch for each of the inference steps"""
         setkey_value_array = torch.tensor(

--- a/nemo/collections/multimodal/speechllm/modules/common/audio_text_generation_strategy.py
+++ b/nemo/collections/multimodal/speechllm/modules/common/audio_text_generation_strategy.py
@@ -72,6 +72,7 @@ class AudioToTextGenerationStrategy(text_generation_strategy.GPTModelTextGenerat
         )
 
         if num_audios is not None:
+            # multiple audio files per sample
             audio_feats = audio_feats.split(num_audios)
             audio_feat_lens = audio_feat_lens.split(num_audios)
 

--- a/nemo/collections/multimodal/speechllm/modules/common/audio_text_generation_strategy.py
+++ b/nemo/collections/multimodal/speechllm/modules/common/audio_text_generation_strategy.py
@@ -72,7 +72,7 @@ class AudioToTextGenerationStrategy(text_generation_strategy.GPTModelTextGenerat
         )
 
         if num_audios is not None:
-            # multiple audio files per sample
+            # handle multiple audio files per sample
             audio_feats = audio_feats.split(num_audios)
             audio_feat_lens = audio_feat_lens.split(num_audios)
 
@@ -84,7 +84,7 @@ class AudioToTextGenerationStrategy(text_generation_strategy.GPTModelTextGenerat
         self.position_ids = position_ids
 
         if num_audios is not None:
-            # sum up the audio_feat_lens for each sample in the batch
+            # handle multiple audio files per sample
             new_context_tokens = shift_tokens_by_multi_audios(
                 context_tokens, context_lengths, audio_feat_lens, context_start_idx, encoder_max_length
             )

--- a/nemo/collections/multimodal/speechllm/modules/modality_adapters.py
+++ b/nemo/collections/multimodal/speechllm/modules/modality_adapters.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+import torch.nn as nn
+
+from nemo.collections.common.parts.multi_layer_perceptron import MultiLayerPerceptron as MLP
+from nemo.core.classes.exportable import Exportable
+from nemo.core.classes.mixins import AccessMixin
+from nemo.core.classes.module import NeuralModule
+
+
+class ConcatPooling(nn.Module):
+    def __init__(self, pooling_factor):
+        super().__init__()
+        self.pooling_factor = pooling_factor
+
+    def forward(self, x):
+        # x: [batch_size, seq_len, input_dim]
+        batch_size, seq_len, input_dim = x.shape
+        if seq_len % self.pooling_factor != 0:
+            x = x[:, : -(seq_len % self.pooling_factor), :]
+        x = x.reshape(batch_size, seq_len // self.pooling_factor, input_dim * self.pooling_factor)
+        return x
+
+
+class PoolingMLPConnectors(NeuralModule, Exportable, AccessMixin):
+    def __init__(
+        self,
+        input_dim,
+        hidden_dim,
+        output_dim=None,
+        num_layers: int = 2,
+        activation: str = "relu",
+        pooling: str = "mean",
+        pooling_factor: int = 2,
+        **kwargs,  # keep this to avoid breaking existing code
+    ):
+        super().__init__()
+        self.input_dim = input_dim
+        self.hidden_dim = hidden_dim
+        self.output_dim = output_dim if output_dim else input_dim
+        self.num_layers = num_layers
+        self.activation = activation
+        self.pooling = pooling
+        self.pooling_factor = pooling_factor
+
+        if num_layers == 1:
+            self.hidden_dim = output_dim
+
+        if pooling == "cat":
+            self.preprocess = nn.Sequential(
+                ConcatPooling(pooling_factor), nn.Linear(input_dim * pooling_factor, self.hidden_dim)
+            )
+        else:
+            self.preprocess = nn.Sequential(
+                nn.AvgPool1d(pooling_factor, stride=pooling_factor), nn.Linear(input_dim, self.hidden_dim)
+            )
+
+        if num_layers == 1:
+            self.mlp = nn.Identity()
+        else:
+            self.mlp = MLP(self.hidden_dim, output_dim, num_layers, activation, log_softmax=False)
+
+    def forward(self, audio_signal, length=None):
+        """
+        Args: 
+            audio_signal: [batch_size, input_dim, seq_len]
+            length: [batch_size]
+        Returns:
+            outputs: [batch_size, output_dim, seq_len//pooling_factor]
+            outputs_len: [batch_size]
+        """
+        outputs = self.preprocess(audio_signal.transpose(1, 2))
+        outputs = self.mlp(outputs)
+        outputs_len = torch.div(length, self.pooling_factor, rounding_mode='floor')
+        return outputs.transpose(1, 2), outputs_len

--- a/nemo/collections/multimodal/speechllm/parts/utils/__init__.py
+++ b/nemo/collections/multimodal/speechllm/parts/utils/__init__.py
@@ -11,12 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-from nemo.collections.multimodal.speechllm.parts.utils.data_utils import (
-    ceil_to_nearest,
-    get_num_samples_from_files,
-    maybe_cast_to_list,
-    shift_tokens_by_multi_audios,
-    to_cuda,
-)

--- a/nemo/collections/multimodal/speechllm/parts/utils/data_utils.py
+++ b/nemo/collections/multimodal/speechllm/parts/utils/data_utils.py
@@ -38,3 +38,48 @@ def get_num_samples_from_files(file_list):
                 num -= 1
             num_samples.append(num)
     return num_samples
+
+
+def to_cuda(inputs, non_blocking=True):
+    """Recursively move inputs to cuda."""
+    if isinstance(inputs, torch.Tensor):
+        return inputs.cuda(non_blocking=non_blocking)
+    elif isinstance(inputs, dict):
+        return {k: to_cuda(v, non_blocking) for k, v in inputs.items()}
+    elif isinstance(inputs, (list, tuple, set)):
+        return inputs.__class__([to_cuda(x, non_blocking) for x in inputs])
+    else:
+        return inputs
+
+
+def shift_tokens_by_multi_audios(
+    context_tokens, context_lengths, audio_feat_lens, context_start_idx, encoder_max_length
+):
+    """
+        split and shift the context tokens by the audio segments, then concatenate them back. This function assumes that the whole context 
+        starts and ends with text tokens, and the audio segments are in between the text tokens. The audio segments are not allowed to be adjacent to each other.
+        Args:
+            context_tokens: tensor of shape [batch, max_context_len]
+            context_lengths: tensor of shape [batch,]
+            audio_feat_lens: List[List[int]]
+            context_start_idx: List[List[int]]
+            encoder_max_length: int
+        """
+    new_context_tokens = []
+    for i in range(context_tokens.shape[0]):
+        start_idx_list_i = context_start_idx[i] + [context_lengths[i]]
+        input_len_list = [start_idx_list_i[j + 1] - start_idx_list_i[j] for j in range(len(start_idx_list_i) - 1)]
+        context_tokens_list = context_tokens[i][: context_lengths[i]].split(input_len_list)
+        context_tokens_i = [context_tokens_list[0]]
+        for j in range(1, len(context_tokens_list)):
+            context_tokens_i.append(
+                torch.zeros(audio_feat_lens[i][j - 1], dtype=torch.long, device=context_tokens.device)
+            )
+            context_tokens_i.append(context_tokens_list[j])
+        context_tokens_i = torch.cat(context_tokens_i)
+        context_tokens_i = torch.nn.functional.pad(
+            context_tokens_i, (0, encoder_max_length - context_tokens_i.shape[0])
+        )
+        new_context_tokens.append(context_tokens_i)
+    new_context_tokens = torch.stack(new_context_tokens)
+    return new_context_tokens

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -292,8 +292,6 @@ class MegatronGPTSFTModel(MegatronGPTModel):
 
     def fwd_bwd_step(self, dataloader_iter, batch_idx, forward_only):
         batch = next(dataloader_iter)
-        # Pass only torch.Tensor to prevent errors when process get_iterator_k_split()
-        batch = {k: v for k, v in batch.items() if isinstance(v, torch.Tensor)}
         _, seq_length = batch['tokens'].shape
         tensor_shape = [seq_length, get_micro_batch_size(), self.cfg.hidden_size]
         data_iter = get_iterator_k_split(batch, get_num_microbatches())

--- a/nemo/collections/nlp/modules/common/megatron/utils.py
+++ b/nemo/collections/nlp/modules/common/megatron/utils.py
@@ -18,6 +18,7 @@ import math
 from typing import Dict, Iterator, List, Tuple, Union
 
 import torch
+from nemo.utils import logging, logging_mode
 
 try:
     from apex.normalization import MixedFusedRMSNorm
@@ -374,14 +375,52 @@ def get_all_params_for_weight_decay_optimization(
     return ({'params': weight_decay_params},)
 
 
-def get_iterator_k_split(batch: List[torch.Tensor], num_microbatches: int) -> Iterator:
+def split_list(inputs, chunk_size):
+    """
+    Split a list into equal sized chunks
+    """
+    assert len(inputs) % chunk_size == 0, "Issue with batch size configuration!"
+    return [inputs[i : i + chunk_size] for i in range(0, len(inputs), chunk_size)]
+
+
+def get_iterator_k_split(batch: Union[Dict, List[torch.Tensor]], num_microbatches: int) -> Iterator:
+    """
+    Split a batch into k microbatches, where the batch size is divisible by k. Batch could be 
+    a dictionary of tensors or a list of tensors. A dictionary batch could also have items of List type,
+    as long as the length of that list is the same as the batch size.
+    """
     if isinstance(batch, dict):
-        items = list(batch.items())
+        discard_items = [k for k, v in batch.items() if not isinstance(v, (torch.Tensor, list))]
+        if len(discard_items) > 0:
+            logging.warning(f"Discarding the following items from the batch: {discard_items}", mode=logging_mode.ONCE)
+
+        batch = {k: v for k, v in batch.items() if isinstance(v, (torch.Tensor, list))}
+        tensor_items = {k: v for k, v in batch.items() if isinstance(v, torch.Tensor)}
+        list_items = {k: v for k, v in batch.items() if isinstance(v, list)}
+
+        # Split tensor items
+        items = list(tensor_items.items())
         assert items[0][1].shape[0] % num_microbatches == 0, "Issue with batch size configuration!"
         split_batch = [torch.tensor_split(item[1], num_microbatches, dim=0) for item in items]
-        microbatches = [[(items[i][0], split_batch[i][j]) for i in range(len(items))] for j in range(num_microbatches)]
+
+        if len(list_items) == 0:
+            # Only have tensor items
+            microbatches = [
+                [(items[i][0], split_batch[i][j]) for i in range(len(items))] for j in range(num_microbatches)
+            ]
+        else:
+            # Split list items
+            list_items = list(list_items.items())
+            split_list_batch = [split_list(item[1], num_microbatches) for item in list_items]
+            # Merge tensor and list items
+            all_keys = [item[0] for item in items] + [item[0] for item in list_items]
+            all_split_batch = split_batch + split_list_batch
+            microbatches = [
+                [(all_keys[i], all_split_batch[i][j]) for i in range(len(all_keys))] for j in range(num_microbatches)
+            ]
         microbatches = [dict(elem) for elem in microbatches]
     else:
+        # Split a list of torch tensors
         assert batch[0].shape[0] % num_microbatches == 0, "Issue with batch size configuration!"
         split_batch = [torch.tensor_split(item, num_microbatches, dim=0) for item in batch]
         microbatches = [[elem[i] for elem in split_batch] for i in range(num_microbatches)]

--- a/workspace/materialize_mt_data.py
+++ b/workspace/materialize_mt_data.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # python materialize_mt_data.py /media/data/datasets/LibriSpeech/en /media/data/datasets/LibriSpeech/zh /media/data/datasets/LibriSpeech/question_en_zh /tmp/t.manifest
 import json
 import random

--- a/workspace/materialize_text_data.py
+++ b/workspace/materialize_text_data.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2023, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # python materialize_text_data.py /media/data/datasets/LibriSpeech/en /tmp/t.manifest
 import json
 import random


### PR DESCRIPTION
# What does this PR do ?

Add few-shot in-context learning for inference and MLP modality adapter.

An example of manifest is:
```
{
"audio_filepath": ["1.wav","2.wav","3.wav"], 
"duration": [1.05,1.05,2.0],
"answer": "this was her dream as nearly as she could recall it", 
"question": "Following are examples of speech audios and their transcriptions. 
    Example 1: audio is |audio|, transcription is 'I have a dream'. 
    Example 2: audio is |audio|, transcription is ' I don't have a dream'. 
    Given the following audio |audio|, transcribe the audio into words."
}
``` 
The `question` field has special audio locator strings (`|audio|` in this case) to indicate the locations of audios specified by the list of audio files in the field `audio_filepath`. In the case of multiple audios, `duration` and `offset` should also be a list of float numbers.  The program will load the three audios and insert their extracted features into the corresponding locations specified by the audio locator in the order they appear in the list. The dataset config should have a field `audio_locator: |audio|`.



**Collection**: [multimodal]

