### PR TITLE
injecting text_field when not present in manifest in AED models transcribe fn[ASR]

### DIFF
--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -114,6 +114,7 @@ class MultiTaskTranscriptionConfig(TranscribeConfig):
             if not hasattr(self, field):
                 raise ValueError(f"`{field}` must be present in the transcription config: {self}")
 
+
 class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRTranscriptionMixin):
     """Base class for AED multi-task models"""
 

--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -108,6 +108,11 @@ class MultiTaskTranscriptionConfig(TranscribeConfig):
 
     _internal: Optional[MultiTaskTranscriptionInternalConfig] = None
 
+    def __post_init__(self):
+        required_fields = ['task', 'pnc', 'source_lang', 'target_lang', 'text_field', 'lang_field']
+        for field in required_fields:
+            if not hasattr(self, field):
+                raise ValueError(f"`{field}` must be present in the transcription config: {self}")
 
 class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRTranscriptionMixin):
     """Base class for AED multi-task models"""
@@ -903,7 +908,7 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRTran
                     'taskname': 'asr' if trcfg.task is None else trcfg.task,
                     'target_lang': 'en' if trcfg.target_lang is None else trcfg.target_lang,
                     'pnc': 'yes' if trcfg.pnc is None else 'yes' if trcfg.pnc else 'no',
-                    'answer': 'nothing',
+                    trcfg.text_field: 'nothing',
                 }
             elif isinstance(item, dict):
                 entry = item
@@ -917,6 +922,8 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRTran
                     entry['target_lang'] = 'en' if trcfg.target_lang is None else trcfg.target_lang
                 if 'pnc' not in entry:
                     entry['pnc'] = 'yes' if trcfg.pnc is None else 'yes' if trcfg.pnc else 'no'
+                if trcfg.text_field not in entry:
+                    entry[trcfg.text_field] = 'nothing'
             else:
                 raise ValueError(f"Expected str or dict, got {type(item)}")
             out_json_items.append(entry)


### PR DESCRIPTION
# What does this PR do ?
injecting text_field when not present in manifest in AED models transcribe fn

**Collection**: [ASR]

**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation


