### PR TITLE
[TTS] Fix Global Style Tokens (GSTs) implementation in FastPitch

### DIFF
--- a/nemo/collections/tts/data/dataset.py
+++ b/nemo/collections/tts/data/dataset.py
@@ -485,11 +485,7 @@ class TTSDataset(Dataset):
         pass
 
     def add_reference_audio(self, **kwargs):
-        assert SpeakerID in self.sup_data_types, "Please add speaker_id in sup_data_types."
-        """Add a mapping for each speaker to their manifest indexes"""
-        self.speaker_to_index_map = defaultdict(set)
-        for i, d in enumerate(self.data):
-            self.speaker_to_index_map[d['speaker_id']].add(i)
+        pass
 
     def get_spec(self, audio):
         with torch.cuda.amp.autocast(enabled=False):
@@ -529,12 +525,6 @@ class TTSDataset(Dataset):
                     [wav, torch.zeros(self.pad_multiple - wav.shape[0] % self.pad_multiple, dtype=torch.float)]
                 )
         return wav
-
-    # Random sample a reference index from the same speaker
-    def sample_reference_index(self, speaker_id):
-        reference_pool = self.speaker_to_index_map[speaker_id]
-        reference_index = random.sample(reference_pool, 1)[0]
-        return reference_index
 
     def __getitem__(self, index):
         sample = self.data[index]
@@ -699,9 +689,8 @@ class TTSDataset(Dataset):
 
         reference_audio, reference_audio_length = None, None
         if ReferenceAudio in self.sup_data_types_set:
-            reference_index = self.sample_reference_index(sample["speaker_id"])
             reference_audio = self.featurizer.process(
-                self.data[reference_index]["audio_filepath"],
+                sample["audio_filepath"],
                 trim=self.trim,
                 trim_ref=self.trim_ref,
                 trim_top_db=self.trim_top_db,

--- a/nemo/collections/tts/modules/submodules.py
+++ b/nemo/collections/tts/modules/submodules.py
@@ -493,7 +493,7 @@ class ConditionalInput(torch.nn.Module):
     def forward(self, inputs, conditioning=None):
         """
         Args:
-            inputs (torch.tensor): B x T x C tensor.
+            inputs (torch.tensor): B x T x H tensor.
             conditioning (torch.tensor): B x 1 x C conditioning embedding.
         """
         if len(self.condition_types) > 0:

--- a/nemo/collections/tts/modules/submodules.py
+++ b/nemo/collections/tts/modules/submodules.py
@@ -510,7 +510,7 @@ class ConditionalInput(torch.nn.Module):
 
             if "concat" in self.condition_types:
                 conditioning = conditioning.repeat(1, inputs.shape[1], 1)
-                inputs = torch.cat([inputs, conditioning])
+                inputs = torch.cat([inputs, conditioning], dim=-1)
                 inputs = self.concat_proj(inputs)
 
         return inputs


### PR DESCRIPTION
# What does this PR do ?

1. Fix bug in `nemo.collections.tts.modules.submodules.ConditionalInput.forward()`
2. Fix implementation of Global Style Tokens in FastPitch

**Collection**: TTS

# Changelog 
- When using `ConditionalInput` in `"concat"` mode, concatenate `inputs` and `conditioning` along the _feature_ dimension, not the _batch_ dimension as before
  - Despite the misleading docstring in `ConditionalInput.forward()` (corrected in this PR), `inputs` and `conditioning` have shapes `B x T x H` and `B x T x C`, respectively (to be even more precise, `conditioning` has shape `B x 1 x C` _before_ the call to `conditioning.repeat()` and `B x T x C` _after_). Consequently, concatenating the two along the batch dimension has 2 problems:
    - If `H != C`, the concatenation will fail
    - If `H == C`, the concatenation results in a `2B x T x C` tensor
       - This causes an error downstream when calling `self.concat_proj()`, which is defined as:
`self.concat_proj = torch.nn.Linear(hidden_dim + condition_dim, hidden_dim)`
       - `self.concat_proj` is meant to map `B x T x (H+C)` tensors to `B x T x H` tensors, so passing a `2B x T x (H=C)` tensor to it results in the following error:
`RuntimeError: mat1 and mat2 shapes cannot be multiplied ((2B*T)x(H=C) and (H+C)xH)` (the actual error message contains constant values, but here I have extracted variables to make my point clearer)
  - **Solution**: concatenate along the feature dimension to obtain a `B x T x (H+C)` tensor
- Fix the implementation of GSTs in FastPitch, specifically regarding the selection of the _reference audio_ for a given training example
  - The current NeMo implementation selects the reference audio for a given training example as a random example from the same speaker. Note that this also forces the user to add `speaker_id` to `sup_data_types` even when they don't want to use speaker embeddings
  - However, the [GSTs paper](https://arxiv.org/abs/1803.09017) clearly states that:
    > During training, the reference signal is ground-truth audio.
  - While this is enough reason to justify amending the current NeMo implementation, I have expressed my thoughts on what selecting the reference audio at random may lead to in [this issue](https://github.com/NVIDIA/NeMo/issues/7420) I opened over a month ago (which went totally unnoticed)

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?
@blisc, @okuchaiev 

# Additional Information
* Related to #7420
* I have run tests, but some failed or errored out. None of the failed tests makes use of my changes though. See [test_short_summary.txt](https://github.com/NVIDIA/NeMo/files/13063436/test_short_summary.txt) for further details
