### PR TITLE
Switch NeMo to safetensors with Compat mode

### DIFF
--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -1015,7 +1015,9 @@ class NLPSaveRestoreConnector(SaveRestoreConnector):
 
         return state_dict
 
-    def _load_state_dict_from_disk(self, model_weights, map_location=None, security_level=CheckpointSecurityLevel.COMPAT):
+    def _load_state_dict_from_disk(
+        self, model_weights, map_location=None, security_level=CheckpointSecurityLevel.COMPAT
+    ):
         # if model_weights with the extension removed is a directory, we assume it is a distributed checkpoint
         # we need to defer loading the state dict so we return None
         uninject_model_weights = uninject_model_parallel_rank(model_weights)

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -57,7 +57,7 @@ from torch.nn.parallel import DistributedDataParallel
 from nemo.collections.nlp.modules.common.megatron.module import Float16Module
 from nemo.collections.nlp.modules.common.megatron.transformer import AutocastTransformerLayer, ParallelTransformerLayer
 from nemo.collections.nlp.parts import utils_funcs
-from nemo.core.connectors.save_restore_connector import SaveRestoreConnector
+from nemo.core.connectors.save_restore_connector import CheckpointSecurityLevel, SaveRestoreConnector
 from nemo.core.optim import MainParamsOptimizerWrapper
 from nemo.core.optim.optimizers import init_optimizer_states
 from nemo.utils import AppState, logging
@@ -1015,14 +1015,14 @@ class NLPSaveRestoreConnector(SaveRestoreConnector):
 
         return state_dict
 
-    def _load_state_dict_from_disk(self, model_weights, map_location=None):
+    def _load_state_dict_from_disk(self, model_weights, map_location=None, security_level=CheckpointSecurityLevel.COMPAT):
         # if model_weights with the extension removed is a directory, we assume it is a distributed checkpoint
         # we need to defer loading the state dict so we return None
         uninject_model_weights = uninject_model_parallel_rank(model_weights)
 
         # legacy model_weights will have mp rank injected
         if os.path.isfile(model_weights):
-            return super()._load_state_dict_from_disk(model_weights, map_location, self.ckpt_security_level)
+            return super()._load_state_dict_from_disk(model_weights, map_location, security_level)
 
         # dist checkpoint will be a dir
         elif os.path.isdir(os.path.splitext(uninject_model_weights)[0]):

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -1022,7 +1022,7 @@ class NLPSaveRestoreConnector(SaveRestoreConnector):
 
         # legacy model_weights will have mp rank injected
         if os.path.isfile(model_weights):
-            return super()._load_state_dict_from_disk(model_weights, map_location)
+            return super()._load_state_dict_from_disk(model_weights, map_location, self.ckpt_security_level)
 
         # dist checkpoint will be a dir
         elif os.path.isdir(os.path.splitext(uninject_model_weights)[0]):

--- a/nemo/core/classes/mixins/hf_io_mixin.py
+++ b/nemo/core/classes/mixins/hf_io_mixin.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from abc import ABC
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Union
-from dataclasses import dataclass, field
 
 from huggingface_hub import HfApi, ModelCard, ModelCardData
 from huggingface_hub import get_token as get_hf_token
@@ -160,9 +160,17 @@ class HuggingFaceFileIO(ABC):
                 limit = mfilter.limit_results
 
             results = api.list_models(
-                author=mfilter.author, language=mfilter.language, tags=mfilter.tags, task=mfilter.task,
-                model_name=mfilter.model_name, library=mfilter.library,
-                token=hf_token, sort="lastModified", direction=-1, cardData=cardData, limit=limit,
+                author=mfilter.author,
+                language=mfilter.language,
+                tags=mfilter.tags,
+                task=mfilter.task,
+                model_name=mfilter.model_name,
+                library=mfilter.library,
+                token=hf_token,
+                sort="lastModified",
+                direction=-1,
+                cardData=cardData,
+                limit=limit,
             )  # type: Iterable[ModelInfo]
 
             for result in results:

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -22,7 +22,6 @@ import tempfile
 import uuid
 from typing import Optional, Set, Union
 
-import safetensors
 import safetensors.torch as safetensors_torch
 import torch
 from omegaconf import DictConfig, OmegaConf

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -816,6 +816,9 @@ def _get_safetensor_device(device: Union[str, torch.device]) -> Union[str, int]:
         The device in a format compatible with safetensors.
     """
     # Translate device to safetensors compatible
+    if device is None:
+        device = "cpu"
+
     rank = None
     if isinstance(device, torch.device):
         rank = device.index

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -616,15 +616,6 @@ class SaveRestoreConnector:
             ckpt_model_weights = model_weights
             safetensors_model_weights = model_weights
 
-        print(
-            "ckpt_model_weights",
-            ckpt_model_weights,
-            "safetensors_model_weights",
-            safetensors_model_weights,
-            "cwd",
-            list(os.listdir(os.path.dirname(ckpt_model_weights))),
-        )
-
         # Check if filepath exists, and determine which exists
         if os.path.exists(safetensors_model_weights):
             model_weights = safetensors_model_weights
@@ -657,7 +648,6 @@ class SaveRestoreConnector:
 
         # If the safetensors load fails, attempt to load the checkpoint via torch as fallback
         if data is None:
-            # print(list(os.listdir(os.path.dirname(ckpt_model_weights))))
             data = torch.load(ckpt_model_weights, map_location=map_location)
 
         return data

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -600,6 +600,18 @@ class SaveRestoreConnector:
             )
 
             filepath = filepath.replace(".ckpt", ".safetensors")
+
+        # Convert shared tensors to independent tensors to make checkpoint saving work with safetensors
+        # NOTE: This duplicates all shared tensor memory so it wastes disk space plus some ram on CPU during
+        # checkpoin loading, but is necessary for safetensors
+        new_state_dict = {}
+        keys = list(state_dict.keys())
+        for key in keys:
+            new_state_dict[key] = state_dict[key].clone()
+            del state_dict[key]
+        del state_dict
+        state_dict = new_state_dict
+
         safetensors_torch.save_file(state_dict, filepath)
 
     @staticmethod

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -593,7 +593,7 @@ class SaveRestoreConnector:
 
     @staticmethod
     def _save_state_dict_to_disk(state_dict, filepath):
-        # NeMo 2.0+ only saves fils in safetensors format
+        # NeMo 2.0+ only saves files in safetensors format
         if filepath.endswith('.ckpt'):
             logging.warning(
                 f"NeMo 2.0+ only supports saving model weights in safetensors format. Renaming the file "
@@ -603,16 +603,6 @@ class SaveRestoreConnector:
             filepath = filepath.replace(".ckpt", ".safetensors")
 
         # Convert shared tensors to independent tensors to make checkpoint saving work with safetensors
-        # NOTE: This duplicates all shared tensor memory so it wastes disk space plus some ram on CPU during
-        # checkpoin loading, but is necessary for safetensors
-        new_state_dict = {}
-        keys = list(state_dict.keys())
-        for key in keys:
-            new_state_dict[key] = state_dict[key].clone()
-            del state_dict[key]
-        del state_dict
-        state_dict = new_state_dict
-
         SaveRestoreConnector._save_safetensor_file_with_shared_tensor_compat(state_dict, filepath)
 
     @staticmethod
@@ -738,10 +728,10 @@ class SaveRestoreConnector:
         There is no metadata as input because the metadata is used to allow the sharing issues to be resolved.
 
         Args:
-            filename:
+            filename: The filename location to load the file from
 
         Returns:
-
+            The state_dict loaded from the file, potentially ordered and with shared tensors resolved.
         """
         safetensor_device = _get_safetensor_device(device)
         state_dict = {}

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -14,20 +14,20 @@
 # limitations under the License.
 from __future__ import annotations  # necessary for lazy types evaluation
 
-import os
 import enum
+import os
 import shutil
 import tarfile
 import tempfile
 import uuid
 from typing import Optional, Set, Union
 
+import safetensors
+import safetensors.torch as safetensors_torch
 import torch
 from omegaconf import DictConfig, OmegaConf
 from omegaconf.omegaconf import open_dict
 from pytorch_lightning.trainer.trainer import Trainer
-import safetensors
-import safetensors.torch as safetensors_torch
 
 from nemo.core import classes as nemo_classes  # to avoid circular import do not import ModelPT directly
 from nemo.utils import logging, model_utils
@@ -617,8 +617,14 @@ class SaveRestoreConnector:
             ckpt_model_weights = model_weights
             safetensors_model_weights = model_weights
 
-        print("ckpt_model_weights", ckpt_model_weights, "safetensors_model_weights", safetensors_model_weights,
-              "cwd", list(os.listdir(os.path.dirname(ckpt_model_weights))))
+        print(
+            "ckpt_model_weights",
+            ckpt_model_weights,
+            "safetensors_model_weights",
+            safetensors_model_weights,
+            "cwd",
+            list(os.listdir(os.path.dirname(ckpt_model_weights))),
+        )
 
         # Check if filepath exists, and determine which exists
         if os.path.exists(safetensors_model_weights):

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,5 @@
 huggingface_hub>=0.20.3
+safetensors>=0.4.2
 numba
 numpy>=1.22
 onnx>=1.7.0

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,10 +1,10 @@
 huggingface_hub>=0.20.3
-safetensors>=0.4.2
 numba
 numpy>=1.22
 onnx>=1.7.0
 python-dateutil
 ruamel.yaml
+safetensors>=0.4.2
 scikit-learn
 setuptools>=65.5.1
 tensorboard

--- a/tests/collections/asr/test_hybrid_asr_tts_models.py
+++ b/tests/collections/asr/test_hybrid_asr_tts_models.py
@@ -126,7 +126,7 @@ class TestASRWithTTSModel:
         assert isinstance(model.tts_model, FastPitchModel)
         assert isinstance(model.asr_model, EncDecCTCModelBPE)
 
-    @pytest.mark.with_downloads
+    # @pytest.mark.with_downloads
     @pytest.mark.unit
     def test_from_pretrained_rnnt_model(self, fastpitch_model_path, conformer_rnnt_bpe_bn_model_path):
         model = ASRWithTTSModel.from_pretrained_models(

--- a/tests/core/test_fileio.py
+++ b/tests/core/test_fileio.py
@@ -17,8 +17,8 @@ import tempfile
 
 import numpy as np
 import pytest
-import torch
 import safetensors.torch as safetensors_torch
+import torch
 from omegaconf import DictConfig, OmegaConf
 
 from nemo.collections.asr.models import EncDecCTCModel
@@ -265,7 +265,6 @@ class TestFileIO:
     @pytest.mark.unit
     def test_save_model_level_pt_ckpt_shared_module(self, asr_model):
         class SharedModel(EncDecCTCModel):
-
             def __init__(self, cfg: DictConfig, trainer=None):
                 super().__init__(cfg, trainer=trainer)
                 self.shared = self.encoder
@@ -350,7 +349,6 @@ class TestFileIO:
     @pytest.mark.unit
     def test_save_module_level_pt_ckpt_shared_modules(self, asr_model):
         class SharedModel(EncDecCTCModel):
-
             def __init__(self, cfg: DictConfig, trainer=None):
                 super().__init__(cfg, trainer=trainer)
                 self.shared = self.encoder

--- a/tests/core/test_save_restore.py
+++ b/tests/core/test_save_restore.py
@@ -218,7 +218,6 @@ class MockModelIncorrectWithNemoArtifact(MockModel):
 
 
 class MockModelWithSharedTensors(MockModel):
-
     def __init__(self, cfg, trainer=None):
         super().__init__(cfg=cfg, trainer=trainer)
         self.shared_tensor = self.w
@@ -278,6 +277,7 @@ def _mock_model_incorrect_with_nemo_artifact_config(child_model_path: str):
     conf = OmegaConf.create({'model': conf})
     OmegaConf.set_struct(conf, True)
     return conf
+
 
 def _mock_model_with_shared_tensors_config():
     conf = {'temp_file': None, 'target': classpath(MockModelWithSharedTensors), 'stub_number': 1}

--- a/tests/core/test_save_restore.py
+++ b/tests/core/test_save_restore.py
@@ -24,8 +24,8 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 from nemo.collections.asr.models import EncDecCTCModel, EncDecCTCModelBPE
 from nemo.collections.nlp.models import PunctuationCapitalizationModel
 from nemo.core.classes import ModelPT
-from nemo.core.connectors import save_restore_connector
 from nemo.core.classes.mixins.hf_io_mixin import ModelFilter
+from nemo.core.connectors import save_restore_connector
 from nemo.utils.app_state import AppState
 from nemo.utils.exceptions import NeMoBaseException
 

--- a/tests/core/test_save_restore.py
+++ b/tests/core/test_save_restore.py
@@ -22,6 +22,7 @@ import torch
 from omegaconf import DictConfig, OmegaConf, open_dict
 
 from nemo.collections.asr.models import EncDecCTCModel, EncDecCTCModelBPE
+
 # from nemo.collections.nlp.models import PunctuationCapitalizationModel
 from nemo.core.classes import ModelPT
 from nemo.core.classes.mixins.hf_io_mixin import ModelFilter


### PR DESCRIPTION
# What does this PR do ?

All checkpoints statedicts will be switched to safetensors following security recommendations against use of pkl (torch internally uses pickle format).

Additionaly, fix the model filter logic for HF based API search.

**Collection**: [Core]

# Changelog 
- Add the support of "ckpt_security_level" flag to SaveRestoreConnector
- Add compact and standard security modes
- In standard mode, only safetensor files can be read and written. If a legacy .ckpt checkpoint is attempted to be loaded into NeMos restoration engine, it will error out.
- In compat mode (the default), both pickle files and safetensors can be loaded for model restoration, however only safetensor files will be written to disk.
  - Compat mode is the default and will enable full backward compatibility with all older checkpoints.
  - It is the default mode (set as default inside the constructor). It must be explicitly updated to "standard" security mode that is stricter and breaks backward compatibility for .ckpt files.
- Fix a bug in an older test for Huggingface filters

# Usage
```python

from nemo.core.connectors.save_restore_connector import SaveRestoreConnector

connector = SaveRestoreConnector()
connector.ckpt_security_level = "standard"

# Will succeed if the checkpoint was saved with safetensors, fail if saved with .ckpt pickle file
model = ModelPT.restore_from("path/model.nemo", save_restore_connector=connector)
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
