### PR TITLE
ConditionalInput: cat along the feature dim, not the batch dim

### DIFF
--- a/nemo/collections/tts/modules/submodules.py
+++ b/nemo/collections/tts/modules/submodules.py
@@ -493,7 +493,7 @@ class ConditionalInput(torch.nn.Module):
     def forward(self, inputs, conditioning=None):
         """
         Args:
-            inputs (torch.tensor): B x T x C tensor.
+            inputs (torch.tensor): B x T x H tensor.
             conditioning (torch.tensor): B x 1 x C conditioning embedding.
         """
         if len(self.condition_types) > 0:
@@ -510,7 +510,7 @@ class ConditionalInput(torch.nn.Module):
 
             if "concat" in self.condition_types:
                 conditioning = conditioning.repeat(1, inputs.shape[1], 1)
-                inputs = torch.cat([inputs, conditioning])
+                inputs = torch.cat([inputs, conditioning], dim=-1)
                 inputs = self.concat_proj(inputs)
 
         return inputs


### PR DESCRIPTION
# What does this PR do ?

Fix bug in `nemo.collections.tts.modules.submodules.ConditionalInput.forward()`: concatenate `inputs` and `conditioning` along the _feature_ dimension, not the _batch_ dimension.

**Collection**: TTS

# Changelog 
- When using `ConditionalInput` in `"concat"` mode, concatenate `inputs` and `conditioning` along the _feature_ dimension, not the _batch_ dimension as before
  - Despite the misleading docstring in `ConditionalInput.forward()` (corrected in this PR), `inputs` and `conditioning` have shapes `B x T x H` and `B x T x C`, respectively (to be even more precise, `conditioning` has shape `B x 1 x C` _before_ the call to `conditioning.repeat()` and `B x T x C` _after_). Consequently, concatenating the two along the batch dimension has 2 problems:
    - If `H != C`, the concatenation will fail
    - If `H == C`, the concatenation results in a `2B x T x C` tensor
       - This causes an error downstream when calling `self.concat_proj()`, which is defined as:
`self.concat_proj = torch.nn.Linear(hidden_dim + condition_dim, hidden_dim)`
       - `self.concat_proj` is meant to map `B x T x (H+C)` tensors to `B x T x H` tensors, so passing a `2B x T x (H=C)` tensor to it results in the following error:
`RuntimeError: mat1 and mat2 shapes cannot be multiplied ((2B*T)x(H=C) and (H+C)xH)` (the actual error message contains constant values, but here I have extracted variables to make my point clearer)
  - **Solution**: concatenate along the feature dimension to obtain a `B x T x (H+C)` tensor

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation


## Who can review?
@subhankar-ghosh, @hsiehjackson

# Additional Information
* Related to #7777 
