### PR TITLE
fixed typo in GPT training explanation

### DIFF
--- a/docs/source/nlp/nemo_megatron/gpt/gpt_training.rst
+++ b/docs/source/nlp/nemo_megatron/gpt/gpt_training.rst
@@ -35,7 +35,7 @@ Now, ``train_data.jsonl`` will contain our training data in the json line format
 
 **Step 3: Train tokenizer**
 
-Below we will condider 2 options for training data tokenizers: Using pre-built HuggingFace BPE and training and using your own Google Sentencepiece tokenizer.
+Below we will consider 2 options for training data tokenizers: Using pre-built HuggingFace BPE and training and using your own Google Sentencepiece tokenizer.
 Note that only second option allows you to experiment with vocabulary size.
 
 *Option 1:* Using HuggingFace GPT2 tokenizer files.


### PR DESCRIPTION
# What does this PR do ?

Fixed a small typo in the GPT model training documentation. 

**Collection**: docs

# Changelog 
- Fixed spelling mistake on line 38.  

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.
  
**PR Type**:
- Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
