### PR TITLE
README edit to change Apple Silicon install instructions (to fix a break introduced by pytorch 2)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -274,7 +274,7 @@ To install NeMo on Mac with Apple M-Series GPU:
     cd NeMo
     pip install 'nemo_toolkit[all]'
 
-    Note that only the ASR toolkit is guaranteed to work on MacBook - so for MacBook use pip install 'nemo_toolkit[asr]'
+    # Note that only the ASR toolkit is guaranteed to work on MacBook - so for MacBook use pip install 'nemo_toolkit[asr]'
 
 Windows Computers
 ~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -272,8 +272,9 @@ To install NeMo on Mac with Apple M-Series GPU:
     # clone the repo and install in development mode
     git clone https://github.com/NVIDIA/NeMo
     cd NeMo
-    ./reinstall.sh
+    pip install 'nemo_toolkit[all]'
 
+    Note that only the ASR toolkit is guaranteed to work on MacBook - so for MacBook use pip install 'nemo_toolkit[asr]'
 
 Windows Computers
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
# What does this PR do ?

This PR aims to correct a small error in the Apple Silcon installation instructions in README, where a triton dependency is problematic due to pytorch 2. The use of `/reinstall.sh` doesn't work, so using `pip install` instead. Also added a note about MacBook, to clarify that only asr toolkit is supported.

# Additional Information
* Related to #8116

