### PR TITLE
Use Pytest with Coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,8 +130,8 @@ pipeline {
         }
       }
       steps {
-        sh 'CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 pytest --junitxml=test_results_cpu.xml --cov-append \
-            --cov=nemo --cov-report=term-missing --cov-report=xml \
+        sh 'CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 pytest --junitxml=test_results_cpu.xml \
+            --cov=nemo --cov-report=term-missing --cov-report=xml --cov-append \
             -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat'
       }
       post {
@@ -1028,7 +1028,7 @@ pipeline {
       parallel {
         stage('Running pytest') {
           steps {
-            sh 'pytest --cov=nemo --cov-report=term-missing \
+            sh 'pytest --cov=nemo --cov-report=term-missing --cov-append \
                 tests/collections/asr/decoding/rnnt_alignments_check.py --durations=-1'
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,9 +111,14 @@ pipeline {
     }
     stage('L0: Unit Tests GPU') {
       steps {
-        sh 'NEMO_NUMBA_MINVER=0.53 pytest \
-            --cov=nemo --cov-report=term-missing --cov-report=xml \
+        sh 'NEMO_NUMBA_MINVER=0.53 pytest --junitxml=test_results_gpu.xml \
+            --cov=nemo --cov-report=term-missing \
             -m "not pleasefixme" --with_downloads'
+      }
+      post {
+        always {
+          junit 'test_results_gpu.xml'
+        }
       }
     }
 
@@ -125,9 +130,14 @@ pipeline {
         }
       }
       steps {
-        sh 'CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 pytest \
+        sh 'CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 pytest --junitxml=test_results_cpu.xml \
             --cov=nemo --cov-report=term-missing --cov-report=xml \
             -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat'
+      }
+      post {
+        always {
+          junit 'test_results_cpu.xml'
+        }
       }
     }
 //

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,7 +126,7 @@ pipeline {
       }
       steps {
         sh 'CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 pytest \
-            --cov=nemo --cov-report=term-missing --cov-report=xml
+            --cov=nemo --cov-report=term-missing --cov-report=xml \
             -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat'
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -130,7 +130,7 @@ pipeline {
         }
       }
       steps {
-        sh 'CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 pytest --junitxml=test_results_cpu.xml \
+        sh 'CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 pytest --junitxml=test_results_cpu.xml --cov-append \
             --cov=nemo --cov-report=term-missing --cov-report=xml \
             -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat'
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1028,7 +1028,7 @@ pipeline {
       parallel {
         stage('Running pytest') {
           steps {
-            sh 'pytest --cov=nemo --cov-report=term-missing --cov-report=xml \
+            sh 'pytest --cov=nemo --cov-report=term-missing \
                 tests/collections/asr/decoding/rnnt_alignments_check.py --durations=-1'
           }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,9 @@ pipeline {
     }
     stage('L0: Unit Tests GPU') {
       steps {
-        sh 'NEMO_NUMBA_MINVER=0.53 pytest -m "not pleasefixme" --with_downloads'
+        sh 'NEMO_NUMBA_MINVER=0.53 pytest \
+            --cov=nemo --cov-report=term-missing --cov-report=xml \
+            -m "not pleasefixme" --with_downloads'
       }
     }
 
@@ -123,7 +125,9 @@ pipeline {
         }
       }
       steps {
-        sh 'CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 pytest -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat'
+        sh 'CUDA_VISIBLE_DEVICES="" NEMO_NUMBA_MINVER=0.53 pytest \
+            --cov=nemo --cov-report=term-missing --cov-report=xml
+            -m "not pleasefixme" --cpu --with_downloads --relax_numba_compat'
       }
     }
 //
@@ -1014,7 +1018,8 @@ pipeline {
       parallel {
         stage('Running pytest') {
           steps {
-            sh 'pytest tests/collections/asr/decoding/rnnt_alignments_check.py --durations=-1'
+            sh 'pytest --cov=nemo --cov-report=term-missing --cov-report=xml \
+                tests/collections/asr/decoding/rnnt_alignments_check.py --durations=-1'
           }
         }
       }

--- a/requirements/requirements_test.txt
+++ b/requirements/requirements_test.txt
@@ -3,7 +3,7 @@ click==8.0.2
 isort>5.1.0,<6.0.0
 parameterized
 pytest
-pytest-runner
+pytest-cov
 ruamel.yaml
 sphinx
 sphinxcontrib-bibtex


### PR DESCRIPTION
# What does this PR do ?

- PyTest on Jenkins runs with coverage (you can see the coverage report in logs for unit tests GPU/CPU)
- Remove deprecated `pytest-runner` (plugin used earlier to run pytest via setup.py, now useless and unsupported)
- You can see now the failing/skipped/passed tests in Jenkins UI, e.g., http://10.110.40.131:8080/blue/organizations/jenkins/NeMo-multibranch/detail/PR-8250/3/tests

**Collection**: [CI]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```shell
pytest --cov=nemo --cov-report=html test_my_awesome_feature.py
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
