### PR TITLE
[Fix] Save best NeMo model only when necessary

### DIFF
--- a/nemo/utils/callbacks/nemo_model_checkpoint.py
+++ b/nemo/utils/callbacks/nemo_model_checkpoint.py
@@ -161,9 +161,10 @@ class NeMoModelCheckpoint(ModelCheckpoint):
                 return
 
             if self.best_model_path == self.previous_best_path:
+                logging.debug('Best model has not changed, skipping save.')
                 return output
 
-            self.previous_model_path = self.best_model_path
+            self.previous_best_path = self.best_model_path
             old_state_dict = deepcopy(pl_module.state_dict())
             checkpoint = torch.load(maybe_injected_best_model_path, map_location='cpu')
             if 'state_dict' in checkpoint:


### PR DESCRIPTION
# What does this PR do ?

Currently, when using `save_best_model`, the best model will be saved every time, even when it is not necessary to update it.
This fix ensures NeMo checkpoints are saved only when necessary.

**Collection**: Core

# Changelog 
- Fix member name when updating `previous_best_path`
- Added a debug log when saving is skipped when previous best is the same as the current best

# Usage
N/A

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
