### PR TITLE
[NLP] ArtifactItem with init=True to make it debuggable

### DIFF
--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -396,10 +396,7 @@ class SaveRestoreConnector:
 
         assert os.path.exists(return_path)
 
-        artifact_item = model_utils.ArtifactItem(
-            path=os.path.abspath(src),
-            path_type=path_type,
-        )
+        artifact_item = model_utils.ArtifactItem(path=os.path.abspath(src), path_type=path_type,)
         model.artifacts[config_path] = artifact_item
         # we were called by ModelPT
         if hasattr(model, "cfg"):
@@ -491,8 +488,7 @@ class SaveRestoreConnector:
 
                         # Update artifacts registry
                         new_artiitem = model_utils.ArtifactItem(
-                            path="nemo:" + artifact_uniq_name,
-                            path_type=model_utils.ArtifactPathType.TAR_PATH,
+                            path="nemo:" + artifact_uniq_name, path_type=model_utils.ArtifactPathType.TAR_PATH,
                         )
                         model.artifacts[conf_path] = new_artiitem
                 finally:

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -359,8 +359,6 @@ class SaveRestoreConnector:
         """
         app_state = AppState()
 
-        artifact_item = model_utils.ArtifactItem()
-
         # This is for backward compatibility, if the src objects exists simply inside of the tarfile
         # without its key having been overriden, this pathway will be used.
         src_obj_name = os.path.basename(src)
@@ -372,18 +370,18 @@ class SaveRestoreConnector:
         # src is a local existing path - register artifact and return exact same path for usage by the model
         if os.path.exists(os.path.abspath(src)):
             return_path = os.path.abspath(src)
-            artifact_item.path_type = model_utils.ArtifactPathType.LOCAL_PATH
+            path_type = model_utils.ArtifactPathType.LOCAL_PATH
 
         # this is the case when artifact must be retried from the nemo file
         # we are assuming that the location of the right nemo file is available from _MODEL_RESTORE_PATH
         elif src.startswith("nemo:"):
             return_path = os.path.abspath(os.path.join(app_state.nemo_file_folder, src[5:]))
-            artifact_item.path_type = model_utils.ArtifactPathType.TAR_PATH
+            path_type = model_utils.ArtifactPathType.TAR_PATH
 
         # backward compatibility implementation
         elif os.path.exists(src_obj_path):
             return_path = src_obj_path
-            artifact_item.path_type = model_utils.ArtifactPathType.TAR_PATH
+            path_type = model_utils.ArtifactPathType.TAR_PATH
         else:
             if verify_src_exists:
                 raise FileNotFoundError(
@@ -398,7 +396,10 @@ class SaveRestoreConnector:
 
         assert os.path.exists(return_path)
 
-        artifact_item.path = os.path.abspath(src)
+        artifact_item = model_utils.ArtifactItem(
+            path=os.path.abspath(src),
+            path_type=path_type,
+        )
         model.artifacts[config_path] = artifact_item
         # we were called by ModelPT
         if hasattr(model, "cfg"):
@@ -489,9 +490,10 @@ class SaveRestoreConnector:
                         shutil.copy2(artifact_base_name, os.path.join(nemo_file_folder, artifact_uniq_name))
 
                         # Update artifacts registry
-                        new_artiitem = model_utils.ArtifactItem()
-                        new_artiitem.path = "nemo:" + artifact_uniq_name
-                        new_artiitem.path_type = model_utils.ArtifactPathType.TAR_PATH
+                        new_artiitem = model_utils.ArtifactItem(
+                            path="nemo:" + artifact_uniq_name,
+                            path_type=model_utils.ArtifactPathType.TAR_PATH,
+                        )
                         model.artifacts[conf_path] = new_artiitem
                 finally:
                     # change back working directory

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -54,7 +54,7 @@ class ArtifactPathType(Enum):
     TAR_PATH = 1
 
 
-@dataclass(init=False)
+@dataclass
 class ArtifactItem:
     path: str
     path_type: ArtifactPathType

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -56,8 +56,8 @@ class ArtifactPathType(Enum):
 
 @dataclass
 class ArtifactItem:
-    path: str
-    path_type: ArtifactPathType
+    path: str = ""
+    path_type: ArtifactPathType = ArtifactPathType.LOCAL_PATH
     hashed_path: Optional[str] = None
 
 


### PR DESCRIPTION
# What does this PR do ?

When debugging artifact items I struggled with `ArtifactItem` as it is defined with `init=False` which results in issues when printing an instance of this class.

The following minimal example illustrates the problem - this code
```
from dataclasses import dataclass


@dataclass(init=False)
class Point:
    x: int
    y: int

p = Point()
print(p)
```
results in **AttributeError: 'Point' object has no attribute 'x'**. So it doesn't make it easier to check what's going on.

**Collection**: [NLP]

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] Improvement


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to https://github.com/NVIDIA/NeMo/pull/7935
