### PR TITLE
Modify GPTSFTPackedDataset to respond to pad_to_max_length setting

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
@@ -504,8 +504,12 @@ class GPTSFTPackedDataset(GPTSFTDataset):
 
         loss_mask = [self._build_loss_mask(item) for item in batch]
 
-        max_length = max(len(l) for l in input_ids)
-        max_length = self._ceil_to_nearest(max_length, 16)
+        if self.pad_to_max_length:
+            max_length = self.max_seq_length
+        else:
+            max_length = max(len(l) for l in input_ids)
+            max_length = min(self.max_seq_length, self._ceil_to_nearest(max_length, 16))
+        assert max_length <= self.max_seq_length
 
         position_ids: List[List[int]] = []
         cu_seqlens: List[List[int]] = []


### PR DESCRIPTION
Several-line change to make GPTSFTPackedDataset pad sequences to max length if pad_to_max_length=true.