### PR TITLE
Fix Megatron losses that were incorrect for micro_batch_size > 1

### DIFF
--- a/nemo/collections/multimodal/models/multimodal_llm/neva/neva_model.py
+++ b/nemo/collections/multimodal/models/multimodal_llm/neva/neva_model.py
@@ -781,10 +781,10 @@ class MegatronNevaModel(MultimodalAdapterModelMixin, MegatronGPTModel):
         logging.info(f'test_loss: {averaged_loss[0]}')
 
     def loss_func(self, loss_mask, output_tensor):
-        losses = output_tensor.float()
-        loss_mask = loss_mask.float()
+        losses = output_tensor.float()  # (B x S)
+        loss_mask = loss_mask.float()  # (B x S)
         # Compute (per-sample) sequence-level NLL. Fully masked samples have zero loss.
-        loss = torch.sum(losses * loss_mask, dim=1) / loss_mask.sum(dim=1).clamp(min=1)
+        loss = torch.sum(losses * loss_mask, dim=1) / loss_mask.sum(dim=1).clamp(min=1)  # (B)
         loss = loss.mean()  # average across all samples in the micro-batch
         return loss
 

--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_dataset.py
@@ -433,6 +433,8 @@ class GPTDataset(Dataset):
         if idx < 0:
             logging.debug('Got negative index. Masking loss from this sample')
             loss_mask = torch.zeros_like(loss_mask)
+        elif loss_mask.sum().item() == 0:
+            logging.warning(f"Sample at index {idx} is fully masked, it will have zero loss")
 
         if self.get_attention_mask_from_fusion:
             return {

--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_chat_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_chat_dataset.py
@@ -382,6 +382,10 @@ class GPTSFTChatDataset(GPTSFTDataset):
         )
         labels = torch.LongTensor(self._collate_item(labels, max_length=max_length, pad_id=self.tokenizer.eos_id))
         loss_mask = torch.LongTensor(self._collate_item(loss_mask, max_length=max_length, pad_id=0))
+        if (loss_mask.sum(dim=1) == 0).any():
+            logging.warning(
+                "Empty loss mask (likely due to truncation to `max_seq_length`), such samples will have zero loss"
+            )
         context_lengths = torch.LongTensor([len(x) for x in contexts])
         contexts = torch.LongTensor(self._collate_item(contexts, max_length=max_length, pad_id=self.tokenizer.eos_id))
         answers = torch.LongTensor(self._collate_item(answers, max_length=max_length, pad_id=self.tokenizer.eos_id))

--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
@@ -456,6 +456,8 @@ class GPTSFTDataset(Dataset):
         )
         labels = torch.LongTensor(self._collate_item(labels, max_length=max_length, pad_id=self.tokenizer.eos_id))
         loss_mask = torch.LongTensor(self._collate_item(loss_mask, max_length=max_length, pad_id=0))
+        if (loss_mask.sum(dim=1) == 0).any():
+            logging.warning("Empty loss mask, such samples will have zero loss")
         contexts = torch.LongTensor(self._collate_item(contexts, max_length=max_length, pad_id=self.tokenizer.eos_id))
         answers = torch.LongTensor(self._collate_item(answers, max_length=max_length, pad_id=self.tokenizer.eos_id))
 
@@ -562,6 +564,8 @@ class GPTSFTPackedDataset(GPTSFTDataset):
         input_ids = self._collate_item(input_ids, max_length=max_length, pad_id=self.tokenizer.eos_id)
         labels = self._collate_item(labels, max_length=max_length, pad_id=self.tokenizer.eos_id)
         loss_mask = self._collate_item(loss_mask, max_length=max_length, pad_id=0)
+        if (loss_mask.sum(dim=1) == 0).any():
+            logging.warning("Empty loss mask, such samples will have zero loss")
         position_ids = self._collate_item(position_ids, max_length=max_length, pad_id=0)
 
         # Pre-generate `cu_seqlens_argmin` and `max_seqlen` as CPU tensor to avoid device-to-host copies.

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -555,14 +555,13 @@ class MegatronBertModel(MegatronBaseModel):
         lm_loss_ = lm_loss_.float()
         loss_mask = loss_mask.float()
 
-        # Sometimes when the number of tokens is very small, none of the tokens get masked for prediction. In that case loss mask is all zeros
-        # i.e Happens when the entire batch is masked out (Practically when MBS=1 or 2, and the number of tokens in each batch is < 7 )
-        if loss_mask.sum() == 0:
-            lm_loss = torch.sum(lm_loss_.view(-1)) * 0.0
-        else:
-            lm_loss = torch.sum(lm_loss_.view(-1) * loss_mask.reshape(-1)) / loss_mask.sum()
+        # Sometimes when the number of tokens is very small, none of the tokens get masked for prediction.=
+        # In that case loss mask is all zeros.
+        lm_loss = torch.sum(lm_loss_ * loss_mask, dim=1) / loss_mask.sum(dim=1).clamp(min=1)
+        lm_loss = lm_loss.mean()  # average across all samples in the micro-batch
 
         if sop_logits is not None:
+            # TODO does this also need fixing?
             sop_loss = F.cross_entropy(sop_logits.view(-1, 2).float(), sentence_order.view(-1), ignore_index=-1)
             sop_loss = sop_loss.float()
             return {'lm loss': lm_loss, 'sop loss': sop_loss}

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -552,12 +552,12 @@ class MegatronBertModel(MegatronBaseModel):
     def loss_func(self, loss_mask, sentence_order, output_tensor):
         lm_loss_, sop_logits = output_tensor
 
-        lm_loss_ = lm_loss_.float()
-        loss_mask = loss_mask.float()
+        lm_loss_ = lm_loss_.float()  # (B x S)
+        loss_mask = loss_mask.float()  # (B x S)
 
         # Sometimes when the number of tokens is very small, none of the tokens get masked for prediction.=
         # In that case loss mask is all zeros.
-        lm_loss = torch.sum(lm_loss_ * loss_mask, dim=1) / loss_mask.sum(dim=1).clamp(min=1)
+        lm_loss = torch.sum(lm_loss_ * loss_mask, dim=1) / loss_mask.sum(dim=1).clamp(min=1)  # (B)
         lm_loss = lm_loss.mean()  # average across all samples in the micro-batch
 
         if sop_logits is not None:

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1164,10 +1164,10 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         self.test_step_outputs.clear()  # free memory
 
     def loss_func(self, loss_mask, num_valid_tokens_per_sample, output_tensor):
-        losses = output_tensor.float()
-        loss_mask = loss_mask.float()
+        losses = output_tensor.float()  # (B x S)
+        loss_mask = loss_mask.float()  # (B x S)
         # Compute (per-sample) sequence-level NLL. Fully masked samples have zero loss.
-        loss = torch.sum(losses * loss_mask, dim=1) / num_valid_tokens_per_sample.clamp(min=1)
+        loss = torch.sum(losses * loss_mask, dim=1) / num_valid_tokens_per_sample.clamp(min=1)  # (B)
         loss = loss.mean()  # average across all samples in the micro-batch
         if parallel_state.get_context_parallel_world_size() > 1:
             torch.distributed.all_reduce(loss, group=parallel_state.get_context_parallel_group())

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -783,10 +783,10 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
         """
         This function takes as input per-token loss and masks non-required values.
         """
-        losses = tokens_loss.float()
-        loss_mask = loss_mask.float()
+        losses = tokens_loss.float()  # (B x S)
+        loss_mask = loss_mask.float()  # (B x S)
         # Compute (per-sample) sequence-level NLL. Fully masked samples have zero loss.
-        loss = torch.sum(losses * loss_mask, dim=1) / loss_mask.sum(dim=1).clamp(min=1)
+        loss = torch.sum(losses * loss_mask, dim=1) / loss_mask.sum(dim=1).clamp(min=1)  # (B)
         loss = loss.mean()  # average across all samples in the micro-batch
         return loss
 


### PR DESCRIPTION
# What does this PR do ?

Fixes the losses of several Megatron models, that were incorrect for `micro_batch_size` > 1

**Collection**: nlp, multimodal

# Changelog 
- Fix losses of several Megatron models (`MegatronGPTModel`, `MegatronNevaModel`, `MegatronBertModel`, `MegatronLMEncoderDecoderModel`) that were incorrect for `micro_batch_size` > 1

# What still needs to be done

- [ ] Probably that some new tests are needed. I first want to check which tests fail to identify potential gaps in testing.
- [ ] There is a `# TODO does this also need fixing?` in `MegatronBertModel` as I'm not familiar with the Sequence Order Prediction loss. Would be helpful if someone could double check it, or at least tell me what are the shapes of `sop_logits` and `sentence_order` so I can figure it out.
- [ ] Check whether the handling of `context_parallel_size` > 1 is correct in `MegatronGPTModel`

# Other breaking changes

While fixing this problem I ran into some related issues that forced me to make some design choices leading to "collateral" breaking changes:

1. The validation loss in `MegatronGPTModel` with `validation_drop_last=False` was inconsistent with `drop_last=True` since it was computing a per-token average across the global batch (at least I believe that's what's happening [here](https://github.com/NVIDIA/NeMo/blob/9940ec600/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py#L483)), while with `drop_last=True` it was using the (incorrect) per-token average across the micro-batch. I changed it so that the behavior should now be a consistent per-sample average across valid samples.

2. The loss could be NaN when all samples in a micro-batch would be fully masked (which typically would only happen with `micro_batch_size=1`). This also led to inconsistency between different micro-batch sizes. I changed it so that there is no NaN anymore, instead fully masked samples have a zero loss. The alternative would be to trigger a NaN as soon as one sample is fully masked, but I decided against it because (i) in order to handle validation with `validation_drop_last=False` we would need to make the loss function depend on this flag, which would make the code more complex (and potentially inconsistent in the presence of fully masked samples in the validation set), and (ii) NaN losses due to fully masked samples is a recurring pain point currently (it forces users to either go through a cumbersome model-dependent data filtering step, or hack the NeMo codebase to work around it).

3. (Follow-up to 2, splitting it for readability) That being said, I think that silently ignoring some samples is also potentially dangerous, so I added a warning when the loss mask is all zeros for some samples. I decided to do it at the dataset level rather than in the model so as to avoid forcing a CPU-GPU synch point on such a check. We could add a flag in the datasets to control whether this is an error or a warning, but I thought I'd get some feedback first.

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

Fixes #8343

Minor remark: I removed some `# TODO: add nemo version here` that seem to date back several years ago and don't make sense to me.