### PR TITLE
Add Lhotse support for `offset` key in NeMo manifests

### DIFF
--- a/nemo/collections/common/data/lhotse/nemo_adapters.py
+++ b/nemo/collections/common/data/lhotse/nemo_adapters.py
@@ -71,6 +71,7 @@ class LazyNeMoIterator(ImitatesDict):
             cut = recording.to_cut()
             if offset is not None:
                 cut = cut.truncate(offset=offset, duration=duration, preserve_id=True)
+                cut.id = f"{cut.id}-{round(offset * 1e2):06d}-{round(duration * 1e2):06d}"
             # Note that start=0 and not start=offset because supervision's start if relative to the
             # start of the cut; and cut.start is already set to offset
             cut.supervisions.append(

--- a/nemo/collections/common/data/lhotse/nemo_adapters.py
+++ b/nemo/collections/common/data/lhotse/nemo_adapters.py
@@ -36,24 +36,25 @@ class LazyNeMoIterator(ImitatesDict):
     Currently, it requires the following keys in NeMo manifests:
     - "audio_filepath"
     - "duration"
-    - "text" (overridable with text_field argument)
+    - "text" (overridable with ``text_field`` argument)
+
+    Specially supported keys are:
+    - "offset" for partial recording reads
+    - "lang" is mapped to Lhotse superivsion's language (overridable with ``lang_field`` argument)
 
     Every other key found in the manifest will be attached to Lhotse Cut and accessible via ``cut.custom[key]``.
 
-    .. caution:: If sampling rate is not specified, we will perform some I/O (as much as required by soundfile.info)
-        to discover the sampling rate of the audio file. Otherwise, if sampling rate is provided, we assume every
-        audio file has the same sampling rate.
+    .. caution:: We will perform some I/O (as much as required by soundfile.info) to discover the sampling rate
+        of the audio file. If this is not acceptable, convert the manifest to Lhotse format which contains
+        sampling rate info.
 
     Example::
 
-        >>> cuts = lhotse.CutSet(LazyNeMoIterator("nemo_manifests/train.json", sampling_rate=16000))
+        >>> cuts = lhotse.CutSet(LazyNeMoIterator("nemo_manifests/train.json"))
     """
 
-    def __init__(
-        self, path: str | Path, sampling_rate: int | None = None, text_field: str = "text", lang_field: str = "lang"
-    ) -> None:
+    def __init__(self, path: str | Path, text_field: str = "text", lang_field: str = "lang") -> None:
         self.source = LazyJsonlIterator(path)
-        self.sampling_rate = sampling_rate
         self.text_field = text_field
         self.lang_field = lang_field
 
@@ -65,17 +66,13 @@ class LazyNeMoIterator(ImitatesDict):
         for data in self.source:
             audio_path = data.pop("audio_filepath")
             duration = data.pop("duration")
-            if self.sampling_rate is None:
-                recording = Recording.from_file(audio_path)
-            else:
-                recording = Recording(
-                    id=Path(audio_path).name,
-                    sources=[AudioSource(type="file", channels=[0], source=audio_path)],
-                    sampling_rate=self.sampling_rate,
-                    duration=duration,
-                    num_samples=compute_num_samples(duration, self.sampling_rate),
-                )
+            offset = data.pop("offset", None)
+            recording = Recording.from_file(audio_path)
             cut = recording.to_cut()
+            if offset is not None:
+                cut = cut.truncate(offset=offset, duration=duration, preserve_id=True)
+            # Note that start=0 and not start=offset because supervision's start if relative to the
+            # start of the cut; and cut.start is already set to offset
             cut.supervisions.append(
                 SupervisionSegment(
                     id=cut.id,
@@ -106,6 +103,9 @@ class LazyNeMoTarredIterator(ImitatesDict):
     - "duration"
     - "text" (overridable with text_field argument)
     - "shard_id"
+
+    Specially supported keys are:
+    - "lang" is mapped to Lhotse superivsion's language (overridable with ``lang_field`` argument)
 
     Every other key found in the manifest will be attached to Lhotse Cut and accessible via ``cut.custom[key]``.
 

--- a/tests/collections/common/test_lhotse_dataloading.py
+++ b/tests/collections/common/test_lhotse_dataloading.py
@@ -680,18 +680,34 @@ def test_lazy_nemo_iterator_with_offset_field(tmp_path: Path):
     from nemo.collections.common.data.lhotse.nemo_adapters import LazyNeMoIterator
 
     # Have to generate as INT16 to avoid quantization error after saving to 16-bit WAV
-    INT16MAX = 32768
+    INT16MAX = 2 ** 15
     expected_audio = np.random.randint(low=-INT16MAX - 1, high=INT16MAX, size=(16000,)).astype(np.float32) / INT16MAX
     audio_path = str(tmp_path / "dummy.wav")
     sf.write(audio_path, expected_audio, 16000)
 
     manifest_path = str(tmp_path / "manifest.json")
     lhotse.serialization.save_to_jsonl(
-        [{"audio_filepath": audio_path, "offset": 0.5, "duration": 0.5, "text": "irrelevant"}], manifest_path,
+        [
+            {"audio_filepath": audio_path, "offset": 0.0, "duration": 0.5, "text": "irrelevant"},
+            {"audio_filepath": audio_path, "offset": 0.5, "duration": 0.5, "text": "irrelevant"},
+        ],
+        manifest_path,
     )
 
     cuts = lhotse.CutSet(LazyNeMoIterator(manifest_path))
+
     cut = cuts[0]
+    assert isinstance(cut, lhotse.MonoCut)
+    assert cut.start == 0.0
+    assert cut.duration == 0.5
+    assert cut.sampling_rate == 16000
+    assert cut.num_samples == 8000
+    assert cut.supervisions[0].text == "irrelevant"
+    audio = cut.load_audio()
+    assert audio.shape == (1, 8000)
+    np.testing.assert_equal(audio[0], expected_audio[:8000])
+
+    cut = cuts[1]
     assert isinstance(cut, lhotse.MonoCut)
     assert cut.start == 0.5
     assert cut.duration == 0.5
@@ -701,3 +717,5 @@ def test_lazy_nemo_iterator_with_offset_field(tmp_path: Path):
     audio = cut.load_audio()
     assert audio.shape == (1, 8000)
     np.testing.assert_equal(audio[0], expected_audio[8000:])
+
+    assert cuts[0].id != cuts[1].id

--- a/tests/collections/common/test_lhotse_dataloading.py
+++ b/tests/collections/common/test_lhotse_dataloading.py
@@ -671,3 +671,33 @@ def test_dataloader_from_nemo_manifest_with_lang_field(nemo_manifest_path: Path,
     dl = get_lhotse_dataloader_from_config(config=config, global_rank=0, world_size=1, dataset=LangDataset())
     b = next(iter(dl))
     assert b == [lang_value] * 2
+
+
+def test_lazy_nemo_iterator_with_offset_field(tmp_path: Path):
+    import numpy as np
+    import soundfile as sf
+
+    from nemo.collections.common.data.lhotse.nemo_adapters import LazyNeMoIterator
+
+    # Have to generate as INT16 to avoid quantization error after saving to 16-bit WAV
+    INT16MAX = 32768
+    expected_audio = np.random.randint(low=-INT16MAX - 1, high=INT16MAX, size=(16000,)).astype(np.float32) / INT16MAX
+    audio_path = str(tmp_path / "dummy.wav")
+    sf.write(audio_path, expected_audio, 16000)
+
+    manifest_path = str(tmp_path / "manifest.json")
+    lhotse.serialization.save_to_jsonl(
+        [{"audio_filepath": audio_path, "offset": 0.5, "duration": 0.5, "text": "irrelevant"}], manifest_path,
+    )
+
+    cuts = lhotse.CutSet(LazyNeMoIterator(manifest_path))
+    cut = cuts[0]
+    assert isinstance(cut, lhotse.MonoCut)
+    assert cut.start == 0.5
+    assert cut.duration == 0.5
+    assert cut.sampling_rate == 16000
+    assert cut.num_samples == 8000
+    assert cut.supervisions[0].text == "irrelevant"
+    audio = cut.load_audio()
+    assert audio.shape == (1, 8000)
+    np.testing.assert_equal(audio[0], expected_audio[8000:])


### PR DESCRIPTION
# What does this PR do ?

Add Lhotse support for `offset` key in NeMo manifests

**Collection**: All speech collections

# Changelog 
- Add Lhotse support for `offset` key in NeMo manifests

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
