### PR TITLE
Fix crash when old checkpoint does not exist anymore

### DIFF
--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -421,7 +421,12 @@ class NLPDDPStrategy(DDPStrategy):
             and self.lightning_module.sharded_state_dict() is not None
         ):
             if self.is_global_zero:
-                shutil.rmtree(ckpt_to_dir(filepath))
+                ckpt_dir = ckpt_to_dir(filepath)
+                if ckpt_dir.exists():
+                    logging.info(f'Removing checkpoint: {ckpt_dir}')
+                    shutil.rmtree(ckpt_dir)
+                else:
+                    logging.warning(f'Cannot remove checkpoint since it does not exist: {ckpt_dir}')
 
         # legacy checkpoint logic, does not use megatron core
         else:


### PR DESCRIPTION
# What does this PR do ?

This prevents NeMo from crashing when trying to delete a checkpoint that has already been deleted.

This situation may happen for instance after manually fixing corrupted checkpoints.

Note that I believe PTL also has a similar safety guard: https://github.com/Lightning-AI/lightning/blob/119039b932c79f1e5daef67345628e675ab3c0bf/src/lightning/fabric/plugins/io/torch_io.py#L94

**Collection**: nlp

# Changelog 
- Fix crash when attempting to delete an old checkpoint that does not actually exist anymore

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.