### PR TITLE
Support relative audio paths in Lhotse `LazyNeMoIterator`

### DIFF
--- a/tests/collections/common/test_lhotse_dataloading.py
+++ b/tests/collections/common/test_lhotse_dataloading.py
@@ -723,3 +723,38 @@ def test_lazy_nemo_iterator_with_offset_field(tmp_path: Path):
     np.testing.assert_equal(audio[0], expected_audio[8000:])
 
     assert cuts[0].id != cuts[1].id
+
+
+def test_lazy_nemo_iterator_with_relative_paths(tmp_path: Path):
+    import numpy as np
+    import soundfile as sf
+
+    from nemo.collections.common.data.lhotse.nemo_adapters import LazyNeMoIterator
+
+    # Have to generate as INT16 to avoid quantization error after saving to 16-bit WAV
+    INT16MAX = 2 ** 15
+    expected_audio = np.random.randint(low=-INT16MAX - 1, high=INT16MAX, size=(16000,)).astype(np.float32) / INT16MAX
+    audio_path = str(tmp_path / "dummy.wav")
+    sf.write(audio_path, expected_audio, 16000)
+
+    manifest_path = str(tmp_path / "manifest.json")
+    lhotse.serialization.save_to_jsonl(
+        [
+            # note: relative path
+            {"audio_filepath": "dummy.wav", "offset": 0.0, "duration": 0.5, "text": "irrelevant"},
+        ],
+        manifest_path,
+    )
+
+    cuts = lhotse.CutSet(LazyNeMoIterator(manifest_path))
+
+    cut = cuts[0]
+    assert isinstance(cut, lhotse.MonoCut)
+    assert cut.start == 0.0
+    assert cut.duration == 0.5
+    assert cut.sampling_rate == 16000
+    assert cut.num_samples == 8000
+    assert cut.supervisions[0].text == "irrelevant"
+    audio = cut.load_audio()
+    assert audio.shape == (1, 8000)
+    np.testing.assert_equal(audio[0], expected_audio[:8000])


### PR DESCRIPTION
# What does this PR do ?

Support relative audio paths in Lhotse `LazyNeMoIterator`

**Collection**: ASR

# Changelog 
- Support relative audio paths in Lhotse `LazyNeMoIterator`

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
