### PR TITLE
Enable megatron core loggers for GPT pretraining

### DIFF
--- a/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml
@@ -211,6 +211,9 @@ model:
   ## Network
   sharp: False # Enable the use of SHARP for NCCL data-parallel communications. This is going to be ignored if the network doesn't support SHARP.
   
+  ## Megatron timers
+  enable_megatron_timers: False
+
   data:
    # Path to data must be specified by the user.
     # Supports List, String and Dictionary

--- a/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml
@@ -213,6 +213,10 @@ model:
   
   ## Megatron timers
   enable_megatron_timers: False
+  megatron_timer_kwargs:
+    log_every_n_steps: 10
+    log_mode: minmax
+    barrier: False
 
   data:
    # Path to data must be specified by the user.

--- a/examples/nlp/language_modeling/conf/megatron_model_base_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_model_base_config.yaml
@@ -38,3 +38,4 @@ num_moe_experts: 1 # When >1, FFNs are changed to MoE layers
 moe_frequency: 1 # every Nth ffn layer will be made MoE 
 moe_dropout: 0.0 # Dropout value for MoE layers
 use_flash_attention: false # Use flash attention in self-attention module
+enable_megatron_timers: false # Megatron timers

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -137,7 +137,7 @@ class MegatronBaseModel(NLPModel):
             if 'log_every_n_steps' not in self.megatron_timers_cfg:
                 self.megatron_timers_cfg['log_every_n_steps'] = self.trainer.log_every_n_steps
             if 'log_option' not in self.megatron_timers_cfg:
-                self.megatron_timers_cfg['log_option'] = 'minmax' # minmax, max, all
+                self.megatron_timers_cfg['log_option'] = 'minmax'  # minmax, max, all
             if 'barrier' not in self.megatron_timers_cfg:
                 self.megatron_timers_cfg['barrier'] = False
             self.megatron_timers = Timers(log_level=2, log_option=self.megatron_timers_cfg['log_option'])
@@ -635,8 +635,10 @@ class MegatronBaseModel(NLPModel):
 
         # Megatron Timers
         if self.megatron_timers:
-            if self.global_step % self.megatron_timers_cfg["log_every_n_steps"] == 0 :
-                logging.info("\n " + self.megatron_timers.get_all_timers_string(barrier = self.megatron_timers_cfg["barrier"]))
+            if self.global_step % self.megatron_timers_cfg["log_every_n_steps"] == 0:
+                logging.info(
+                    "\n " + self.megatron_timers.get_all_timers_string(barrier=self.megatron_timers_cfg["barrier"])
+                )
 
         # TODO: Replace with newer override for scheduler.step() instead of
         # search for plugins for fp16 GradScalar

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -69,11 +69,12 @@ except (ImportError, ModuleNotFoundError):
 
     HAVE_MEGATRON_CORE = False
 
-HAVE_MEGATRON_CORE_TIMERS = False
 try:
     from megatron.core import Timers
 
     HAVE_MEGATRON_CORE_TIMERS = True
+except (ImportError, ModuleNotFoundError):
+    HAVE_MEGATRON_CORE_TIMERS = False
 
 __all__ = ["MegatronBaseModel"]
 
@@ -132,7 +133,14 @@ class MegatronBaseModel(NLPModel):
 
         self.megatron_timers = None
         if self.cfg.get('enable_megatron_timers', False) and HAVE_MEGATRON_CORE_TIMERS:
-            self.megatron_timers = Timers(log_level=2, log_option='minmax')
+            self.megatron_timers_cfg = dict(self.cfg.get('megatron_timer_kwargs', dict()))
+            if 'log_every_n_steps' not in self.megatron_timers_cfg:
+                self.megatron_timers_cfg['log_every_n_steps'] = self.trainer.log_every_n_steps
+            if 'log_option' not in self.megatron_timers_cfg:
+                self.megatron_timers_cfg['log_option'] = 'minmax' # minmax, max, all
+            if 'barrier' not in self.megatron_timers_cfg:
+                self.megatron_timers_cfg['barrier'] = False
+            self.megatron_timers = Timers(log_level=2, log_option=self.megatron_timers_cfg['log_option'])
 
         # set the megatron core model parallel config
         self.model_parallel_config: ModelParallelConfig = self.build_model_parallel_config()
@@ -624,6 +632,11 @@ class MegatronBaseModel(NLPModel):
 
     def on_train_batch_end(self, outputs, dataloader_iter: Any, batch_idx: int, unused: Optional[int] = 0) -> None:
         super().on_train_batch_end(outputs, dataloader_iter, batch_idx)
+
+        # Megatron Timers
+        if self.megatron_timers:
+            if self.global_step % self.megatron_timers_cfg["log_every_n_steps"] == 0 :
+                logging.info("\n " + self.megatron_timers.get_all_timers_string(barrier = self.megatron_timers_cfg["barrier"]))
 
         # TODO: Replace with newer override for scheduler.step() instead of
         # search for plugins for fp16 GradScalar
@@ -1176,18 +1189,7 @@ class MegatronBaseModel(NLPModel):
         if self.megatron_timers:
             self.megatron_timers(name).stop()
 
-    def on_before_optimizer_step(self, *args, **kwargs):
-        print("starting optim")
+    def optimizer_step(self, *args, **kwargs):
         self.megatron_timer_start('optimizer', log_level=1)
-        return super().on_before_optimizer_step(*args, **kwargs)
-
-    def on_train_batch_end(self, *args, **kwargs):
-        print("stopping optim")
+        super().optimizer_step(*args, **kwargs)
         self.megatron_timer_stop('optimizer')
-        return super().on_train_batch_end(*args, **kwargs)
-
-    def on_fit_end(self, *args, **kwargs):
-        if self.megatron_timers:
-            names = self.megatron_timers.get_names()
-            self.megatron_timers.log(names, rank=0)
-        return super().on_fit_end(*args, **kwargs)

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -660,8 +660,11 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
 
         # when using sequence parallelism, the sequence parallel layernorm grads must be all-reduced
         if self.cfg.get('tensor_model_parallel_size', 1) > 1 and self.cfg.get('sequence_parallel', False):
+            self.megatron_timer_start('allreduce_sequence_parallel_gradients', log_level=1)
             self.allreduce_sequence_parallel_gradients()
-
+            self.megatron_timer_stop('allreduce_sequence_parallel_gradients')
+        
+        self.megatron_timer_start('gradient_allreduce', log_level=1)
         if self.use_fsdp:
             # Reduce the gradients omitted from FSDP-sharding
             self.allreduce_fsdp_sharding_omitted_gradients()
@@ -679,12 +682,15 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             # async grad allreduce is not currently implemented for O1/autocasting mixed precision training
             # so we all-reduce gradients after the pipeline
             self.allreduce_gradients()  # @sangkug we think this is causing memory to blow up (hurts perf)
+        self.megatron_timer_stop('gradient_allreduce')
 
         if self.cfg.get('pipeline_model_parallel_size', 1) > 1 and self.cfg.get(
             'share_embeddings_and_output_weights', True
         ):
+            self.megatron_timer_start('allreduce_first_last_embeddings', log_level=1)
             # when using pipeline parallelism the first and last stage must keep embeddings in sync
             self.allreduce_first_last_embeddings()
+            self.megatron_timer_stop('allreduce_first_last_embeddings')
 
         ## logging
         if self.log_train_loss:

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -663,7 +663,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             self.megatron_timer_start('allreduce_sequence_parallel_gradients', log_level=1)
             self.allreduce_sequence_parallel_gradients()
             self.megatron_timer_stop('allreduce_sequence_parallel_gradients')
-        
+
         self.megatron_timer_start('gradient_allreduce', log_level=1)
         if self.use_fsdp:
             # Reduce the gradients omitted from FSDP-sharding


### PR DESCRIPTION
# What does this PR do ?

Enables use of megatron timers in NeMo GPT pretraining and megatron_base based models.

Collection: collections/nlp/models/language_modeling

Usage
 model.enable_megatron_timers=True
 model.megatron_timer_kwargs.log_every_n_steps= 10
 model.megatron_timer_kwargs.log_mode=minmax
 model.megatron_timer_kwargs.barrier= False 
torchrun --nnodes=1 --nproc-per-node=8 \
    /gsw/code/NeMo/examples/nlp/language_modeling/megatron_gpt_pretraining.py  \
    --config-path=/gsw/code/NeMo/examples/nlp/language_modeling/conf \
    --config-name=megatron_gpt_config \
    trainer.devices=8 \
    trainer.num_nodes=1 \
    model.enable_megatron_timers=True \
    ++model.megatron_timer_kwargs.log_option=max \

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
