### PR TITLE
Fixed the bug in CTM line processing function

### DIFF
--- a/scripts/speaker_tasks/create_alignment_manifest.py
+++ b/scripts/speaker_tasks/create_alignment_manifest.py
@@ -35,7 +35,6 @@ def get_seg_info_from_ctm_line(
 
     CTM Format: 
         <SOURCE>< <CHANNEL> <BEG-TIME> <DURATION> <TOKEN> <CONF> <TYPE> <SPEAKER>
-    
 
     Args:
         ctm_list (list): List containing CTM items. e.g.: ['sw02001-A', '1', '0.000', '0.200', 'hello', '0.98', 'lex', 'speaker3']
@@ -47,7 +46,6 @@ def get_seg_info_from_ctm_line(
         speaker_id (str): Speaker ID of the segment.
     """
     speaker_id = ctm_list[speaker_index]
-
     start = float(ctm_list[start_time_index])
     end = float(ctm_list[start_time_index]) + float(ctm_list[duration_index])
     start = round(start, output_precision)

--- a/scripts/speaker_tasks/create_alignment_manifest.py
+++ b/scripts/speaker_tasks/create_alignment_manifest.py
@@ -32,7 +32,11 @@ def get_seg_info_from_ctm_line(
     """
     Get time stamp information and speaker labels from CTM lines.
     This is following CTM format appeared in `Rich Transcription Meeting Eval Plan: RT09` document.
+
+    CTM Format: 
+        <SOURCE>< <CHANNEL> <BEG-TIME> <DURATION> <TOKEN> <CONF> <TYPE> <SPEAKER>
     
+
     Args:
         ctm_list (list): List containing CTM items. e.g.: ['sw02001-A', '1', '0.000', '0.200', 'hello', '0.98', 'lex', 'speaker3']
         output_precision (int): Precision for CTM outputs in integer.
@@ -43,10 +47,13 @@ def get_seg_info_from_ctm_line(
         speaker_id (str): Speaker ID of the segment.
     """
     speaker_id = ctm_list[speaker_index]
+
     start = float(ctm_list[start_time_index])
     end = float(ctm_list[start_time_index]) + float(ctm_list[duration_index])
     start = round(start, output_precision)
     end = round(end, output_precision)
+    if type(speaker_id) == str:
+        speaker_id = speaker_id.strip()
     return start, end, speaker_id
 
 
@@ -106,7 +113,7 @@ def create_new_ctm_entry(session_name, speaker_id, wordlist, alignments, output_
                 start_time=align1,
                 duration=align2,
                 token=word,
-                conf=0,
+                conf=None,
                 type_of_token='lex',
                 speaker=speaker_id,
                 output_precision=output_precision,
@@ -245,7 +252,7 @@ def create_manifest_with_alignments(
         prev_end = 0
         for i in range(len(lines)):
             ctm = lines[i].split(' ')
-            speaker_id, start, end = get_seg_info_from_ctm_line(ctm_list=ctm, output_precision=output_precision)
+            start, end, speaker_id = get_seg_info_from_ctm_line(ctm_list=ctm, output_precision=output_precision)
             interval = start - prev_end
 
             if (i == 0 and interval > 0) or (i > 0 and interval > silence_dur_threshold):


### PR DESCRIPTION
# What does this PR do ?

This PR fixes the bug in `scripts/speaker_tasks/create_alignment_manifest.py`.
The `get_seg_info_from_ctm_line` function was outputing values in a wrong order.
Plus, confidence value could be set to `None` to prevent any type error issues.

**Collection**: [Note which collection this PR will affect]

# Changelog 

- the output variable orders in `get_seg_info_from_ctm_line` function.
- `conf=0` to `conf=None`

# Usage
* You can potentially add a usage example below

```python
python scripts/speaker_tasks/create_alignment_manifest.py \                                                                                                                                                
  --input_manifest_filepath LibriSpeech/dev_clean.json \                                                                                                                                                         
  --base_alignment_path LibriSpeech_Alignments \                                                                                                                                                                 
  --output_manifest_filepath ./dev-clean-align.json \                                                                                                                                                            
  --ctm_output_directory ./ctm_out \                                                                                                                                                                             
  --libri_dataset_split dev-clean          
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in ASR can review this. 

# Additional Information
* Related to # (issue)
