### PR TITLE
Fix Transcription data classes for Python 3.11

### DIFF
--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -106,7 +106,9 @@ class MultiTaskTranscriptionConfig(TranscribeConfig):
     text_field: str = "answer"
     lang_field: str = "target_lang"
 
-    _internal: Optional[MultiTaskTranscriptionInternalConfig] = field(default_factory=MultiTaskTranscriptionInternalConfig)
+    _internal: Optional[MultiTaskTranscriptionInternalConfig] = field(
+        default_factory=MultiTaskTranscriptionInternalConfig
+    )
 
 
 class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRTranscriptionMixin):

--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -107,7 +107,7 @@ class MultiTaskTranscriptionConfig(TranscribeConfig):
     lang_field: str = "target_lang"
 
     _internal: Optional[MultiTaskTranscriptionInternalConfig] = field(
-        default_factory=MultiTaskTranscriptionInternalConfig
+        default_factory=lambda: MultiTaskTranscriptionInternalConfig()
     )
 
 

--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import ceil
 from typing import Any, Dict, List, Optional, Union
 
@@ -106,7 +106,7 @@ class MultiTaskTranscriptionConfig(TranscribeConfig):
     text_field: str = "answer"
     lang_field: str = "target_lang"
 
-    _internal: Optional[MultiTaskTranscriptionInternalConfig] = None
+    _internal: Optional[MultiTaskTranscriptionInternalConfig] = field(default_factory=MultiTaskTranscriptionInternalConfig)
 
 
 class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRTranscriptionMixin):

--- a/nemo/collections/asr/models/classification_models.py
+++ b/nemo/collections/asr/models/classification_models.py
@@ -17,7 +17,7 @@ import json
 import os
 import tempfile
 from abc import abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from math import ceil, floor
 from typing import Any, Dict, List, Optional, Union
 
@@ -48,7 +48,7 @@ class ClassificationInferConfig:
     batch_size: int = 4
     logprobs: bool = False
 
-    _internal: InternalTranscribeConfig = InternalTranscribeConfig()
+    _internal: InternalTranscribeConfig = field(default_factory=lambda: InternalTranscribeConfig())
 
 
 @dataclass
@@ -56,7 +56,7 @@ class RegressionInferConfig:
     batch_size: int = 4
     logprobs: bool = True
 
-    _internal: InternalTranscribeConfig = InternalTranscribeConfig()
+    _internal: InternalTranscribeConfig = field(default_factory=lambda: InternalTranscribeConfig())
 
 
 class _EncDecBaseModel(ASRModel, ExportableEncDecModel, TranscriptionMixin):


### PR DESCRIPTION
# What does this PR do ?

Update dataclass instantiation to support python 3.11

**Collection**: [ASR]

# Changelog 
- Update the field init for internal config of transcription for Classification and AED models

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
