### PR TITLE
only enable query key scaling during fp16

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,9 +9,6 @@ pipeline {
     timeout(time: 8, unit: 'HOURS')
     disableConcurrentBuilds(abortPrevious: true)
   }
-  environment {
-    NVTE_APPLY_QK_LAYER_SCALING = 1
-  }
 
   stages {
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1545,7 +1545,8 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         attention_softmax_in_fp32 = False  # not currently used in NeMo unless apply_query_key_layer_scaling is True
         apply_query_key_layer_scaling = self.cfg.get('apply_query_key_layer_scaling', False)
 
-        if apply_query_key_layer_scaling and not model_parallel_config.fp16:
+        fp16_enabled = self.trainer.precision in [16, '16', '16-mixed']
+        if apply_query_key_layer_scaling and not fp16_enabled:
             logging.warning("apply_query_key_layer_scaling is only enabled when using FP16, setting it to False")
             apply_query_key_layer_scaling = False
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1550,7 +1550,11 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             if fp16_enabled:
                 os.environ["NVTE_APPLY_QK_LAYER_SCALING"] = "1"
             else:
-                logging.warning("apply_query_key_layer_scaling is only enabled when using FP16, setting it to False")
+                logging.warning(
+                    "apply_query_key_layer_scaling is only enabled when using FP16, setting it to False "
+                    "and setting NVTE_APPLY_QK_LAYER_SCALING=0"
+                )
+                os.environ["NVTE_APPLY_QK_LAYER_SCALING"] = "0"
                 apply_query_key_layer_scaling = False
 
         if apply_query_key_layer_scaling:

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1546,9 +1546,12 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         apply_query_key_layer_scaling = self.cfg.get('apply_query_key_layer_scaling', False)
 
         fp16_enabled = self.trainer.precision in [16, '16', '16-mixed']
-        if apply_query_key_layer_scaling and not fp16_enabled:
-            logging.warning("apply_query_key_layer_scaling is only enabled when using FP16, setting it to False")
-            apply_query_key_layer_scaling = False
+        if apply_query_key_layer_scaling:
+            if fp16_enabled:
+                os.environ["NVTE_APPLY_QK_LAYER_SCALING"] = "1"
+            else:
+                logging.warning("apply_query_key_layer_scaling is only enabled when using FP16, setting it to False")
+                apply_query_key_layer_scaling = False
 
         if apply_query_key_layer_scaling:
             attention_softmax_in_fp32 = True

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1543,10 +1543,12 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             output_layer_init_method = scaled_init_method_normal(init_method_std, num_layers=num_layers)
 
         attention_softmax_in_fp32 = False  # not currently used in NeMo unless apply_query_key_layer_scaling is True
-        # only enabled when we use fp16
-        apply_query_key_layer_scaling = (
-            self.cfg.get('apply_query_key_layer_scaling', False) and model_parallel_config.fp16
-        )
+        apply_query_key_layer_scaling = self.cfg.get('apply_query_key_layer_scaling', False)
+
+        if apply_query_key_layer_scaling and not model_parallel_config.fp16:
+            logging.warning("apply_query_key_layer_scaling is only enabled when using FP16, setting it to False")
+            apply_query_key_layer_scaling = False
+
         if apply_query_key_layer_scaling:
             attention_softmax_in_fp32 = True
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1543,7 +1543,10 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             output_layer_init_method = scaled_init_method_normal(init_method_std, num_layers=num_layers)
 
         attention_softmax_in_fp32 = False  # not currently used in NeMo unless apply_query_key_layer_scaling is True
-        apply_query_key_layer_scaling = self.cfg.get('apply_query_key_layer_scaling', False)
+        # only enabled when we use fp16
+        apply_query_key_layer_scaling = (
+            self.cfg.get('apply_query_key_layer_scaling', False) and model_parallel_config.fp16
+        )
         if apply_query_key_layer_scaling:
             attention_softmax_in_fp32 = True
 
@@ -1570,6 +1573,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
 
         # any configs that are not in the nemo model config will be added here
         config_mapping = {
+            'apply_query_key_layer_scaling': apply_query_key_layer_scaling,
             'apply_residual_connection_post_layernorm': False,  # we don't use this in NeMo
             'layernorm_zero_centered_gamma': layernorm_zero_centered_gamma,
             'add_bias_linear': add_bias_linear,


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

Enable query key scaling only during fp16, since this is when TE enables query key scaling. https://github.com/NVIDIA/TransformerEngine/blob/666539f36275fa9c0fbc99f9ea50f2d6e29e336f/transformer_engine/pytorch/attention.py#L940 
