### PR TITLE
Fix a bug caused by a command line option typo for `–local-rank` in megatron_ckpt_to_nemo.py

### DIFF
--- a/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
+++ b/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py
@@ -21,7 +21,24 @@ Conversion script to convert PTL checkpoints into nemo checkpoint.
      --checkpoint_name <checkpoint_name> \
      --nemo_file_path <path_to_output_nemo_file> \
      --tensor_model_parallel_size <tensor_model_parallel_size> \
-     --pipeline_model_parallel_size <pipeline_model_parallel_size>
+     --pipeline_model_parallel_size <pipeline_model_parallel_size> \
+     --gpus_per_node <gpus_per_node> \
+     --model_type <model_type>
+
+If you want to convert a checkpoint that was created from training, you will need to provide
+`hparams.yaml` that was used during training. You will also need to update the `hparams.yaml`.
+
+In `hparams.yaml`, replace "nemo:..." with the full paths to the tokenizer files (*.model). 
+You can find the tokenizer files by untarring the original .nemo checkpoint. 
+
+```
+-    model: nemo:***************************************************.model
++    model: <full path to model>
+-    tokenizer_model: nemo:***************************************************.model
++    tokenizer_model: <full path to tokenizer_model>
+```
+
+Add `--hparams_file <path to hparams.yaml>` option when running the conversion script.
 """
 
 import dis
@@ -95,7 +112,7 @@ def get_args():
         default="gpt",
         choices=["gpt", "sft", "t5", "bert", "nmt", "bart", "retro"],
     )
-    parser.add_argument("--local_rank", type=int, required=False, default=os.getenv('LOCAL_RANK', -1))
+    parser.add_argument("--local-rank", type=int, required=False, default=os.getenv('LOCAL_RANK', -1))
     parser.add_argument("--bcp", action="store_true", help="Whether on BCP platform")
     parser.add_argument(
         "--precision",


### PR DESCRIPTION
# What does this PR do ?

This PR fixes a command line argument typo in `megatron_ckpt_to_nemo.py`, which causes an error when `torch.distributed.launch --nproc_per_node=n (n>1)` is used. It also adds information about necessary changes in `hparams.yaml` as a comment.

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

# Details

When I used `torch.distributed.launch --nproc_node=n` following the example in the comment. I got the following error. Apparently, the command line argument has to be `--local-rank` not `--local_rank`.

> If your script expects `--local-rank` argument to be set, please
change it to read from `os.environ['LOCAL_RANK']` instead. See 

```
# python -m torch.distributed.launch --nproc_per_node=4      ${NEMO_HOME_DIR}/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py      --checkpoint_folder ${CKPT_DIR}      --checkpoint_nam
e ${CKPT_NAME}      --nemo_file_path ${OUTPUT_NAME}      --tensor_model_parallel_size 4      --pipeline_model_parallel_size 1      --gpus_per_node 8      --precision bf16-mixed      --model_type gpt      --hparams_file ${HPARAMS_F
ILEPATH}
/usr/local/lib/python3.10/dist-packages/torch/distributed/launch.py:181: FutureWarning: The module torch.distributed.launch is deprecated
and will be removed in future. Use torchrun.
Note that --use-env is set by default in torchrun.
If your script expects `--local-rank` argument to be set, please
change it to read from `os.environ['LOCAL_RANK']` instead. See 
https://pytorch.org/docs/stable/distributed.html#launch-utility for 
further instructions

  warnings.warn(
[2024-01-11 03:38:10,336] torch.distributed.run: [WARNING] 
[2024-01-11 03:38:10,336] torch.distributed.run: [WARNING] *****************************************
[2024-01-11 03:38:10,336] torch.distributed.run: [WARNING] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
[2024-01-11 03:38:10,336] torch.distributed.run: [WARNING] *****************************************
[NeMo W 2024-01-11 03:38:18 nemo_logging:349] /usr/local/lib/python3.10/dist-packages/pandas/core/computation/expressions.py:20: UserWarning: Pandas requires version '2.7.3' or newer of 'numexpr' (version '2.7.2' currently install
ed).
      from pandas.core.computation.check import NUMEXPR_INSTALLED
    
usage: megatron_ckpt_to_nemo.py [-h] --checkpoint_folder CHECKPOINT_FOLDER --checkpoint_name CHECKPOINT_NAME [--hparams_file HPARAMS_FILE] --nemo_file_path NEMO_FILE_PATH --gpus_per_node GPUS_PER_NODE
                                --tensor_model_parallel_size TENSOR_MODEL_PARALLEL_SIZE --pipeline_model_parallel_size PIPELINE_MODEL_PARALLEL_SIZE [--pipeline_model_parallel_split_rank PIPELINE_MODEL_PARALLEL_SPLIT_RANK]
                                --model_type {gpt,sft,t5,bert,nmt,bart,retro} [--local_rank LOCAL_RANK] [--bcp] [--precision {32-true,16-mixed,bf16-mixed}]
megatron_ckpt_to_nemo.py: error: unrecognized arguments: --local-rank=2
[2024-01-11 03:38:25,357] torch.distributed.elastic.multiprocessing.api: [WARNING] Sending process 2521 closing signal SIGTERM
[2024-01-11 03:38:25,357] torch.distributed.elastic.multiprocessing.api: [WARNING] Sending process 2522 closing signal SIGTERM
[2024-01-11 03:38:25,357] torch.distributed.elastic.multiprocessing.api: [WARNING] Sending process 2524 closing signal SIGTERM
[2024-01-11 03:38:25,420] torch.distributed.elastic.multiprocessing.api: [ERROR] failed (exitcode: 2) local_rank: 2 (pid: 2523) of binary: /usr/bin/python
Traceback (most recent call last):
  File "/usr/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/usr/local/lib/python3.10/dist-packages/torch/distributed/launch.py", line 196, in <module>
    main()
  File "/usr/local/lib/python3.10/dist-packages/torch/distributed/launch.py", line 192, in main
    launch(args)
  File "/usr/local/lib/python3.10/dist-packages/torch/distributed/launch.py", line 177, in launch
    run(args)
  File "/usr/local/lib/python3.10/dist-packages/torch/distributed/run.py", line 797, in run
    elastic_launch(
  File "/usr/local/lib/python3.10/dist-packages/torch/distributed/launcher/api.py", line 134, in __call__
    return launch_agent(self._config, self._entrypoint, list(args))
  File "/usr/local/lib/python3.10/dist-packages/torch/distributed/launcher/api.py", line 264, in launch_agent
    raise ChildFailedError(
torch.distributed.elastic.multiprocessing.errors.ChildFailedError: 
============================================================
/opt/NeMo//examples/nlp/language_modeling/megatron_ckpt_to_nemo.py FAILED
------------------------------------------------------------
Failures:
  <NO_OTHER_FAILURES>
------------------------------------------------------------
Root Cause (first observed failure):
[0]:
  time      : 2024-01-11_03:38:25
  host      : dgxa0335p.av4.bm.infra.nvda.ai
  rank      : 2 (local_rank: 2)
  exitcode  : 2 (pid: 2523)
  error_file: <N/A>
  traceback : To enable traceback see: https://pytorch.org/docs/stable/elastic/errors.html
```

