### PR TITLE
Flashlight and Pyctcdecode decoders to branch 1.23

### DIFF
--- a/examples/asr/speech_to_text_eval.py
+++ b/examples/asr/speech_to_text_eval.py
@@ -24,8 +24,8 @@ same directory during execution.
 << All arguments of `transcribe_speech.py` are inherited by this script, so please refer to `transcribe_speech.py`
 for full list of arguments >>
 
-    dataset_manifest: Required - path to dataset JSON manifest file (in NeMo format)
-    output_filename: Optional - output filename where the transcriptions will be written. (if scores_per_sample=True, 
+    input_manifest: Required - path to dataset JSON manifest file (in NeMo format)
+    output_manifest: Optional - output filename where the transcriptions will be written. (if scores_per_sample=True, 
     metrics per sample will be written there too)
 
     use_cer: Bool, whether to compute CER or WER
@@ -36,17 +36,17 @@ for full list of arguments >>
 
     only_score_manifest: Bool, when set will skip audio transcription and just calculate WER of provided manifest.
     scores_per_sample: Bool, compute metrics for each sample separately (if only_score_manifest=True, scores per sample
-    will be added to the manifest at the dataset_manifest path)
+    will be added to the manifest at the input_manifest path)
 
 # Usage
 
 ## To score a dataset with a manifest file that does not contain previously transcribed `pred_text`.
 
 python speech_to_text_eval.py \
-    model_path=null \
+    nemo_model_file=null \
     pretrained_name=null \
-    dataset_manifest=<Mandatory: Path to an ASR dataset manifest file> \
-    output_filename=<Optional: Some output filename which will hold the transcribed text as a manifest> \
+    input_manifest=<Mandatory: Path to an ASR dataset manifest file> \
+    output_manifest=<Optional: Some output filename which will hold the transcribed text as a manifest> \
     batch_size=32 \
     amp=True \
     use_cer=False
@@ -56,7 +56,7 @@ This is useful when one uses `transcribe_speech_parallel.py` to transcribe large
 to a manifest which has the two keys `text` (for ground truth) and `pred_text` (for model's transcription)
 
 python speech_to_text_eval.py \
-    dataset_manifest=<Mandatory: Path to an ASR dataset manifest file> \
+    input_manifest=<Mandatory: Path to an ASR dataset manifest file> \
     use_cer=False \
     only_score_manifest=True
 
@@ -84,8 +84,8 @@ from nemo.utils import logging
 
 @dataclass
 class EvaluationConfig(transcribe_speech.TranscriptionConfig):
-    dataset_manifest: str = MISSING
-    output_filename: Optional[str] = "evaluation_transcripts.json"
+    input_manifest: str = MISSING
+    output_manifest: Optional[str] = "evaluation_transcripts.json"
 
     # decoder type: ctc or rnnt, can be used to switch between CTC and RNNT decoder for Joint RNNT/CTC models
     decoder_type: Optional[str] = None
@@ -114,11 +114,11 @@ def main(cfg: EvaluationConfig):
     if cfg.audio_dir is not None:
         raise RuntimeError(
             "Evaluation script requires ground truth labels to be passed via a manifest file. "
-            "If manifest file is available, submit it via `dataset_manifest` argument."
+            "If manifest file is available, submit it via `input_manifest` argument."
         )
 
-    if not os.path.exists(cfg.dataset_manifest):
-        raise FileNotFoundError(f"The dataset manifest file could not be found at path : {cfg.dataset_manifest}")
+    if not os.path.exists(cfg.input_manifest):
+        raise FileNotFoundError(f"The dataset manifest file could not be found at path : {cfg.input_manifest}")
 
     if not cfg.only_score_manifest:
         # Transcribe speech into an output directory
@@ -131,13 +131,13 @@ def main(cfg: EvaluationConfig):
         logging.info("Finished transcribing speech dataset. Computing ASR metrics..")
 
     else:
-        cfg.output_filename = cfg.dataset_manifest
+        cfg.output_manifest = cfg.input_manifest
         transcription_cfg = cfg
 
     ground_truth_text = []
     predicted_text = []
     invalid_manifest = False
-    with open(transcription_cfg.output_filename, 'r') as f:
+    with open(transcription_cfg.output_manifest, 'r') as f:
         for line in f:
             data = json.loads(line)
 
@@ -163,7 +163,7 @@ def main(cfg: EvaluationConfig):
     # Test for invalid manifest supplied
     if invalid_manifest:
         raise ValueError(
-            f"Invalid manifest provided: {transcription_cfg.output_filename} does not "
+            f"Invalid manifest provided: {transcription_cfg.output_manifest} does not "
             f"contain value for `pred_text`."
         )
 
@@ -182,12 +182,12 @@ def main(cfg: EvaluationConfig):
             metrics_to_compute.append("punct_er")
 
         samples_with_metrics = compute_metrics_per_sample(
-            manifest_path=cfg.dataset_manifest,
+            manifest_path=cfg.input_manifest,
             reference_field="text",
             hypothesis_field="pred_text",
             metrics=metrics_to_compute,
             punctuation_marks=cfg.text_processing.punctuation_marks,
-            output_manifest_path=cfg.output_filename,
+            output_manifest_path=cfg.output_manifest,
         )
 
     # Compute the WER

--- a/scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram_transducer.py
+++ b/scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram_transducer.py
@@ -95,13 +95,17 @@ class EvalBeamSearchNGramConfig:
     probs_cache_file: Optional[str] = None  # The cache file for storing the logprobs of the model
 
     # Parameters for inference
-    acoustic_batch_size: int = 128  # The batch size to calculate log probabilities
+    batch_size: int = 128  # The batch size to calculate log probabilities
     beam_batch_size: int = 128  # The batch size to be used for beam search decoding
     device: str = "cuda"  # The device to load the model onto to calculate log probabilities
-    use_amp: bool = False  # Whether to use AMP if available to calculate log probabilities
+    amp: bool = False  # Whether to use AMP if available to calculate log probabilities
     num_workers: int = 1  # Number of workers for DataLoader
 
     # The decoding scheme to be used for evaluation
+    # TODO add  decoding.strategy=beam
+    #           decoding.greedy =
+    #           decoding.beam =
+    #  and so on 
     decoding_strategy: str = "greedy_batch" # ["greedy_batch", "beam", "tsd", "alsd", "maes"]
 
     # Beam Search hyperparameters
@@ -300,7 +304,7 @@ def main(cfg: EvalBeamSearchNGramConfig):
         def default_autocast():
             yield
 
-        if cfg.use_amp:
+        if cfg.amp:
             if torch.cuda.is_available() and hasattr(torch.cuda, 'amp') and hasattr(torch.cuda.amp, 'autocast'):
                 logging.info("AMP is enabled!\n")
                 autocast = torch.cuda.amp.autocast
@@ -325,7 +329,7 @@ def main(cfg: EvalBeamSearchNGramConfig):
                             fp.write(json.dumps(entry) + '\n')
                     config = {
                         'paths2audio_files': audio_file_paths,
-                        'batch_size': cfg.acoustic_batch_size,
+                        'batch_size': cfg.batch_size,
                         'temp_dir': tmpdir,
                         'num_workers': cfg.num_workers,
                         'channel_selector': None,

--- a/scripts/asr_language_modeling/ngram_lm/kenlm_utils.py
+++ b/scripts/asr_language_modeling/ngram_lm/kenlm_utils.py
@@ -34,6 +34,7 @@ from joblib import Parallel, delayed
 from tqdm.auto import tqdm
 
 import nemo.collections.asr as nemo_asr
+from nemo.collections.asr.modules.flashlight_decoder import create_lexicon
 from nemo.collections.asr.parts.submodules.ctc_beam_decoding import DEFAULT_TOKEN_OFFSET
 from nemo.utils import logging
 
@@ -221,3 +222,17 @@ def write_dataset(chunks, path):
             for text in chunks[chunk_idx]:
                 line = ' '.join(text)
                 path.write((line + '\n').encode())
+
+def save_flashlight_lexicon(tokenizer, kenlm_file):
+    save_path = os.path.dirname(kenlm_file)
+    os.makedirs(save_path, exist_ok=True)
+
+    lex_file = os.path.join(save_path, os.path.splitext(os.path.basename(kenlm_file))[0] + '.flashlight_lexicon')
+
+    logging.info(f"Writing Lexicon file to: {lex_file}...")
+    with open(lex_file, "w", encoding='utf_8', newline='\n') as f:
+        lexicon = create_lexicon(tokenizer)
+        lexicon.pop("<unk>")
+        for word in lexicon:
+            f.write("{w}\t{s}\n".format(w=word, s=lexicon[word][0][0]))
+    return lex_file

--- a/scripts/asr_language_modeling/ngram_lm/kenlm_utils.py
+++ b/scripts/asr_language_modeling/ngram_lm/kenlm_utils.py
@@ -223,6 +223,7 @@ def write_dataset(chunks, path):
                 line = ' '.join(text)
                 path.write((line + '\n').encode())
 
+
 def save_flashlight_lexicon(tokenizer, kenlm_file):
     save_path = os.path.dirname(kenlm_file)
     os.makedirs(save_path, exist_ok=True)

--- a/scripts/asr_language_modeling/ngram_lm/train_kenlm.py
+++ b/scripts/asr_language_modeling/ngram_lm/train_kenlm.py
@@ -87,6 +87,7 @@ def main(args: TrainKenlmConfig):
 
     if encoding_level == "subword":
         discount_arg = "--discount_fallback"  # --discount_fallback is needed for training KenLM for BPE-based models
+        kenlm_utils.save_flashlight_lexicon(tokenizer, args.kenlm_model_file)
     else:
         discount_arg = ""
 


### PR DESCRIPTION
# Preserve CPU Flashlight and Pyctcdecode beamsearch with Ngram LM 

Support Flashlight and Pyctcdecode decoding with pure KenLM and NeMo KenLM 
Standardize API of CLI inference scripts

**Collection**: ASR

# Changelog 
- Add specific line by line info of high level changes in this PR.

```python
python3 scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram_ctc.py \
nemo_model_file=am_model.nemo  \
input_manifest=manifest.json  \
preds_output_folder=/tmp   \
ctc_decoding.strategy=flashlight \
ctc_decoding.beam.kenlm_path=am_model.kenlm \
ctc_decoding.beam.beam_size=[4]   \
ctc_decoding.beam.beam_alpha=[0.5]   \
ctc_decoding.beam.beam_beta=[0.5] \
ctc_decoding.beam.flashlight_cfg.lexicon_path=am_model.flashlight_lexicon \ # DEFAULT_TOKEN_OFFSET
batch_size=32  \
beam_batch_size=1 \
device=cuda:1

python3 examples/asr/speech_to_text_eval.py  \
nemo_model_file=am_model.nemo \ 
input_manifest=manifest.json \
decoder_type=ctc  
ctc_decoding.strategy=flashlight \  
ctc_decoding.beam.kenlm_path=am_model.bin \
ctc_decoding.beam.beam_size=4   \
ctc_decoding.beam.beam_alpha=0.5   \
ctc_decoding.beam.beam_beta=0.5 \
ctc_decoding.beam.flashlight_cfg.lexicon_path=am_model.flashlight_lexicon \ # DEFAULT_TOKEN_OFFSET
ctc_decoding.beam.return_best_hypothesis=true \
batch_size=32  \
output_manifest=/tmp/manifest_out.json 
```
**PR Type**:
- [ V] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
