### PR TITLE
Fix requirement for `megatron-core>0.6.0`

### DIFF
--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -10,7 +10,7 @@ ijson
 jieba
 markdown2
 matplotlib>=3.3.2
-megatron_core>0.6.0
+megatron_core>=0.6.0
 nltk>=3.6.5
 opencc<1.1.7
 pangu


### PR DESCRIPTION
# What does this PR do ?

This PR fix the following error when build form `Dockerfile`:

```
[+] Building 3256.2s (33/41)                                                                                         docker:default
 => [internal] load build definition from Dockerfile                                                                           0.0s
 => => transferring dockerfile: 6.72kB                                                                                         0.0s
 => resolve image config for docker-image://docker.io/docker/dockerfile:experimental                                           0.3s
 => [auth] docker/dockerfile:pull token for registry-1.docker.io                                                               0.0s
 => CACHED docker-image://docker.io/docker/dockerfile:experimental@sha256:600e5c62eedff338b3f7a0850beb7c05866e0ef27b2d2e8c02a  0.0s
 => [internal] load .dockerignore                                                                                              0.0s
 => => transferring context: 226B                                                                                              0.0s
 => [internal] load build definition from Dockerfile                                                                           0.0s
 => [internal] load metadata for nvcr.io/nvidia/pytorch:24.01-py3                                                              0.7s
 => [internal] load build context                                                                                              3.4s
 => => transferring context: 105.39MB                                                                                          3.4s
 => [nemo-deps  1/22] FROM nvcr.io/nvidia/pytorch:24.01-py3@sha256:afd682405d620a620f61f38cb9d9bbc6a5230817699a48e9ed193546e8  0.0s
 => CACHED [nemo-deps  2/22] RUN apt-get update &&   apt-get upgrade -y &&   apt-get install -y   libsndfile1 sox   libfreety  0.0s
 => CACHED [nemo-deps  3/22] RUN apt-get update &&   apt-get install -y   libtool   libltdl-dev   automake   autoconf   bison  0.0s
 => CACHED [nemo-deps  4/22] WORKDIR /workspace/                                                                               0.0s
 => CACHED [nemo-deps  5/22] RUN git clone https://github.com/NVIDIA/Megatron-LM.git &&   cd Megatron-LM &&   git checkout 36  0.0s
 => [nemo-deps  6/22] RUN git clone https://github.com/NVIDIA/apex.git &&   cd apex &&   git checkout f058162b215791b15507  2267.0s
 => [nemo-src 1/1] COPY . .                                                                                                    0.2s
 => [nemo-deps  7/22] RUN git clone https://github.com/NVIDIA/TransformerEngine.git &&   cd TransformerEngine &&   git fetc  293.9s
 => [nemo-deps  8/22] WORKDIR /tmp/                                                                                            0.6s
 => [nemo-deps  9/22] RUN pip3 uninstall -y sacrebleu torchtext                                                                2.0s
 => [nemo-deps 10/22] WORKDIR /tmp/torchaudio_build                                                                            0.1s
 => [nemo-deps 11/22] COPY scripts/installers /tmp/torchaudio_build/scripts/installers/                                        0.1s
 => [nemo-deps 12/22] RUN INSTALL_MSG=$(/bin/bash /tmp/torchaudio_build/scripts/installers/install_torchaudio_latest.sh); I  176.7s
 => [nemo-deps 13/22] COPY scripts /tmp/nemo/scripts/                                                                          0.1s
 => [nemo-deps 14/22] RUN INSTALL_MSG=$(/bin/bash /tmp/nemo/scripts/installers/install_graphviz.sh --docker); INSTALL_CODE=$  84.6s
 => [nemo-deps 15/22] COPY scripts /tmp/nemo/scripts/                                                                          0.1s
 => [nemo-deps 16/22] RUN INSTALL_MSG=$(/bin/bash /tmp/nemo/scripts/installers/install_k2.sh); INSTALL_CODE=$?;   echo ${IN  201.3s
 => [nemo-deps 17/22] WORKDIR /tmp/nemo                                                                                        0.1s
 => [nemo-deps 18/22] COPY requirements .                                                                                      0.0s
 => [nemo-deps 19/22] RUN for f in $(ls requirements*.txt); do pip3 install --disable-pip-version-check --no-cache-dir -r $  151.3s
 => [nemo-deps 20/22] RUN pip install flash-attn                                                                               5.2s
 => [nemo-deps 21/22] RUN pip install numba>=0.57.1                                                                            4.3s
 => [nemo-deps 22/22] RUN pip install nvidia-ammo~=0.7.0 --extra-index-url https://pypi.nvidia.com --no-cache-dir             10.9s
 => [nemo  1/10] RUN /usr/bin/test -n "2.0.0" &&   /bin/echo "export NEMO_VERSION=2.0.0" >> /root/.bashrc &&   /bin/echo "exp  0.6s
 => ERROR [nemo  2/10] RUN --mount=from=nemo-src,target=/tmp/nemo,rw cd /tmp/nemo && pip install ".[all]"                     14.5s
------
 > [nemo  2/10] RUN --mount=from=nemo-src,target=/tmp/nemo,rw cd /tmp/nemo && pip install ".[all]":
3.533 Looking in indexes: https://pypi.org/simple, https://pypi.ngc.nvidia.com
3.540 Processing /tmp/nemo
3.543   Installing build dependencies: started
9.221   Installing build dependencies: finished with status 'done'
9.222   Getting requirements to build wheel: started
9.526   Getting requirements to build wheel: finished with status 'done'
9.528   Preparing metadata (pyproject.toml): started
9.891   Preparing metadata (pyproject.toml): finished with status 'done'
10.15 Requirement already satisfied: huggingface-hub>=0.20.3 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.22.2)
10.15 Requirement already satisfied: numba in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.57.1+1.g1ff679645)
10.15 Requirement already satisfied: numpy>=1.22 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.24.4)
10.15 Requirement already satisfied: onnx>=1.7.0 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.15.0rc2)
10.15 Requirement already satisfied: python-dateutil in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (2.8.2)
10.15 Requirement already satisfied: ruamel.yaml in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.18.6)
10.15 Requirement already satisfied: scikit-learn in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.2.0)
10.15 Requirement already satisfied: setuptools>=65.5.1 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (68.2.2)
10.15 Requirement already satisfied: tensorboard in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (2.9.0)
10.15 Requirement already satisfied: text-unidecode in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.3)
10.15 Requirement already satisfied: torch in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (2.2.0a0+81ea7a4)
10.15 Requirement already satisfied: tqdm>=4.41.0 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (4.66.1)
10.15 Requirement already satisfied: wget in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (3.2)
10.15 Requirement already satisfied: wrapt in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.16.0)
10.23 Requirement already satisfied: black==19.10b0 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (19.10b0)
10.23 Requirement already satisfied: click==8.0.2 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (8.0.2)
10.23 Requirement already satisfied: isort<6.0.0,>5.1.0 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (5.13.2)
10.23 Requirement already satisfied: parameterized in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.9.0)
10.23 Requirement already satisfied: pytest in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (7.4.4)
10.23 Requirement already satisfied: pytest-mock in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (3.14.0)
10.23 Requirement already satisfied: pytest-runner in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (6.0.1)
10.23 Requirement already satisfied: sphinx in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (7.3.7)
10.24 Requirement already satisfied: sphinxcontrib-bibtex in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (2.6.2)
10.24 Requirement already satisfied: wandb in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.16.6)
10.24 Requirement already satisfied: hydra-core<=1.3.2,>1.3 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.3.2)
10.24 Requirement already satisfied: omegaconf<=2.3 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (2.3.0)
10.24 Requirement already satisfied: pytorch-lightning>=2.2.1 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (2.2.2)
10.24 Requirement already satisfied: torchmetrics>=0.11.0 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.3.2)
10.24 Requirement already satisfied: transformers>=4.36.0 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (4.40.0)
10.24 Requirement already satisfied: webdataset>=0.2.86 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.2.86)
10.24 Requirement already satisfied: datasets in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (2.19.0)
10.24 Requirement already satisfied: inflect in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (7.2.0)
10.25 Requirement already satisfied: pandas in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.5.3)
10.25 Requirement already satisfied: sacremoses>=0.0.43 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.1.1)
10.25 Requirement already satisfied: sentencepiece<1.0.0 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.2.0)
10.25 Requirement already satisfied: braceexpand in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.1.7)
10.25 Requirement already satisfied: editdistance in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.8.1)
10.25 Requirement already satisfied: g2p-en in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (2.1.0)
10.25 Requirement already satisfied: ipywidgets in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (8.1.2)
10.25 Requirement already satisfied: jiwer in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (3.0.3)
10.25 Requirement already satisfied: kaldi-python-io in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.2.2)
10.25 Requirement already satisfied: kaldiio in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (2.18.0)
10.25 Requirement already satisfied: lhotse>=1.22.0 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.22.0)
10.26 Requirement already satisfied: librosa>=0.10.0 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.10.1)
10.26 Requirement already satisfied: marshmallow in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (3.21.1)
10.26 Requirement already satisfied: matplotlib in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (3.8.2)
10.26 Requirement already satisfied: packaging in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (23.2)
10.26 Requirement already satisfied: pyannote.core in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (5.0.0)
10.26 Requirement already satisfied: pyannote.metrics in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (3.2.1)
10.26 Requirement already satisfied: pydub in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.25.1)
10.26 Requirement already satisfied: pyloudnorm in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.1.1)
10.26 Requirement already satisfied: resampy in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.4.3)
10.26 Requirement already satisfied: scipy>=0.14 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.12.0)
10.26 Requirement already satisfied: soundfile in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.12.1)
10.27 Requirement already satisfied: sox in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.5.0)
10.27 Requirement already satisfied: texterrors in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.4.4)
10.27 Requirement already satisfied: boto3 in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (1.34.89)
10.27 Requirement already satisfied: einops in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.7.0)
10.79 Collecting faiss-cpu (from nemo_toolkit==2.0.0rc0)
10.88   Downloading faiss_cpu-1.8.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (3.6 kB)
11.20 Collecting fasttext (from nemo_toolkit==2.0.0rc0)
11.22   Downloading fasttext-0.9.2.tar.gz (68 kB)
11.24      ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 68.8/68.8 kB 3.8 MB/s eta 0:00:00
11.25   Preparing metadata (setup.py): started
11.55   Preparing metadata (setup.py): finished with status 'done'
11.87 Collecting flask-restful (from nemo_toolkit==2.0.0rc0)
11.89   Downloading Flask_RESTful-0.3.10-py2.py3-none-any.whl.metadata (1.0 kB)
11.89 Requirement already satisfied: ftfy in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (6.2.0)
12.22 Collecting gdown (from nemo_toolkit==2.0.0rc0)
12.23   Downloading gdown-5.1.0-py3-none-any.whl.metadata (5.7 kB)
12.58 Collecting h5py (from nemo_toolkit==2.0.0rc0)
12.60   Downloading h5py-3.11.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (2.5 kB)
12.96 Collecting ijson (from nemo_toolkit==2.0.0rc0)
12.98   Downloading ijson-3.2.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (20 kB)
12.98 Requirement already satisfied: jieba in /usr/local/lib/python3.10/dist-packages (from nemo_toolkit==2.0.0rc0) (0.42.1)
13.30 Collecting markdown2 (from nemo_toolkit==2.0.0rc0)
13.32   Downloading markdown2-2.4.13-py2.py3-none-any.whl.metadata (2.0 kB)
13.64 INFO: pip is looking at multiple versions of nemo-toolkit[all] to determine which version is compatible with other requirements. This could take a while.
13.64 ERROR: Could not find a version that satisfies the requirement megatron-core>0.6.0; extra == "all" (from nemo-toolkit[all]) (from versions: 0.1.0, 0.2.0, 0.3.0, 0.4.0, 0.5.0, 0.6.0)
13.64 ERROR: No matching distribution found for megatron-core>0.6.0; extra == "all"
13.98 
13.98 [notice] A new release of pip is available: 23.3.2 -> 24.0
13.98 [notice] To update, run: python -m pip install --upgrade pip
------
Dockerfile:153
--------------------
 151 |     
 152 |     # Install NeMo
```

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

There's no need to comment `jenkins` on the PR to trigger Jenkins CI.
The GitHub Actions CI will run automatically when the PR is opened.
To run CI on an untrusted fork, a NeMo user with write access must click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
