### PR TITLE
Accelerate CTC greedy decoding by around 10%

### DIFF
--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -666,9 +666,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
             # See comment in
             # ctc_greedy_decoding.py::GreedyCTCInfer::forward() to
             # understand this idiom.
-            logits_cpu = torch.empty(logits.shape,
-                                     dtype=logits.dtype,
-                                     pin_memory=True)
+            logits_cpu = torch.empty(logits.shape, dtype=logits.dtype, pin_memory=True)
             logits_cpu.copy_(logits)
             logits_len = logits_len.cpu()
             # dump log probs per file

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -667,10 +667,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
                 # See comment in
                 # ctc_greedy_decoding.py::GreedyCTCInfer::forward() to
                 # understand this idiom.
-                logits_cpu = torch.empty(logits.shape,
-                                         dtype=logits.dtype,
-                                         device=torch.device("cpu"),
-                                         pin_memory=True)
+                logits_cpu = torch.empty(logits.shape, dtype=logits.dtype, device=torch.device("cpu"), pin_memory=True)
                 logits_cpu.copy_(logits, non_blocking=True)
             else:
                 logits_cpu = logits

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -662,14 +662,21 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         current_hypotheses, all_hyp = self.decoding.ctc_decoder_predictions_tensor(
             logits, decoder_lengths=logits_len, return_hypotheses=trcfg.return_hypotheses,
         )
-        logits = logits.cpu()
-
         if trcfg.return_hypotheses:
+            # See comment in
+            # ctc_greedy_decoding.py::GreedyCTCInfer::forward() to
+            # understand this idiom.
+            logits_cpu = torch.empty(logits.shape,
+                                     dtype=logits.dtype,
+                                     pin_memory=True)
+            logits_cpu.copy_(logits)
+            logits_len = logits_len.cpu()
             # dump log probs per file
-            for idx in range(logits.shape[0]):
-                current_hypotheses[idx].y_sequence = logits[idx][: logits_len[idx]]
+            for idx in range(logits_cpu.shape[0]):
+                current_hypotheses[idx].y_sequence = logits_cpu[idx][: logits_len[idx]]
                 if current_hypotheses[idx].alignments is None:
                     current_hypotheses[idx].alignments = current_hypotheses[idx].y_sequence
+            del logits_cpu
 
         # cleanup memory
         del logits, logits_len

--- a/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
@@ -161,7 +161,21 @@ class GreedyCTCInfer(Typing, ConfidenceMethodMixin):
         with torch.inference_mode():
             hypotheses = []
             # Process each sequence independently
-            prediction_cpu_tensor = decoder_output.cpu()
+
+            # This two-liner is around twenty times faster than:
+            # `prediction_cpu_tensor = decoder_output.cpu()`
+            # cpu() does not use pinned memory, meaning that a slow pageable
+            # copy must be done instead.
+            prediction_cpu_tensor = torch.empty(decoder_output.shape,
+                                                dtype=decoder_output.dtype,
+                                                pin_memory=True)
+            prediction_cpu_tensor.copy_(decoder_output)
+            if decoder_lengths is not None and isinstance(decoder_lengths, torch.Tensor):
+                # Before this change, self._greedy_decode_labels would copy
+                # each scalar from GPU to CPU one at a time, in the line:
+                # prediction = prediction[:out_len]
+                # Doing one GPU to CPU copy ahead of time amortizes that overhead.
+                decoder_lengths = decoder_lengths.cpu()
 
             if prediction_cpu_tensor.ndim < 2 or prediction_cpu_tensor.ndim > 3:
                 raise ValueError(
@@ -192,7 +206,7 @@ class GreedyCTCInfer(Typing, ConfidenceMethodMixin):
 
         # Initialize blank state and empty label set in Hypothesis
         hypothesis = rnnt_utils.Hypothesis(score=0.0, y_sequence=[], dec_state=None, timestep=[], last_token=None)
-        prediction = x.detach().cpu()
+        prediction = x.cpu()
 
         if out_len is not None:
             prediction = prediction[:out_len]
@@ -200,7 +214,7 @@ class GreedyCTCInfer(Typing, ConfidenceMethodMixin):
         prediction_logprobs, prediction_labels = prediction.max(dim=-1)
 
         non_blank_ids = prediction_labels != self.blank_id
-        hypothesis.y_sequence = prediction_labels.numpy().tolist()
+        hypothesis.y_sequence = prediction_labels.tolist()
         hypothesis.score = (prediction_logprobs[non_blank_ids]).sum()
 
         if self.preserve_alignments:
@@ -208,7 +222,7 @@ class GreedyCTCInfer(Typing, ConfidenceMethodMixin):
             hypothesis.alignments = (prediction.clone(), prediction_labels.clone())
 
         if self.compute_timestamps:
-            hypothesis.timestep = torch.nonzero(non_blank_ids, as_tuple=False)[:, 0].numpy().tolist()
+            hypothesis.timestep = torch.nonzero(non_blank_ids, as_tuple=False)[:, 0].tolist()
 
         if self.preserve_frame_confidence:
             hypothesis.frame_confidence = self._get_confidence(prediction)
@@ -222,20 +236,20 @@ class GreedyCTCInfer(Typing, ConfidenceMethodMixin):
 
         # Initialize blank state and empty label set in Hypothesis
         hypothesis = rnnt_utils.Hypothesis(score=0.0, y_sequence=[], dec_state=None, timestep=[], last_token=None)
-        prediction_labels = x.detach().cpu()
+        prediction_labels = x.cpu()
 
         if out_len is not None:
             prediction_labels = prediction_labels[:out_len]
 
         non_blank_ids = prediction_labels != self.blank_id
-        hypothesis.y_sequence = prediction_labels.numpy().tolist()
+        hypothesis.y_sequence = prediction_labels.tolist()
         hypothesis.score = -1.0
 
         if self.preserve_alignments:
             raise ValueError("Requested for alignments, but predictions provided were labels, not log probabilities.")
 
         if self.compute_timestamps:
-            hypothesis.timestep = torch.nonzero(non_blank_ids, as_tuple=False)[:, 0].numpy().tolist()
+            hypothesis.timestep = torch.nonzero(non_blank_ids, as_tuple=False)[:, 0].tolist()
 
         if self.preserve_frame_confidence:
             raise ValueError(

--- a/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
@@ -167,10 +167,9 @@ class GreedyCTCInfer(Typing, ConfidenceMethodMixin):
                 # `prediction_cpu_tensor = decoder_output.cpu()`
                 # cpu() does not use pinned memory, meaning that a slow pageable
                 # copy must be done instead.
-                prediction_cpu_tensor = torch.empty(decoder_output.shape,
-                                                    dtype=decoder_output.dtype,
-                                                    device=torch.device("cpu"),
-                                                    pin_memory=True)
+                prediction_cpu_tensor = torch.empty(
+                    decoder_output.shape, dtype=decoder_output.dtype, device=torch.device("cpu"), pin_memory=True
+                )
                 prediction_cpu_tensor.copy_(decoder_output, non_blocking=True)
             else:
                 prediction_cpu_tensor = decoder_output

--- a/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
@@ -166,9 +166,7 @@ class GreedyCTCInfer(Typing, ConfidenceMethodMixin):
             # `prediction_cpu_tensor = decoder_output.cpu()`
             # cpu() does not use pinned memory, meaning that a slow pageable
             # copy must be done instead.
-            prediction_cpu_tensor = torch.empty(decoder_output.shape,
-                                                dtype=decoder_output.dtype,
-                                                pin_memory=True)
+            prediction_cpu_tensor = torch.empty(decoder_output.shape, dtype=decoder_output.dtype, pin_memory=True)
             prediction_cpu_tensor.copy_(decoder_output)
             if decoder_lengths is not None and isinstance(decoder_lengths, torch.Tensor):
                 # Before this change, self._greedy_decode_labels would copy


### PR DESCRIPTION
# What does this PR do ?

Accelerate CTC greedy decoding by around 10x, speeding up overall CTC runtime for parakeet-ctc-1.1b by close to 10%.

**Collection**: ASR

# Changelog 

There were a few problems with CTC greedy decoding before:

- It would copy GPU memory to pageable memory originally, which is very slow compared to copying to pinned memory. Unfortunately, cudaMallocHost() is synchronous and "slow", but fortunately pytorch has a free list of recent pinned memory allocations in its pinned memory allocator, allowing us to reduce the number of these calls. The cost of the memcpy before my change is excessive, taking ~20-40ms. After changing to use pinned memory, it takes only 2-4ms. This is the primary source of the 10x speedup. Note that doing the initial pinned memory allocations is slow (discussed later in this message).

<img width="789" alt="image" src="https://github.com/NVIDIA/NeMo/assets/4767568/11a1addd-b9a7-4060-84f7-712ea36062e3">

- A single scalar of logits_len/decoder_lengths was copied from GPU to CPU at a time, rather than all at once in a single call. This caused neddless overhead. We could also use a pinned memory allocation for copying logits_len as well, but using pinned memory is less important for small allocations. The original code's trace looks like this:
<img width="1061" alt="image" src="https://github.com/NVIDIA/NeMo/assets/4767568/9467224f-a1a0-492d-a4a5-9f3804e975ae"> Each red box followed by a green box is copying a single scalar value from GPU to CPU

- detatch() was called in function marked with @nograd

- For some reason, someone was using torch_tensor.numpy().tolist() instead of torch_tensor.tolist(). I don't believe numpy() makes a copy of the data, but it is unnecessary.

The main important improvements are the first two bullet points. Everything else is unimportant.

There are more opportunities for improvement. In particular, logits gets copied to cpu twice if trcfg.return_hypotheses is True. However, this overhead is now small since it will always just use the previous pinned host allocation from the free list.

Performance improvements:

I ran this code on an A100 GPU, on a machine with 16 CPU cores:

```
python examples/asr/speech_to_text_eval.py \
pretrained_name=nvidia/parakeet-ctc-1.1b \
dataset_manifest=/home/dgalvez/scratch/data/test_other.json \
batch_size=16  output_filename=test_other_decoded.jsonl  amp=true \
amp_dtype=bfloat16  use_cer=false num_workers=1
```

I applied this diff to run multiple times:

```
modified   examples/asr/transcribe_speech.py                                                                                                                                                              
@@ -367,14 +367,19 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis                                                                                                    
                     decoder_type=cfg.decoder_type,                                                                                                                                                       
                 )                                                                                                                                                                                        
             else:                                                                                                                                                                                        
-                transcriptions = asr_model.transcribe(                                                                                                                                                   
-                    audio=filepaths,                                                                                                                                                                     
-                    batch_size=cfg.batch_size,                                                                                                                                                           
-                    num_workers=cfg.num_workers,                                                                                                                                                         
-                    return_hypotheses=cfg.return_hypotheses,                                                                                                                                             
-                    channel_selector=cfg.channel_selector,                                                                                                                                               
-                    augmentor=augmentor,                                                                                                                                                                 
-                )                                                                                                                                                                                        
+                for i in range(5):                                                                                                                                                                       
+                    if i == 1:                                                                                                                                                                           
+                        torch.cuda.cudart().cudaProfilerStart()                                                                                                                                          
+                    transcriptions = asr_model.transcribe(                                                                                                                                               
+                        audio=filepaths,                                                                                                                                                                 
+                        batch_size=cfg.batch_size,                                                                                                                                                       
+                        num_workers=cfg.num_workers,                                                                                                                                                     
+                        return_hypotheses=cfg.return_hypotheses,                                                                                                                                         
+                        channel_selector=cfg.channel_selector,                                                                                                                                           
+                        augmentor=augmentor,                                                                                                                                                             
+                    )                                                                                                                                                                                    
+                    if i == 1:                                                                                                                                                                           
+                        torch.cuda.cudart().cudaProfilerStop()                                                                                                                                           
                                                                                                                                                                                                          
     if cfg.dataset_manifest is not None:                                                                                                                                                                 
         logging.info(f"Finished transcribing from manifest file: {cfg.dataset_manifest}")                                                                                                                
```

Time to do each of 5 evaluations of librispeech test other before my changes: 

32 seconds
28
29
29
29

Average: 29.4 seconds
Average excluding first (warmup): 28.75 seconds

Time to do each of 5 evaluations of librispeech test other after my changes:

30 seconds
26
26
25
25
Average: 26.4 seconds
Average excluding first (warmup): 25.5 seconds

This corresponds to an almost 10% speedup. This meets expectations, since 10% of the time was originally spent on CTC greedy decoding before.

P99 latency can increase for the first few calls to the model with this change. This is because we are now calling cudaMallocHost(), and then doing a pinned memory copy from GPU to CPU, which is slower than doing a paged memory copy from GPU to CPU. However, the cudaMallocHost() calls will be cached over time, allowing us to avoid the overhead of them in later evaluations of the dataset. The expense of a cudaMallocHost() (or cudaHostAlloc()) call can be seen here:

<img width="921" alt="image" src="https://github.com/NVIDIA/NeMo/assets/4767568/fd7fd4bc-833d-43ba-9226-959ebb7c9ee6">



# Usage

See above

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [X] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

