### PR TITLE
Make sampler length independent from consumed samples.

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py
@@ -78,7 +78,7 @@ class BaseMegatronSampler:
         )
 
     def __len__(self):
-        num_available_samples: int = self.total_samples - self.consumed_samples
+        num_available_samples: int = self.total_samples # - self.consumed_samples   # the length should always be the total lenght, even if we restart halfway through.
         if self.global_batch_size is not None:
             if self.drop_last:
                 num_global_batches = num_available_samples // self.global_batch_size
@@ -162,7 +162,7 @@ class MegatronPretrainingRandomSampler(BaseMegatronSampler):
 
     def __len__(self):
         active_total_samples = self.total_samples - (self.last_batch_size if self.drop_last else 0)
-        num_available_samples = active_total_samples - self.consumed_samples % active_total_samples
+        num_available_samples = active_total_samples # - self.consumed_samples % active_total_samples  # do not redefine length if we start in the middle
         if self.global_batch_size is not None:
             if self.drop_last:
                 num_global_batches = num_available_samples // self.global_batch_size

--- a/nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/data_samplers.py
@@ -78,7 +78,7 @@ class BaseMegatronSampler:
         )
 
     def __len__(self):
-        num_available_samples: int = self.total_samples # - self.consumed_samples   # the length should always be the total lenght, even if we restart halfway through.
+        num_available_samples: int = self.total_samples  # - self.consumed_samples   # the length should always be the total lenght, even if we restart halfway through.
         if self.global_batch_size is not None:
             if self.drop_last:
                 num_global_batches = num_available_samples // self.global_batch_size
@@ -162,7 +162,7 @@ class MegatronPretrainingRandomSampler(BaseMegatronSampler):
 
     def __len__(self):
         active_total_samples = self.total_samples - (self.last_batch_size if self.drop_last else 0)
-        num_available_samples = active_total_samples # - self.consumed_samples % active_total_samples  # do not redefine length if we start in the middle
+        num_available_samples = active_total_samples  # - self.consumed_samples % active_total_samples  # do not redefine length if we start in the middle
         if self.global_batch_size is not None:
             if self.drop_last:
                 num_global_batches = num_available_samples // self.global_batch_size


### PR DESCRIPTION
When resuming a training job, the pytorch lightning trainer seems to use the data loader to determine the number of total steps left in the epoch. When you kill/resume a training job partway through, the data sampler length will be reduced by `consumed_samples` in the current implementation, while the current step of the trainer will be restored. This results in a double impact to the number of remaining samples, and we can get into a situation where the trainer crashes out when the current_step is greater than the length of the dataloader. Leaving the length unchanged seems to fix this issue, and since it is an iterator, the stop_iteration (based on consumed_samples) does what it is supposed to do.

# What does this PR do ?

Leave len(sampler) as is, not making it a function of consumed_samples. Default behavior of pytorch lightning trainer resumption seems to behave better with this configuration.

**Collection**: all

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
