### PR TITLE
Add support to perform "inference-only" without loading training data

### DIFF
--- a/nemo/collections/nlp/models/information_retrieval/megatron_sbert_model.py
+++ b/nemo/collections/nlp/models/information_retrieval/megatron_sbert_model.py
@@ -391,15 +391,21 @@ class MegatronSBertModel(MegatronBertModel):
         self.cross_entropy_loss = torch.nn.CrossEntropyLoss(label_smoothing=cfg.get('label_smoothing', 0.0))
         softmax_temp = cfg.get('softmax_temp', 0.05)
         self.scale = 1.0 / softmax_temp
-        train_file_path = self.cfg.data.data_prefix
-        with open(train_file_path) as f:
-            train_data = json.load(f)
+        try:
+          train_file_path = self.cfg.data.data_prefix
+          with open(train_file_path) as f:
+              train_data = json.load(f)
 
-        random_seed = 42
-        set_seed(random_seed)
-        random.shuffle(train_data)
+          random_seed = 42
+          set_seed(random_seed)
+          random.shuffle(train_data)
 
-        self.train_data = train_data
+          self.train_data = train_data
+          logging.warning("Model is running in training mode")
+        except:
+          logging.warning("Model is running inference mode as training data is not specified, or could not be loaded")
+          random_seed = 42
+          set_seed(random_seed)
 
     def model_provider_func(self, pre_process, post_process):
         cfg = self.cfg

--- a/nemo/collections/nlp/models/information_retrieval/megatron_sbert_model.py
+++ b/nemo/collections/nlp/models/information_retrieval/megatron_sbert_model.py
@@ -392,20 +392,22 @@ class MegatronSBertModel(MegatronBertModel):
         softmax_temp = cfg.get('softmax_temp', 0.05)
         self.scale = 1.0 / softmax_temp
         try:
-          train_file_path = self.cfg.data.data_prefix
-          with open(train_file_path) as f:
-              train_data = json.load(f)
+            train_file_path = self.cfg.data.data_prefix
+            with open(train_file_path) as f:
+                train_data = json.load(f)
 
-          random_seed = 42
-          set_seed(random_seed)
-          random.shuffle(train_data)
+            random_seed = 42
+            set_seed(random_seed)
+            random.shuffle(train_data)
 
-          self.train_data = train_data
-          logging.warning("Model is running in training mode")
+            self.train_data = train_data
+            logging.warning("Model is running in training mode")
         except:
-          logging.warning("Model is running inference mode as training data is not specified, or could not be loaded")
-          random_seed = 42
-          set_seed(random_seed)
+            logging.warning(
+                "Model is running inference mode as training data is not specified, or could not be loaded"
+            )
+            random_seed = 42
+            set_seed(random_seed)
 
     def model_provider_func(self, pre_process, post_process):
         cfg = self.cfg


### PR DESCRIPTION
Hi,
Currently, the MegatronSBERT model cannot run inference. Essentially, a user may not be able to simply load a trained .nemo checkpoint and run inference (forward()) function on it.

This patch adds a try/except block to handle cases where training data is not specified

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
