### PR TITLE
fix device setting to allow using accelerator cpu

### DIFF
--- a/nemo/collections/asr/modules/wav2vec_modules.py
+++ b/nemo/collections/asr/modules/wav2vec_modules.py
@@ -32,7 +32,6 @@ from nemo.collections.nlp.modules.common.transformer import TransformerEncoder
 from nemo.core.classes.module import NeuralModule
 from nemo.core.neural_types import AcousticEncodedRepresentation, AudioSignal, LengthsType, NeuralType, SpectrogramType
 
-DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
 
 class TransposeLast(torch.nn.Module):
@@ -341,7 +340,7 @@ class Wav2VecTransformerEncoder(TransformerEncoder):
     def create_padding_mask(self, length):
         # Broadcast to vectorize creating the padding mask
         max_len = max(length)
-        padding_mask = torch.arange(max_len, device=DEVICE)
+        padding_mask = torch.arange(max_len, device=length.device)
 
         # Switch to binary for transformer, 1 for valid tokens, 0 for padding
         padding_mask = (padding_mask.expand(len(length), max_len) < length.unsqueeze(1)).type(torch.uint8)

--- a/nemo/collections/asr/modules/wav2vec_modules.py
+++ b/nemo/collections/asr/modules/wav2vec_modules.py
@@ -33,7 +33,6 @@ from nemo.core.classes.module import NeuralModule
 from nemo.core.neural_types import AcousticEncodedRepresentation, AudioSignal, LengthsType, NeuralType, SpectrogramType
 
 
-
 class TransposeLast(torch.nn.Module):
     """
     Transposes last dimension. Useful for adding to a sequential block.


### PR DESCRIPTION
# What does this PR do ?

It is currently impossible to run wav2vec with `trainer.accelerator=cpu` if the machine has a gpu. 
The padding_mask is already on the device set in `trainer.accelerator` but if the machine has a GPU the DEVICE variable will contain cuda and this error message will be received:

```
File /mnt/NVM/oren/anaconda3_10/envs/nemo/lib/python3.10/site-packages/nemo/collections/asr/modules/wav2vec_modules.py:348, in Wav2VecTransformerEncoder.create_padding_mask(self, length)
    345 padding_mask = torch.arange(max_len, device=DEVICE)
    347 # Switch to binary for transformer, 1 for valid tokens, 0 for padding
--> 348 padding_mask = (padding_mask.expand(len(length), max_len) < length.unsqueeze(1)).type(torch.uint8)
    350 return padding_mask

RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!

```
  
**PR Type**:
- [x] Bugfix


# Additional Information
* Related to # (issue)
* 
@titu1994, @redoctopus, @jbalam-nv, or @okuchaiev