### PR TITLE
Remove OpenAI Triton from requirements

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/attention.py
+++ b/nemo/collections/nlp/modules/common/megatron/attention.py
@@ -65,17 +65,14 @@ except (ImportError, ModuleNotFoundError):
 
     HAVE_MEGATRON_CORE = False
 
-# try:
+try:
     # Flash Attention Triton
-    # import pkg_resources
-    # from flash_attn.flash_attn_triton import flash_attn_func as flash_attn_func_triton
+    import pkg_resources
+    from flash_attn.flash_attn_triton import flash_attn_func as flash_attn_func_triton
 
-    # pinned triton version for flash-attention triton https://github.com/HazyResearch/flash-attention/blob/main/flash_attn/flash_attn_triton.py#L3
-    # assert pkg_resources.get_distribution("triton").version == '2.0.0.dev20221202'
+except (ImportError, ModuleNotFoundError, pkg_resources.DistributionNotFound):
 
-# except (ImportError, ModuleNotFoundError, AssertionError, pkg_resources.DistributionNotFound):
-
-#     flash_attn_func_triton = None
+    flash_attn_func_triton = None
 
 
 try:

--- a/nemo/collections/nlp/modules/common/megatron/attention.py
+++ b/nemo/collections/nlp/modules/common/megatron/attention.py
@@ -65,17 +65,17 @@ except (ImportError, ModuleNotFoundError):
 
     HAVE_MEGATRON_CORE = False
 
-try:
+# try:
     # Flash Attention Triton
-    import pkg_resources
-    from flash_attn.flash_attn_triton import flash_attn_func as flash_attn_func_triton
+    # import pkg_resources
+    # from flash_attn.flash_attn_triton import flash_attn_func as flash_attn_func_triton
 
     # pinned triton version for flash-attention triton https://github.com/HazyResearch/flash-attention/blob/main/flash_attn/flash_attn_triton.py#L3
-    assert pkg_resources.get_distribution("triton").version == '2.0.0.dev20221202'
+    # assert pkg_resources.get_distribution("triton").version == '2.0.0.dev20221202'
 
-except (ImportError, ModuleNotFoundError, AssertionError, pkg_resources.DistributionNotFound):
+# except (ImportError, ModuleNotFoundError, AssertionError, pkg_resources.DistributionNotFound):
 
-    flash_attn_func_triton = None
+#     flash_attn_func_triton = None
 
 
 try:

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -10,6 +10,5 @@ tensorboard
 text-unidecode
 torch
 tqdm>=4.41.0
-triton
 wget
 wrapt

--- a/tests/collections/nlp/test_flash_attention.py
+++ b/tests/collections/nlp/test_flash_attention.py
@@ -38,17 +38,13 @@ try:
 except (ImportError, ModuleNotFoundError):
     HAVE_FA = False
 
-HAVE_TRITON = True
-# try:
-#     import pkg_resources
-#     import triton
-# 
-#     # pinned triton version for flash-attention triton https://github.com/HazyResearch/flash-attention/blob/main/flash_attn/flash_attn_triton.py#L3
-#     assert pkg_resources.get_distribution("triton").version == '2.0.0.dev20221202'
-# 
-#     HAVE_TRITON = True
-# except (ImportError, ModuleNotFoundError, AssertionError):
-#     HAVE_TRITON = False
+try:
+    import pkg_resources
+    import triton
+
+    HAVE_TRITON = True
+except (ImportError, ModuleNotFoundError):
+    HAVE_TRITON = False
 
 try:
     import pynvml

--- a/tests/collections/nlp/test_flash_attention.py
+++ b/tests/collections/nlp/test_flash_attention.py
@@ -38,16 +38,17 @@ try:
 except (ImportError, ModuleNotFoundError):
     HAVE_FA = False
 
-try:
-    import pkg_resources
-    import triton
-
-    # pinned triton version for flash-attention triton https://github.com/HazyResearch/flash-attention/blob/main/flash_attn/flash_attn_triton.py#L3
-    assert pkg_resources.get_distribution("triton").version == '2.0.0.dev20221202'
-
-    HAVE_TRITON = True
-except (ImportError, ModuleNotFoundError, AssertionError):
-    HAVE_TRITON = False
+HAVE_TRITON = True
+# try:
+#     import pkg_resources
+#     import triton
+# 
+#     # pinned triton version for flash-attention triton https://github.com/HazyResearch/flash-attention/blob/main/flash_attn/flash_attn_triton.py#L3
+#     assert pkg_resources.get_distribution("triton").version == '2.0.0.dev20221202'
+# 
+#     HAVE_TRITON = True
+# except (ImportError, ModuleNotFoundError, AssertionError):
+#     HAVE_TRITON = False
 
 try:
     import pynvml


### PR DESCRIPTION
# What does this PR do ?

Removes mandatory installation of OpenAI Triton from requirements.txt

**Collection**: nlp

# Changelog 
- Remove triton from requirements.txt
- Remove assertion errors for pinned triton versions

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
