### PR TITLE
Add selection criteria for reference audios in the `GlobalStyleToken` submodule

### DIFF
--- a/examples/tts/conf/fastpitch_align_44100_adapter.yaml
+++ b/examples/tts/conf/fastpitch_align_44100_adapter.yaml
@@ -31,6 +31,8 @@ window: hann
 phoneme_dict_path: "scripts/tts_dataset_files/cmudict-0.7b_nv22.10"
 heteronyms_path: "scripts/tts_dataset_files/heteronyms-052722"
 
+reference_audio_type: "same-speaker"
+
 model:
   unfreeze_aligner: false
   unfreeze_duration_predictor: false
@@ -136,6 +138,7 @@ model:
       pitch_mean: ${model.pitch_mean}
       pitch_std: ${model.pitch_std}
       use_beta_binomial_interpolator: true
+      reference_audio_type: ${reference_audio_type}
       
     dataloader_params:
       drop_last: false
@@ -168,6 +171,7 @@ model:
       pitch_mean: ${model.pitch_mean}
       pitch_std: ${model.pitch_std}
       use_beta_binomial_interpolator: true
+      reference_audio_type: ${reference_audio_type}
 
     dataloader_params:
       drop_last: false

--- a/examples/tts/conf/fastpitch_align_44100_adapter.yaml
+++ b/examples/tts/conf/fastpitch_align_44100_adapter.yaml
@@ -31,7 +31,7 @@ window: hann
 phoneme_dict_path: "scripts/tts_dataset_files/cmudict-0.7b_nv22.10"
 heteronyms_path: "scripts/tts_dataset_files/heteronyms-052722"
 
-reference_audio_type: "same-speaker"
+reference_audio_type: "same-speaker"  # options: ["same-speaker", "ground-truth"]
 
 model:
   unfreeze_aligner: false

--- a/examples/tts/conf/fastpitch_align_ipa_adapter.yaml
+++ b/examples/tts/conf/fastpitch_align_ipa_adapter.yaml
@@ -32,6 +32,8 @@ window: hann
 phoneme_dict_path: "scripts/tts_dataset_files/ipa_cmudict-0.7b_nv23.01.txt"
 heteronyms_path: "scripts/tts_dataset_files/heteronyms-052722"
 
+reference_audio_type: "same-speaker"
+
 model:
   unfreeze_aligner: false
   unfreeze_duration_predictor: false
@@ -141,6 +143,7 @@ model:
       pitch_mean: ${model.pitch_mean}
       pitch_std: ${model.pitch_std}
       use_beta_binomial_interpolator: true
+      reference_audio_type: ${reference_audio_type}
       
     dataloader_params:
       drop_last: false
@@ -173,6 +176,7 @@ model:
       pitch_mean: ${model.pitch_mean}
       pitch_std: ${model.pitch_std}
       use_beta_binomial_interpolator: true
+      reference_audio_type: ${reference_audio_type}
 
     dataloader_params:
       drop_last: false

--- a/examples/tts/conf/fastpitch_align_ipa_adapter.yaml
+++ b/examples/tts/conf/fastpitch_align_ipa_adapter.yaml
@@ -32,7 +32,7 @@ window: hann
 phoneme_dict_path: "scripts/tts_dataset_files/ipa_cmudict-0.7b_nv23.01.txt"
 heteronyms_path: "scripts/tts_dataset_files/heteronyms-052722"
 
-reference_audio_type: "same-speaker"
+reference_audio_type: "same-speaker"  # options: ["same-speaker", "ground-truth"]
 
 model:
   unfreeze_aligner: false

--- a/nemo/collections/tts/data/dataset.py
+++ b/nemo/collections/tts/data/dataset.py
@@ -494,7 +494,9 @@ class TTSDataset(Dataset):
             for i, d in enumerate(self.data):
                 speaker_to_index_map[d["speaker_id"]].add(i)
             # Random sample a reference audio from the same speaker
-            self.get_reference_for_sample = lambda sample: self.data[speaker_to_index_map[sample["speaker_id"]]]
+            self.get_reference_for_sample = (
+                lambda sample: self.data[random.sample(speaker_to_index_map[sample["speaker_id"]], 1)[0]]
+            )
         elif reference_audio_type == "ground-truth":
             # Use ground truth audio as reference audio
             self.get_reference_for_sample = lambda sample: sample

--- a/nemo/collections/tts/data/dataset.py
+++ b/nemo/collections/tts/data/dataset.py
@@ -177,6 +177,7 @@ class TTSDataset(Dataset):
             pitch_norm (Optional[bool]): Whether to normalize pitch or not. If True, requires providing either
                 pitch_stats_path or (pitch_mean and pitch_std).
             pitch_stats_path (Optional[Path, str]): Path to file containing speaker level pitch statistics.
+            reference_audio_type (Optional[str]): Criterion for the selection of reference audios for the GlobalStyleToken submodule. Currently, supported values are "ground-truth" (reference audio = ground truth audio, like in the original GST paper) and "same-speaker" (reference audio = random audio from the same speaker). Defaults to "same-speaker".
         """
         super().__init__()
 
@@ -485,11 +486,20 @@ class TTSDataset(Dataset):
         pass
 
     def add_reference_audio(self, **kwargs):
-        assert SpeakerID in self.sup_data_types, "Please add speaker_id in sup_data_types."
-        """Add a mapping for each speaker to their manifest indexes"""
-        self.speaker_to_index_map = defaultdict(set)
-        for i, d in enumerate(self.data):
-            self.speaker_to_index_map[d['speaker_id']].add(i)
+        reference_audio_type = kwargs.pop("reference_audio_type", "same-speaker")
+        if reference_audio_type == "same-speaker":
+            assert SpeakerID in self.sup_data_types, "Please add speaker_id in sup_data_types."
+            # Add a mapping for each speaker to their manifest indexes
+            speaker_to_index_map = defaultdict(set)
+            for i, d in enumerate(self.data):
+                speaker_to_index_map[d["speaker_id"]].add(i)
+            # Random sample a reference audio from the same speaker
+            self.get_reference_for_sample = lambda sample: self.data[speaker_to_index_map[sample["speaker_id"]]]
+        elif reference_audio_type == "ground-truth":
+            # Use ground truth audio as reference audio
+            self.get_reference_for_sample = lambda sample: sample
+        else:
+            raise NotImplementedError(f"Reference audio type \"{reference_audio_type}\" is not supported.")
 
     def get_spec(self, audio):
         with torch.cuda.amp.autocast(enabled=False):
@@ -529,12 +539,6 @@ class TTSDataset(Dataset):
                     [wav, torch.zeros(self.pad_multiple - wav.shape[0] % self.pad_multiple, dtype=torch.float)]
                 )
         return wav
-
-    # Random sample a reference index from the same speaker
-    def sample_reference_index(self, speaker_id):
-        reference_pool = self.speaker_to_index_map[speaker_id]
-        reference_index = random.sample(reference_pool, 1)[0]
-        return reference_index
 
     def __getitem__(self, index):
         sample = self.data[index]
@@ -699,9 +703,9 @@ class TTSDataset(Dataset):
 
         reference_audio, reference_audio_length = None, None
         if ReferenceAudio in self.sup_data_types_set:
-            reference_index = self.sample_reference_index(sample["speaker_id"])
+            reference = self.get_reference_for_sample(sample)
             reference_audio = self.featurizer.process(
-                self.data[reference_index]["audio_filepath"],
+                reference["audio_filepath"],
                 trim=self.trim,
                 trim_ref=self.trim_ref,
                 trim_top_db=self.trim_top_db,

--- a/nemo/collections/tts/data/dataset.py
+++ b/nemo/collections/tts/data/dataset.py
@@ -494,9 +494,9 @@ class TTSDataset(Dataset):
             for i, d in enumerate(self.data):
                 speaker_to_index_map[d["speaker_id"]].add(i)
             # Random sample a reference audio from the same speaker
-            self.get_reference_for_sample = (
-                lambda sample: self.data[random.sample(speaker_to_index_map[sample["speaker_id"]], 1)[0]]
-            )
+            self.get_reference_for_sample = lambda sample: self.data[
+                random.sample(speaker_to_index_map[sample["speaker_id"]], 1)[0]
+            ]
         elif reference_audio_type == "ground-truth":
             # Use ground truth audio as reference audio
             self.get_reference_for_sample = lambda sample: sample


### PR DESCRIPTION
# What does this PR do ?

- Allow specifying the criterion with which the _reference audio_ is selected for a given training/validation example

**Collection**: TTS

# Changelog 
- The current NeMo implementation selects the reference audio for a given training example as a random example from the same speaker. As discussed in #7777, this allows the GST module to extract speaker information, and _not_ speaking style information, from the reference spectrogram, thereby making it easier to fine-tune on new speakers with very little data
- On the other hand, the [GSTs paper](https://arxiv.org/abs/1803.09017) states that:
    > During training, the reference signal is ground-truth audio.
- As discussed in #7777, it is desirable to support both use cases as opposed to just one of the two

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation


## Who can review?
@subhankar-ghosh, @hsiehjackson


# Additional Information
* Related to #7777
