### PR TITLE
Move logic for distopt FP32 grads to models

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -768,32 +768,6 @@ class MegatronBaseModel(NLPModel):
             optim_dtype = str_to_dtype(get_config_arg('dtype', torch.float32))
             optim_kwargs['dtype'] = optim_dtype
 
-            # Make sure embedding grad reductions are in FP32
-            if optim_dtype == torch.float32:
-                fp32_params = []
-                modules = self.get_model_module_list()
-                if parallel_state.is_pipeline_first_stage(ignore_virtual=True):
-                    if self.mcore_gpt:
-                        fp32_params.append(modules[0].shared_embedding_or_output_weight())
-                        fp32_params.append(modules[0].embedding.position_embeddings.weight)
-                    else:
-                        fp32_params.append(modules[0].word_embeddings_weight())
-                        fp32_params.append(modules[0].position_embeddings_weight())
-                if parallel_state.is_pipeline_last_stage(ignore_virtual=True):
-                    share_embeddings_and_output_weights = (
-                        modules[-1].share_embeddings_and_output_weights
-                        if self.mcore_gpt
-                        else modules[-1].share_token_embeddings
-                    )
-                    if share_embeddings_and_output_weights:
-                        if self.mcore_gpt:
-                            fp32_params.append(modules[-1].shared_embedding_or_output_weight())
-                        else:
-                            fp32_params.append(modules[-1].word_embeddings_weight())
-                for param in fp32_params:
-                    if param is not None:
-                        param._with_fp32_optimizer = True
-
             # Match param allgather with model dtype
             model_dtype = torch.float32
             if self.megatron_amp_O2 and hasattr(self, 'autocast_dtype'):

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -92,7 +92,6 @@ try:
     from megatron.core import InferenceParams, parallel_state, tensor_parallel
     from megatron.core.datasets.blended_megatron_dataset_builder import BlendedMegatronDatasetBuilder
     from megatron.core.datasets.gpt_dataset import GPTDataset, GPTDatasetConfig, MockGPTDataset
-    from megatron.core.deploy.gpt.model_specs import get_gpt_layer_ammo_spec
     from megatron.core.models.gpt import GPTModel as MCoreGPTModel
     from megatron.core.models.gpt.gpt_layer_specs import (
         get_gpt_layer_local_spec,
@@ -103,8 +102,10 @@ try:
     from megatron.core.transformer.transformer_config import TransformerConfig
     from megatron.core.utils import drain_embedding_wgrad_compute, init_method_normal, scaled_init_method_normal
 
-    # TODO @tmoon: Use once available in Megatron-LM
-    # from megatron.core.pipeline_parallel.schedules import DataIteratorList
+    try:
+        from megatron.core.deploy.gpt.model_specs import get_gpt_layer_ammo_spec
+    except (ImportError, ModuleNotFoundError):
+        from megatron.core.inference.gpt.model_specs import get_gpt_layer_ammo_spec
 
     HAVE_MEGATRON_CORE = True
 
@@ -495,36 +496,51 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
 
         if self.with_distributed_adam:
 
-            # Disable overlapped grad sync for embedding grad when
-            # pipeline parallelism is enabled
-            if parallel_state.get_pipeline_model_parallel_world_size() > 1:
-                modules = self.get_model_module_list()
-                if parallel_state.is_pipeline_first_stage(ignore_virtual=True):
-                    if len(modules) > 1:
-                        module = modules[0]  # only the first virtual rank has the embeddings
-                    else:
-                        module = modules[0]
-                    if self.cfg.get('share_embeddings_and_output_weights', True):
-                        param = (
-                            module.shared_embedding_or_output_weight()
-                            if self.mcore_gpt
-                            else module.word_embeddings_weight()
-                        )
-                        param._disable_greedy_grad_copy = not self.megatron_amp_O2
-                        param._disable_overlap_grad_sync = True
-                if parallel_state.is_pipeline_last_stage(ignore_virtual=True):
-                    if len(modules) > 1:
-                        module = modules[-1]  # only the last virtual rank has the embeddings
-                    else:
-                        module = modules[0]
-                    if self.cfg.get('share_embeddings_and_output_weights', True):
-                        param = (
-                            module.shared_embedding_or_output_weight()
-                            if self.mcore_gpt
-                            else module.word_embeddings_weight()
-                        )
-                        param._disable_greedy_grad_copy = not self.megatron_amp_O2
-                        param._disable_overlap_grad_sync = True
+            # Special handling for embedding grads
+            modules = self.get_model_module_list()
+            if parallel_state.is_pipeline_first_stage(ignore_virtual=True):
+                module = modules[0]  # first virtual rank has the embeddings
+
+                # Word embeddings: use FP32 grads and disable
+                # overlapped grad sync with pipeline parallelism
+                word_embeddings = (
+                    module.shared_embedding_or_output_weight()
+                    if self.mcore_gpt
+                    else module.word_embeddings_weight()
+                )
+                word_embeddings._with_fp32_optimizer = True
+                if (
+                    parallel_state.get_pipeline_model_parallel_world_size() > 1
+                    and self.cfg.get('share_embeddings_and_output_weights', True)
+                ):
+                    word_embeddings._disable_greedy_grad_copy = not self.megatron_amp_O2
+                    word_embeddings._disable_overlap_grad_sync = True
+
+                # Position embeddings: use FP32 grads
+                position_embeddings = None
+                if self.mcore_gpt:
+                    if module.embedding.add_position_embedding:
+                        position_embeddings = module.embedding.position_embeddings.weight
+                else:
+                    position_embeddings = module.position_embeddings_weight()
+                if position_embeddings is not None:
+                    position_embeddings._with_fp32_optimizer = True
+
+            # Handle case where embeddings are used in output layer
+            if (
+                parallel_state.is_pipeline_last_stage(ignore_virtual=True)
+                and self.cfg.get('share_embeddings_and_output_weights', True)
+            ):
+                module = modules[-1]  # last virtual rank has the embeddings
+                word_embeddings = (
+                    module.shared_embedding_or_output_weight()
+                    if self.mcore_gpt
+                    else module.word_embeddings_weight()
+                )
+                word_embeddings._with_fp32_optimizer = True
+                if parallel_state.get_pipeline_model_parallel_world_size() > 1:
+                    word_embeddings._disable_greedy_grad_copy = not self.megatron_amp_O2
+                    word_embeddings._disable_overlap_grad_sync = True
 
             # Disable overlapped grad sync for layer norm grads when
             # sequence parallelism is enabled

--- a/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_lm_encoder_decoder_model.py
@@ -189,6 +189,15 @@ class MegatronLMEncoderDecoderModel(MegatronBaseModel):
                 param._disable_greedy_grad_copy = not self.megatron_amp_O2
                 param._disable_overlap_grad_sync = True
 
+            # Make sure embedding grads are reduced in FP32
+            for name, param in self.named_parameters():
+                if (
+                    'word_embedding' in name
+                    or 'position_embedding' in name
+                    or 'output_layer' in name
+                ):
+                    param._with_fp32_optimizer = True
+
         return super().configure_optimizers()
 
     def _handle_bias_activation_fusion_args(self, cfg):


### PR DESCRIPTION
# What does this PR do ?

https://github.com/NVIDIA/NeMo/pull/8792 introduced some runtime failures in T5 since it adds GPT-specific logic to `MegatronBaseModel`. This PR moves the distopt FP32 grad logic to the specific models.

**Collection**: NLP

# Changelog 
- Move logic for distopt FP32 grads to models

# Usage

Run T5, e.g. with the config at https://github.com/NVIDIA/NeMo/blob/main/examples/nlp/language_modeling/conf/megatron_t5_config.yaml.

Enable the distributed optimizer with model.optim.name=distributed_fused_adam.

# Jenkins CI
To run Jenkins, a NeMo User with write access must comment `jenkins` on the PR.

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Fixes bug from https://github.com/NVIDIA/NeMo/pull/8792
* Closes https://github.com/NVIDIA/NeMo/pull/8857
* Closes https://github.com/NVIDIA/NeMo/pull/8810