### PR TITLE
.ctm in data simulator annotator compliant with RT-09 specification

### DIFF
--- a/nemo/collections/asr/parts/utils/data_simulation_utils.py
+++ b/nemo/collections/asr/parts/utils/data_simulation_utils.py
@@ -774,7 +774,7 @@ class DataAnnotator(object):
                 prev_align = 0 if i == 0 else alignments[i - 1]
                 align1 = round(float(prev_align + start), self._params.data_simulator.outputs.output_precision)
                 align2 = round(float(alignments[i] - prev_align), self._params.data_simulator.outputs.output_precision)
-                text = f"{session_name} 0 {align1} {align2} {word} <NA> <NA> <NA> {speaker_id} \n"
+                text = f"{session_name} 0 {align1} {align2} {word} <NA> <NA> <NA> {speaker_id}\n"
                 arr.append((align1, text))
         return arr
 

--- a/nemo/collections/asr/parts/utils/data_simulation_utils.py
+++ b/nemo/collections/asr/parts/utils/data_simulation_utils.py
@@ -774,7 +774,7 @@ class DataAnnotator(object):
                 prev_align = 0 if i == 0 else alignments[i - 1]
                 align1 = round(float(prev_align + start), self._params.data_simulator.outputs.output_precision)
                 align2 = round(float(alignments[i] - prev_align), self._params.data_simulator.outputs.output_precision)
-                text = f"{session_name} {speaker_id} {align1} {align2} {word} 0\n"
+                text = f"{session_name} 0 {align1} {align2} {word} <NA> <NA> <NA> {speaker_id} \n"
                 arr.append((align1, text))
         return arr
 


### PR DESCRIPTION
An attempt to fix https://github.com/NVIDIA/NeMo/issues/7445 so that the data simulator .ctm are compliant with RT-09 specification (see https://web.archive.org/web/20170119114252/http://www.itl.nist.gov/iad/mig/tests/rt/2009/docs/rt09-meeting-eval-plan-v2.pdf): 
```
<SOURCE><SP><CHANNEL><SP> <BEG-TIME><SP><DURATION><SP><TOKEN><SP>
<CONF><SP><TYPE><SP><SPEAKER><NEWLINE>
```

I have put <NA> for fields unknown e.g. <TOKEN>. 
This makes it also easy to use the generated sessions with https://github.com/lhotse-speech/lhotse