### PR TITLE
Add support for non-FP32 distributed optimizer state

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -493,7 +493,9 @@ class MegatronBaseModel(NLPModel):
             optim_kwargs['param_sync_dtype'] = model_dtype
 
             # Determine whether to store master params in optimizer
-            if optim_dtype == model_dtype:
+            if self.cfg.get('fp8_params', False):
+                optim_kwargs['store_params'] = True
+            elif optim_dtype == model_dtype:
                 optim_kwargs['store_params'] = False
             elif optim_dtype == torch.float32 and model_dtype == torch.bfloat16:
                 optim_kwargs['store_params'] = False

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -39,7 +39,7 @@ from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenize
 from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.parts.nlp_overrides import NEMO_MEGATRON_MODEL_PARALLEL_APPSTATE_OVERRIDE, GradScaler
 from nemo.core.optim import MainParamsOptimizerWrapper, prepare_lr_scheduler
-from nemo.utils import AppState, logging
+from nemo.utils import AppState, logging, str_to_dtype
 from nemo.utils.get_rank import is_global_rank_zero
 
 try:
@@ -457,19 +457,34 @@ class MegatronBaseModel(NLPModel):
         self, optim_config: Optional[Union[DictConfig, Dict]] = None, optim_kwargs: Optional[Dict[str, Any]] = None,
     ):
         optim_kwargs = {} if optim_kwargs is None else optim_kwargs.copy()
+
+        def get_config_arg(key: str, default_value: Optional[Any] = None) -> Any:
+            """Get keyword argument from config"""
+            val = None
+            if val is None and optim_kwargs:
+                val = optim_kwargs.get(key, None)
+            if val is None and optim_config:
+                val = optim_config.get(key, None)
+            if val is None and self._cfg.optim:
+                val = self._cfg.optim.get(key, None)
+            if val is None:
+                val = default_value
+            return val
+
         if self.with_distributed_adam:
 
             # Allocate contiguous buffer to avoid extra copies
             optim_kwargs['contiguous_grad_buffer'] = True
 
             # Make sure optimizer state is in FP32
-            optim_dtype = torch.float32
+            optim_dtype = str_to_dtype(get_config_arg('dtype', torch.float32))
             optim_kwargs['dtype'] = optim_dtype
 
             # Make sure embedding grad reductions are in FP32
-            for name, param in self.named_parameters():
-                if 'word_embedding' in name or 'position_embedding' in name or 'output_layer' in name:
-                    param._with_fp32_optimizer = True
+            if optim_dtype == torch.float32:
+                for name, param in self.named_parameters():
+                    if 'word_embedding' in name or 'position_embedding' in name or 'output_layer' in name:
+                        param._with_fp32_optimizer = True
 
             # Match param allgather with model dtype
             model_dtype = torch.float32

--- a/nemo/core/optim/distributed_adam.py
+++ b/nemo/core/optim/distributed_adam.py
@@ -14,12 +14,12 @@
 
 from typing import Callable, Iterable, Optional, Union
 
+import torch
 from apex.contrib.optimizers.distributed_fused_adam import DistributedFusedAdam, _disable_pre_forward_hook
 from megatron.core import parallel_state
 from megatron.core.dist_checkpointing.dict_utils import dict_list_map_inplace
 from megatron.core.dist_checkpointing.mapping import ShardedTensor
 from megatron.core.dist_checkpointing.optimizer import get_param_id_to_sharded_param_map, optim_state_to_sharding_state
-import torch
 
 from nemo.utils import str_to_dtype
 
@@ -71,9 +71,9 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
                     filter(lambda param: getattr(param, '_with_fp32_optimizer', False), param_group['params'],)
                 )
             if fp32_params:
-                assert self.dtype == torch.float32, (
-                    f'Param requires FP32 state but optimizer is initialized with {self.dtype}'
-                )
+                assert (
+                    self.dtype == torch.float32
+                ), f'Param requires FP32 state but optimizer is initialized with {self.dtype}'
                 self.init_params_bucket(
                     fp32_params, grad_sync_dtype=torch.float32,
                 )

--- a/nemo/utils/__init__.py
+++ b/nemo/utils/__init__.py
@@ -22,6 +22,7 @@ from nemo.utils.cast_utils import (
     cast_all,
     cast_tensor,
 )
+from nemo.utils.dtype import str_to_dtype
 from nemo.utils.nemo_logging import Logger as _Logger
 from nemo.utils.nemo_logging import LogMode as logging_mode
 

--- a/nemo/utils/dtype.py
+++ b/nemo/utils/dtype.py
@@ -38,6 +38,7 @@ _str_to_dtype: Dict[str, torch.dtype] = dict(
     bool=torch.bool,
 )
 
+
 def str_to_dtype(dtype: Union[str, torch.dtype]) -> torch.dtype:
     """Convert a data type name to a PyTorch data type"""
     if isinstance(dtype, torch.dtype):

--- a/nemo/utils/dtype.py
+++ b/nemo/utils/dtype.py
@@ -1,0 +1,52 @@
+# Copyright (c) 2023, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Dict, Union
+
+import torch
+
+_str_to_dtype: Dict[str, torch.dtype] = dict(
+    float32=torch.float32,
+    float=torch.float32,
+    float64=torch.float64,
+    double=torch.float64,
+    float16=torch.float16,
+    half=torch.float16,
+    bfloat16=torch.bfloat16,
+    bf16=torch.bfloat16,
+    uint8=torch.uint8,
+    byte=torch.uint8,
+    int8=torch.int8,
+    char=torch.int8,
+    int16=torch.int16,
+    short=torch.int16,
+    int32=torch.int32,
+    int=torch.int32,
+    int64=torch.int64,
+    long=torch.int64,
+    bool=torch.bool,
+)
+
+def str_to_dtype(dtype: Union[str, torch.dtype]) -> torch.dtype:
+    """Convert a data type name to a PyTorch data type"""
+    if isinstance(dtype, torch.dtype):
+        return dtype
+    name = str(dtype).strip().lower()
+    if name.startswith("torch."):
+        name = name.replace("torch.", "", 1)
+    if name.startswith("fp"):
+        name = name.replace("fp", "float", 1)
+    if name not in _str_to_dtype:
+        raise ValueError(f"Unrecognized dtype ({name})")
+    return _str_to_dtype[name]


### PR DESCRIPTION
# What does this PR do ?

The distributed Adam optimizer can now be configured with BF16 or FP16 optimizer state.

**Collection**: NLP

# Changelog 
- Add support for non-FP32 distributed optimizer state

# Usage

Run a language model, e.g. with the config at https://github.com/NVIDIA/NeMo/blob/main/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml.

Enable the distributed optimizer with `model.optim.name=distributed_fused_adam` and set the optimizer state dtype with `+model.optim.dtype=bfloat16`.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

