### PR TITLE
Update for robust manifest loading

### DIFF
--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -26,7 +26,7 @@ from tqdm.auto import tqdm
 import nemo.collections.asr as nemo_asr
 from nemo.collections.asr.metrics.wer import word_error_rate
 from nemo.collections.asr.models import ASRModel, EncDecHybridRNNTCTCModel, EncDecMultiTaskModel
-from nemo.collections.asr.parts.utils import rnnt_utils
+from nemo.collections.asr.parts.utils import manifest_utils, rnnt_utils
 from nemo.collections.asr.parts.utils.streaming_utils import FrameBatchASR, FrameBatchMultiTaskAED
 from nemo.collections.common.metrics.punct_er import OccurancePunctuationErrorRate
 from nemo.collections.common.parts.preprocessing.manifest import get_full_path
@@ -295,10 +295,9 @@ def prepare_audio_data(cfg: DictConfig) -> Tuple[List[str], bool]:
     return filepaths, partial_audio
 
 
-def read_and_maybe_sort_manifest(path: str, try_sort: bool = False) -> list[dict]:
+def read_and_maybe_sort_manifest(path: str, try_sort: bool = False) -> List[dict]:
     """Sorts the manifest if duration key is available for every utterance."""
-    with open(path) as f:
-        items = [json.loads(l) for l in f]
+    items = manifest_utils.read_manifest(path)
     if try_sort and all("duration" in item for item in items):
         items = sorted(items, reverse=True, key=lambda item: item["duration"])
     return items
@@ -563,8 +562,8 @@ def compute_metrics_per_sample(
     manifest_path: str,
     reference_field: str = "text",
     hypothesis_field: str = "pred_text",
-    metrics: list[str] = ["wer"],
-    punctuation_marks: list[str] = [".", ",", "?"],
+    metrics: List[str] = ["wer"],
+    punctuation_marks: List[str] = [".", ",", "?"],
     output_manifest_path: str = None,
 ) -> dict:
 


### PR DESCRIPTION
# What does this PR do ?

Update manifest loading code for better robustness and error handling.

- Strip spaces/newlines before/after each line
- Skip lines that are empty after `line.strip()`
- Cache json decode errors during reading, then print out all error lines and raise runtime error

**Collection**: [all]

