### PR TITLE
Fix error of exporting megatron-gpt-model

### DIFF
--- a/examples/nlp/language_modeling/megatron_export.py
+++ b/examples/nlp/language_modeling/megatron_export.py
@@ -102,7 +102,11 @@ def nemo_export(cfg):
                 pretrained_cfg.precision = trainer.precision
                 if trainer.precision == "16":
                     pretrained_cfg.megatron_amp_O2 = False
-            model = ModelPT.restore_from(
+                if "tokenizer" in pretrained_cfg and "model" in pretrained_cfg["tokenizer"]:
+                    pretrained_cfg.model_type = pretrained_cfg.tokenizer.model
+
+            model_cls = get_model_class(pretrained_cfg)
+            model = model_cls.restore_from(
                 restore_path=cfg.gpt_model_file,
                 trainer=trainer,
                 override_config_path=pretrained_cfg,


### PR DESCRIPTION
# What does this PR do ?
Use below steps to export Megatron GPT model:
1. Pull NeMo container [23.06](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo/tags)
2. Download megatron gpt model `wget https://huggingface.co/nvidia/nemo-megatron-gpt-1.3B/resolve/main/nemo_gpt1.3B_fp16.nemo`
3. Using command `python3 examples/nlp/language_modeling/megatron_export.py ++model_type=gpt ++onnx_model_file=nemo_gpt1.3B_fp16.onnx +gpt_model_file=nemo_gpt1.3B_fp16.nemo`

then it will report error:
```
Error executing job with overrides: ['++model_type=gpt', '++onnx_model_file=nemo_gpt1.3B_fp16.onnx', '+gpt_model_file=/mnt/robin.nemo']
Traceback (most recent call last):
  File "/workspace/nemo/examples/nlp/language_modeling/megatron_export.py", line 142, in nemo_export
    raise e
  File "/workspace/nemo/examples/nlp/language_modeling/megatron_export.py", line 105, in nemo_export
    model = ModelPT.restore_from(
  File "/usr/local/lib/python3.10/dist-packages/nemo/core/classes/modelPT.py", line 435, in restore_from
    instance = cls._save_restore_connector.restore_from(
  File "/usr/local/lib/python3.10/dist-packages/nemo/collections/nlp/parts/nlp_overrides.py", line 393, in restore_from
    loaded_params = super().load_config_and_state_dict(
  File "/usr/local/lib/python3.10/dist-packages/nemo/core/connectors/save_restore_connector.py", line 164, in load_config_and_state_dict
    instance = calling_cls.from_config_dict(config=conf, trainer=trainer)
  File "/usr/local/lib/python3.10/dist-packages/nemo/core/classes/common.py", line 507, in from_config_dict
    raise e
  File "/usr/local/lib/python3.10/dist-packages/nemo/core/classes/common.py", line 499, in from_config_dict
    instance = cls(cfg=config, trainer=trainer)
TypeError: Can't instantiate abstract class ModelPT with abstract methods list_available_models, setup_training_data, setup_validation_data
```
The configuration in `nemo_gpt1.3B_fp16.nemo` is:
```
{
  "micro_batch_size":3,
  "tensor_model_parallel_size":1,
  "encoder_seq_length":2048,
  "max_position_embeddings":2048,
  "num_layers":24,
  "hidden_size":2048,
  "ffn_hidden_size":3072,
  "num_attention_heads":16,
  "init_method_std":0.015,
  "hidden_dropout":0.1,
  "kv_channels":"None",
  "apply_query_key_layer_scaling":true,
  "layernorm_epsilon":1e-05,
  "make_vocab_size_divisible_by":128,
  "pre_process":true,
  "post_process":true,
  "tokenizer":{
    "library":"megatron",
    "type":"GPT2BPETokenizer",
    "model":"gpt",
    "vocab_file":"/artifacts/vocab.json",
    "merge_file":"/artifacts/merges.txt"
  },
  "native_amp_init_scale":4294967296,
  "native_amp_growth_interval":1000,
  "fp32_residual_connection":false,
  "fp16_lm_cross_entropy":false,
  "seed":1234,
  "use_cpu_initialization":false,
  "onnx_safe":false,
  "activations_checkpoint_method":"None",
  "activations_checkpoint_num_layers":1,
...
```
"ModelPT" has abstract functions so it can not be instantiated. Therefore the solution is reading "model" attribute from the configuration and checking it for the class before restoring the model from the file.

# Changelog 
- Fix error of exporting megatron-gpt-model.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

@XuesongYang @MaximumEntropy @ericharper @ekmb @yzhang123 @VahidooX @vladgets @okuchaiev

# Additional Information
* Related to #7673 
