### PR TITLE
Fix FSDP SHARP integration

### DIFF
--- a/nemo/collections/nlp/parts/megatron_trainer_builder.py
+++ b/nemo/collections/nlp/parts/megatron_trainer_builder.py
@@ -69,6 +69,7 @@ class MegatronTrainerBuilder:
                 sharded_checkpoint=sharded_checkpoint,
                 precision=self.cfg.trainer.precision,
                 nccl_communicator_config_path=self.cfg.model.get('nccl_communicator_config_path', None),
+                sharp=self.cfg.model.get('sharp', False),
             )
 
         return NLPDDPStrategy(

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -517,6 +517,7 @@ class NLPFSDPStrategy(FSDPStrategy):
         sharded_checkpoint: bool = False,
         precision: Union[int, str] = 'bf16-mixed',
         nccl_communicator_config_path: Optional[str] = None,
+        sharp: bool = False,
         **kwargs: Union[Any, Dict[str, Any]],
     ) -> None:
         if not HAVE_APEX:
@@ -561,6 +562,7 @@ class NLPFSDPStrategy(FSDPStrategy):
         )
 
         self.nccl_communicator_config_path = nccl_communicator_config_path
+        self.sharp = sharp
         super().__init__(**kwargs)
 
     def _set_mixed_precision_recipe(


### PR DESCRIPTION
The attribute was never implemented.

# What does this PR do ?

For NeMo NLP, the FSDP sharding strategy cannot be used currently because the `sharp` attribute for the `NLPFSDPStrategy` was not actually implemented in https://github.com/NVIDIA/NeMo/pull/7793, even though it is queried.

**Collection**:
- NLP

# Changelog 
- Implement missing `NLPFSDPStrategy.sharp` attribute.

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
Related to #7793 (pull request)
