### PR TITLE
[NLP] Use register_artifact from superclass directly

### DIFF
--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -145,13 +145,6 @@ class NLPModel(ModelPT, Exportable):
             # register encoder config
             self.register_bert_model()
 
-    def register_artifact(
-        self, config_path: str, src: str, verify_src_exists: bool = False,
-    ):
-        """ Overrides ModelPT register_artifact default behavior.
-        NLP models usually need artifacts that are optional."""
-        return super().register_artifact(config_path, src, verify_src_exists=verify_src_exists)
-
     @rank_zero_only
     def register_bert_model(self):
         """Adds encoder config to .nemo archive for Jarvis.


### PR DESCRIPTION
# What does this PR do ?

Removes explicit code to call superclass method (cleanup).

**Collection**: [NLP]

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] Improvement

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to https://github.com/NVIDIA/NeMo/pull/7935
