### PR TITLE
Option to control matmul precision in transcribe speech

### DIFF
--- a/examples/asr/speech_multitask/speech_to_text_aed_chunked_infer.py
+++ b/examples/asr/speech_multitask/speech_to_text_aed_chunked_infer.py
@@ -46,7 +46,7 @@ import copy
 import glob
 import os
 from dataclasses import dataclass, is_dataclass
-from typing import Literal, Optional
+from typing import Optional
 
 import pytorch_lightning as pl
 import torch

--- a/examples/asr/speech_multitask/speech_to_text_aed_chunked_infer.py
+++ b/examples/asr/speech_multitask/speech_to_text_aed_chunked_infer.py
@@ -99,7 +99,7 @@ class TranscriptionConfig:
     cuda: Optional[int] = None
     amp: bool = False
     amp_dtype: str = "float16"  # can be set to "float16" or "bfloat16" when using amp
-    matmul_precision: Literal["highest", "high", "medium"] = "highest"
+    matmul_precision: str = "highest"  # Literal["highest", "high", "medium"]
     audio_type: str = "wav"
 
     # Recompute model transcription, even if the output folder exists with scores.

--- a/examples/asr/speech_multitask/speech_to_text_aed_chunked_infer.py
+++ b/examples/asr/speech_multitask/speech_to_text_aed_chunked_infer.py
@@ -46,7 +46,7 @@ import copy
 import glob
 import os
 from dataclasses import dataclass, is_dataclass
-from typing import Optional
+from typing import Literal, Optional
 
 import pytorch_lightning as pl
 import torch
@@ -99,6 +99,7 @@ class TranscriptionConfig:
     cuda: Optional[int] = None
     amp: bool = False
     amp_dtype: str = "float16"  # can be set to "float16" or "bfloat16" when using amp
+    matmul_precision: Literal["highest", "high", "medium"] = "highest"
     audio_type: str = "wav"
 
     # Recompute model transcription, even if the output folder exists with scores.
@@ -137,6 +138,7 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
         manifest = None  # ignore dataset_manifest if audio_dir and dataset_manifest both presents
 
     # setup GPU
+    torch.set_float32_matmul_precision(cfg.matmul_precision)
     if cfg.cuda is None:
         if torch.cuda.is_available():
             device = [0]  # use 0th CUDA device

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -16,7 +16,7 @@ import contextlib
 import glob
 import os
 from dataclasses import dataclass, is_dataclass
-from typing import List, Literal, Optional, Union
+from typing import List, Optional, Union
 
 import pytorch_lightning as pl
 import torch

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -145,7 +145,7 @@ class TranscriptionConfig:
     allow_mps: bool = False  # allow to select MPS device (Apple Silicon M-series GPU)
     amp: bool = False
     amp_dtype: str = "float16"  # can be set to "float16" or "bfloat16" when using amp
-    matmul_precision: Literal["highest", "high", "medium"] = "highest"
+    matmul_precision: str = "highest"  # Literal["highest", "high", "medium"]
     audio_type: str = "wav"
 
     # Recompute model transcription, even if the output folder exists with scores.

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -16,7 +16,7 @@ import contextlib
 import glob
 import os
 from dataclasses import dataclass, is_dataclass
-from typing import List, Optional, Union
+from typing import List, Literal, Optional, Union
 
 import pytorch_lightning as pl
 import torch
@@ -145,6 +145,7 @@ class TranscriptionConfig:
     allow_mps: bool = False  # allow to select MPS device (Apple Silicon M-series GPU)
     amp: bool = False
     amp_dtype: str = "float16"  # can be set to "float16" or "bfloat16" when using amp
+    matmul_precision: Literal["highest", "high", "medium"] = "highest"
     audio_type: str = "wav"
 
     # Recompute model transcription, even if the output folder exists with scores.
@@ -215,6 +216,7 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
         logging.info(f"Will apply on-the-fly augmentation on samples during transcription: {augmentor} ")
 
     # setup GPU
+    torch.set_float32_matmul_precision(cfg.matmul_precision)
     if cfg.cuda is None:
         if torch.cuda.is_available():
             device = [0]  # use 0th CUDA device


### PR DESCRIPTION
# What does this PR do ?

We're adding an option to control matmul precision in transcribe speech and chunked infer scripts.
By setting it to `medium` we achieve **about 2x speedup** in transcription with Canary, without impact on WER (to be confirmed on larger scale tests). Possibly other models can benefit from that setting as well, esp. if they were trained with bfloat16.

**Collection**: ASR

# Changelog 
- Option to control matmul precision in transcribe speech

# Usage

```bash
python NeMo/examples/asr/transcribe_speech.py \
  dataset_manifest=input.json \
  output_filename=output.json \
  batch_size=32 \
  pretrained_name=nvidia/canary-1b \
  gt_text_attr_name=answer \
  matmul_precision=medium
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
