### PR TITLE
MCore dataset compatibility for tokenizers

### DIFF
--- a/nemo/collections/common/tokenizers/huggingface/auto_tokenizer.py
+++ b/nemo/collections/common/tokenizers/huggingface/auto_tokenizer.py
@@ -122,9 +122,6 @@ class AutoTokenizer(TokenizerSpec):
             if token is not None and token not in self.tokenizer.get_vocab():
                 new_tokens_in_vocab.append(token)
 
-        # value is required for megatron-core
-        self.unique_identifiers = OrderedDict()
-
         if len(new_tokens_in_vocab) > 0:
             """
             Special tokens that were not previously included in the tokenizer's vocabulary file will be added to 
@@ -229,11 +226,6 @@ class AutoTokenizer(TokenizerSpec):
 
     @property
     def eos_id(self):
-        return self.tokens_to_ids([getattr(self, 'eos_token')])[0]
-
-    @property
-    def eod(self):
-        """Returns EOS token id. Exact copy of the eos_id function. Required for megatron-core."""
         return self.tokens_to_ids([getattr(self, 'eos_token')])[0]
 
     @property

--- a/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
+++ b/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
@@ -214,10 +214,6 @@ class SentencePieceTokenizer(TokenizerSpec):
         return eos_id
 
     @property
-    def eod(self):
-        return self.eos_id
-
-    @property
     def sep_id(self):
         if self.legacy:
             return self.tokens_to_ids([self.sep_token])[0]

--- a/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
+++ b/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
@@ -214,6 +214,10 @@ class SentencePieceTokenizer(TokenizerSpec):
         return eos_id
 
     @property
+    def eod(self):
+        return self.eos_id
+
+    @property
     def sep_id(self):
         if self.legacy:
             return self.tokens_to_ids([self.sep_token])[0]

--- a/nemo/collections/common/tokenizers/tokenizer_spec.py
+++ b/nemo/collections/common/tokenizers/tokenizer_spec.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from abc import ABC, abstractmethod
+from collections import OrderedDict
 from typing import List
 
 __all__ = ['TokenizerSpec']
@@ -53,3 +54,8 @@ class TokenizerSpec(ABC):
     @property
     def name(self):
         return type(self).__name__
+
+    @property
+    def unique_identifiers(self):
+        """Property required for use with megatron-core datasets."""
+        return OrderedDict({"class": f"{type(self).__module__}.{type(self).__qualname__}"})

--- a/nemo/collections/common/tokenizers/tokenizer_spec.py
+++ b/nemo/collections/common/tokenizers/tokenizer_spec.py
@@ -59,3 +59,55 @@ class TokenizerSpec(ABC):
     def unique_identifiers(self):
         """Property required for use with megatron-core datasets."""
         return OrderedDict({"class": f"{type(self).__module__}.{type(self).__qualname__}"})
+
+    @property
+    def cls(self):
+        """Property alias to match MegatronTokenizer; returns cls_id if available."""
+        if hasattr(self, 'cls_id'):
+            return self.cls_id
+        raise AttributeError(f"{type(self).__name__} has no attribute 'cls' or 'cls_id'")
+
+    @property
+    def sep(self):
+        """Property alias to match MegatronTokenizer; returns sep_id if available."""
+        if hasattr(self, 'sep_id'):
+            return self.sep_id
+        raise AttributeError(f"{type(self).__name__} has no attribute 'sep' or 'sep_id'")
+
+    @property
+    def pad(self):
+        """Property alias to match MegatronTokenizer; returns pad_id if available."""
+        if hasattr(self, 'pad_id'):
+            return self.pad_id
+        raise AttributeError(f"{type(self).__name__} has no attribute 'pad' or 'pad_id'")
+
+    @property
+    def eod(self):
+        """Property alias to match MegatronTokenizer; returns eod_id if available."""
+        if hasattr(self, 'eod_id'):
+            return self.eod_id
+        if hasattr(self, 'eos_id'):
+            # Default to end-of-sentence id if end-of-document is not defined.
+            return self.eos_id
+        raise AttributeError(f"{type(self).__name__} has no attribute 'eod', 'eod_id', 'eos', or 'eos_id'")
+
+    @property
+    def bos(self):
+        """Property alias to match MegatronTokenizer; returns bos_id if available."""
+        if hasattr(self, 'bos_id'):
+            return self.bos_id
+        raise AttributeError(f"{type(self).__name__} has no attribute 'bos' or 'bos_id'")
+
+    @property
+    def eos(self):
+        """Property alias to match MegatronTokenizer; returns eos_id if available."""
+        if hasattr(self, 'eos_id'):
+            return self.eos_id
+        raise AttributeError(f"{type(self).__name__} has no attribute 'eos' or 'eos_id'")
+
+    @property
+    def mask(self):
+        """Property alias to match MegatronTokenizer; returns mask_id if available."""
+        if hasattr(self, 'mask_id'):
+            return self.mask_id
+        raise AttributeError(f"{type(self).__name__} has no attribute 'mask' or 'mask_id'")


### PR DESCRIPTION
# What does this PR do ?

Adds properties required by megatron-core to NeMo tokenizers via the base TokenizerSpec class (see #8283).

**Collection**: common (tokenizers)

# Changelog 
- Adds a `unique_identifiers` OrderedDict which is needed when using alongside megatron-core datasets (following [megatron_tokenizer.py](https://github.com/NVIDIA/Megatron-LM/blob/0052bf0de70b266d8648e2655da16f7eb2c9ca56/megatron/core/datasets/megatron_tokenizer.py))
- Adds several property-decorated methods as aliases for equivalent properties already present in tokenizers that inherit from TokenizerSpec
- Removes now-redundant individual fix from AutoTokenizer

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
