### PR TITLE
Fix to peft & virtual pipeline parallel unsupported check

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -89,9 +89,6 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
             if hasattr(self.cfg.data.test_ds, "metric"):
                 self.test_metric_label_key = self.cfg.data.test_ds.metric.get('label_key', 'labels')
 
-        if self.use_peft and self.cfg.get('virtual_pipeline_model_parallel_size', None):
-            raise ValueError('Virtual pipeline model parallel is not supported when using PEFT')
-
         # Set the profile start and end steps in the unit of global batach
         if hasattr(self, '_nsys_profile_enabled'):
             self._nsys_profile_start_step = self.cfg.nsys_profile.get('start_step', 0)

--- a/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
+++ b/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
@@ -173,6 +173,9 @@ class NLPAdapterModelMixin:
             peft_cfgs: One or more PEFTConfig objects that specify the PEFT method configuration
         """
 
+        if self.cfg.get('virtual_pipeline_model_parallel_size', None):
+            raise ValueError('Virtual pipeline model parallel is not supported when using PEFT')
+
         if not isinstance(peft_cfgs, List):
             peft_cfgs = [peft_cfgs]
 


### PR DESCRIPTION
# What does this PR do ?

Corrects the check added in [PR-7964](https://github.com/NVIDIA/NeMo/pull/7964) to raise a ValueError when attempting to run virtual pipeline parallel with peft.

**Collection**: nlp/language_modeling

# Changelog 
- Moves this safety check from `MegatronGPTSFTModel.__init__` (where self.use_peft had not yet been set to true, so the check did not function) to `NLPAdapterModelMixin.add_adapter`

# Usage
Running with the unsupported combination of peft and virtual pipeline parallel now yields a more useful error message:

```
python examples/nlp/language_modeling/tuning/megatron_gpt_peft_tuning.py \
    ++model.virtual_pipeline_model_parallel_size=10 \
    ++model.peft.peft_scheme=lora \
    ...
```
gives
```
  File "/opt/NeMo/examples/nlp/language_modeling/tuning/megatron_gpt_peft_tuning.py", line 73, in main
    model.add_adapter(peft_cfg_cls(model_cfg))
  File "/opt/NeMo/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py", line 178, in add_adapter
    raise ValueError('Virtual pipeline model parallel is not supported when using PEFT')
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
