### PR TITLE
run with non-dev option

### DIFF
--- a/tutorials/asr/Confidence_Ensembles.ipynb
+++ b/tutorials/asr/Confidence_Ensembles.ipynb
@@ -44,7 +44,7 @@
     "    NEMO_DIR = os.path.join(WORKSPACE_DIR, 'NeMo')\n",
     "\n",
     "# installing nemo (from source code)\n",
-    "!cd $NEMO_DIR && ./reinstall.sh\n",
+    "!cd $NEMO_DIR && ./reinstall.sh non-dev\n",
     "\n",
     "# clone SDP and install requirements\n",
     "!git clone https://github.com/NVIDIA/NeMo-speech-data-processor $WORKSPACE_DIR/NeMo-speech-data-processor\n",
@@ -509,9 +509,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.10"
+   "version": "3.10.13"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
# What does this PR do ?

Looks like pip installs run with -e option, don;t load well without restarting. 

**Collection**: [TUTORIALS]

# Changelog 
- Run without pip editable

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation