### PR TITLE
Fix canary transcribe

### DIFF
--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import contextlib
+import glob
 import os
 from dataclasses import dataclass, is_dataclass
 from typing import List, Optional, Union
@@ -314,8 +315,11 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
     if isinstance(asr_model, EncDecMultiTaskModel):
         # Special case for EncDecMultiTaskModel, where the input manifest is directly passed into the model's transcribe() function
         partial_audio = False
-        filepaths = cfg.dataset_manifest
-        assert cfg.dataset_manifest is not None
+        if cfg.audio_dir is not None and not cfg.append_pred:
+            filepaths = list(glob.glob(os.path.join(cfg.audio_dir, f"**/*.{cfg.audio_type}"), recursive=True))
+        else:
+            filepaths = cfg.dataset_manifest
+            assert cfg.dataset_manifest is not None
     else:
         # prepare audio filepaths and decide wether it's partial audio
         filepaths, partial_audio = prepare_audio_data(cfg)

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -376,7 +376,10 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
                     augmentor=augmentor,
                 )
 
-    logging.info(f"Finished transcribing {len(filepaths)} files !")
+    if cfg.dataset_manifest is not None:
+        logging.info(f"Finished transcribing from manifest file: {cfg.dataset_manifest}")
+    else:
+        logging.info(f"Finished transcribing {len(filepaths)} files !")
     logging.info(f"Writing transcriptions into file: {cfg.output_filename}")
 
     # if transcriptions form a tuple of (best_hypotheses, all_hypotheses), extract just best hypothesis


### PR DESCRIPTION
# What does this PR do ?

Fix `transcribe_speech.py` to use `audio_dir` as input instead of just `dataset_manifest`, also fix logging message. Tested on my local machine

**Collection**: [asr]


**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

