### PR TITLE
Allow MegatronPretrainingRandomSampler to do multi-epoch training

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py
@@ -147,16 +147,17 @@ class MegatronPretrainingRandomSampler(BaseMegatronSampler):
             pad_samples_to_global_batch_size=pad_samples_to_global_batch_size,
         )
         assert (
-            pad_samples_to_global_batch_size == False
+            not pad_samples_to_global_batch_size
         ), "`MegatronPretrainingRandomSampler` does not support sample padding"
+        if (not drop_last) and self.micro_batch_times_data_parallel_size > 1:
+            raise RuntimeError("`MegatronPretrainingRandomSampler` does not support drop_last=False when micro_batch_size * data_parallel_size > 1. \
+                                please reduce your MBS and data parallelism to 1 if you want to use drop_last=False, or switch to drop_last=True to avoid this error")
         self.last_batch_size = self.total_samples % self.micro_batch_times_data_parallel_size
         self.seed = seed
 
     def __len__(self):
         active_total_samples = self.total_samples - (self.last_batch_size if self.drop_last else 0)
-        num_available_samples = (
-            active_total_samples * (1 + (self.consumed_samples // active_total_samples))
-        ) - self.consumed_samples
+        num_available_samples = active_total_samples - self.consumed_samples % active_total_samples
         if self.global_batch_size is not None:
             if self.drop_last:
                 return num_available_samples // self.global_batch_size

--- a/nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py
@@ -152,7 +152,7 @@ class MegatronPretrainingRandomSampler(BaseMegatronSampler):
         if (not drop_last) and self.micro_batch_times_data_parallel_size > 1:
             raise RuntimeError(
                 "`MegatronPretrainingRandomSampler` does not support drop_last=False when micro_batch_size * data_parallel_size > 1. \
-                                please reduce your MBS and data parallelism to 1 if you want to use drop_last=False, or switch to drop_last=True to avoid this error"
+                  please reduce your MBS and data parallelism to 1 if you want to use drop_last=False, or switch to drop_last=True to avoid this error"
             )
         self.last_batch_size = self.total_samples % self.micro_batch_times_data_parallel_size
         self.seed = seed

--- a/nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py
@@ -134,6 +134,7 @@ class MegatronPretrainingRandomSampler(BaseMegatronSampler):
         drop_last: bool = True,
         global_batch_size: Optional[int] = None,
         pad_samples_to_global_batch_size: Optional[bool] = False,
+        seed: int = 0,
     ) -> None:
         super().__init__(
             total_samples=total_samples,
@@ -149,9 +150,13 @@ class MegatronPretrainingRandomSampler(BaseMegatronSampler):
             pad_samples_to_global_batch_size == False
         ), "`MegatronPretrainingRandomSampler` does not support sample padding"
         self.last_batch_size = self.total_samples % self.micro_batch_times_data_parallel_size
+        self.seed = seed
 
     def __len__(self):
-        num_available_samples: int = self.total_samples
+        active_total_samples = self.total_samples - (self.last_batch_size if self.drop_last else 0)
+        num_available_samples = (
+            active_total_samples * (1 + (self.consumed_samples // active_total_samples))
+        ) - self.consumed_samples
         if self.global_batch_size is not None:
             if self.drop_last:
                 return num_available_samples // self.global_batch_size
@@ -175,7 +180,7 @@ class MegatronPretrainingRandomSampler(BaseMegatronSampler):
         start_idx = self.data_parallel_rank * bucket_size
 
         g = torch.Generator()
-        g.manual_seed(self.epoch)
+        g.manual_seed(self.seed + self.epoch)
         random_idx = torch.randperm(bucket_size, generator=g).tolist()
         idx_range = [start_idx + x for x in random_idx[bucket_offset:]]
 

--- a/nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py
@@ -150,8 +150,10 @@ class MegatronPretrainingRandomSampler(BaseMegatronSampler):
             not pad_samples_to_global_batch_size
         ), "`MegatronPretrainingRandomSampler` does not support sample padding"
         if (not drop_last) and self.micro_batch_times_data_parallel_size > 1:
-            raise RuntimeError("`MegatronPretrainingRandomSampler` does not support drop_last=False when micro_batch_size * data_parallel_size > 1. \
-                                please reduce your MBS and data parallelism to 1 if you want to use drop_last=False, or switch to drop_last=True to avoid this error")
+            raise RuntimeError(
+                "`MegatronPretrainingRandomSampler` does not support drop_last=False when micro_batch_size * data_parallel_size > 1. \
+                                please reduce your MBS and data parallelism to 1 if you want to use drop_last=False, or switch to drop_last=True to avoid this error"
+            )
         self.last_batch_size = self.total_samples % self.micro_batch_times_data_parallel_size
         self.seed = seed
 

--- a/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -208,8 +208,10 @@ class MegatronPretrainingRandomBatchSampler(BaseMegatronBatchSampler):
             not pad_samples_to_global_batch_size
         ), "`MegatronPretrainingRandomBatchSampler` does not support sample padding"
         if (not drop_last) and self.micro_batch_times_data_parallel_size > 1:
-            raise RuntimeError("`MegatronPretrainingRandomBatchSampler` does not support drop_last=False when micro_batch_size * data_parallel_size > 1. \
-                                please reduce your MBS and data parallelism to 1 if you want to use drop_last=False, or switch to drop_last=True to avoid this error")
+            raise RuntimeError(
+                "`MegatronPretrainingRandomBatchSampler` does not support drop_last=False when micro_batch_size * data_parallel_size > 1. \
+                                please reduce your MBS and data parallelism to 1 if you want to use drop_last=False, or switch to drop_last=True to avoid this error"
+            )
         self.last_batch_size = self.total_samples % self._global_batch_size
         self.seed = seed
 

--- a/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py
@@ -210,7 +210,7 @@ class MegatronPretrainingRandomBatchSampler(BaseMegatronBatchSampler):
         if (not drop_last) and self.micro_batch_times_data_parallel_size > 1:
             raise RuntimeError(
                 "`MegatronPretrainingRandomBatchSampler` does not support drop_last=False when micro_batch_size * data_parallel_size > 1. \
-                                please reduce your MBS and data parallelism to 1 if you want to use drop_last=False, or switch to drop_last=True to avoid this error"
+                  please reduce your MBS and data parallelism to 1 if you want to use drop_last=False, or switch to drop_last=True to avoid this error"
             )
         self.last_batch_size = self.total_samples % self._global_batch_size
         self.seed = seed


### PR DESCRIPTION
# What does this PR do ?

Allows the MegatronPretrainingRandomSampler class to correctly handle multi-epoch training by calculating length correctly when consumed_samples > total_samples

**Collection**: NLP

# Changelog 
- nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py: modified MegatronPretrainingRandomSampler to correctly return length for multi-epoch training when consumed_samples > total_samples
- nemo/collections/nlp/data/language_modeling/megatron/megatron_batch_samplers.py: fixed len calculation to be correct when drop_last=False, and also cleaned up constructor logic caused by these fixes: https://github.com/NVIDIA/NeMo/pull/7728/files#diff-26575f60355f81991aef1f635e947a368b086afe220c5a81817e35b1c00b2e38

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
