### PR TITLE
Improved `shard_id` parsing in `LazyNemoTarredIterator`, enables AIS dataloading

### DIFF
--- a/nemo/collections/common/data/lhotse/nemo_adapters.py
+++ b/nemo/collections/common/data/lhotse/nemo_adapters.py
@@ -192,7 +192,10 @@ class LazyNeMoTarredIterator:
             shard_ids = []
             for p in self.paths:
                 m = json_pattern.search(p)
-                assert m is not None, f"Cannot determine shard_id from manifest input specified: {p}"
+                assert m is not None, (
+                    f"Cannot determine shard_id from manifest input specified: "
+                    f"we searched with regex '{json_pattern.pattern}' in input '{p}'"
+                )
                 shard_ids.append(int(m.group(1)))
             self.shard_id_to_manifest = {sid: LazyJsonlIterator(p) for sid, p in zip(shard_ids, self.paths)}
             self.source = LazyIteratorChain(*self.shard_id_to_manifest.values())
@@ -202,7 +205,10 @@ class LazyNeMoTarredIterator:
         shard_ids = []
         for p in self.tar_paths:
             m = tar_pattern.search(p)
-            assert m is not None, f"Cannot determine shard_id from tar input specifier: {p}"
+            assert m is not None, (
+                f"Cannot determine shard_id from tar input specifier: "
+                f"we searched with regex '{tar_pattern.pattern}' in input '{p}'"
+            )
             shard_ids.append(int(m.group(1)))
         self.shard_id_to_tar_path = dict(zip(shard_ids, self.tar_paths))
 


### PR DESCRIPTION
# What does this PR do ?

Improves the path-based `shard_id` parsing in `LazyNemoTarredIterator`; removes the assumption of a rigid path structure and instead searches the string with regex pattern that must contain `manifest/audio`, `_(shard_id)`, and `json/tar` with no slashes in between. It allows loading data directly from AIStore (`pipe:ais get ais://bucket/audio_{0..N}.tar -`) and other cloud storage CLIs; it also allows more path patterns such as `manifest_0_punctuation.json` (CC @krishnacpuvvada).

For example, it's possible to train a NeMo model from AIStore data just by passing the following config options (assuming [`ais`](https://github.com/NVIDIA/aistore/blob/main/docs/getting_started.md#local-playground) binary is available):
```yaml
manifest_filepath: 'pipe:ais get ais://my-bucket/sharded_manifests/manifest__OP_0..127_CL_.json -'
tarred_audio_filepaths: 'pipe:ais get ais://my-bucket/audio__OP_0..127_CL_.tar -'
```

Finally it improves the assertion messages about mismatches in paths/shard_ids/items between JSON and tar inputs to provide more details for debugging multi-dataset setups with wrong input specification.
 
**Collection**: ASR, multimodal

# Changelog 
- Support AIStore dataloading for ASR/multimodal and allow more general path patterns

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# Jenkins CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

There's no need to comment `jenkins` on the PR to trigger Jenkins CI.
The GitHub Actions CI will run automatically when the PR is opened.
To run CI on an untrusted fork, a NeMo user with write access must click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
