### PR TITLE
fix race condition in exp manager

### DIFF
--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -176,7 +176,7 @@ class ExpManagerConfig:
     # Wall clock time limit
     max_time_per_run: Optional[str] = None
     # time to sleep non 0 ranks during initialization
-    seconds_to_sleep: float = 1
+    seconds_to_sleep: float = 5
 
 
 class TimingCallback(Callback):

--- a/tests/core_ptl/check_for_ranks.py
+++ b/tests/core_ptl/check_for_ranks.py
@@ -112,13 +112,16 @@ def get_rank_info(texts: list, rank_key: str) -> int:
 
 @rank_zero_only
 def check_model_ranks(model: ExampleModel):
-    basedir = os.path.join('./ddp_check/', 'default', 'version_0')
+    basedir = os.path.join('./ddp_check/', 'default')
+    to_add = ""
     file_template = "nemo_log_globalrank-{rank}_localrank-{rank}.txt"
 
     world_size = torch.cuda.device_count()
     for rank in range(world_size):
+        to_add = "version_0" if rank == 0 else ""
+
         filename = file_template.format(rank=rank)
-        filepath = os.path.join(basedir, filename)
+        filepath = os.path.join(basedir, to_add, filename)
 
         with open(filepath, 'r', encoding='utf-8') as f:
             texts = f.readlines()

--- a/tests/core_ptl/check_for_ranks.py
+++ b/tests/core_ptl/check_for_ranks.py
@@ -113,13 +113,11 @@ def get_rank_info(texts: list, rank_key: str) -> int:
 @rank_zero_only
 def check_model_ranks(model: ExampleModel):
     basedir = os.path.join('./ddp_check/', 'default')
-    to_add = ""
     file_template = "nemo_log_globalrank-{rank}_localrank-{rank}.txt"
 
     world_size = torch.cuda.device_count()
     for rank in range(world_size):
         to_add = "version_0" if rank == 0 else ""
-
         filename = file_template.format(rank=rank)
         filepath = os.path.join(basedir, to_add, filename)
 


### PR DESCRIPTION
# What does this PR do ?

in exp manager we move files on rank0, but this move is not always completed by the time the other ranks go and do other things such as try to run `ls` on the file system. So this adds a sync to make sure
