### PR TITLE
Force valid samples to 1 only if limit_val_batches is float

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3568,6 +3568,7 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
       }
     }
     // @chcui: model.cpu_offloading_num_layers=7 # temp workaround before m-lm !1124 is merged
+    // @athitten: Revert limit_val_batches to 2 until limit_val_batches 1.0 leading to no validation is fixed
     stage('L2: Megatron GPT Pretraining and Resume Training TP=2') {
       when {
         anyOf {
@@ -3582,7 +3583,7 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
         trainer.accelerator=gpu \
         trainer.log_every_n_steps=1 \
         trainer.val_check_interval=2 \
-        trainer.limit_val_batches=1.0 \
+        trainer.limit_val_batches=2 \
         trainer.accumulate_grad_batches=1 \
         trainer.max_steps=3 \
         trainer.precision=16 \
@@ -3617,7 +3618,7 @@ assert_frame_equal(training_curve, gt_curve, rtol=1e-3, atol=1e-3)"'''
         trainer.accelerator=gpu \
         trainer.log_every_n_steps=1 \
         trainer.val_check_interval=2 \
-        trainer.limit_val_batches=1.0 \
+        trainer.limit_val_batches=2 \
         trainer.accumulate_grad_batches=1 \
         trainer.max_steps=6 \
         trainer.precision=16 \

--- a/nemo/collections/nlp/models/language_modeling/megatron/gpt_full_te_layer_autocast_spec.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/gpt_full_te_layer_autocast_spec.py
@@ -16,14 +16,14 @@ from typing import Any, Callable, Optional
 
 import torch
 
-from nemo.collections.nlp.parts import utils_funcs
 from nemo.collections.nlp.modules.common.megatron.utils import ApexGuardDefaults
+from nemo.collections.nlp.parts import utils_funcs
 
 try:
     from megatron.core import parallel_state, tensor_parallel
     from megatron.core.transformer.spec_utils import ModuleSpec
-    from megatron.core.transformer.utils import make_sharded_tensors_for_checkpoint
     from megatron.core.transformer.transformer_layer import BaseTransformerLayer
+    from megatron.core.transformer.utils import make_sharded_tensors_for_checkpoint
 
     HAVE_MEGATRON_CORE = True
 

--- a/nemo/collections/nlp/models/language_modeling/megatron/gpt_full_te_layer_autocast_spec.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/gpt_full_te_layer_autocast_spec.py
@@ -15,13 +15,25 @@
 from typing import Any, Callable, Optional
 
 import torch
-from megatron.core import parallel_state, tensor_parallel
-from megatron.core.transformer.spec_utils import ModuleSpec
-from megatron.core.transformer.utils import make_sharded_tensors_for_checkpoint
-
-from transformer_engine.pytorch import TransformerLayer
 
 from nemo.collections.nlp.parts import utils_funcs
+from nemo.collections.nlp.modules.common.megatron.utils import ApexGuardDefaults
+
+try:
+    from megatron.core import parallel_state, tensor_parallel
+    from megatron.core.transformer.spec_utils import ModuleSpec
+    from megatron.core.transformer.utils import make_sharded_tensors_for_checkpoint
+    from megatron.core.transformer.transformer_layer import BaseTransformerLayer
+
+    HAVE_MEGATRON_CORE = True
+
+except (ImportError, ModuleNotFoundError):
+
+    BaseTransformerLayer = ApexGuardDefaults
+
+    HAVE_MEGATRON_CORE = False
+
+from transformer_engine.pytorch import TransformerLayer
 
 
 # Copied from nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -135,9 +147,6 @@ class AutocastTransformerLayer(TransformerLayer):
                 is_first_microbatch=is_first_microbatch,
                 checkpoint_core_attention=checkpoint_core_attention,
             )
-
-
-from megatron.core.transformer.transformer_layer import BaseTransformerLayer
 
 
 class TETransformerLayerAutocast(AutocastTransformerLayer, BaseTransformerLayer):

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1193,6 +1193,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         eval_iters = (max_train_steps // self.trainer.val_check_interval + 1) * self.trainer.limit_val_batches
         test_iters = self.trainer.limit_test_batches
 
+        # TODO: @athitten make num of eval and test samples 1 always, after clarifying its working.
         train_valid_test_num_samples = [
             max_train_steps * global_batch_size,
             eval_iters * global_batch_size,

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1190,19 +1190,28 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         logging.info('Building GPT datasets.')
         global_batch_size = self.cfg.global_batch_size
         max_train_steps = self.trainer.max_steps
+        eval_iters = (max_train_steps // self.trainer.val_check_interval + 1) * self.trainer.limit_val_batches
+        test_iters = self.trainer.limit_test_batches
 
-        # Add extra FIM tokens to tokenizer
-        if self.cfg.data.get('add_fim', False) and self.cfg.tokenizer.library == 'megatron':
-            fim_tokens = self.cfg.data.fim.extra_tokens
-            fim_tokens = [fim_tokens.prefix, fim_tokens.middle, fim_tokens.suffix, fim_tokens.pad, fim_tokens.eod]
-            self.tokenizer.add_special_tokens({'additional_special_tokens': fim_tokens})
+        train_valid_test_num_samples = [
+            max_train_steps * global_batch_size,
+            eval_iters * global_batch_size,
+            test_iters * global_batch_size,
+        ]
 
         # The line below exploits a quirk in mcore dataset construction, to make number of epochs for validation and test equal to 1
         # The mcore dataset implementation uses the number N we provide via train_valid_test_num_samples to derive parameter E such that
         # E = argmin_e e * N_d >= N, or equivalently E = ceildiv(N, N_d)
         # Where N_d is the total number of samples in a dataset (files), and N is the requested number of samples (provided for every split in the list below).
         # Setting N = 1 we force E to be 1 as well
-        train_valid_test_num_samples = [max_train_steps * global_batch_size, 1, 1]
+        if self.trainer.limit_val_batches <= 1.0 and isinstance(self.trainer.limit_val_batches, float):
+            train_valid_test_num_samples[1] = 1
+
+        # Add extra FIM tokens to tokenizer
+        if self.cfg.data.get('add_fim', False) and self.cfg.tokenizer.library == 'megatron':
+            fim_tokens = self.cfg.data.fim.extra_tokens
+            fim_tokens = [fim_tokens.prefix, fim_tokens.middle, fim_tokens.suffix, fim_tokens.pad, fim_tokens.eod]
+            self.tokenizer.add_special_tokens({'additional_special_tokens': fim_tokens})
 
         mock_dataset = True if self.cfg.data.get("data_impl", "mmap") == "mock" else False
         kwargs = {


### PR DESCRIPTION
# What does this PR do ?

1. Revert having num eval samples as 1 only for float `limit_val_batches` value until the issue of num of eval samples becoming 0 with CI datasets is figured.

2. Also, add import guards for megatron related imports in `gpt_full_te_layer_autocast_spec.py`



**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
