### PR TITLE
Provides CPU fallback for `getKneighborsConnections` avoiding OOM

### DIFF
--- a/nemo/collections/asr/parts/utils/offline_clustering.py
+++ b/nemo/collections/asr/parts/utils/offline_clustering.py
@@ -307,10 +307,7 @@ def isGraphFullyConnected(affinity_mat: torch.Tensor, device: torch.device) -> t
 
 
 def getKneighborsConnections(
-    affinity_mat: torch.Tensor,
-    p_value: int,
-    mask_method: str = 'binary',
-    max_dim_on_gpu: int = -1,
+    affinity_mat: torch.Tensor, p_value: int, mask_method: str = 'binary', max_dim_on_gpu: int = -1,
 ) -> torch.Tensor:
     """
     Binarize top-p values for each row from the given affinity matrix.


### PR DESCRIPTION
# What does this PR do ?

Provide a fallback to CPU for `getKneighborsConnections` preventing OOM when applying to large cluster of embeddings (i.e when applying diarization to a long audio with multiple speakers).

**Collection**: ASR

# Changelog 
- `getKneighborsConnections` now takes an optional argument `max_dim_on_gpu` that trigger a fallback to CPU when one of the dim is higher than `max_dim_on_gpu`.

# Usage

We were encountering OOMs when applying diarization to a longer audio (2h+) with multiple speakers. It appears that `getKneighborsConnections` double the VRAM needed to store the embedding when applying `binarized_affinity_mat = torch.zeros_like(affinity_mat).half()` as it use the same device as for `affinity_mat`.

This PR reduced the VRAM used when applying diarization on this same audio from 41Go (32 + 9Go) to 29Go by increase the inference time by only one seconde.

In order to allow user to use this param we either should add a kwargs to `getKneighborsConnections` (and all the function that called it) or use a more global param that's automatically propagated (i.e env var). As this choice need some thought on your side I prefer to only add `max_dim_on_gpu` to `getKneighborsConnections` for now and let you decide how to proceed (unless you already have some suggestion). 

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] ~~Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)~~
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

