### PR TITLE
Add option for mutex timeout in distributed optimizer backward hook

### DIFF
--- a/nemo/core/optim/distributed_adam.py
+++ b/nemo/core/optim/distributed_adam.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import collections
+import contextlib
 import itertools
 from typing import Callable, Dict, Iterable, Optional, Union
 
@@ -108,6 +109,8 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
             but requires larger memory than distributing within all
             ranks, especially for pure data parallel models.
             (default: False).
+        lock_timeout (float, optional): timeout for callback mutex in
+            seconds.
         **kwargs: keyword arguments to pass to Apex
             DistributedFusedAdam.
 
@@ -118,6 +121,7 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
         params: Union[Iterable[torch.nn.Parameter], Iterable[dict]],
         disable_distributed_parameters: bool = False,
         distribute_within_nodes: bool = False,
+        lock_timeout: Optional[float] = None,
         **kwargs,
     ):
 
@@ -152,6 +156,19 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
         # Construct distributed optimizer
         super().__init__(param_groups, **kwargs)
 
+        # Create mutex with timeout
+        self._lock_with_timeout = None
+        if lock_timeout is not None:
+            @contextlib.contextmanager
+            def lock_with_timeout():
+                result = self._lock.acquire(timeout=lock_timeout)
+                try:
+                    yield result
+                finally:
+                    if result:
+                        self._lock.release()
+            self._lock_with_timeout = lock_with_timeout
+
     def _broadcast_params(self) -> None:
         # Assume params have already been synchronized
         pass
@@ -166,7 +183,10 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
                     'before the forward pass (e.g. by calling data_ptr) '
                     'or run DistributedFusedAdam with overlap_param_sync=False.'
                 )
-            with self._lock:
+            lock = self._lock
+            if self._lock_with_timeout is not None:
+                lock = self._lock_with_timeout()
+            with lock:
                 need_to_initialize = 'fragments' not in self.state[param]
                 if need_to_initialize:
                     self._init_param_state(param, param_group_id, param_id)

--- a/nemo/core/optim/distributed_adam.py
+++ b/nemo/core/optim/distributed_adam.py
@@ -159,6 +159,7 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
         # Create mutex with timeout
         self._lock_with_timeout = None
         if lock_timeout is not None:
+
             @contextlib.contextmanager
             def lock_with_timeout():
                 result = self._lock.acquire(timeout=lock_timeout)
@@ -167,6 +168,7 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
                 finally:
                     if result:
                         self._lock.release()
+
             self._lock_with_timeout = lock_with_timeout
 
     def _broadcast_params(self) -> None:


### PR DESCRIPTION
# What does this PR do ?

This is to help debug a hang at https://github.com/NVIDIA/NeMo/blob/f658b6f0445403c338c7371941b1fe644832df48/nemo/core/optim/distributed_adam.py#L131

Add a one line overview of what this PR aims to accomplish.

**Collection**: NLP

# Changelog 
- Add option for mutex timeout in distributed optimizer backward hook

# Usage

Run GPT, e.g. with the config at https://github.com/NVIDIA/NeMo/blob/main/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml.

Enable the distributed optimizer with `model.optim.name=distributed_fused_adam` and set the timeout with `model.optim.lock_timeout=<seconds>`.

# Jenkins CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

There's no need to comment `jenkins` on the PR to trigger Jenkins CI.
The GitHub Actions CI will run automatically when the PR is opened.
To run CI on an untrusted fork, a NeMo user with write access must click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

