### PR TITLE
Fix for TransformerLayer MLP parameters not being set with specific hyperparameters

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -803,6 +803,9 @@ class AutocastTransformerLayer(TransformerLayer):
         autocast_dtype: Any = 16,
         zero_centered_gamma: bool = False,
         device: str = 'cuda',
+        bias: bool = True,
+        activation: str = 'gelu',
+        normalization: str = "LayerNorm",
         **kwargs,
     ) -> None:
         transformer_layer_args = {
@@ -836,6 +839,9 @@ class AutocastTransformerLayer(TransformerLayer):
             "ub_bulk_wgrad": ub_bulk_wgrad,
             "ub_bulk_dgrad": ub_bulk_dgrad,
             "device": device,
+            "bias": bias,
+            "activation": activation,
+            "normalization": normalization
         }
         te_version = packaging.version.Version(version("transformer-engine"))
         if te_version > packaging.version.Version("1.5.0"):
@@ -1096,6 +1102,9 @@ class ParallelTransformer(MegatronModule):
                     "ub_bulk_dgrad": config.tp_comm_bulk_dgrad,
                     "zero_centered_gamma": normalization == 'layernorm1p',
                     "device": 'cpu' if config.use_cpu_initialization else 'cuda',
+                    "bias": bias,
+                    "activation": activation,
+                    "normalization": {"layernorm": "LayerNorm", "rmsnorm": "RMSNorm"}[normalization]
                 }
                 te_version = packaging.version.Version(version("transformer-engine"))
                 if te_version > packaging.version.Version("1.5.0"):

--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -841,7 +841,7 @@ class AutocastTransformerLayer(TransformerLayer):
             "device": device,
             "bias": bias,
             "activation": activation,
-            "normalization": normalization
+            "normalization": normalization,
         }
         te_version = packaging.version.Version(version("transformer-engine"))
         if te_version > packaging.version.Version("1.5.0"):
@@ -1104,7 +1104,7 @@ class ParallelTransformer(MegatronModule):
                     "device": 'cpu' if config.use_cpu_initialization else 'cuda',
                     "bias": bias,
                     "activation": activation,
-                    "normalization": {"layernorm": "LayerNorm", "rmsnorm": "RMSNorm"}[normalization]
+                    "normalization": {"layernorm": "LayerNorm", "rmsnorm": "RMSNorm"}[normalization],
                 }
                 te_version = packaging.version.Version(version("transformer-engine"))
                 if te_version > packaging.version.Version("1.5.0"):


### PR DESCRIPTION
# What does this PR do ?

**Detailed description here: https://github.com/NVIDIA/NeMo/issues/8846**
This PR fixes Transformer layer MLP hyperparameters not being set with model.mcore_gpt=False, model.transformer_engine=True, and model.megatron_amp_O2=True.

**Collection**: NLP

# Changelog 
- Passing missing arguments to layer constructors.

# Usage
* Add the following lines to opt/NeMo/examples/nlp/language_modeling/megatron_gpt_pretraining.py after model initialization to debug:

```
logging.warning(f"DEBUG: layernorm_mlp.activation={model.model.module.language_model.encoder.layers._modules['0'].layernorm_mlp.activation}")
logging.warning(f"DEBUG: layernorm_mlp.use_bias={model.model.module.language_model.encoder.layers._modules['0'].layernorm_mlp.use_bias}")
logging.warning(f"DEBUG: layernorm_mlp.normalization={model.model.module.language_model.encoder.layers._modules['0'].layernorm_mlp.normalization}")
logging.warning(f"DEBUG: layernorm_mlp.layernorm_mlp.fc1_weight.shape={model.model.module.language_model.encoder.layers._modules['0'].layernorm_mlp.fc1_weight.shape}")
logging.warning(f"DEBUG: layernorm_mlp.layernorm_mlp.fc2_weight.shape={model.model.module.language_model.encoder.layers._modules['0'].layernorm_mlp.fc2_weight.shape}")
```

Test with the following script with and without the changes:
```
#!/bin/bash

python /opt/NeMo/examples/nlp/language_modeling/megatron_gpt_pretraining.py \
    model.mcore_gpt=False \
    model.transformer_engine=True \
    trainer.precision=bf16 \
    model.megatron_amp_O2=True \
    model.activation=fast-swiglu \
    model.bias=false \
    model.normalization=rmsnorm \
```
The bias, normalization, and activation should be correctly set with the fix.


# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
