### PR TITLE
Reworked MegatronPretrainingRandomBatchSampler to correctly handle epochs > 1

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -175,6 +175,11 @@ class MegatronPretrainingRandomBatchSampler(BaseMegatronBatchSampler):
     # are necessary for ViT training. However, to keep this simple,
     # I omit those two arguments.
     # commit: https://github.com/NVIDIA/Megatron-LM/commit/7a77abd9b6267dc0020a60b424b4748fc22790bb
+    #
+    # NOTE (degert): I have re-written this class somewhat as previous implementation relied on the
+    # base class constructor which would have thrown in the case of consumed_samples >= total_samples
+    # which this class was designed to do, as that is how it implicitly calculates the current epoch
+    # I have also added an explicit seed which allows us to remove Dataset-side shuffling in Nemo-Aligner
     def __init__(
         self,
         total_samples: int,
@@ -184,22 +189,46 @@ class MegatronPretrainingRandomBatchSampler(BaseMegatronBatchSampler):
         data_parallel_rank: int,
         data_parallel_size: int,
         drop_last: bool,
+        pad_samples_to_global_batch_size: bool = False,
+        seed: int = 0,
     ) -> None:
-        super().__init__(
-            total_samples=total_samples,
-            consumed_samples=consumed_samples,
-            micro_batch_size=micro_batch_size,
-            global_batch_size=global_batch_size,
-            data_parallel_rank=data_parallel_rank,
-            data_parallel_size=data_parallel_size,
-            drop_last=drop_last,
-        )
-        self.last_batch_size = self.total_samples % self._global_batch_size
+        
+        # Sanity checks.
+        if total_samples <= 0:
+            raise RuntimeError("no sample to consume: {}".format(total_samples))
+        if micro_batch_size <= 0:
+            raise RuntimeError(f"micro_batch_size size must be greater than 0, but {micro_batch_size}")
+        if data_parallel_size <= 0:
+            raise RuntimeError(f"data parallel size must be greater than 0, but {data_parallel_size}")
+        if data_parallel_rank >= data_parallel_size:
+            raise RuntimeError(
+                "data_parallel_rank should be smaller than data size, but {} >= {}".format(
+                    data_parallel_rank, data_parallel_size
+                )
+            )
+        
+        self.total_samples: int = total_samples
+        self.consumed_samples: int = consumed_samples
+        self.micro_batch_size: int = micro_batch_size
+        self.data_parallel_rank: int = data_parallel_rank
+        self.data_parallel_size: int = data_parallel_size
+        self.drop_last: bool = drop_last
+        self.pad_samples_to_global_batch_size = pad_samples_to_global_batch_size
+        self.seed = seed
 
-    def __len__(self):
+        self.update_global_batch_size(global_batch_size)
+        self.last_batch_size = self.total_samples % self._global_batch_size
+    
+    def __len__(self) -> int:
+        """Length of Random Batch Sampler.
+
+        ..note::
+            When `rampup_batch_size` is enabled, the return value can be not exactly precise.
+
+        """
         num_available_samples = self.total_samples
         if self.drop_last:
-            return num_available_samples // self.global_batch_size
+            return (num_available_samples - self.last_batch_size) // self.global_batch_size
         else:
             return (num_available_samples + self.global_batch_size - 1) // self.global_batch_size
 
@@ -215,7 +244,7 @@ class MegatronPretrainingRandomBatchSampler(BaseMegatronBatchSampler):
         start_idx = self.data_parallel_rank * bucket_size
 
         g = torch.Generator()
-        g.manual_seed(self.epoch)
+        g.manual_seed(self.seed + self.epoch)
         random_idx = torch.randperm(bucket_size, generator=g).tolist()
         idx_range = [start_idx + x for x in random_idx[bucket_offset:]]
 

--- a/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -227,7 +227,9 @@ class MegatronPretrainingRandomBatchSampler(BaseMegatronBatchSampler):
 
         """
         active_total_samples = self.total_samples - self.last_batch_size
-        num_available_samples = (active_total_samples * (1 + (self.consumed_samples // active_total_samples))) - self.consumed_samples
+        num_available_samples = (
+            active_total_samples * (1 + (self.consumed_samples // active_total_samples))
+        ) - self.consumed_samples
         if self.drop_last:
             return num_available_samples // self.global_batch_size
         else:

--- a/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -192,7 +192,7 @@ class MegatronPretrainingRandomBatchSampler(BaseMegatronBatchSampler):
         pad_samples_to_global_batch_size: bool = False,
         seed: int = 0,
     ) -> None:
-        
+
         # Sanity checks.
         if total_samples <= 0:
             raise RuntimeError("no sample to consume: {}".format(total_samples))
@@ -206,7 +206,7 @@ class MegatronPretrainingRandomBatchSampler(BaseMegatronBatchSampler):
                     data_parallel_rank, data_parallel_size
                 )
             )
-        
+
         self.total_samples: int = total_samples
         self.consumed_samples: int = consumed_samples
         self.micro_batch_size: int = micro_batch_size
@@ -218,7 +218,7 @@ class MegatronPretrainingRandomBatchSampler(BaseMegatronBatchSampler):
 
         self.update_global_batch_size(global_batch_size)
         self.last_batch_size = self.total_samples % self._global_batch_size
-    
+
     def __len__(self) -> int:
         """Length of Random Batch Sampler.
 

--- a/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -226,9 +226,10 @@ class MegatronPretrainingRandomBatchSampler(BaseMegatronBatchSampler):
             When `rampup_batch_size` is enabled, the return value can be not exactly precise.
 
         """
-        num_available_samples = self.total_samples
+        active_total_samples = self.total_samples - self.last_batch_size
+        num_available_samples = (active_total_samples * (1 + (self.consumed_samples // active_total_samples))) - self.consumed_samples
         if self.drop_last:
-            return (num_available_samples - self.last_batch_size) // self.global_batch_size
+            return num_available_samples // self.global_batch_size
         else:
             return (num_available_samples + self.global_batch_size - 1) // self.global_batch_size
 


### PR DESCRIPTION
# What does this PR do ?

Fixes MegatronPretrainingRandomBatchSampler to correctly instantiate when consumed_samples >= total_samples

**Collection**: NLP

# Changelog 
- nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py: slightly rewrote the MegatronPretrainingRandomBatchSampler class

# Usage
No change to how it was used before, however, I have run many training runs using this fixed version in Nemo-Aligner and it appears to work correctly with no issues.

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
