### PR TITLE
Handle case where num_query_groups is set to null for LoRA config setup

### DIFF
--- a/nemo/collections/nlp/parts/peft_config.py
+++ b/nemo/collections/nlp/parts/peft_config.py
@@ -121,6 +121,9 @@ class LoraPEFTConfig(PEFTConfig):
         kv_channels = self._calculate_kv_channels(cfg)
         projection_size = kv_channels * cfg.num_attention_heads
         num_query_groups = cfg.get("num_query_groups", cfg.num_attention_heads)
+        if num_query_groups is None:
+            # Cover the case where num_query_groups is explicitly set to null
+            num_query_groups = cfg.num_attention_heads
 
         qkv_projection_size = projection_size + (2 * kv_channels * num_query_groups)
 


### PR DESCRIPTION
# What does this PR do ?

Currently, LoRA setup uses either the num_query_groups setting (if set) or the num_attention_heads setting, if not.  However, if num_query_groups is set explicitly to null, this line evaluates to None instead of the num_attention_heads value, resulting in `TypeError: unsupported operand type(s) for *: 'int' and 'NoneType'`.  This tiny change just adds an additional check to account for this situation.

**Collection**: nlp

# Changelog 
- Adds an additional check to LoRA config setup, setting num_query_groups to num_attention_heads if None.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

There's no need to comment `jenkins` on the PR to trigger Jenkins CI.
The GitHub Actions CI will run automatically when the PR is opened.
To run CI on an untrusted fork, a NeMo user with write access must click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
