### PR TITLE
Script for estimating Lhotse dynamic duration buckets

### DIFF
--- a/nemo/collections/common/data/lhotse/cutset.py
+++ b/nemo/collections/common/data/lhotse/cutset.py
@@ -14,6 +14,7 @@
 
 import logging
 import warnings
+from itertools import repeat
 from pathlib import Path
 from typing import Sequence, Tuple
 
@@ -47,7 +48,6 @@ def read_cutset_from_config(config) -> Tuple[CutSet, bool]:
 
 
 def read_lhotse_manifest(config, is_tarred: bool) -> CutSet:
-
     if is_tarred:
         # Lhotse Shar is the equivalent of NeMo's native "tarred" dataset.
         # The combination of shuffle_shards, and repeat causes this to
@@ -95,7 +95,7 @@ def read_lhotse_manifest(config, is_tarred: bool) -> CutSet:
                 logging.info(f"- {path=} {weight=}")
                 cutsets.append(cs.repeat())
                 weights.append(weight)
-            cuts = CutSet.mux(*cutsets, weights=weights)
+            cuts = mux(*cutsets, weights=weights, max_open_streams=config.max_open_streams)
     else:
         # Regular Lhotse manifest points to individual audio files (like native NeMo manifest).
         cuts = CutSet.from_file(config.cuts_path)
@@ -107,11 +107,10 @@ def read_nemo_manifest(config, is_tarred: bool) -> CutSet:
         "text_field": config.text_field,
         "lang_field": config.lang_field,
     }
-    if is_tarred:
-        if isinstance(config.manifest_filepath, (str, Path)):
-            logging.info(
-                f"Initializing Lhotse CutSet from a single NeMo manifest (tarred): '{config.manifest_filepath}'"
-            )
+    notar_kwargs = {"dummy_mode": config.dummy_mode}
+    if isinstance(config.manifest_filepath, (str, Path)):
+        logging.info(f"Initializing Lhotse CutSet from a single NeMo manifest (tarred): '{config.manifest_filepath}'")
+        if is_tarred:
             cuts = CutSet(
                 LazyNeMoTarredIterator(
                     config.manifest_filepath,
@@ -121,61 +120,70 @@ def read_nemo_manifest(config, is_tarred: bool) -> CutSet:
                 )
             )
         else:
-            # Format option 1:
-            #   Assume it's [[path1], [path2], ...] (same for tarred_audio_filepaths).
-            #   This is the format for multiple NeMo buckets.
-            #   Note: we set "weights" here to be proportional to the number of utterances in each data source.
-            #         this ensures that we distribute the data from each source uniformly throughout each epoch.
-            #         Setting equal weights would exhaust the shorter data sources closer the towards the beginning
-            #         of an epoch (or over-sample it in the case of infinite CutSet iteration with .repeat()).
-            # Format option 1:
-            #   Assume it's [[path1, weight1], [path2, weight2], ...] (while tarred_audio_filepaths remain unchanged).
-            #   Note: this option allows to manually set the weights for multiple datasets.
-            logging.info(
-                f"Initializing Lhotse CutSet from multiple tarred NeMo manifest sources with a weighted multiplexer. "
-                f"We found the following sources and weights: "
-            )
-            cutsets = []
-            weights = []
-            for manifest_info, (tar_path,) in zip(config.manifest_filepath, config.tarred_audio_filepaths):
-                if len(manifest_info) == 1:
-                    (manifest_path,) = manifest_info
-                    nemo_iter = LazyNeMoTarredIterator(
-                        manifest_path=manifest_path, tar_paths=tar_path, shuffle_shards=config.shuffle, **common_kwargs
-                    )
-                    weight = len(nemo_iter)
-                else:
-                    assert (
-                        isinstance(manifest_info, Sequence)
-                        and len(manifest_info) == 2
-                        and isinstance(manifest_info[1], (int, float))
-                    ), (
-                        "Supported inputs types for config.manifest_filepath are: "
-                        "str | list[list[str]] | list[tuple[str, number]] "
-                        "where str is a path and number is a mixing weight (it may exceed 1.0). "
-                        f"We got: '{manifest_info}'"
-                    )
-                    manifest_path, weight = manifest_info
-                    nemo_iter = LazyNeMoTarredIterator(
-                        manifest_path=manifest_path, tar_paths=tar_path, shuffle_shards=config.shuffle, **common_kwargs
-                    )
-                logging.info(f"- {manifest_path=} {weight=}")
-                if config.max_open_streams is not None:
-                    for subiter in nemo_iter.to_shards():
-                        cutsets.append(CutSet(subiter))
-                        weights.append(weight)
-                else:
-                    cutsets.append(CutSet(nemo_iter))
-                    weights.append(weight)
-            if config.max_open_streams is not None:
-                cuts = CutSet.infinite_mux(
-                    *cutsets, weights=weights, seed="trng", max_open_streams=config.max_open_streams
+            cuts = CutSet(LazyNeMoIterator(config.manifest_filepath, **notar_kwargs, **common_kwargs))
+    else:
+        # Format option 1:
+        #   Assume it's [[path1], [path2], ...] (same for tarred_audio_filepaths).
+        #   This is the format for multiple NeMo buckets.
+        #   Note: we set "weights" here to be proportional to the number of utterances in each data source.
+        #         this ensures that we distribute the data from each source uniformly throughout each epoch.
+        #         Setting equal weights would exhaust the shorter data sources closer the towards the beginning
+        #         of an epoch (or over-sample it in the case of infinite CutSet iteration with .repeat()).
+        # Format option 1:
+        #   Assume it's [[path1, weight1], [path2, weight2], ...] (while tarred_audio_filepaths remain unchanged).
+        #   Note: this option allows to manually set the weights for multiple datasets.
+        logging.info(
+            f"Initializing Lhotse CutSet from multiple tarred NeMo manifest sources with a weighted multiplexer. "
+            f"We found the following sources and weights: "
+        )
+        cutsets = []
+        weights = []
+        tar_paths = config.tarred_audio_filepaths if is_tarred else repeat((None,))
+        # Create a stream for each dataset.
+        for manifest_info, (tar_path,) in zip(config.manifest_filepath, tar_paths):
+            # First, convert manifest_path[+tar_path] to an iterator.
+            manifest_path = manifest_info[0]
+            if is_tarred:
+                nemo_iter = LazyNeMoTarredIterator(
+                    manifest_path=manifest_path, tar_paths=tar_path, shuffle_shards=config.shuffle, **common_kwargs
                 )
             else:
-                cuts = CutSet.mux(*[cs.repeat() for cs in cutsets], weights=weights, seed="trng")
+                nemo_iter = LazyNeMoIterator(manifest_path, **notar_kwargs, **common_kwargs)
+            # Then, determine the weight or use one provided
+            if len(manifest_info) == 1:
+                weight = len(nemo_iter)
+            else:
+                assert (
+                    isinstance(manifest_info, Sequence)
+                    and len(manifest_info) == 2
+                    and isinstance(manifest_info[1], (int, float))
+                ), (
+                    "Supported inputs types for config.manifest_filepath are: "
+                    "str | list[list[str]] | list[tuple[str, number]] "
+                    "where str is a path and number is a mixing weight (it may exceed 1.0). "
+                    f"We got: '{manifest_info}'"
+                )
+                weight = manifest_info[1]
+            logging.info(f"- {manifest_path=} {weight=}")
+            # [optional] When we have a limit on the number of open streams,
+            #   split the manifest to individual shards if applicable.
+            #   This helps the multiplexing achieve closer data distribution
+            #   to the one desired in spite of the limit.
+            if config.max_open_streams is not None:
+                for subiter in nemo_iter.to_shards():
+                    cutsets.append(CutSet(subiter))
+                    weights.append(weight)
+            else:
+                cutsets.append(CutSet(nemo_iter))
+                weights.append(weight)
+        # Finally, we multiplex the dataset streams to mix the data.
+        cuts = mux(*cutsets, weights=weights, max_open_streams=config.max_open_streams)
+    return cuts
+
+
+def mux(*cutsets: CutSet, weights: list[int | float], max_open_streams: int | None = None) -> CutSet:
+    if max_open_streams is not None:
+        cuts = CutSet.infinite_mux(*cutsets, weights=weights, seed="trng", max_open_streams=max_open_streams)
     else:
-        logging.info(
-            f"Initializing Lhotse CutSet from a single NeMo manifest (non-tarred): '{config.manifest_filepath}'"
-        )
-        cuts = CutSet(LazyNeMoIterator(config.manifest_filepath, **common_kwargs))
+        cuts = CutSet.mux(*[cs.repeat() for cs in cutsets], weights=weights, seed="trng")
     return cuts

--- a/nemo/collections/common/data/lhotse/dataloader.py
+++ b/nemo/collections/common/data/lhotse/dataloader.py
@@ -93,6 +93,7 @@ class LhotseDataLoadingConfig:
     # 5. Other Lhotse options.
     text_field: str = "text"  # key to read the transcript from
     lang_field: str = "lang"  # key to read the language tag from
+    dummy_mode: bool = False  # Enables iteration of NeMo non-tarred manifests without performing any I/O
 
 
 def get_lhotse_dataloader_from_config(

--- a/scripts/speech_recognition/estimate_duration_bins.py
+++ b/scripts/speech_recognition/estimate_duration_bins.py
@@ -1,0 +1,100 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+from lhotse.dataset.sampling.dynamic_bucketing import estimate_duration_buckets
+from omegaconf import OmegaConf
+
+from nemo.collections.common.data.lhotse.cutset import read_cutset_from_config
+from nemo.collections.common.data.lhotse.dataloader import LhotseDataLoadingConfig
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="Estimate duration bins for Lhotse dynamic bucketing using a sample of the input dataset. "
+        "The dataset is read either from one or more manifest files and supports data weighting."
+    )
+    parser.add_argument(
+        "input",
+        help='Same input format as in model configs under model.train_ds.manifest_filepath. Options: '
+        '1) "path.json"; '
+        '2) "[path1.json,path2.json,...]"; '
+        '3) "[[path1.json,weight1],[path2.json,weight2],...]"',
+    )
+    parser.add_argument("-b", "--buckets", type=int, default=30, help="The desired number of buckets.")
+    parser.add_argument(
+        "-n",
+        "--num_examples",
+        type=int,
+        default=-1,
+        help="The number of examples (utterances) to estimate the bins. -1 means use all data.",
+    )
+    parser.add_argument(
+        "-l",
+        "--min_duration",
+        type=float,
+        default=-float("inf"),
+        help="If specified, we'll filter out utterances shorter than this.",
+    )
+    parser.add_argument(
+        "-u",
+        "--max_duration",
+        type=float,
+        default=float("inf"),
+        help="If specified, we'll filter out utterances longer than this.",
+    )
+    parser.add_argument(
+        "-q", "--quiet", type=bool, default=False, help="When specified, only print the estimated duration bins."
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    config = OmegaConf.merge(
+        OmegaConf.structured(LhotseDataLoadingConfig),
+        OmegaConf.create({"manifest_filepath": args.input, "dummy_mode": True}),
+    )
+    cuts, _ = read_cutset_from_config(config)
+    min_dur, max_dur = args.min_duration, args.max_duration
+    discarded, tot = 0, 0
+
+    def duration_ok(cut) -> bool:
+        nonlocal discarded, tot
+        ans = min_dur <= cut.duration <= max_dur
+        if not ans:
+            discarded += 1
+        tot += 1
+        return ans
+
+    cuts = cuts.filter(duration_ok)
+    if (N := args.num_examples) > 0:
+        cuts = cuts.subset(first=N)
+    duration_bins = estimate_duration_buckets(cuts, num_buckets=args.buckets)
+    duration_bins = f"[{','.join(str(round(b, ndigits=5)) for b in duration_bins)}]"
+    if args.quiet:
+        print(duration_bins)
+        return
+    if discarded:
+        ratio = discarded / tot
+        print(f"Note: we discarded {discarded}/{tot} ({ratio:.2%}) utterances due to min/max duration filtering.")
+    print("Use the following options in your config:")
+    print(f"\tnum_buckets={args.buckets}")
+    print(f"\tbucket_duration_bins={duration_bins}")
+    print("Computing utterance duration distribution...")
+    cuts.describe()  # prints a nice table with duration stats + other info
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
# What does this PR do ?

The script provides the user with the optimal, data-driven value of `model.train_ds.bucket_duration_bins` to avoid computing it at the start of the training.

It requires tiny changes to enable dataset mixing with non-tarred manifests (as we don't want to actually load any data here) and triggered an opportunity for a small refactor of the `CutSet` initialization code. Another issue was that NeMo manifests do not have `sampling_rate` info but Lhotse must have it to create a Recording object -- I introduced a `dummy_mode` for use-cases like this where we only need to iterate the metadata.

**Collection**: All speech collections

# Changelog 
- Script for estimating Lhotse dynamic duration buckets

# Usage

## Help message
```bash
$ python scripts/speech_recognition/estimate_duration_bins.py --help
usage: estimate_duration_bins.py [-h] [-b BUCKETS] [-n NUM_EXAMPLES]
                                 [-l MIN_DURATION] [-u MAX_DURATION] [-q QUIET]
                                 input

Estimate duration bins for Lhotse dynamic bucketing using a sample of the input
dataset. The dataset is read either from one or more manifest files and supports
data weighting.

positional arguments:
  input                 Same input format as in model configs under
                        model.train_ds.manifest_filepath. Options: 1)
                        "path.json"; 2) "[path1.json,path2.json,...]"; 3)
                        "[[path1.json,weight1],[path2.json,weight2],...]"

options:
  -h, --help            show this help message and exit
  -b BUCKETS, --buckets BUCKETS
                        The desired number of buckets.
  -n NUM_EXAMPLES, --num_examples NUM_EXAMPLES
                        The number of examples (utterances) to estimate the
                        bins. -1 means use all data.
  -l MIN_DURATION, --min_duration MIN_DURATION
                        If specified, we'll filter out utterances shorter than
                        this.
  -u MAX_DURATION, --max_duration MAX_DURATION
                        If specified, we'll filter out utterances longer than
                        this.
  -q QUIET, --quiet QUIET
                        When specified, only print the estimated duration bins.
```

## Example manifest and options
```bash
$ python scripts/speech_recognition/estimate_duration_bins.py -b 30 -l 2 -u 2.5 -n 10000 manifest.json
Note: we discarded 50168/60168 (83.38%) utterances due to min/max duration filtering.
Use the following options in your config:
        num_buckets=30
        bucket_duration_bins=[2.03,2.05419,2.08,2.11,2.13452,2.16,2.18,2.2,2.22,2.24,2.2531,2.27,2.285,2.3,2.3175,2.33,2.342,2.36,2.37,2.3896,2.4,2.41369,2.4295,2.44,2.45,2.46,2.47,2.48,2.491]
Computing utterance duration distribution...
Cut statistics:
╒═══════════════════════════╤══════════╕
│ Cuts count:               │ 10000    │
├───────────────────────────┼──────────┤
│ Total duration (hh:mm:ss) │ 06:21:17 │
├───────────────────────────┼──────────┤
│ mean                      │ 2.3      │
├───────────────────────────┼──────────┤
│ std                       │ 0.1      │
├───────────────────────────┼──────────┤
│ min                       │ 2.0      │
├───────────────────────────┼──────────┤
│ 25%                       │ 2.2      │
├───────────────────────────┼──────────┤
│ 50%                       │ 2.3      │
├───────────────────────────┼──────────┤
│ 75%                       │ 2.4      │
├───────────────────────────┼──────────┤
│ 99%                       │ 2.5      │
├───────────────────────────┼──────────┤
│ 99.5%                     │ 2.5      │
├───────────────────────────┼──────────┤
│ 99.9%                     │ 2.5      │
├───────────────────────────┼──────────┤
│ max                       │ 2.5      │
├───────────────────────────┼──────────┤
│ Recordings available:     │ 10000    │
├───────────────────────────┼──────────┤
│ Features available:       │ 0        │
├───────────────────────────┼──────────┤
│ Supervisions available:   │ 10000    │
╘═══════════════════════════╧══════════╛
CUT custom fields:
- shard_id (in 10000 cuts)
- text (in 10000 cuts)
- pcstrip_text (in 10000 cuts)
- source_lang (in 10000 cuts)
- target_lang (in 10000 cuts)
- taskname (in 10000 cuts)
- pnc (in 10000 cuts)
- answer (in 10000 cuts)
Speech duration statistics:
╒══════════════════════════════╤══════════╤══════════════════════╕
│ Total speech duration        │ 06:21:17 │ 100.00% of recording │
├──────────────────────────────┼──────────┼──────────────────────┤
│ Total speaking time duration │ 06:21:17 │ 100.00% of recording │
├──────────────────────────────┼──────────┼──────────────────────┤
│ Total silence duration       │ 00:00:01 │ 0.00% of recording   │
╘══════════════════════════════╧══════════╧══════════════════════╛

```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
