### PR TITLE
fix to RNNT bug

### DIFF
--- a/nemo/collections/asr/metrics/wer.py
+++ b/nemo/collections/asr/metrics/wer.py
@@ -346,8 +346,8 @@ class WER(Metric):
             # Compute Levenstein's distance
             scores += editdistance.eval(h_list, r_list)
 
-        self.scores = torch.tensor(scores, device=self.scores.device, dtype=self.scores.dtype)
-        self.words = torch.tensor(words, device=self.words.device, dtype=self.words.dtype)
+        self.scores += torch.tensor(scores, device=self.scores.device, dtype=self.scores.dtype)
+        self.words += torch.tensor(words, device=self.words.device, dtype=self.words.dtype)
 
     def compute(self):
         scores = self.scores.detach().float()


### PR DESCRIPTION
# What does this PR do ?

Safer fix for https://github.com/NVIDIA/NeMo/pull/8587#event-12018166291

Metrics should accumulate between calls. This little fix allows that function for `WER`.

**Collection**: [ASR]

# Changelog 
- Added accumulation to wer metrics

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [Y] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [N] Did you write any new necessary tests?
- [N] Did you add or update any necessary documentation?
- [N] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [Y] New Feature
- [Y] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
