### PR TITLE
Temporary pin Lightning-Utilities version due to broken NamedTuple

### DIFF
--- a/requirements/requirements_lightning.txt
+++ b/requirements/requirements_lightning.txt
@@ -5,3 +5,4 @@ torchmetrics>=0.11.0
 transformers>=4.0.1,<=4.33.3
 wandb
 webdataset>=0.1.48,<=0.1.62
+lightning-utilities<0.10.0  # temporary fix, broken named tuples in 0.10.0, remove once fixed

--- a/requirements/requirements_lightning.txt
+++ b/requirements/requirements_lightning.txt
@@ -1,8 +1,8 @@
 hydra-core>1.3,<=1.3.2
+lightning-utilities<0.10.0  # temporary fix, broken named tuples in 0.10.0, remove once fixed
 omegaconf<=2.3
 pytorch-lightning>=2.0,<=2.0.7
 torchmetrics>=0.11.0
 transformers>=4.0.1,<=4.33.3
 wandb
 webdataset>=0.1.48,<=0.1.62
-lightning-utilities<0.10.0  # temporary fix, broken named tuples in 0.10.0, remove once fixed


### PR DESCRIPTION
# What does this PR do ?

Pin Lightning-Utitilies package version due to broken NamedTuple in `0.10.0`
https://github.com/Lightning-AI/utilities/pull/160 introduced the issue, 
https://github.com/Lightning-AI/utilities/blob/a00e1144dd300e3bc2fc8746a8e85510ffe35aa7/src/lightning_utilities/core/apply_func.py#L67 here NamedTuple force converted to tuple.

This fixes the bug https://nvbugspro.nvidia.com/bug/4405798 (broken `ASR_TTS_Tutorial`)

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
