### PR TITLE
Fix `model_name` check for only tokenizer libraries which need `model_name`

### DIFF
--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -168,11 +168,9 @@ def get_nmt_tokenizer(
     else:
         special_tokens_dict = special_tokens
 
-    if (library != 'byte-level') and (
-        (tokenizer_model is None or not os.path.isfile(tokenizer_model))
-    ):
+    if (library != 'byte-level') and ((tokenizer_model is None or not os.path.isfile(tokenizer_model))):
         raise ValueError("No Tokenizer path provided or file does not exist!")
-    
+
     if library in ['huggingface', 'megatron'] and model_name is None:
         raise ValueError(f"Please specify model_name as you are using the following library: {library}")
 

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -169,9 +169,12 @@ def get_nmt_tokenizer(
         special_tokens_dict = special_tokens
 
     if (library != 'byte-level') and (
-        model_name is None and (tokenizer_model is None or not os.path.isfile(tokenizer_model))
+        (tokenizer_model is None or not os.path.isfile(tokenizer_model))
     ):
         raise ValueError("No Tokenizer path provided or file does not exist!")
+    
+    if library in ['huggingface', 'megatron'] and model_name is None:
+        raise ValueError(f"Please specify model_name as you are using the following library: {library}")
 
     if library == 'huggingface':
         logging.info(f'Getting HuggingFace AutoTokenizer with pretrained_model_name: {model_name}')


### PR DESCRIPTION
# What does this PR do ?

For the function `get_nmt_tokenizer`, the user may use libraries which do not require `model_name` (e.g. `sentencepiece`, which is the default library), thus would not pass in `model_name` to the function. 

The current implementation throws a `ValueError` for such cases.

This PR fixes the `model_name` check for only libraries which need them.


# Usage
From step 4, option 2 in this nvidia [tutorial](https://docs.nvidia.com/deeplearning/nemo/user-guide/docs/en/stable/nlp/nemo_megatron/gpt/gpt_training.html)

```
python <NeMo_ROOT_FOLDER>/scripts/nlp_language_modeling/preprocess_data_for_megatron.py \
--input=train_data.jsonl \
--json-keys=text \
--tokenizer-library=sentencepiece \
--tokenizer-model=spm_32k_wiki.model \
--output-prefix=gpt_training_data \
--append-eod \
--workers=32
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?
@MaximumEntropy, @ericharper 
Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
