### PR TITLE
[DRAFT] Add timeout parameter

### DIFF
--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -22,6 +22,7 @@ from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, Iterator, List, Literal, Mapping, Optional, Sized, Union
+from datetime import timedelta
 
 import pytorch_lightning as pl
 import torch
@@ -105,7 +106,7 @@ except (ImportError, ModuleNotFoundError):
 NEMO_MEGATRON_MODEL_PARALLEL_APPSTATE_OVERRIDE = "NEMO_MEGATRON_MODEL_PARALLEL_APPSTATE_OVERRIDE"
 
 
-def init_model_parallel(sharp: bool, nccl_communicator_config_path: str = None) -> None:
+def init_model_parallel(sharp: bool, nccl_communicator_config_path: str = None, timeout: timedelta = None) -> None:
     """ Initializes Megatron-LM model parallel if using model parallelism.
 
     Args:
@@ -130,6 +131,7 @@ def init_model_parallel(sharp: bool, nccl_communicator_config_path: str = None) 
                 nccl_communicator_config_path=nccl_communicator_config_path,
                 use_sharp=sharp,
                 expert_model_parallel_size=app_state.expert_model_parallel_size,
+                timeout=timeout
             )
 
             # assert that fake tp and pp rank match after model parallel init
@@ -208,7 +210,7 @@ class NLPDDPStrategy(DDPStrategy):
             app_state = AppState()
 
             if app_state.model_parallel_size is not None:
-                init_model_parallel(self.sharp, self.nccl_communicator_config_path)
+                init_model_parallel(self.sharp, self.nccl_communicator_config_path, timeout=self._timeout)
 
     def configure_ddp(self):
         """ Override LightningModule ddp if using model parallel.

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -20,9 +20,9 @@ import shutil
 import tempfile
 from collections import OrderedDict, defaultdict
 from contextlib import contextmanager
+from datetime import timedelta
 from pathlib import Path
 from typing import Any, Callable, Dict, Generator, Iterator, List, Literal, Mapping, Optional, Sized, Union
-from datetime import timedelta
 
 import pytorch_lightning as pl
 import torch
@@ -68,6 +68,7 @@ from nemo.utils.model_utils import ckpt_to_dir, inject_model_parallel_rank, unin
 
 try:
     from apex.transformer.pipeline_parallel.utils import get_num_microbatches
+
     from nemo.core.optim.distributed_adam import MegatronDistributedFusedAdam
 
     HAVE_APEX = True
@@ -131,7 +132,7 @@ def init_model_parallel(sharp: bool, nccl_communicator_config_path: str = None, 
                 nccl_communicator_config_path=nccl_communicator_config_path,
                 use_sharp=sharp,
                 expert_model_parallel_size=app_state.expert_model_parallel_size,
-                timeout=timeout
+                timeout=timeout,
             )
 
             # assert that fake tp and pp rank match after model parallel init


### PR DESCRIPTION
# What does this PR do ?

Based on https://github.com/NVIDIA/Megatron-LM/pull/723, this PR aims to make user-set timeout applicable to all ProcessGroups instead of just default ProcessGroups

**Collection**: [Note which collection this PR will affect]

# Changelog 
During model parallel initialization, it will pass a timeout parameter (which is the existing attribute of `NLPDDPStrategy`) to new ProcessGroup creation (`new_group`)

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
Need to wait https://github.com/NVIDIA/Megatron-LM/pull/723 to be merged first
