### PR TITLE
fix for missing mcore arg

### DIFF
--- a/scripts/nlp_language_modeling/merge_lora_weights/merge.py
+++ b/scripts/nlp_language_modeling/merge_lora_weights/merge.py
@@ -196,7 +196,9 @@ def main(cfg) -> None:
         raise ValueError("need at least a nemo file or checkpoint dir")
 
     if hasattr(model, 'mcore_gpt'):
-        assert model.mcore_gpt == False, "merge script does not support mcore_gpt models" #TODO: revisit support for mcore models
+        assert (
+            model.mcore_gpt == False
+        ), "merge script does not support mcore_gpt models"  # TODO: revisit support for mcore models
     lora_model_cfg = MegatronGPTLoRAModel.restore_from(
         restore_path=cfg.lora_model_path, trainer=trainer, return_config=True,
     )
@@ -211,7 +213,7 @@ def main(cfg) -> None:
         tp=model.cfg.tensor_model_parallel_size,
         num_layers=model.cfg.num_layers,
         curr_rank=model.global_rank,
-        mcore=False, # (@adithyare) TODO: revisit mcore support for merge script.
+        mcore=False,  # (@adithyare) TODO: revisit mcore support for merge script.
     )
 
     # load the merged_weights back into the base model, for this current rank.

--- a/scripts/nlp_language_modeling/merge_lora_weights/merge.py
+++ b/scripts/nlp_language_modeling/merge_lora_weights/merge.py
@@ -195,8 +195,10 @@ def main(cfg) -> None:
     else:
         raise ValueError("need at least a nemo file or checkpoint dir")
 
+    if hasattr(model, 'mcore_gpt'):
+        assert model.mcore_gpt == False, "merge script does not support mcore_gpt models" #TODO: revisit support for mcore models
     lora_model_cfg = MegatronGPTLoRAModel.restore_from(
-        restore_path=cfg.lora_model_path, trainer=trainer, return_config=True, mcore=model.mcore_gpt,
+        restore_path=cfg.lora_model_path, trainer=trainer, return_config=True,
     )
 
     # load the lora weights on cpu for all ranks of the lora model
@@ -209,6 +211,7 @@ def main(cfg) -> None:
         tp=model.cfg.tensor_model_parallel_size,
         num_layers=model.cfg.num_layers,
         curr_rank=model.global_rank,
+        mcore=False, # (@adithyare) TODO: revisit mcore support for merge script.
     )
 
     # load the merged_weights back into the base model, for this current rank.


### PR DESCRIPTION
# What does this PR do ?

Mcore refactor introduced an error when trying to merge.
```
Loading distributed checkpoint with TensorStoreLoadShardedStrategy
[NeMo I 2023-12-13 12:13:12 nlp_overrides:752] Model MegatronGPTModel was successfully restored from /workspace/models/nemo_version/llama2-7b.nemo.
Error executing job with overrides: []
Traceback (most recent call last):
  File "/workspace/NeMo/scripts/nlp_language_modeling/merge_lora_weights/merge.py", line 198, in main
    lora_model_cfg = MegatronGPTLoRAModel.restore_from(
TypeError: NLPModel.restore_from() got an unexpected keyword argument 'mcore'
```
This PR is a patch for this error.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
