### PR TITLE
add guard if its a distributed checkpoint

### DIFF
--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -624,6 +624,10 @@ def ckpt_to_dir(filepath: Union[str, Path]) -> Path:
 
     filepath = Path(filepath)
 
+    # if it is already a distributed checkpoint, then return
+    if filepath.suffix != ".ckpt" and filepath.is_dir():
+        return filepath
+
     # adding this assert because we will later remove directories based on the return value of this method
     assert filepath.suffix == ".ckpt", f'filepath: {filepath} must have .ckpt extension'
 


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

adds guard in case we pick up a distributed checkpoint

# Changelog 
- Add specific line by line info of high level changes in this PR.

Fix issue when resuming topk from distributed checkpoint, the logic will [look](https://github.com/NVIDIA/NeMo/blob/8c061debd05837148e86fac19abf024e7210c35d/nemo/utils/callbacks/nemo_model_checkpoint.py#L92) for topk checkpoints and then delete them.

However, the [_saved_checkpoint_paths](https://github.com/NVIDIA/NeMo/blob/8c061debd05837148e86fac19abf024e7210c35d/nemo/utils/callbacks/nemo_model_checkpoint.py#L92C50-L92C73) returns paths without the .ckpt prefix as they are distributed formats, yet the code still calls [ckpt_to_dir](https://github.com/NVIDIA/NeMo/blob/8c061debd05837148e86fac19abf024e7210c35d/nemo/utils/callbacks/nemo_model_checkpoint.py#L226) which crashes since there is no .ckpt prefix on distributed checkpoints. This PR adds a guard to make sure if we see a distributed checkpoint we just return.

  
**PR Type**:
- [x] Bugfix


When resuming from topk with distributed checkpoint 