### PR TITLE
Tar codec

### DIFF
--- a/nemo/collections/asr/data/audio_to_label.py
+++ b/nemo/collections/asr/data/audio_to_label.py
@@ -566,7 +566,6 @@ class _TarredAudioLabelDataset(IterableDataset):
             world_size=world_size,
             global_rank=global_rank,
         )
-        print("world_size", world_size)
         # Put together WebDataset
         self._dataset = wd.WebDataset(urls=audio_tar_filepaths, nodesplitter=None)
 

--- a/nemo/collections/asr/data/audio_to_label.py
+++ b/nemo/collections/asr/data/audio_to_label.py
@@ -566,6 +566,7 @@ class _TarredAudioLabelDataset(IterableDataset):
             world_size=world_size,
             global_rank=global_rank,
         )
+        print("world_size", world_size)
         # Put together WebDataset
         self._dataset = wd.WebDataset(urls=audio_tar_filepaths, nodesplitter=None)
 

--- a/nemo/collections/tts/data/vocoder_dataset.py
+++ b/nemo/collections/tts/data/vocoder_dataset.py
@@ -218,7 +218,7 @@ class VocoderDataset(Dataset):
 
 class TarredVocoderDataset(IterableDataset):
     """
-    A similar Dataset to the VocoderDataset, but which loads tarred audio files.
+    A similar Dataset to the VocoderDataset, but loads tarred audio files.
 
     Accepts a single comma-separated JSON manifest file (in the same style as for the VocoderDataset),
     as well as the path(s) to the tarball(s) containing the wav files. Each line of the manifest should
@@ -280,7 +280,6 @@ class TarredVocoderDataset(IterableDataset):
 
     def __init__(
         self,
-        *,
         dataset_meta: Dict,
         sample_rate: int = 24000,
         n_samples: Optional[int] = None,
@@ -295,6 +294,11 @@ class TarredVocoderDataset(IterableDataset):
         **kwargs,
     ):
         super().__init__()
+
+        if len(kwargs) > 0:
+            logging.warning(
+                f"Arguments {kwargs.keys()} does not support for TarredVocoderDataset, they will be ignored."
+            )
 
         self.sample_rate = sample_rate
         self.n_samples = n_samples

--- a/nemo/collections/tts/data/vocoder_dataset.py
+++ b/nemo/collections/tts/data/vocoder_dataset.py
@@ -25,8 +25,6 @@ import webdataset as wd
 from nemo.collections.asr.data.audio_to_text import cache_datastore_manifests, expand_sharded_filepaths
 from nemo.collections.asr.parts.preprocessing.segment import available_formats as valid_sf_formats
 from nemo.collections.asr.parts.utils.manifest_utils import read_manifest
-from nemo.collections.asr.parts.preprocessing.segment import available_formats as valid_sf_formats
-from nemo.collections.asr.parts.utils.manifest_utils import read_manifest
 from nemo.collections.tts.parts.preprocessing.feature_processors import FeatureProcessor
 from nemo.collections.tts.parts.utils.tts_dataset_utils import (
     filter_dataset_by_duration,
@@ -82,6 +80,7 @@ def audio_collate_fn(batch: List[dict]):
     }
 
     return batch_dict
+
 
 def audio_collate_fn(batch: List[dict]):
     dataset_name_list = []

--- a/nemo/collections/tts/data/vocoder_dataset.py
+++ b/nemo/collections/tts/data/vocoder_dataset.py
@@ -12,12 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import io
+import os
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
+import soundfile as sf
 import torch.utils.data
+import webdataset as wd
 
+from nemo.collections.asr.data.audio_to_text import cache_datastore_manifests, expand_sharded_filepaths
+from nemo.collections.asr.parts.preprocessing.segment import available_formats as valid_sf_formats
+from nemo.collections.asr.parts.utils.manifest_utils import read_manifest
+from nemo.collections.asr.parts.preprocessing.segment import available_formats as valid_sf_formats
 from nemo.collections.asr.parts.utils.manifest_utils import read_manifest
 from nemo.collections.tts.parts.preprocessing.feature_processors import FeatureProcessor
 from nemo.collections.tts.parts.utils.tts_dataset_utils import (
@@ -27,9 +35,11 @@ from nemo.collections.tts.parts.utils.tts_dataset_utils import (
     sample_audio,
     stack_tensors,
 )
-from nemo.core.classes import Dataset
+from nemo.core.classes import Dataset, IterableDataset
 from nemo.utils import logging
 from nemo.utils.decorators import experimental
+
+VALID_FILE_FORMATS = ';'.join(['wav', 'mp3', 'flac'] + [fmt.lower() for fmt in valid_sf_formats.keys()])
 
 
 @dataclass
@@ -37,6 +47,7 @@ class DatasetMeta:
     manifest_path: Path
     audio_dir: Path
     sample_weight: float = 1.0
+    audio_tar_filepaths: Optional[List[str]] = None
 
 
 @dataclass
@@ -44,6 +55,59 @@ class DatasetSample:
     dataset_name: str
     manifest_entry: dict
     audio_dir: Path
+
+
+def audio_collate_fn(batch: List[dict]):
+    dataset_name_list = []
+    audio_filepath_list = []
+    audio_list = []
+    audio_len_list = []
+
+    for example in batch:
+        dataset_name_list.append(example["dataset_name"])
+        audio_filepath_list.append(example["audio_filepath"])
+        audio_list.append(example["audio"])
+        audio_len_list.append(example["audio_len"])
+
+    batch_audio_len = torch.IntTensor(audio_len_list)
+    audio_max_len = int(batch_audio_len.max().item())
+
+    batch_audio = stack_tensors(audio_list, max_lens=[audio_max_len])
+
+    batch_dict = {
+        "dataset_names": dataset_name_list,
+        "audio_filepaths": audio_filepath_list,
+        "audio": batch_audio,
+        "audio_lens": batch_audio_len,
+    }
+
+    return batch_dict
+
+def audio_collate_fn(batch: List[dict]):
+    dataset_name_list = []
+    audio_filepath_list = []
+    audio_list = []
+    audio_len_list = []
+
+    for example in batch:
+        dataset_name_list.append(example["dataset_name"])
+        audio_filepath_list.append(example["audio_filepath"])
+        audio_list.append(example["audio"])
+        audio_len_list.append(example["audio_len"])
+
+    batch_audio_len = torch.IntTensor(audio_len_list)
+    audio_max_len = int(batch_audio_len.max().item())
+
+    batch_audio = stack_tensors(audio_list, max_lens=[audio_max_len])
+
+    batch_dict = {
+        "dataset_names": dataset_name_list,
+        "audio_filepaths": audio_filepath_list,
+        "audio": batch_audio,
+        "audio_lens": batch_audio_len,
+    }
+
+    return batch_dict
 
 
 @experimental
@@ -175,28 +239,294 @@ class VocoderDataset(Dataset):
 
         return example
 
-    def collate_fn(self, batch: List[dict]):
-        dataset_name_list = []
-        audio_filepath_list = []
-        audio_list = []
-        audio_len_list = []
+    def collate_fn(self, batch):
+        return audio_collate_fn(batch)
 
-        for example in batch:
-            dataset_name_list.append(example["dataset_name"])
-            audio_filepath_list.append(example["audio_filepath"])
-            audio_list.append(example["audio"])
-            audio_len_list.append(example["audio_len"])
 
-        batch_audio_len = torch.IntTensor(audio_len_list)
-        audio_max_len = int(batch_audio_len.max().item())
+class _TarredVocoderDataset(IterableDataset):
+    """
+    A similar Dataset to the AudioToMultiLabelDataset, but which loads tarred audio files.
 
-        batch_audio = stack_tensors(audio_list, max_lens=[audio_max_len])
+    Accepts a single comma-separated JSON manifest file (in the same style as for the AudioToSpeechLabelDataset),
+    as well as the path(s) to the tarball(s) containing the wav files. Each line of the manifest should
+    contain the information for one audio file, including at least the transcript and name of the audio
+    file within the tarball.
 
-        batch_dict = {
-            "dataset_names": dataset_name_list,
-            "audio_filepaths": audio_filepath_list,
-            "audio": batch_audio,
-            "audio_lens": batch_audio_len,
+    Valid formats for the audio_tar_filepaths argument include:
+    (1) a single string that can be brace-expanded, e.g. 'path/to/audio.tar' or 'path/to/audio_{1..100}.tar.gz', or
+    (2) a list of file paths that will not be brace-expanded, e.g. ['audio_1.tar', 'audio_2.tar', ...].
+
+    See the WebDataset documentation for more information about accepted data and input formats.
+
+    If using multiple processes the number of shards should be divisible by the number of workers to ensure an
+    even split among workers. If it is not divisible, logging will give a warning but training will proceed.
+    In addition, if using mutiprocessing, each shard MUST HAVE THE SAME NUMBER OF ENTRIES after filtering
+    is applied. We currently do not check for this, but your program may hang if the shards are uneven!
+
+    Notice that a few arguments are different from the AudioToBPEDataset; for example, shuffle (bool) has been
+    replaced by shuffle_n (int).
+
+    Additionally, please note that the len() of this DataLayer is assumed to be the length of the manifest
+    after filtering. An incorrect manifest length may lead to some DataLoader issues down the line.
+
+    Args:
+        audio_tar_filepaths: Either a list of audio tarball filepaths, or a
+            string (can be brace-expandable).
+        manifest_filepath (str): Path to the manifest.
+        shuffle_n (int): How many samples to look ahead and load to be shuffled.
+            See WebDataset documentation for more details.
+            Defaults to 0.
+        min_duration (float): Dataset parameter.
+            All training files which have a duration less than min_duration
+            are dropped. Note: Duration is read from the manifest JSON.
+            Defaults to 0.1.
+        max_duration (float): Dataset parameter.
+            All training files which have a duration more than max_duration
+            are dropped. Note: Duration is read from the manifest JSON.
+            Defaults to None.
+        trim(bool): Whether to use trim silence from beginning and end
+            of audio signal using librosa.effects.trim().
+            Defaults to False.
+        window_length_in_sec (float): time length of window/slice (in seconds) # Pass this only for speaker recognition and VAD task
+        shift_length_in_sec (float): amount of shift of window for generating the frame for VAD task. in a batch # Pass this only for VAD task during inference.
+        normalize_audio (bool): Whether to normalize audio signal. Defaults to False.
+        shard_strategy (str): Tarred dataset shard distribution strategy chosen as a str value during ddp.
+            -   `scatter`: The default shard strategy applied by WebDataset, where each node gets
+                a unique set of shards, which are permanently pre-allocated and never changed at runtime.
+            -   `replicate`: Optional shard strategy, where each node gets all of the set of shards
+                available in the tarred dataset, which are permanently pre-allocated and never changed at runtime.
+                The benefit of replication is that it allows each node to sample data points from the entire
+                dataset independently of other nodes, and reduces dependence on value of `shuffle_n`.
+
+                .. warning::
+                    Replicated strategy allows every node to sample the entire set of available tarfiles,
+                    and therefore more than one node may sample the same tarfile, and even sample the same
+                    data points! As such, there is no assured guarantee that all samples in the dataset will be
+                    sampled at least once during 1 epoch. Scattered strategy, on the other hand, on specific
+                    occasions (when the number of shards is not divisible with ``world_size``), will not sample
+                    the entire dataset. For these reasons it is not advisable to use tarred datasets as validation
+                    or test datasets.
+        global_rank (int): Worker rank, used for partitioning shards. Defaults to 0.
+        world_size (int): Total number of processes, used for partitioning shards. Defaults to 0.
+        delimiter (Optional[str]): Delimiter to use when splitting the label string, default to None.
+        normalize_audio_db (Optional[float]):  normalize audio signal to a target db, default to None.
+    """
+
+    def collate_fn(self, batch):
+        return audio_collate_fn(batch)
+
+
+class _TarredVocoderDataset(IterableDataset):
+    """
+    A similar Dataset to the VocoderDataset, but which loads tarred audio files.
+
+    Accepts a single comma-separated JSON manifest file (in the same style as for the VocoderDataset),
+    as well as the path(s) to the tarball(s) containing the wav files. Each line of the manifest should
+    contain the information for one audio file, and duration of audio.
+
+    Valid formats for the audio_tar_filepaths argument include:
+    (1) a single string that can be brace-expanded, e.g. 'path/to/audio.tar' or 'path/to/audio_{1..100}.tar.gz', or
+    (2) a list of file paths that will not be brace-expanded, e.g. ['audio_1.tar', 'audio_2.tar', ...].
+
+    See the WebDataset documentation for more information about accepted data and input formats.
+
+    If using multiple processes the number of shards should be divisible by the number of workers to ensure an
+    even split among workers. If it is not divisible, logging will give a warning but training will proceed.
+    In addition, if using mutiprocessing, each shard MUST HAVE THE SAME NUMBER OF ENTRIES after filtering
+    is applied. We currently do not check for this, but your program may hang if the shards are uneven!
+
+    Notice that a few arguments are different from the AudioToBPEDataset; for example, shuffle (bool) has been
+    replaced by shuffle_n (int).
+
+    Additionally, please note that the len() of this DataLayer is assumed to be the length of the manifest
+    after filtering. An incorrect manifest length may lead to some DataLoader issues down the line.
+
+    Args:
+        audio_tar_filepaths: Either a list of audio tarball filepaths, or a
+            string (can be brace-expandable).
+        dataset_meta: Dict of dataset names (string) to dataset metadata.
+        sample_rate: Sample rate to load audio as. If the audio is stored at a different sample rate, then it will
+            be resampled.
+        n_samples: Optional int, if provided then n_samples samples will be randomly sampled from the full
+            audio file.
+        feature_processors: Optional, list of feature processors to run on training examples.
+        min_duration: Optional float, if provided audio files in the training manifest shorter than 'min_duration'
+            will be ignored.
+        max_duration: Optional float, if provided audio files in the training manifest longer than 'max_duration'
+            will be ignored.
+        trunc_duration: Optional int, if provided audio will be truncated to at most 'trunc_duration' seconds.
+        volume_norm: Whether to apply volume normalization to loaded audio.
+        shuffle_n (int): How many samples to look ahead and load to be shuffled.
+            See WebDataset documentation for more details.
+            Defaults to 0.
+        window_length_in_sec (float): time length of window/slice (in seconds) # Pass this only for speaker recognition and VAD task
+        shift_length_in_sec (float): amount of shift of window for generating the frame for VAD task. in a batch # Pass this only for VAD task during inference.
+        normalize_audio (bool): Whether to normalize audio signal. Defaults to False.
+        shard_strategy (str): Tarred dataset shard distribution strategy chosen as a str value during ddp.
+            -   `scatter`: The default shard strategy applied by WebDataset, where each node gets
+                a unique set of shards, which are permanently pre-allocated and never changed at runtime.
+            -   `replicate`: Optional shard strategy, where each node gets all of the set of shards
+                available in the tarred dataset, which are permanently pre-allocated and never changed at runtime.
+                The benefit of replication is that it allows each node to sample data points from the entire
+                dataset independently of other nodes, and reduces dependence on value of `shuffle_n`.
+
+                .. warning::
+                    Replicated strategy allows every node to sample the entire set of available tarfiles,
+                    and therefore more than one node may sample the same tarfile, and even sample the same
+                    data points! As such, there is no assured guarantee that all samples in the dataset will be
+                    sampled at least once during 1 epoch. Scattered strategy, on the other hand, on specific
+                    occasions (when the number of shards is not divisible with ``world_size``), will not sample
+                    the entire dataset. For these reasons it is not advisable to use tarred datasets as validation
+                    or test datasets.
+        global_rank (int): Worker rank, used for partitioning shards. Defaults to 0.
+        world_size (int): Total number of processes, used for partitioning shards. Defaults to 0.
+        delimiter (Optional[str]): Delimiter to use when splitting the label string, default to None.
+        normalize_audio_db (Optional[float]):  normalize audio signal to a target db, default to None.
+    """
+
+    def __init__(
+        self,
+        *,
+        dataset_meta: Dict,
+        sample_rate: int,
+        n_samples: Optional[int] = None,
+        shuffle_n: int = 0,
+        min_duration: float = 0.1,
+        max_duration: Optional[float] = None,
+        trunc_duration: Optional[float] = None,
+        feature_processors: Optional[Dict[str, FeatureProcessor]] = None,
+        num_audio_retries: int = 5,
+        shard_strategy: str = "scatter",
+        global_rank: int = 0,
+        world_size: int = 2,
+    ):
+        super().__init__()
+        self.sample_rate = sample_rate
+        self.n_samples = n_samples
+        self.num_audio_retries = num_audio_retries
+        self.load_precomputed_mel = False
+
+        if trunc_duration:
+            self.trunc_samples = int(trunc_duration * self.sample_rate)
+        else:
+            self.trunc_samples = None
+
+        if feature_processors:
+            logging.info(f"Found feature processors {feature_processors.keys()}")
+            self.feature_processors = list(feature_processors.values())
+        else:
+            self.feature_processors = []
+
+        self.data_samples = []
+        self.sample_weights = []
+        self.audio_tar_filepaths = []
+        for dataset_name, dataset_info in dataset_meta.items():
+            audio_tar_filepaths = dataset_info['audio_tar_filepaths']
+            self.audio_tar_filepaths += audio_tar_filepaths
+            dataset = DatasetMeta(**dataset_info)
+            samples, weights = VocoderDataset._preprocess_manifest(
+                dataset_name=dataset_name, dataset=dataset, min_duration=min_duration, max_duration=max_duration,
+            )
+            self.data_samples += samples
+            self.sample_weights += weights
+        self.mapping = {}
+        for idx, sample in enumerate(self.data_samples):
+            file_id = os.path.splitext(os.path.basename(sample.manifest_entry["audio_filepath"]))[0]
+            if file_id not in self.mapping:
+                self.mapping[file_id] = sample
+            else:
+                raise ValueError(
+                    f"Duplicate file_id {file_id} found in manifest {sample.manifest_entry['audio_filepath']}"
+                )
+
+        logging.info(f"world size: {world_size}")
+        audio_tar_filepaths = expand_sharded_filepaths(
+            sharded_filepaths=audio_tar_filepaths,
+            global_rank=global_rank,
+            world_size=world_size,
+            shard_strategy=shard_strategy,
+        )
+
+        self._dataset = wd.WebDataset(audio_tar_filepaths, nodesplitter=None)
+
+        if shuffle_n > 0:
+            self._dataset = self._dataset.shuffle(shuffle_n)
+        else:
+            logging.info("WebDataset will not shuffle data. Consider setting shuffle_n > 0.")
+
+        self._dataset = (
+            self._dataset.rename(audio=VALID_FILE_FORMATS, key='__key__')
+            .to_tuple('audio', 'key')
+            .pipe(self._filter)
+            .map(f=self._build_sample)
+        )
+
+    def _filter(self, iterator):
+        class FilteredIterator:
+            def __init__(self, mapping):
+                self.iterator = iterator
+                self.mapping = mapping
+
+            def __iter__(self):
+                return self
+
+            def __next__(self):
+                while True:
+                    audio_bytes, audio_filename = next(self.iterator)
+                    file_id = os.path.splitext(os.path.basename(audio_filename))[0]
+                    if file_id in self.mapping:
+                        return audio_bytes, audio_filename
+
+        return FilteredIterator(self.mapping)
+
+    def _build_sample(self, tup):
+        audio_bytes, audio_filename = tup
+        file_id = os.path.splitext(os.path.basename(audio_filename))[0]
+        data = self.mapping[file_id]
+
+        audio_array, _ = sf.read(file=io.BytesIO(audio_bytes), dtype='float32')
+        audio_array = torch.from_numpy(audio_array)
+        if self.n_samples:
+            len_audio = audio_array.shape[0]
+            if len_audio > self.n_samples:
+                start = torch.randint(0, len_audio - self.n_samples, (1,))
+                audio_array = audio_array[start : start + self.n_samples]
+            else:
+                audio_array = audio_array[: self.n_samples]
+
+        if self.trunc_samples:
+            audio_array = audio_array[: self.trunc_samples]
+
+        audio_len = torch.tensor(audio_array.shape[0])
+
+        example = {
+            "dataset_name": data.dataset_name,
+            "audio_filepath": audio_filename,
+            "audio": audio_array,
+            "audio_len": audio_len,
         }
 
-        return batch_dict
+        for processor in self.feature_processors:
+            processor.process(example)
+
+        return example
+
+    def collate_fn(self, batch):
+        return audio_collate_fn(batch)
+
+    def __iter__(self):
+        return self._dataset.__iter__()
+
+    def __len__(self):
+        return len(self.mapping)
+
+    def __iter__(self):
+        return self._dataset.__iter__()
+
+    def __len__(self):
+        return len(self.mapping)
+
+
+class TarredVocoderDataset(_TarredVocoderDataset):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)

--- a/nemo/collections/tts/data/vocoder_dataset.py
+++ b/nemo/collections/tts/data/vocoder_dataset.py
@@ -235,29 +235,26 @@ class TarredVocoderDataset(IterableDataset):
     In addition, if using mutiprocessing, each shard MUST HAVE THE SAME NUMBER OF ENTRIES after filtering
     is applied. We currently do not check for this, but your program may hang if the shards are uneven!
 
-    Notice that a few arguments are different from the AudioToBPEDataset; for example, shuffle (bool) has been
-    replaced by shuffle_n (int).
-
     Additionally, please note that the len() of this DataLayer is assumed to be the length of the manifest
     after filtering. An incorrect manifest length may lead to some DataLoader issues down the line.
 
-    Args:
+    Args:        
+        dataset_meta: Dict of dataset names (string) to dataset metadata.
         audio_tar_filepaths: Either a list of audio tarball filepaths, or a
             string (can be brace-expandable).
-        dataset_meta: Dict of dataset names (string) to dataset metadata.
         sample_rate: Sample rate to load audio as. If the audio is stored at a different sample rate, then it will
             be resampled.
         n_samples: Optional int, if provided then n_samples samples will be randomly sampled from the full
             audio file.
-        feature_processors: Optional, list of feature processors to run on training examples.
+        shuffle_n (int): How many samples to look ahead and load to be shuffled.
+            See WebDataset documentation for more details.
+            Defaults to 0.
         min_duration: Optional float, if provided audio files in the training manifest shorter than 'min_duration'
             will be ignored.
         max_duration: Optional float, if provided audio files in the training manifest longer than 'max_duration'
             will be ignored.
         trunc_duration: Optional int, if provided audio will be truncated to at most 'trunc_duration' seconds.
-        shuffle_n (int): How many samples to look ahead and load to be shuffled.
-            See WebDataset documentation for more details.
-            Defaults to 0.
+        feature_processors: Optional, list of feature processors to run on training examples.
         shard_strategy (str): Tarred dataset shard distribution strategy chosen as a str value during ddp.
             -   `scatter`: The default shard strategy applied by WebDataset, where each node gets
                 a unique set of shards, which are permanently pre-allocated and never changed at runtime.

--- a/nemo/collections/tts/data/vocoder_dataset.py
+++ b/nemo/collections/tts/data/vocoder_dataset.py
@@ -132,7 +132,7 @@ class VocoderDataset(Dataset):
     def __init__(
         self,
         dataset_meta: Dict,
-        sample_rate: int = 24000,
+        sample_rate: int,
         n_samples: Optional[int] = None,
         weighted_sampling_steps_per_epoch: Optional[int] = None,
         feature_processors: Optional[Dict[str, FeatureProcessor]] = None,
@@ -278,7 +278,7 @@ class TarredVocoderDataset(IterableDataset):
     def __init__(
         self,
         dataset_meta: Dict,
-        sample_rate: int = 24000,
+        sample_rate: int,
         n_samples: Optional[int] = None,
         shuffle_n: int = 0,
         min_duration: float = 0.1,
@@ -343,7 +343,7 @@ class TarredVocoderDataset(IterableDataset):
         self._dataset = wd.WebDataset(audio_tar_filepaths, nodesplitter=None)
 
         if shuffle_n > 0:
-            self._dataset = self._dataset.shuffle(shuffle_n)
+            self._dataset = self._dataset.shuffle(shuffle_n, initial=shuffle_n)
         else:
             logging.info("WebDataset will not shuffle data. Consider setting shuffle_n > 0.")
 

--- a/nemo/collections/tts/models/audio_codec.py
+++ b/nemo/collections/tts/models/audio_codec.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import itertools
+from math import ceil
 from pathlib import Path
 from typing import List, Tuple
 
@@ -48,6 +49,9 @@ class AudioCodecModel(ModelPT):
         # Convert to Hydra 1.0 compatible DictConfig
         cfg = model_utils.convert_model_config_to_dict_config(cfg)
         cfg = model_utils.maybe_update_config_version(cfg)
+        self.world_size = 1
+        if trainer is not None:
+            self.world_size = trainer.num_nodes * trainer.num_devices
 
         super().__init__(cfg=cfg, trainer=trainer)
 
@@ -474,9 +478,25 @@ class AudioCodecModel(ModelPT):
         self.log_dict(metrics, on_epoch=True, sync_dist=True)
 
     @staticmethod
+    def get_dataset(cfg):
+        if 'is_sharded' in cfg.dataset:
+            is_sharded = cfg.dataset.is_sharded
+            del cfg.dataset.is_sharded
+        else:
+            is_sharded = False
+
+        if is_sharded:
+            cfg.dataset._target_ = 'nemo.collections.tts.data.vocoder_dataset.TarredVocoderDataset'
+            dataset = instantiate(cfg.dataset)
+            sampler = None
+        else:
+            dataset = instantiate(cfg.dataset)
+            sampler = dataset.get_sampler(cfg.dataloader_params.batch_size)
+        return dataset, sampler
+
+    @staticmethod
     def _setup_train_dataloader(cfg):
-        dataset = instantiate(cfg.dataset)
-        sampler = dataset.get_sampler(cfg.dataloader_params.batch_size)
+        dataset, sampler = AudioCodecModel.get_dataset(cfg)
         data_loader = torch.utils.data.DataLoader(
             dataset, collate_fn=dataset.collate_fn, sampler=sampler, **cfg.dataloader_params
         )
@@ -490,6 +510,28 @@ class AudioCodecModel(ModelPT):
 
     def setup_training_data(self, cfg):
         self._train_dl = self._setup_train_dataloader(cfg)
+        batch_size = cfg['dataloader_params']['batch_size']
+        # Need to set this because if using an IterableDataset, the length of the dataloader is the total number
+        # of samples rather than the number of batches, and this messes up the tqdm progress bar.
+        # So we set the number of steps manually (to the correct number) to fix this.
+        if (
+            self._train_dl is not None
+            and hasattr(self._train_dl, 'dataset')
+            and isinstance(self._train_dl.dataset, torch.utils.data.IterableDataset)
+        ):
+            # We also need to check if limit_train_batches is already set.
+            # If it's an int, we assume that the user has set it to something sane, i.e. <= # training batches,
+            # and don't change it. Otherwise, adjust batches accordingly if it's a float (including 1.0).
+            if self._trainer is not None and isinstance(self._trainer.limit_train_batches, float):
+                self._trainer.limit_train_batches = int(
+                    self._trainer.limit_train_batches
+                    * ceil((len(self._train_dl.dataset) / self.world_size) / batch_size)
+                )
+            elif self._trainer is None:
+                logging.warning(
+                    "Model Trainer was not set before constructing the dataset, incorrect number of "
+                    "training batches will be used. Please set the trainer and rebuild the dataset."
+                )
 
     def setup_validation_data(self, cfg):
         self._validation_dl = self._setup_test_dataloader(cfg)
@@ -507,7 +549,6 @@ class AudioCodecModel(ModelPT):
 
         if "steps_per_epoch" in self._cfg:
             return self._cfg.max_epochs * self._cfg.steps_per_epoch
-
         return compute_max_steps(
             max_epochs=self._cfg.max_epochs,
             accumulate_grad_batches=self.trainer.accumulate_grad_batches,

--- a/nemo/collections/tts/models/audio_codec.py
+++ b/nemo/collections/tts/models/audio_codec.py
@@ -24,7 +24,6 @@ from hydra.utils import instantiate
 from omegaconf import DictConfig, OmegaConf, open_dict
 from pytorch_lightning import Trainer
 
-from nemo.collections.tts.data.vocoder_dataset import TarredVocoderDataset, VocoderDataset
 from nemo.collections.tts.losses.audio_codec_loss import (
     MultiResolutionMelLoss,
     MultiResolutionSTFTLoss,


### PR DESCRIPTION
Add webdataset support for VocoderDataset

**Collection**: TTS

# Changelog
- Add TarredVocderDataset class for dataset fetching
- sampler is not supported with IterableDataset
- added a conditional code to calculate correct number of max steps when webdataset is used

Known issue:
- Haven;t tested for passing multiple tarred datasets. Will be pushing a PR later to support it. 

# Usage
* add `is_sharded=True`  in cfg for train_ds to load webdataset

# Before your PR is Ready for review
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation