### PR TITLE
Fix layer_norm_1p Apex call to match Apex API

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/layer_norm_1p.py
+++ b/nemo/collections/nlp/modules/common/megatron/layer_norm_1p.py
@@ -40,7 +40,7 @@ if HAVE_APEX:
             torch.nn.init.zeros_(self.bias)
 
         def forward(self, x):
-            return _fast_layer_norm(x, self.weight + 1, self.bias, self.epsilon)
+            return _fast_layer_norm(x, self.weight + 1, self.bias, self.epsilon, self.memory_efficient)
 
 
 else:


### PR DESCRIPTION
# What does this PR do ?

Apex _fast_layer_norm expects required memory_efficient parameter to be passed when it is called: https://github.com/NVIDIA/apex/blob/master/apex/contrib/layer_norm/layer_norm.py#L37 

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
