### PR TITLE
Add fp8 support for SD/Update notebook paths

### DIFF
--- a/examples/multimodal/text_to_image/stable_diffusion/conf/sd_train.yaml
+++ b/examples/multimodal/text_to_image/stable_diffusion/conf/sd_train.yaml
@@ -121,6 +121,7 @@ model:
     use_flash_attention: True
     enable_amp_o2_fp16: False
     resblock_gn_groups: 32
+    use_te_fp8: False
 
   first_stage_config:
     _target_: nemo.collections.multimodal.models.text_to_image.stable_diffusion.ldm.autoencoder.AutoencoderKL
@@ -191,7 +192,7 @@ model:
       synthetic_data_length: 10000
       train:
           dataset_path:
-              - /datasets/coyo/test.pkl
+            - /datasets/coyo/wdinfo/coyo-700m/wdinfo-selene.pkl
           augmentations:
             resize_smallest_side: 512
             center_crop_h_w: 512, 512

--- a/examples/multimodal/text_to_image/stable_diffusion/sd_infer.py
+++ b/examples/multimodal/text_to_image/stable_diffusion/sd_infer.py
@@ -28,6 +28,9 @@ def main(cfg):
         model_cfg.unet_config.use_flash_attention = False
         model_cfg.unet_config.from_pretrained = None
         model_cfg.first_stage_config.from_pretrained = None
+        model_cfg.first_stage_config._target_ = (
+            'nemo.collections.multimodal.models.text_to_image.stable_diffusion.ldm.autoencoder.AutoencoderKL'
+        )
 
     torch.backends.cuda.matmul.allow_tf32 = True
     trainer, megatron_diffusion_model = setup_trainer_and_model_for_inference(

--- a/nemo/collections/multimodal/modules/stable_diffusion/attention.py
+++ b/nemo/collections/multimodal/modules/stable_diffusion/attention.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 import math
 import os
+from inspect import isfunction
+
 import torch
 import torch.nn.functional as F
 from apex.contrib.group_norm import GroupNorm
 from einops import rearrange
-from inspect import isfunction
 from torch import einsum, nn
 from torch._dynamo import disable
 
@@ -110,7 +111,7 @@ class FeedForward(nn.Module):
         if use_te:
             activation = 'gelu' if not glu else 'geglu'
             # TODO: more parameters to be confirmed, dropout, seq_length
-            self.net = LayerNormMLP(hidden_size=dim, ffn_hidden_size=inner_dim, activation=activation, )
+            self.net = LayerNormMLP(hidden_size=dim, ffn_hidden_size=inner_dim, activation=activation,)
         else:
             norm = nn.LayerNorm(dim)
             project_in = nn.Sequential(LinearWrapper(dim, inner_dim), nn.GELU()) if not glu else GEGLU(dim, inner_dim)
@@ -229,15 +230,15 @@ class LinearWrapper(nn.Linear, adapter_mixins.AdapterModuleMixin):
 
 class CrossAttention(nn.Module):
     def __init__(
-            self,
-            query_dim,
-            context_dim=None,
-            heads=8,
-            dim_head=64,
-            dropout=0.0,
-            use_flash_attention=False,
-            lora_network_alpha=None,
-            use_te=False,
+        self,
+        query_dim,
+        context_dim=None,
+        heads=8,
+        dim_head=64,
+        dropout=0.0,
+        use_flash_attention=False,
+        lora_network_alpha=None,
+        use_te=False,
     ):
         super().__init__()
 
@@ -345,17 +346,17 @@ class CrossAttention(nn.Module):
 class BasicTransformerBlock(nn.Module):
     def __init__(
         self,
-            dim,
-            n_heads,
-            d_head,
-            dropout=0.0,
-            context_dim=None,
-            gated_ff=True,
-            use_checkpoint=False,
-            use_flash_attention=False,
-            disable_self_attn=False,
-            lora_network_alpha=None,
-            use_te=False,
+        dim,
+        n_heads,
+        d_head,
+        dropout=0.0,
+        context_dim=None,
+        gated_ff=True,
+        use_checkpoint=False,
+        use_flash_attention=False,
+        disable_self_attn=False,
+        lora_network_alpha=None,
+        use_te=False,
     ):
         super().__init__()
         self.disable_self_attn = disable_self_attn
@@ -407,17 +408,17 @@ class SpatialTransformer(nn.Module):
     def __init__(
         self,
         in_channels,
-            n_heads,
-            d_head,
-            depth=1,
-            dropout=0.0,
-            context_dim=None,
-            disable_self_attn=False,
-            use_linear=False,
-            use_checkpoint=False,
-            use_flash_attention=False,
-            lora_network_alpha=None,
-            use_te=False,
+        n_heads,
+        d_head,
+        depth=1,
+        dropout=0.0,
+        context_dim=None,
+        disable_self_attn=False,
+        use_linear=False,
+        use_checkpoint=False,
+        use_flash_attention=False,
+        lora_network_alpha=None,
+        use_te=False,
     ):
         super().__init__()
         if exists(context_dim) and not isinstance(context_dim, list):

--- a/nemo/collections/multimodal/modules/stable_diffusion/diffusionmodules/openaimodel.py
+++ b/nemo/collections/multimodal/modules/stable_diffusion/diffusionmodules/openaimodel.py
@@ -12,16 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
-import numpy as np
 import os
+from abc import abstractmethod
+from contextlib import nullcontext
+
+import numpy as np
 import torch
 import torch as th
 import torch.nn as nn
 import torch.nn.functional as F
+
 # FP8 related import
 import transformer_engine
-from abc import abstractmethod
-from contextlib import nullcontext
 
 from nemo.collections.multimodal.modules.stable_diffusion.attention import SpatialTransformer
 from nemo.collections.multimodal.modules.stable_diffusion.diffusionmodules.util import (
@@ -87,7 +89,7 @@ class AttentionPool2d(nn.Module):
     """
 
     def __init__(
-            self, spacial_dim: int, embed_dim: int, num_heads_channels: int, output_dim: int = None,
+        self, spacial_dim: int, embed_dim: int, num_heads_channels: int, output_dim: int = None,
     ):
         super().__init__()
         self.positional_embedding = nn.Parameter(th.randn(embed_dim, spacial_dim ** 2 + 1) / embed_dim ** 0.5)
@@ -497,17 +499,17 @@ class UNetModel(nn.Module):
         use_new_attention_order=False,
         use_spatial_transformer=False,  # custom transformer support
         transformer_depth=1,  # custom transformer support
-            context_dim=None,  # custom transformer support
-            n_embed=None,  # custom support for prediction of discrete ids into codebook of first stage vq model
-            legacy=True,
-            use_linear_in_transformer=False,
-            from_pretrained: str = None,
-            from_NeMo=False,
-            # It must be specified when from pretrained is not None. It indicates loading unet from NeMo trained ckpt or HF
-            use_flash_attention: bool = False,
-            enable_amp_o2_fp16: bool = False,
-            lora_network_alpha=None,
-            use_te_fp8: bool = False,
+        context_dim=None,  # custom transformer support
+        n_embed=None,  # custom support for prediction of discrete ids into codebook of first stage vq model
+        legacy=True,
+        use_linear_in_transformer=False,
+        from_pretrained: str = None,
+        from_NeMo=False,
+        # It must be specified when from pretrained is not None. It indicates loading unet from NeMo trained ckpt or HF
+        use_flash_attention: bool = False,
+        enable_amp_o2_fp16: bool = False,
+        lora_network_alpha=None,
+        use_te_fp8: bool = False,
     ):
         super().__init__()
         if use_spatial_transformer:
@@ -1069,7 +1071,7 @@ class UNetModel(nn.Module):
 
     def forward(self, x, timesteps=None, context=None, y=None, **kwargs):
         with transformer_engine.pytorch.fp8_autocast(
-                enabled=self.use_te_fp8, fp8_recipe=self.fp8_recipe,
+            enabled=self.use_te_fp8, fp8_recipe=self.fp8_recipe,
         ) if self.use_te_fp8 else nullcontext():
             out = self._forward(x, timesteps, context, y, **kwargs)
         return out
@@ -1082,7 +1084,7 @@ class EncoderUNetModel(nn.Module):
     """
 
     def __init__(
-            self,
+        self,
         image_size,
         in_channels,
         model_channels,

--- a/nemo/collections/multimodal/modules/stable_diffusion/diffusionmodules/openaimodel.py
+++ b/nemo/collections/multimodal/modules/stable_diffusion/diffusionmodules/openaimodel.py
@@ -12,13 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import math
-from abc import abstractmethod
-
 import numpy as np
+import os
 import torch
 import torch as th
 import torch.nn as nn
 import torch.nn.functional as F
+# FP8 related import
+import transformer_engine
+from abc import abstractmethod
+from contextlib import nullcontext
 
 from nemo.collections.multimodal.modules.stable_diffusion.attention import SpatialTransformer
 from nemo.collections.multimodal.modules.stable_diffusion.diffusionmodules.util import (
@@ -45,13 +48,46 @@ def convert_module_to_fp16(module):
     convert_module_to_dtype(module, torch.float16)
 
 
+def convert_module_to_fp32(module):
+    convert_module_to_dtype(module, torch.float32)
+
+
+def convert_module_to_fp8(model):
+    def _set_module(model, submodule_key, module):
+        tokens = submodule_key.split('.')
+        sub_tokens = tokens[:-1]
+        cur_mod = model
+        for s in sub_tokens:
+            cur_mod = getattr(cur_mod, s)
+        setattr(cur_mod, tokens[-1], module)
+
+    import copy
+
+    from transformer_engine.pytorch.module import Linear as te_Linear
+
+    for n, v in model.named_modules():
+        if isinstance(v, torch.nn.Linear):
+            # if n in ['class_embed', 'bbox_embed.layers.0', 'bbox_embed.layers.1', 'bbox_embed.layers.2']: continue
+            logging.info(f'[INFO] Replace Linear: {n}, weight: {v.weight.shape}')
+            if v.bias is None:
+                is_bias = False
+            else:
+                is_bias = True
+            newlinear = te_Linear(v.in_features, v.out_features, bias=is_bias)
+            newlinear.weight = copy.deepcopy(v.weight)
+            if v.bias is not None:
+                newlinear.bias = copy.deepcopy(v.bias)
+            _set_module(model, n, newlinear)
+
+
+## go
 class AttentionPool2d(nn.Module):
     """
     Adapted from CLIP: https://github.com/openai/CLIP/blob/main/clip/model.py
     """
 
     def __init__(
-        self, spacial_dim: int, embed_dim: int, num_heads_channels: int, output_dim: int = None,
+            self, spacial_dim: int, embed_dim: int, num_heads_channels: int, output_dim: int = None,
     ):
         super().__init__()
         self.positional_embedding = nn.Parameter(th.randn(embed_dim, spacial_dim ** 2 + 1) / embed_dim ** 0.5)
@@ -461,16 +497,17 @@ class UNetModel(nn.Module):
         use_new_attention_order=False,
         use_spatial_transformer=False,  # custom transformer support
         transformer_depth=1,  # custom transformer support
-        context_dim=None,  # custom transformer support
-        n_embed=None,  # custom support for prediction of discrete ids into codebook of first stage vq model
-        legacy=True,
-        use_linear_in_transformer=False,
-        from_pretrained: str = None,
-        from_NeMo=False,
-        # It must be specified when from pretrained is not None. It indicates loading unet from NeMo trained ckpt or HF
-        use_flash_attention: bool = False,
-        enable_amp_o2_fp16: bool = False,
-        lora_network_alpha=None,
+            context_dim=None,  # custom transformer support
+            n_embed=None,  # custom support for prediction of discrete ids into codebook of first stage vq model
+            legacy=True,
+            use_linear_in_transformer=False,
+            from_pretrained: str = None,
+            from_NeMo=False,
+            # It must be specified when from pretrained is not None. It indicates loading unet from NeMo trained ckpt or HF
+            use_flash_attention: bool = False,
+            enable_amp_o2_fp16: bool = False,
+            lora_network_alpha=None,
+            use_te_fp8: bool = False,
     ):
         super().__init__()
         if use_spatial_transformer:
@@ -526,6 +563,7 @@ class UNetModel(nn.Module):
         input_block_chans = [model_channels]
         ch = model_channels
         ds = 1
+        self.use_te_fp8 = use_te_fp8
         for level, mult in enumerate(channel_mult):
             for _ in range(num_res_blocks):
                 layers = [
@@ -568,6 +606,7 @@ class UNetModel(nn.Module):
                             use_linear=use_linear_in_transformer,
                             use_checkpoint=use_checkpoint,
                             use_flash_attention=use_flash_attention,
+                            use_te=self.use_te_fp8,
                             lora_network_alpha=lora_network_alpha,
                         )
                     )
@@ -633,6 +672,7 @@ class UNetModel(nn.Module):
                 use_linear=use_linear_in_transformer,
                 use_checkpoint=use_checkpoint,
                 use_flash_attention=use_flash_attention,
+                use_te=self.use_te_fp8,
                 lora_network_alpha=lora_network_alpha,
             ),
             ResBlock(
@@ -660,6 +700,7 @@ class UNetModel(nn.Module):
                         dims=dims,
                         use_checkpoint=use_checkpoint,
                         use_scale_shift_norm=use_scale_shift_norm,
+                        resblock_gn_groups=resblock_gn_groups,
                     )
                 ]
                 ch = model_channels * mult
@@ -690,6 +731,7 @@ class UNetModel(nn.Module):
                             use_linear=use_linear_in_transformer,
                             use_checkpoint=use_checkpoint,
                             use_flash_attention=use_flash_attention,
+                            use_te=self.use_te_fp8,
                             lora_network_alpha=lora_network_alpha,
                         )
                     )
@@ -745,6 +787,32 @@ class UNetModel(nn.Module):
 
         if enable_amp_o2_fp16:
             self.convert_to_fp16()
+
+        elif self.use_te_fp8:
+            assert enable_amp_o2_fp16 is False, "fp8 training can't work with fp16 O2 amp recipe"
+            convert_module_to_fp8(self)
+
+            fp8_margin = int(os.getenv("FP8_MARGIN", '0'))
+            fp8_interval = int(os.getenv("FP8_INTERVAL", '1'))
+            fp8_format = os.getenv("FP8_FORMAT", "hybrid")
+            fp8_amax_history_len = int(os.getenv("FP8_HISTORY_LEN", '1024'))
+            fp8_amax_compute_algo = os.getenv("FP8_COMPUTE_ALGO", 'max')
+            fp8_wgrad = os.getenv("FP8_WGRAD", '1') == '1'
+
+            fp8_format_dict = {
+                'hybrid': transformer_engine.common.recipe.Format.HYBRID,
+                'e4m3': transformer_engine.common.recipe.Format.E4M3,
+            }
+            fp8_format = fp8_format_dict[fp8_format]
+
+            self.fp8_recipe = transformer_engine.common.recipe.DelayedScaling(
+                margin=fp8_margin,
+                interval=fp8_interval,
+                fp8_format=fp8_format,
+                amax_history_len=fp8_amax_history_len,
+                amax_compute_algo=fp8_amax_compute_algo,
+                override_linear_precision=(False, False, not fp8_wgrad),
+            )
 
     def _input_blocks_mapping(self, input_dict):
         res_dict = {}
@@ -960,7 +1028,7 @@ class UNetModel(nn.Module):
         """
         self.apply(convert_module_to_fp16)
 
-    def forward(self, x, timesteps=None, context=None, y=None, **kwargs):
+    def _forward(self, x, timesteps=None, context=None, y=None, **kwargs):
         """
         Apply the model to an input batch.
 
@@ -999,6 +1067,13 @@ class UNetModel(nn.Module):
         else:
             return self.out(h)
 
+    def forward(self, x, timesteps=None, context=None, y=None, **kwargs):
+        with transformer_engine.pytorch.fp8_autocast(
+                enabled=self.use_te_fp8, fp8_recipe=self.fp8_recipe,
+        ) if self.use_te_fp8 else nullcontext():
+            out = self._forward(x, timesteps, context, y, **kwargs)
+        return out
+
 
 class EncoderUNetModel(nn.Module):
     """
@@ -1007,7 +1082,7 @@ class EncoderUNetModel(nn.Module):
     """
 
     def __init__(
-        self,
+            self,
         image_size,
         in_channels,
         model_channels,

--- a/nemo/collections/multimodal/parts/stable_diffusion/pipeline.py
+++ b/nemo/collections/multimodal/parts/stable_diffusion/pipeline.py
@@ -14,10 +14,11 @@
 import os
 import pickle
 import time
-import torch
-from PIL import Image
 from collections import defaultdict
 from itertools import chain
+
+import torch
+from PIL import Image
 
 from nemo.collections.multimodal.models.text_to_image.stable_diffusion.samplers.ddim import DDIMSampler
 from nemo.collections.multimodal.models.text_to_image.stable_diffusion.samplers.para_ddim import ParaDDIMSampler

--- a/nemo/collections/multimodal/parts/stable_diffusion/pipeline.py
+++ b/nemo/collections/multimodal/parts/stable_diffusion/pipeline.py
@@ -14,11 +14,10 @@
 import os
 import pickle
 import time
-from collections import defaultdict
-from itertools import chain
-
 import torch
 from PIL import Image
+from collections import defaultdict
+from itertools import chain
 
 from nemo.collections.multimodal.models.text_to_image.stable_diffusion.samplers.ddim import DDIMSampler
 from nemo.collections.multimodal.models.text_to_image.stable_diffusion.samplers.para_ddim import ParaDDIMSampler

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -15,18 +15,20 @@
 import functools
 import itertools
 import os
-import pytorch_lightning as pl
 import re
 import shutil
 import tempfile
-import torch
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Dict, Generator, Iterator, List, Literal, Mapping, Optional, Sized, Union
+
+import pytorch_lightning as pl
+import torch
 from lightning_fabric.utilities.cloud_io import get_filesystem
 from lightning_fabric.utilities.optimizer import _optimizer_to_device
 from megatron.core.tensor_parallel.layers import param_is_not_tensor_parallel_duplicate
 from omegaconf import OmegaConf
-from pathlib import Path
 from pytorch_lightning.callbacks.progress import TQDMProgressBar
 from pytorch_lightning.callbacks.progress.tqdm_progress import _update_n
 from pytorch_lightning.core.optimizer import LightningOptimizer
@@ -52,7 +54,6 @@ from torch.distributed.fsdp import (
 from torch.distributed.fsdp.api import FullOptimStateDictConfig, ShardedOptimStateDictConfig
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from torch.nn.parallel import DistributedDataParallel
-from typing import Any, Callable, Dict, Generator, Iterator, List, Literal, Mapping, Optional, Sized, Union
 
 from nemo.collections.nlp.modules.common.megatron.module import Float16Module
 from nemo.collections.nlp.modules.common.megatron.transformer import AutocastTransformerLayer, ParallelTransformerLayer
@@ -66,6 +67,7 @@ from nemo.utils.model_utils import ckpt_to_dir, inject_model_parallel_rank, unin
 
 try:
     from apex.transformer.pipeline_parallel.utils import get_num_microbatches
+
     from nemo.core.optim.distributed_adam import MegatronDistributedFusedAdam
 
     HAVE_APEX = True

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -15,20 +15,18 @@
 import functools
 import itertools
 import os
+import pytorch_lightning as pl
 import re
 import shutil
 import tempfile
+import torch
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
-from pathlib import Path
-from typing import Any, Callable, Dict, Generator, Iterator, List, Literal, Mapping, Optional, Sized, Union
-
-import pytorch_lightning as pl
-import torch
 from lightning_fabric.utilities.cloud_io import get_filesystem
 from lightning_fabric.utilities.optimizer import _optimizer_to_device
 from megatron.core.tensor_parallel.layers import param_is_not_tensor_parallel_duplicate
 from omegaconf import OmegaConf
+from pathlib import Path
 from pytorch_lightning.callbacks.progress import TQDMProgressBar
 from pytorch_lightning.callbacks.progress.tqdm_progress import _update_n
 from pytorch_lightning.core.optimizer import LightningOptimizer
@@ -54,6 +52,7 @@ from torch.distributed.fsdp import (
 from torch.distributed.fsdp.api import FullOptimStateDictConfig, ShardedOptimStateDictConfig
 from torch.distributed.fsdp.wrap import transformer_auto_wrap_policy
 from torch.nn.parallel import DistributedDataParallel
+from typing import Any, Callable, Dict, Generator, Iterator, List, Literal, Mapping, Optional, Sized, Union
 
 from nemo.collections.nlp.modules.common.megatron.module import Float16Module
 from nemo.collections.nlp.modules.common.megatron.transformer import AutocastTransformerLayer, ParallelTransformerLayer
@@ -999,6 +998,30 @@ class NLPSaveRestoreConnector(SaveRestoreConnector):
                     new_state_dict[new_key_] = state_dict[key_]
                 else:
                     new_state_dict[key_] = state_dict[key_]
+            state_dict = new_state_dict
+
+        if conf.get('unet_config') and conf.get('unet_config').get('use_te_fp8') == False:
+            # remove _extra_state in fp8 if there is.
+            new_state_dict = {}
+            for key in state_dict.keys():
+                if 'extra_state' in key:
+                    continue
+
+                ### LayerNormLinear
+                # norm_to_q.layer_norm_{weight|bias} -> norm_to_q.0.{weight|bias}
+                # norm_to_q.weight -> norm_to_q.1.weight
+                new_key = key.replace('norm_to_q.layer_norm_', 'norm_to_q.0.')
+                new_key = new_key.replace('norm_to_q.weight', 'norm_to_q.1.weight')
+
+                ### LayerNormMLP
+                # ff.net.layer_norm_{weight|bias} -> ff.net.0.{weight|bias}
+                # ff.net.fc1_{weight|bias} -> ff.net.1.proj.{weight|bias}
+                # ff.net.fc2_{weight|bias} -> ff.net.3.{weight|bias}
+                new_key = new_key.replace('ff.net.layer_norm_', 'ff.net.0.')
+                new_key = new_key.replace('ff.net.fc1_', 'ff.net.1.proj.')
+                new_key = new_key.replace('ff.net.fc2_', 'ff.net.3.')
+
+                new_state_dict[new_key] = state_dict[key]
             state_dict = new_state_dict
 
         return state_dict

--- a/tutorials/multimodal/DreamBooth Tutorial.ipynb
+++ b/tutorials/multimodal/DreamBooth Tutorial.ipynb
@@ -124,10 +124,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! python /opt/NeMo/examples/multimodal/foundation/clip/convert_external_clip_to_nemo.py \\\n",
+    "! python /opt/NeMo/examples/multimodal/vision_language_foundation/clip/convert_external_clip_to_nemo.py \\\n",
     "        --arch ViT-L-14 \\\n",
     "        --version openai \\\n",
-    "        --hparams_file /opt/NeMo/examples/multimodal/foundation/clip/conf/megatron_clip_VIT-L-14.yaml \\\n",
+    "        --hparams_file /opt/NeMo/examples/multimodal/vision_language_foundation/clip/conf/megatron_clip_VIT-L-14.yaml \\\n",
     "        --nemo_file /ckpts/openai.nemo"
    ]
   },
@@ -167,7 +167,7 @@
    "outputs": [],
    "source": [
     "## This is the example command for running dreambooth training\n",
-    "! python /opt/NeMo/examples/multimodal/generative/dreambooth/dreambooth.py \\\n",
+    "! python /opt/NeMo/examples/multimodal/text_to_image/dreambooth/dreambooth.py \\\n",
     "    model.unet_config.from_pretrained=/ckpts/unet.bin \\\n",
     "    model.unet_config.from_NeMo=False \\\n",
     "    model.first_stage_config.from_pretrained=/ckpts/vae.bin \\\n",
@@ -196,7 +196,7 @@
    "outputs": [],
    "source": [
     "## This is the example command for running DreamBooth inference\n",
-    "! torchrun /opt/NeMo/examples/multimodal/generative/dreambooth/dreambooth_infer.py \\\n",
+    "! torchrun /opt/NeMo/examples/multimodal/text_to_image/dreambooth/dreambooth_infer.py \\\n",
     "    model.restore_from_path='/opt/NeMo/tutorials/multimodal/nemo_experiments/Dreambooth/checkpoints/Dreambooth.nemo' \\\n",
     "    infer.num_images_per_prompt=4 \\\n",
     "    infer.inference_steps=50 \\\n",

--- a/tutorials/multimodal/Stable Diffusion Tutorial.ipynb
+++ b/tutorials/multimodal/Stable Diffusion Tutorial.ipynb
@@ -9,7 +9,7 @@
     "# Stable Diffusion Training / Inference Tutorial\n",
     "\n",
     "### Note:\n",
-    "Currently, this notebook must be run in a NeMo container. An example command to launch the container:\n",
+    "Currently, this notebook must be run in a NeMo container (> 24.01). An example command to launch the container:\n",
     "\n",
     "```\n",
     "docker run --gpus all -it --rm -v <your_nemo_dir>:/opt/NeMo --shm-size=8g \\\n",
@@ -30,7 +30,7 @@
     "\n",
     "## Datasets\n",
     "\n",
-    "Please refer to [ADD LINK]() for how to prepare a training dataset for Stable diffusion.\n",
+    "Please refer to [Dataset Tutorial](https://github.com/NVIDIA/NeMo/blob/main/tutorials/multimodal/Multimodal%20Data%20Preparation.ipynb) for how to prepare a training dataset for Stable diffusion.\n",
     "\n",
     "For a pre-cached Stable Diffusion dataset, each webdataset tar file should, at a minimum, include the pickle files that store the pre-cached image and text features:\n",
     "\n",
@@ -117,10 +117,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! python examples/multimodal/foundation/clip/convert_external_clip_to_nemo.py \\\n",
+    "! python /opt/NeMo/examples/multimodal/vision_language_foundation/clip/convert_external_clip_to_nemo.py \\\n",
     "        --arch ViT-L-14 \\\n",
     "        --version openai \\\n",
-    "        --hparams_file /opt/NeMo/examples/multimodal/foundation/clip/conf/megatron_clip_VIT-L-14.yaml \\\n",
+    "        --hparams_file /opt/NeMo/examples/multimodal/vision_language_foundation/clip/conf/megatron_clip_VIT-L-14.yaml \\\n",
     "        --nemo_file /ckpts/openai.nemo"
    ]
   },
@@ -151,7 +151,7 @@
     "\n",
     "### Option 2: Training on Precached Dataset (Training UNet Only)\n",
     "\n",
-    "When using precached dataset (please refer to the [Dataset Tutorial](ADD_LINK) for details), every text feature and image feature are stored as key-value pairs in `.pickle` file:\n",
+    "When using precached dataset (please refer to the [Dataset Tutorial](https://github.com/NVIDIA/NeMo/blob/main/tutorials/multimodal/Multimodal%20Data%20Preparation.ipynb) for details), every text feature and image feature are stored as key-value pairs in `.pickle` file:\n",
     "\n",
     "```\n",
     "{\n",
@@ -201,7 +201,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! torchrun /opt/NeMo/examples/multimodal/generative/stable_diffusion/sd_train.py trainer.max_steps=100 model.data.synthetic_data=True"
+    "! torchrun /opt/NeMo/examples/multimodal/text_to_image/stable_diffusion/sd_train.py trainer.max_steps=100 model.data.synthetic_data=True"
    ]
   },
   {
@@ -247,7 +247,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "! ! torchrun  /opt/NeMo/examples/multimodal/generative/stable_diffusion/sd_infer.py model.restore_from_path='/opt/NeMo/tutorials/multimodal/nemo_experiments/stable-diffusion-train/checkpoints/stable-diffusion-train.nemo'"
+    "! torchrun  /opt/NeMo/examples/multimodal/text_to_image/stable_diffusion/sd_infer.py model.restore_from_path='/opt/NeMo/tutorials/multimodal/nemo_experiments/stable-diffusion-train/checkpoints/stable-diffusion-train.nemo'"
    ]
   }
  ],


### PR DESCRIPTION
# What does this PR do ?

Add FP8 support for SD training.

**Collection**: [multimodal/text_to_image/statble_diffusion]

# Changelog 
- Add config argument - use_te_fp8 to switch between fp16 and fp8 training
- Add transformer engine fp8 layers to Stable diffusion Unet
- Update a few legacy paths in notebook tutorial

# Usage

```yaml
unet_config:
    use_te_fp8=True
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
