### PR TITLE
Enable Pipeline Parallelism for P-Tuning

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
@@ -478,7 +478,7 @@ class GPTSFTDataset(Dataset):
 class GPTSFTPackedDataset(GPTSFTDataset):
     def __init__(self, file_path: str, tokenizer: TokenizerSpec, **kwargs):
         super().__init__(file_path, tokenizer, **kwargs)
-
+        assert self.virtual_tokens == 0, "P-Tuning with packed sequence is not supported."
         self._load_packed_dataset(file_path)
 
     def __getitem__(self, idx):

--- a/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
+++ b/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
@@ -65,7 +65,9 @@ class NLPAdapterModelMixin:
         self.use_peft = False
         self.tunable_base_param_names = []
         self.setup_complete = False
-        self.use_ptuning_only = False
+
+        # for P-Tuning with PP, second stage and onward have no trainable parameters so need to be handled
+        self.ptuning_only_and_non_first_stage = False
         super().__init__(*args, **kwargs)
 
         self.use_mcore_gpt = hasattr(self, 'mcore_gpt') and self.mcore_gpt
@@ -177,19 +179,19 @@ class NLPAdapterModelMixin:
         if not isinstance(peft_cfgs, List):
             peft_cfgs = [peft_cfgs]
 
+        ptuning_only = len(peft_cfgs) == 1 and isinstance(peft_cfgs[0], PtuningPEFTConfig)
+        self.ptuning_only_and_non_first_stage = ptuning_only and not self.first_stage_of_pipeline()
+        if self.ptuning_only_and_non_first_stage:
+            # There are no params to add if we are not in the first state of the pipeline
+            return
+
         self.base_keys = self._get_all_keys()
         self.freeze()
         logging.info(f"Before adding PEFT params:\n{self.summarize()}")
 
-        self.use_ptuning_only = len(peft_cfgs) == 1 and isinstance(peft_cfgs[0], PtuningPEFTConfig)
-
         for peft_cfg in peft_cfgs:
-            if self.use_ptuning_only:
-                if not self.first_stage_of_pipeline():
-                    # There are no params to add if we are not in the first state of the pipeline
-                    continue
+            if isinstance(peft_cfg, PtuningPEFTConfig):
                 self.virtual_tokens = peft_cfg.virtual_tokens
-
             self._check_and_add_peft_cfg(peft_cfg)
 
         logging.info(f"After adding PEFT params:\n{self.summarize()}")
@@ -238,19 +240,23 @@ class NLPAdapterModelMixin:
         """
         if self.use_peft:
             self.freeze()  # Freeze the entire model
-            opt_params = []
-            for _, module in self.named_modules():
-                if isinstance(module, AdapterModuleMixin) and module.is_adapter_available():
-                    module.set_enabled_adapters(enabled=True)
-                    module.unfreeze_enabled_adapters()  # selectively unfreeze the adapter modules.
-                    opt_params += [p for p in module.parameters() if p.requires_grad]
+            if not self.ptuning_only_and_non_first_stage:
+                opt_params = []
+                for _, module in self.named_modules():
+                    if isinstance(module, AdapterModuleMixin) and module.is_adapter_available():
+                        module.set_enabled_adapters(enabled=True)
+                        module.unfreeze_enabled_adapters()  # selectively unfreeze the adapter modules.
+                        opt_params += [p for p in module.parameters() if p.requires_grad]
 
-            for name, param in self.named_parameters():
-                if name in self.tunable_base_param_keys:
-                    param.requires_grad = True
-                    opt_params += [param]
+                for name, param in self.named_parameters():
+                    if name in self.tunable_base_param_keys:
+                        param.requires_grad = True
+                        opt_params += [param]
 
-            self._optimizer_param_groups = ({"params": opt_params},)
+                self._optimizer_param_groups = ({"params": opt_params},)
+            else:
+                self._optimizer_param_groups = ({"params": []},)
+            print("******* self._optimizer_param_groups", type(self._optimizer_param_groups[0]['params']))
             logging.info(f"Optimizer groups set:\n{self.summarize()}")
         else:
             super().setup_optimizer_param_groups()
@@ -356,6 +362,8 @@ class NLPAdapterModelMixin:
     def state_dict(self, destination=None, prefix=None, keep_vars=False):
         if self.use_peft and self.setup_complete:
             # Once setup is complete we no longer need to track the frozen part of the model. Only there adapter state dict keeps changing so state_dict only track these.
+            if self.ptuning_only_and_non_first_stage:
+                return {}
             return self.get_peft_state_dict()
         else:
             # we want all the params with the same keys as calling self.state_dict()
@@ -379,8 +387,9 @@ class NLPAdapterModelMixin:
             # setting strict=False will ignore the missing keys (which are not being updated anyway)
             # explicitly check if state_dict.keys matches all the expected self.adapter_keys since we don't have the
             # safety in strict=True anymore.
-            assert set(state_dict.keys()) == self.adapter_keys.union(self.tunable_base_param_keys)
-            super().load_state_dict(state_dict, strict=False)
+            if not self.ptuning_only_and_non_first_stage:
+                assert set(state_dict.keys()) == self.adapter_keys.union(self.tunable_base_param_keys)
+                super().load_state_dict(state_dict, strict=False)
         else:
             super().load_state_dict(state_dict, strict=True)
 
@@ -389,7 +398,7 @@ class NLPAdapterModelMixin:
         https://pytorch-lightning.readthedocs.io/en/stable/common/lightning_module.html#on-load-checkpoint
         """
         if self.use_peft and self.setup_complete:
-            if not self.use_ptuning_only or self.first_stage_of_pipeline():
+            if not self.ptuning_only_and_non_first_stage:
                 # same as super().on_load_checkpoint() but strict=False and only check unexpected keys
                 # mcore uses distributed checkpointing
                 if hasattr(self, 'mcore_gpt') and self.mcore_gpt:

--- a/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
+++ b/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
@@ -176,10 +176,11 @@ class NLPAdapterModelMixin:
         if self.cfg.optim.name == "distributed_fused_adam":
             raise ValueError('distributed_fused_adam is not supported for PEFT. Please use fused_adam')
 
+        self.use_peft = True
         if not isinstance(peft_cfgs, List):
             peft_cfgs = [peft_cfgs]
 
-        # @chcui crucial to set self.virtual_tokens for all PP ranks
+        # @chcui crucial to set self.virtual_tokens and self.use_peft for all PP ranks
         for peft_cfg in peft_cfgs:
             if isinstance(peft_cfg, PtuningPEFTConfig):
                 self.virtual_tokens = peft_cfg.virtual_tokens
@@ -206,7 +207,6 @@ class NLPAdapterModelMixin:
 
             if hasattr(cfg, "tunable_base_param_names") and cfg.tunable_base_param_names:
                 self.set_tunable_base_params(cfg)
-        self.use_peft = True
 
     def _get_config_and_state_dict_from_nemo(self, filepath, map_location):
         cwd = os.getcwd()

--- a/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
+++ b/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
@@ -179,6 +179,10 @@ class NLPAdapterModelMixin:
         if not isinstance(peft_cfgs, List):
             peft_cfgs = [peft_cfgs]
 
+        # @chcui crucial to set self.virtual_tokens for all PP ranks
+        for peft_cfg in peft_cfgs:
+            if isinstance(peft_cfg, PtuningPEFTConfig):
+                self.virtual_tokens = peft_cfg.virtual_tokens
         ptuning_only = len(peft_cfgs) == 1 and isinstance(peft_cfgs[0], PtuningPEFTConfig)
         self.ptuning_only_and_non_first_stage = ptuning_only and not self.first_stage_of_pipeline()
         if self.ptuning_only_and_non_first_stage:
@@ -190,8 +194,6 @@ class NLPAdapterModelMixin:
         logging.info(f"Before adding PEFT params:\n{self.summarize()}")
 
         for peft_cfg in peft_cfgs:
-            if isinstance(peft_cfg, PtuningPEFTConfig):
-                self.virtual_tokens = peft_cfg.virtual_tokens
             self._check_and_add_peft_cfg(peft_cfg)
 
         logging.info(f"After adding PEFT params:\n{self.summarize()}")

--- a/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
+++ b/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
@@ -256,7 +256,6 @@ class NLPAdapterModelMixin:
                 self._optimizer_param_groups = ({"params": opt_params},)
             else:
                 self._optimizer_param_groups = ({"params": []},)
-            print("******* self._optimizer_param_groups", type(self._optimizer_param_groups[0]['params']))
             logging.info(f"Optimizer groups set:\n{self.summarize()}")
         else:
             super().setup_optimizer_param_groups()

--- a/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
+++ b/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
@@ -66,7 +66,7 @@ class NLPAdapterModelMixin:
         self.tunable_base_param_names = []
         self.setup_complete = False
 
-        # for P-Tuning with PP, second stage and onward have no trainable parameters so need to be handled
+        # for P-Tuning with PP, second stage and onward have no trainable parameters so only first stage needs peft handling
         self.ptuning_only_and_non_first_stage = False
         super().__init__(*args, **kwargs)
 
@@ -300,7 +300,8 @@ class NLPAdapterModelMixin:
             ), "Inferring peft scheme is only supported for .nemo checkpoints. Please supply the `peft_cfgs` argument."
             peft_cfgs = [PEFT_CONFIG_MAP[conf.peft.peft_scheme](conf)]
         self.add_adapter(peft_cfgs)
-        assert set(state_dict.keys()) == self.adapter_keys.union(self.tunable_base_param_keys)
+        if not self.ptuning_only_and_non_first_stage:
+            assert set(state_dict.keys()) == self.adapter_keys.union(self.tunable_base_param_keys)
         super().load_state_dict(state_dict, strict=False)
 
     def set_tunable_base_params(self, peft_cfg):


### PR DESCRIPTION
# What does this PR do ?

Enable pipeline parallelism (PP) for p-tuning.
PP has already been supported for the rest of the PEFT methods as well as SFT. P-tuning needed to be handled separately because there are only trainable parameters in the first stage, so the rest of the stages have to be ignored for certain optimizer setup and checkpoints save/load logic.

Tested p-tuning with  TP {1, 2, 4} x PP {1, 2, 4} configurations and validations losses match within 1%.

**Collection**: NLP

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
