### PR TITLE
Fix TP>1 issue for conversion script

### DIFF
--- a/scripts/nlp_language_modeling/convert_nemo_llama_to_hf.py
+++ b/scripts/nlp_language_modeling/convert_nemo_llama_to_hf.py
@@ -87,13 +87,14 @@ def convert(input_nemo_file, output_hf_file, precision=None, cpu_only=False) -> 
     Convert NeMo weights to HF weights
     """
     dummy_trainer = Trainer(devices=1, accelerator='cpu', strategy=NLPDDPStrategy())
+    model_config = MegatronGPTModel.restore_from(input_nemo_file, trainer=dummy_trainer, return_config=True)
+    model_config.tensor_model_parallel_size = 1
+    model_config.pipeline_model_parallel_size = 1
     if cpu_only:
         map_location = torch.device('cpu')
-        model_config = MegatronGPTModel.restore_from(input_nemo_file, trainer=dummy_trainer, return_config=True)
         model_config.use_cpu_initialization = True
-        model_config.tensor_model_parallel_size = 1
     else:
-        map_location, model_config = None, None
+        map_location = None
 
     if cpu_only:
         logging.info("******** Loading model on CPU. This will take a significant amount of time.")


### PR DESCRIPTION
# What does this PR do ?

Fix issue where nemo -> hf conversion script crashes for models trained with TP > 1 

**Collection**: NLP

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #7770 #7922 
