### PR TITLE
Fix bug in RNNT Joint WER calculation for fused batch

### DIFF
--- a/nemo/collections/asr/modules/rnnt.py
+++ b/nemo/collections/asr/modules/rnnt.py
@@ -1394,6 +1394,7 @@ class RNNTJoint(rnnt_abstract.AbstractRNNTJoint, Exportable, AdapterModuleMixin)
                 )
 
             losses = []
+            wers, wer_nums, wer_denoms = [], [], []
             target_lengths = []
             batch_size = int(encoder_outputs.size(0))  # actual batch size
 
@@ -1476,6 +1477,13 @@ class RNNTJoint(rnnt_abstract.AbstractRNNTJoint, Exportable, AdapterModuleMixin)
                         targets=sub_transcripts,
                         targets_lengths=sub_transcript_lens,
                     )
+                    # Sync and all_reduce on all processes, compute global WER
+                    wer, wer_num, wer_denom = self.wer.compute()
+                    self.wer.reset()
+
+                    wers.append(wer)
+                    wer_nums.append(wer_num)
+                    wer_denoms.append(wer_denom)
 
                 del sub_enc, sub_transcripts, sub_enc_lens, sub_transcript_lens
 
@@ -1485,9 +1493,9 @@ class RNNTJoint(rnnt_abstract.AbstractRNNTJoint, Exportable, AdapterModuleMixin)
 
             # Collect sub batch wer results
             if compute_wer:
-                # Sync and all_reduce on all processes, compute global WER
-                wer, wer_num, wer_denom = self.wer.compute()
-                self.wer.reset()
+                wer = sum(wers) / len(wers)
+                wer_num = sum(wer_nums)
+                wer_denom = sum(wer_denoms)
             else:
                 wer = None
                 wer_num = None
@@ -1899,6 +1907,7 @@ class SampledRNNTJoint(RNNTJoint):
             )
 
         losses = []
+        wers, wer_nums, wer_denoms = [], [], []
         target_lengths = []
         batch_size = int(encoder_outputs.size(0))  # actual batch size
 
@@ -1992,6 +2001,14 @@ class SampledRNNTJoint(RNNTJoint):
                     targets_lengths=sub_transcript_lens,
                 )
 
+                # Sync and all_reduce on all processes, compute global WER
+                wer, wer_num, wer_denom = self.wer.compute()
+                self.wer.reset()
+
+                wers.append(wer)
+                wer_nums.append(wer_num)
+                wer_denoms.append(wer_denom)
+
             del sub_enc, sub_transcripts, sub_enc_lens, sub_transcript_lens
 
         # Reduce over sub batches
@@ -2000,9 +2017,9 @@ class SampledRNNTJoint(RNNTJoint):
 
         # Collect sub batch wer results
         if compute_wer:
-            # Sync and all_reduce on all processes, compute global WER
-            wer, wer_num, wer_denom = self.wer.compute()
-            self.wer.reset()
+            wer = sum(wers) / len(wers)
+            wer_num = sum(wer_nums)
+            wer_denom = sum(wer_denoms)
         else:
             wer = None
             wer_num = None


### PR DESCRIPTION
# What does this PR do ?

Fix metric calculation in the case fused batch size > 1 during training / validation calculation.

Previously, the RNNT metric was stateful while the CTC one was not ([r1.22.0](https://github.com/NVIDIA/NeMo/blob/r1.22.0/nemo/collections/asr/metrics/rnnt_wer_bpe.py#L419-L420), [r1.23.0](https://github.com/NVIDIA/NeMo/blob/r1.23.0/nemo/collections/asr/metrics/wer.py#L333))

Therefore this calculation in the RNNT joint for fused operation worked properly. However with the unification of metrics in r1.23.0, a bug was introduced where only the last sub-batch of metrics calculates the scores and does not accumulate.

**Collection**: [ASR]

# Changelog 
- Preserve the list of metric outputs from each sub-batch
- take average of batch wer, compute running sum of numerator and denominator


# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
