### PR TITLE
GPU-based vectorized `SpecAug`

### DIFF
--- a/nemo/collections/asr/parts/submodules/spectr_augment.py
+++ b/nemo/collections/asr/parts/submodules/spectr_augment.py
@@ -38,6 +38,10 @@ class SpecAugment(nn.Module, Typing):
         to be cut in one segment.
         If a float value, defines maximum percentage of timesteps that
         are cut adaptively.
+    fast - GPU-based implementation with batched masking and GPU rng,
+        setting it to False reverts to the legacy implementation.
+        Fast implementation is inspired by torchaudio:
+        https://github.com/pytorch/audio/blob/ea437b31ce316ea3d66fe73768c0dcb94edb79ad/src/torchaudio/functional/functional.py#L816
     """
 
     @property
@@ -56,7 +60,14 @@ class SpecAugment(nn.Module, Typing):
         return {"augmented_spec": NeuralType(('B', 'D', 'T'), SpectrogramType())}
 
     def __init__(
-        self, freq_masks=0, time_masks=0, freq_width=10, time_width=10, rng=None, mask_value=0.0,
+        self,
+        freq_masks: int = 0,
+        time_masks: int = 0,
+        freq_width: int = 10,
+        time_width: int | float = 10,
+        rng: random.Random | None = None,
+        mask_value: float = 0.0,
+        fast: bool = True,
     ):
         super().__init__()
 
@@ -69,6 +80,7 @@ class SpecAugment(nn.Module, Typing):
         self.time_width = time_width
 
         self.mask_value = mask_value
+        self.fast = fast
 
         if isinstance(time_width, int):
             self.adaptive_temporal_width = False
@@ -81,6 +93,12 @@ class SpecAugment(nn.Module, Typing):
     @typecheck()
     @torch.no_grad()
     def forward(self, input_spec, length):
+        if self.fast:
+            return self._forward_fast(input_spec, length)
+        else:
+            return self._forward_legacy(input_spec, length)
+
+    def _forward_legacy(self, input_spec, length):
         batch_size, num_freq_bins, _ = input_spec.shape
         # Move lengths to CPU before repeated indexing
         lengths_cpu = length.cpu().numpy()
@@ -111,6 +129,33 @@ class SpecAugment(nn.Module, Typing):
         fill_mask = torch.from_numpy(fill_mask).to(input_spec.device)
         masked_spec = input_spec.masked_fill(mask=fill_mask, value=self.mask_value)
         return masked_spec
+
+    def _forward_fast(self, input_spec: torch.Tensor, length: torch.Tensor) -> torch.Tensor:
+        for _ in range(self.time_masks):
+            input_spec = self._apply_mask(
+                input_spec, length, width=self.time_width, mask_value=self.mask_value, axis=2
+            )
+        for _ in range(self.freq_masks):
+            input_spec = self._apply_mask(
+                input_spec, length, width=self.freq_width, mask_value=self.mask_value, axis=1
+            )
+        return input_spec
+
+    def _apply_mask(
+        self, x: torch.Tensor, length: torch.Tensor, width: int | float, mask_value: float, axis: int,
+    ) -> torch.Tensor:
+        if isinstance(width, float):
+            width = length * width
+        value = torch.rand(x.shape[0], device=x.device, dtype=x.dtype) * width
+        min_value = torch.rand(x.shape[0], device=x.device, dtype=x.dtype) * (x.size(axis) - value)
+        mask_start = min_value.long()[..., None, None]
+        mask_end = (min_value.long() + value.long())[..., None, None]
+        mask = torch.arange(0, x.shape[axis], device=x.device, dtype=x.dtype)
+        if axis == 2:
+            mask = mask[None, None, :]
+        else:
+            mask = mask[None, :, None]
+        return x.masked_fill((mask >= mask_start) & (mask < mask_end), mask_value)
 
 
 class SpecCutout(nn.Module, Typing):


### PR DESCRIPTION
# What does this PR do ?

Context: together with @galv we found feature normalization and specaug to take approx 30% of the total forward step time in Canary training, due to CPU-bottlenecked implementations. Feature normalization is addressed in #8964. 

This PR adds a GPU based SpecAugment. The original implementation loops over every example and every mask, then waits on CPU RNG to sample the numbers. The new fast implementation still applies masks sequentially, but is vectorized on batch size and uses GPU's RNG. We found approx. 5x speedup (70ms -> 17ms in profiling, but both numbers include profiler overhead). I also added a flag to be able to revert to the old implementation in case anybody encounters a compatibility issue.

I validated visually that the new impl behavior is as expected. 

Old:
<img width="1696" alt="image" src="https://github.com/NVIDIA/NeMo/assets/15930688/78c5b421-e2ba-4bc7-a121-20eab75f9c29">

New:
<img width="1696" alt="image" src="https://github.com/NVIDIA/NeMo/assets/15930688/31df5106-326b-4679-9ca0-3c9446c0a49e">

**Collection**: ASR

# Changelog 
- 5x faster SpecAugment to reduce typical forward step time by ~10%.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

There's no need to comment `jenkins` on the PR to trigger Jenkins CI.
The GitHub Actions CI will run automatically when the PR is opened.
To run CI on an untrusted fork, a NeMo user with write access must click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
