### PR TITLE
Enable using hybrid asr models in CTC Segmentation tool

### DIFF
--- a/tools/ctc_segmentation/scripts/prepare_data.py
+++ b/tools/ctc_segmentation/scripts/prepare_data.py
@@ -363,13 +363,12 @@ if __name__ == "__main__":
             )
 
         # get vocabulary list
-        if hasattr(asr_model, 'tokenizer'): # i.e. tokenization is BPE-based
+        if hasattr(asr_model, 'tokenizer'):  # i.e. tokenization is BPE-based
             vocabulary = asr_model.tokenizer.vocab
         elif hasattr(asr_model.decoder, "vocabulary"):  # i.e. tokenization is character-based
             vocabulary = asr_model.cfg.decoder.vocabulary
         else:
             raise ValueError("Unexpected model type. Vocabulary list not found.")
-
 
         if os.path.isdir(args.in_text):
             text_files = glob(f"{args.in_text}/*.txt")

--- a/tools/ctc_segmentation/scripts/prepare_data.py
+++ b/tools/ctc_segmentation/scripts/prepare_data.py
@@ -26,6 +26,8 @@ from sox import Transformer
 from tqdm import tqdm
 
 from nemo.collections.asr.models import ASRModel
+from nemo.collections.asr.models.ctc_models import EncDecCTCModel
+from nemo.collections.asr.models.hybrid_rnnt_ctc_models import EncDecHybridRNNTCTCModel
 from nemo.utils import model_utils
 
 try:
@@ -354,7 +356,20 @@ if __name__ == "__main__":
             asr_model = ASRModel.from_pretrained(model_name=args.model)  # type: ASRModel
             model_name = args.model
 
-        vocabulary = asr_model.cfg.decoder.vocabulary
+        if not (isinstance(asr_model, EncDecCTCModel) or isinstance(asr_model, EncDecHybridRNNTCTCModel)):
+            raise NotImplementedError(
+                f"Model is not an instance of NeMo EncDecCTCModel or ENCDecHybridRNNTCTCModel."
+                " Currently only instances of these models are supported"
+            )
+
+        # get vocabulary list
+        if hasattr(asr_model, 'tokenizer'): # i.e. tokenization is BPE-based
+            vocabulary = asr_model.tokenizer.vocab
+        elif hasattr(asr_model.decoder, "vocabulary"):  # i.e. tokenization is character-based
+            vocabulary = asr_model.cfg.decoder.vocabulary
+        else:
+            raise ValueError("Unexpected model type. Vocabulary list not found.")
+
 
         if os.path.isdir(args.in_text):
             text_files = glob(f"{args.in_text}/*.txt")

--- a/tools/ctc_segmentation/scripts/run_ctc_segmentation.py
+++ b/tools/ctc_segmentation/scripts/run_ctc_segmentation.py
@@ -27,6 +27,8 @@ from tqdm import tqdm
 from utils import get_segments
 
 import nemo.collections.asr as nemo_asr
+from nemo.collections.asr.models.ctc_models import EncDecCTCModel
+from nemo.collections.asr.models.hybrid_rnnt_ctc_models import EncDecHybridRNNTCTCModel
 
 parser = argparse.ArgumentParser(description="CTC Segmentation")
 parser.add_argument("--output_dir", default="output", type=str, help="Path to output directory")
@@ -72,18 +74,21 @@ if __name__ == "__main__":
     logging.basicConfig(handlers=handlers, level=level)
 
     if os.path.exists(args.model):
-        asr_model = nemo_asr.models.EncDecCTCModel.restore_from(args.model)
-    elif args.model in nemo_asr.models.EncDecCTCModel.get_available_model_names():
-        asr_model = nemo_asr.models.EncDecCTCModel.from_pretrained(args.model, strict=False)
+        asr_model = nemo_asr.models.ASRModel.restore_from(args.model)
     else:
-        try:
-            asr_model = nemo_asr.models.EncDecCTCModelBPE.from_pretrained(args.model)
-        except:
-            raise ValueError(
-                f"Provide path to the pretrained checkpoint or choose from {nemo_asr.models.EncDecCTCModel.get_available_model_names()}"
-            )
+        asr_model = nemo_asr.models.ASRModel.from_pretrained(args.model, strict=False)
 
-    bpe_model = isinstance(asr_model, nemo_asr.models.EncDecCTCModelBPE)
+
+    if not (isinstance(asr_model, EncDecCTCModel) or isinstance(asr_model, EncDecHybridRNNTCTCModel)):
+        raise NotImplementedError(
+            f"Model is not an instance of NeMo EncDecCTCModel or ENCDecHybridRNNTCTCModel."
+            " Currently only instances of these models are supported"
+        )
+
+    bpe_model = (
+        isinstance(asr_model, nemo_asr.models.EncDecCTCModelBPE)
+        or isinstance(asr_model, nemo_asr.models.EncDecHybridRNNTCTCBPEModel)
+    )
 
     # get tokenizer used during training, None for char based models
     if bpe_model:
@@ -91,8 +96,18 @@ if __name__ == "__main__":
     else:
         tokenizer = None
 
+    if isinstance(asr_model, EncDecHybridRNNTCTCModel):
+        asr_model.change_decoding_strategy(decoder_type="ctc")
+
     # extract ASR vocabulary and add blank symbol
-    vocabulary = ["ε"] + list(asr_model.cfg.decoder.vocabulary)
+    if hasattr(asr_model, 'tokenizer'): # i.e. tokenization is BPE-based
+        vocabulary = asr_model.tokenizer.vocab
+    elif hasattr(asr_model.decoder, "vocabulary"):  # i.e. tokenization is character-based
+        vocabulary = asr_model.cfg.decoder.vocabulary
+    else:
+        raise ValueError("Unexpected model type. Vocabulary list not found.")
+
+    vocabulary = ["ε"] + list(vocabulary)
     logging.debug(f"ASR Model vocabulary: {vocabulary}")
 
     data = Path(args.data)
@@ -136,9 +151,12 @@ if __name__ == "__main__":
             logging.debug(f"len(signal): {len(signal)}, sr: {sample_rate}")
             logging.debug(f"Duration: {original_duration}s, file_name: {path_audio}")
 
-            log_probs = asr_model.transcribe(audio=[str(path_audio)], batch_size=1, return_hypotheses=True)[
-                0
-            ].alignments
+            hypotheses = asr_model.transcribe([str(path_audio)], batch_size=1, return_hypotheses=True)
+            # if hypotheses form a tuple (from Hybrid model), extract just "best" hypothesis
+            if type(hypotheses) == tuple and len(hypotheses) == 2:
+                hypotheses = hypotheses[0]
+            log_probs = hypotheses[0].alignments # note: "[0]" is for batch dimension unpacking (and here batch size=1)
+
             # move blank values to the first column (ctc-package compatibility)
             blank_col = log_probs[:, -1].reshape((log_probs.shape[0], 1))
             log_probs = np.concatenate((blank_col, log_probs[:, :-1]), axis=1)

--- a/tools/ctc_segmentation/scripts/run_ctc_segmentation.py
+++ b/tools/ctc_segmentation/scripts/run_ctc_segmentation.py
@@ -78,16 +78,14 @@ if __name__ == "__main__":
     else:
         asr_model = nemo_asr.models.ASRModel.from_pretrained(args.model, strict=False)
 
-
     if not (isinstance(asr_model, EncDecCTCModel) or isinstance(asr_model, EncDecHybridRNNTCTCModel)):
         raise NotImplementedError(
             f"Model is not an instance of NeMo EncDecCTCModel or ENCDecHybridRNNTCTCModel."
             " Currently only instances of these models are supported"
         )
 
-    bpe_model = (
-        isinstance(asr_model, nemo_asr.models.EncDecCTCModelBPE)
-        or isinstance(asr_model, nemo_asr.models.EncDecHybridRNNTCTCBPEModel)
+    bpe_model = isinstance(asr_model, nemo_asr.models.EncDecCTCModelBPE) or isinstance(
+        asr_model, nemo_asr.models.EncDecHybridRNNTCTCBPEModel
     )
 
     # get tokenizer used during training, None for char based models
@@ -100,7 +98,7 @@ if __name__ == "__main__":
         asr_model.change_decoding_strategy(decoder_type="ctc")
 
     # extract ASR vocabulary and add blank symbol
-    if hasattr(asr_model, 'tokenizer'): # i.e. tokenization is BPE-based
+    if hasattr(asr_model, 'tokenizer'):  # i.e. tokenization is BPE-based
         vocabulary = asr_model.tokenizer.vocab
     elif hasattr(asr_model.decoder, "vocabulary"):  # i.e. tokenization is character-based
         vocabulary = asr_model.cfg.decoder.vocabulary
@@ -155,7 +153,9 @@ if __name__ == "__main__":
             # if hypotheses form a tuple (from Hybrid model), extract just "best" hypothesis
             if type(hypotheses) == tuple and len(hypotheses) == 2:
                 hypotheses = hypotheses[0]
-            log_probs = hypotheses[0].alignments # note: "[0]" is for batch dimension unpacking (and here batch size=1)
+            log_probs = hypotheses[
+                0
+            ].alignments  # note: "[0]" is for batch dimension unpacking (and here batch size=1)
 
             # move blank values to the first column (ctc-package compatibility)
             blank_col = log_probs[:, -1].reshape((log_probs.shape[0], 1))


### PR DESCRIPTION
# What does this PR do ?

Currently, NeMo CTC Segmentation tool throws errors if you try to use a hybrid model (as mentioned in this issue https://github.com/NVIDIA/NeMo/issues/8750). This PR fixes that.

cc @ekmb 

**Collection**: tools/ctc_segmentation

# Changelog 
- allows for `vocabulary = asr_model.tokenizer.vocab` and `vocabulary = asr_model.cfg.decoder.vocabulary`
- checks if model.transcribe returns a tuple of hypotheses
- also various checks for model instance (since we can only use pure CTC or CTC from a hybrid model)

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to https://github.com/NVIDIA/NeMo/issues/8750
