### PR TITLE
Fix code block typo in docs

### DIFF
--- a/docs/source/asr/intro.rst
+++ b/docs/source/asr/intro.rst
@@ -31,9 +31,9 @@ You can also obtain timestamps for each word in the transcription as follows:
     from omegaconf import OmegaConf, open_dict
     decoding_cfg = asr_model.cfg.decoding
     with open_dict(decoding_cfg):
-    decoding_cfg.preserve_alignments = True
-    decoding_cfg.compute_timestamps = True
-    asr_model.change_decoding_strategy(decoding_cfg)
+        decoding_cfg.preserve_alignments = True
+        decoding_cfg.compute_timestamps = True
+        asr_model.change_decoding_strategy(decoding_cfg)
 
     # specify flag `return_hypotheses=True``        
     hypotheses = asr_model.transcribe(["path/to/audio_file.wav"], return_hypotheses=True)


### PR DESCRIPTION
# What does this PR do ?

Fix typo in code block in docs

**Collection**: Docs

# Changelog 
- Add indendation after `with open_dict(decoding_cfg):` in code block

# Usage
N/A

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [x] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
