### PR TITLE
NMT lang code fix en to any training

### DIFF
--- a/examples/nlp/machine_translation/conf/aayn_base_megatron.yaml
+++ b/examples/nlp/machine_translation/conf/aayn_base_megatron.yaml
@@ -46,7 +46,8 @@ model:
   shared_tokenizer: True # train tokenizer model across src and tgt train data
   preproc_out_dir: null # path to store data preprocessing outputs
   src_language: 'en'
-  tgt_language: 'de'
+  tgt_language: ['cs', 'da']
+  pretrained_language_list: ['cs', 'da', 'de', 'el', 'es', 'fi', 'fr', 'hu', 'it', 'lt', 'lv', 'nl', 'no', 'pl', 'pt', 'ro', 'ru', 'sk', 'sv', 'zh', 'ja', 'hi', 'ko', 'et', 'sl', 'bg', 'uk', 'hr', 'ar', 'vi', 'tr', 'id']
   max_generation_delta: 20 # Maximum decoder sequence length is encoder sequence length + this parameter.
   pretrained_model_path: null # Path to a pretrained model 
   pretrained_model_type: T5

--- a/examples/nlp/machine_translation/megatron_nmt_training.py
+++ b/examples/nlp/machine_translation/megatron_nmt_training.py
@@ -110,8 +110,9 @@ def main(cfg) -> None:
             pretrained_cfg.label_smoothing = cfg.model.label_smoothing
 
             # Set tokenizer paths:
-            pretrained_cfg.encoder_tokenizer = pretrained_cfg.tokenizer
-            pretrained_cfg.decoder_tokenizer = pretrained_cfg.tokenizer
+            if hasattr(pretrained_cfg, 'tokenizer'):
+                pretrained_cfg.encoder_tokenizer = pretrained_cfg.tokenizer
+                pretrained_cfg.decoder_tokenizer = pretrained_cfg.tokenizer
 
             # Pre-trained models should use the legacy sentencepiece tokenizer ex: mT5
             pretrained_cfg.encoder_tokenizer.sentencepiece_legacy = True
@@ -140,6 +141,9 @@ def main(cfg) -> None:
             # Override micro/global batch
             pretrained_cfg.micro_batch_size = cfg.model.micro_batch_size
             pretrained_cfg.global_batch_size = cfg.model.global_batch_size
+            
+            # override vocab size to correct embedding size before loading the weights
+            pretrained_cfg.make_vocab_size_divisible_by = cfg.model.make_vocab_size_divisible_by
 
             # O2 AMP
             pretrained_cfg.megatron_amp_O2 = cfg.model.get('megatron_amp_O2', False)
@@ -162,12 +166,18 @@ def main(cfg) -> None:
 
             # Optimizer overrides.
             pretrained_cfg.optim = cfg.model.optim
+            
+         
+             # override hidden_size
+            if hasattr(pretrained_cfg.encoder, 'hidden_size'):
+                pretrained_cfg.hidden_size = pretrained_cfg.encoder.hidden_size
 
         model = MegatronNMTModel.restore_from(
             cfg.model.pretrained_model_path,
             trainer=trainer,
             override_config_path=pretrained_cfg,
             save_restore_connector=NLPSaveRestoreConnector(),
+            pretrained_language_list=cfg.model.pretrained_language_list,
         )
     else:
         model = MegatronNMTModel(cfg.model, trainer)

--- a/examples/nlp/machine_translation/megatron_nmt_training.py
+++ b/examples/nlp/machine_translation/megatron_nmt_training.py
@@ -141,7 +141,7 @@ def main(cfg) -> None:
             # Override micro/global batch
             pretrained_cfg.micro_batch_size = cfg.model.micro_batch_size
             pretrained_cfg.global_batch_size = cfg.model.global_batch_size
-            
+
             # override vocab size to correct embedding size before loading the weights
             pretrained_cfg.make_vocab_size_divisible_by = cfg.model.make_vocab_size_divisible_by
 
@@ -166,9 +166,8 @@ def main(cfg) -> None:
 
             # Optimizer overrides.
             pretrained_cfg.optim = cfg.model.optim
-            
-         
-             # override hidden_size
+
+            # override hidden_size
             if hasattr(pretrained_cfg.encoder, 'hidden_size'):
                 pretrained_cfg.hidden_size = pretrained_cfg.encoder.hidden_size
 

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -671,7 +671,7 @@ class NLPSaveRestoreConnector(SaveRestoreConnector):
         strict: bool = True,
         return_config: bool = False,
         trainer: Trainer = None,
-        pretrained_language_list = None,
+        pretrained_language_list=None,
     ):
         """
         Restores model instance (weights and configuration) into .nemo file
@@ -699,7 +699,15 @@ class NLPSaveRestoreConnector(SaveRestoreConnector):
         # Get path where the command is executed - the artifacts will be "retrieved" there
         # (original .nemo behavior)
         loaded_params = super().load_config_and_state_dict(
-            calling_cls, restore_path, override_config_path, map_location, strict, return_config, trainer, pretrained_language_list = pretrained_language_list)
+            calling_cls,
+            restore_path,
+            override_config_path,
+            map_location,
+            strict,
+            return_config,
+            trainer,
+            pretrained_language_list=pretrained_language_list,
+        )
         if not isinstance(loaded_params, tuple) or return_config is True:
             return loaded_params
         conf, instance, state_dict = loaded_params

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -671,6 +671,7 @@ class NLPSaveRestoreConnector(SaveRestoreConnector):
         strict: bool = True,
         return_config: bool = False,
         trainer: Trainer = None,
+        pretrained_language_list = None,
     ):
         """
         Restores model instance (weights and configuration) into .nemo file
@@ -698,8 +699,7 @@ class NLPSaveRestoreConnector(SaveRestoreConnector):
         # Get path where the command is executed - the artifacts will be "retrieved" there
         # (original .nemo behavior)
         loaded_params = super().load_config_and_state_dict(
-            calling_cls, restore_path, override_config_path, map_location, strict, return_config, trainer,
-        )
+            calling_cls, restore_path, override_config_path, map_location, strict, return_config, trainer, pretrained_language_list = pretrained_language_list)
         if not isinstance(loaded_params, tuple) or return_config is True:
             return loaded_params
         conf, instance, state_dict = loaded_params

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -397,7 +397,7 @@ class ModelPT(LightningModule, Model):
         return_config: bool = False,
         save_restore_connector: SaveRestoreConnector = None,
         trainer: Optional[Trainer] = None,
-        pretrained_language_list = None
+        pretrained_language_list=None,
     ):
         """
         Restores model instance (weights and configuration) from .nemo file.
@@ -443,11 +443,20 @@ class ModelPT(LightningModule, Model):
 
         if pretrained_language_list is None:
             instance = cls._save_restore_connector.restore_from(
-            cls, restore_path, override_config_path, map_location, strict, return_config, trainer)
+                cls, restore_path, override_config_path, map_location, strict, return_config, trainer
+            )
         else:
             instance = cls._save_restore_connector.restore_from(
-            cls, restore_path, override_config_path, map_location, strict, return_config, trainer, pretrained_language_list = pretrained_language_list)
-            
+                cls,
+                restore_path,
+                override_config_path,
+                map_location,
+                strict,
+                return_config,
+                trainer,
+                pretrained_language_list=pretrained_language_list,
+            )
+
         if isinstance(instance, ModelPT):
             instance._save_restore_connector = save_restore_connector
         return instance

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -397,6 +397,7 @@ class ModelPT(LightningModule, Model):
         return_config: bool = False,
         save_restore_connector: SaveRestoreConnector = None,
         trainer: Optional[Trainer] = None,
+        pretrained_language_list = None
     ):
         """
         Restores model instance (weights and configuration) from .nemo file.
@@ -439,9 +440,14 @@ class ModelPT(LightningModule, Model):
         app_state.model_restore_path = restore_path
 
         cls.update_save_restore_connector(save_restore_connector)
-        instance = cls._save_restore_connector.restore_from(
-            cls, restore_path, override_config_path, map_location, strict, return_config, trainer
-        )
+
+        if pretrained_language_list is None:
+            instance = cls._save_restore_connector.restore_from(
+            cls, restore_path, override_config_path, map_location, strict, return_config, trainer)
+        else:
+            instance = cls._save_restore_connector.restore_from(
+            cls, restore_path, override_config_path, map_location, strict, return_config, trainer, pretrained_language_list = pretrained_language_list)
+            
         if isinstance(instance, ModelPT):
             instance._save_restore_connector = save_restore_connector
         return instance

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -78,6 +78,7 @@ class SaveRestoreConnector:
         strict: bool = True,
         return_config: bool = False,
         trainer: Trainer = None,
+        pretrained_language_list = None,
     ):
         """
         Restores model instance (weights and configuration) into .nemo file
@@ -160,6 +161,8 @@ class SaveRestoreConnector:
                 OmegaConf.set_struct(conf, True)
                 os.chdir(cwd)
                 # get the class
+                if pretrained_language_list is not None:
+                    conf['tgt_language'] = pretrained_language_list
                 calling_cls._set_model_restore_state(is_being_restored=True, folder=tmpdir)
                 instance = calling_cls.from_config_dict(config=conf, trainer=trainer)
                 instance = instance.to(map_location)

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -78,7 +78,7 @@ class SaveRestoreConnector:
         strict: bool = True,
         return_config: bool = False,
         trainer: Trainer = None,
-        pretrained_language_list = None,
+        pretrained_language_list=None,
     ):
         """
         Restores model instance (weights and configuration) into .nemo file


### PR DESCRIPTION
# What does this PR do ?

Fix for en to any training / finetuning of model for different language pairs, 
With this fix , the en to any NMT model can be finetuned for a different subset of language pairs than the model was originally pretrained on. During pretraining , we need to set the pretrained_language_list to - null.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Adds a new field pretrained_language_list in the aayn_base_megatron.yaml config file, which specifies the list of languages the model was pretrained on
- Changes to the lang id processing so that the model can finetuned on a small subset of languages of the initial pretrained list

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
