### PR TITLE
Draft: Fix the "cast ping pong" problem when we run AMP inference.

### DIFF
--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -253,7 +253,10 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
 
     trainer = pl.Trainer(devices=device, accelerator=accelerator)
     asr_model.set_trainer(trainer)
+
+    # assert all(param.requires_grad for param in asr_model.parameters())
     asr_model = asr_model.eval()
+    # assert all(param.requires_grad for param in asr_model.parameters())
 
     # we will adjust this flag if the model does not support it
     compute_timestamps = cfg.compute_timestamps
@@ -407,7 +410,27 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
                 override_cfg.augmentor = augmentor
                 override_cfg.text_field = cfg.gt_text_attr_name
                 override_cfg.lang_field = cfg.gt_lang_attr_name
-                transcriptions = asr_model.transcribe(audio=filepaths, override_config=override_cfg,)
+                # assert all(param.requires_grad for param in asr_model.parameters())
+                for i in range(5):
+                    if i == 1:
+                        # import nvtx
+                        # pr = nvtx.Profile()
+                        # pr.enable()  # begin annotating function calls
+                        # ctx = torch.autograd.profiler.emit_nvtx()
+                        # ctx.__enter__()
+                        torch.cuda.cudart().cudaProfilerStart()
+                    import time
+                    start_time = time.time()
+                    # assert all(param.requires_grad for param in asr_model.parameters())
+                    transcriptions = asr_model.transcribe(audio=filepaths, override_config=override_cfg,)
+                    # assert all(param.requires_grad for param in asr_model.parameters())
+                    end_time = time.time()
+                    print(5.1 * 60 * 60 / (end_time - start_time))
+                    if i == 1:
+                        # pr.disable()
+                        # ctx.__exit__(None, None, None)
+                        torch.cuda.cudart().cudaProfilerStop()
+
 
     if cfg.dataset_manifest is not None:
         logging.info(f"Finished transcribing from manifest file: {cfg.dataset_manifest}")

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -420,6 +420,7 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
                         # ctx.__enter__()
                         torch.cuda.cudart().cudaProfilerStart()
                     import time
+
                     start_time = time.time()
                     # assert all(param.requires_grad for param in asr_model.parameters())
                     transcriptions = asr_model.transcribe(audio=filepaths, override_config=override_cfg,)
@@ -430,7 +431,6 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
                         # pr.disable()
                         # ctx.__exit__(None, None, None)
                         torch.cuda.cudart().cudaProfilerStop()
-
 
     if cfg.dataset_manifest is not None:
         logging.info(f"Finished transcribing from manifest file: {cfg.dataset_manifest}")

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -686,7 +686,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
                 # See comment in
                 # ctc_greedy_decoding.py::GreedyCTCInfer::forward() to
                 # understand this idiom.
-                
+
                 # This is way way wayyyyy too slow. A single
                 # cudaHostAlloc takes an average of 10ms if the
                 # caching allocator fails to return an

--- a/nemo/collections/asr/parts/mixins/transcription.py
+++ b/nemo/collections/asr/parts/mixins/transcription.py
@@ -770,7 +770,6 @@ class ASRTranscriptionMixin(TranscriptionMixin):
         # assert all(param.requires_grad for param in self.parameters())
         # import ipdb; ipdb.set_trace()
 
-
     def _transcribe_on_end(self, trcfg: TranscribeConfig):
         """
         Internal function to teardown the model after transcription. Perform all teardown and post-checks here.

--- a/nemo/collections/asr/parts/mixins/transcription.py
+++ b/nemo/collections/asr/parts/mixins/transcription.py
@@ -183,7 +183,7 @@ class TranscriptionMixin(ABC):
 
     """
 
-    @torch.no_grad()
+    @torch.inference_mode()
     def transcribe(
         self,
         audio: Union[str, List[str], np.ndarray],
@@ -234,6 +234,8 @@ class TranscriptionMixin(ABC):
                 - Dict[str, List[str/Hypothesis]]
         """
 
+        # assert all(param.requires_grad for param in self.parameters())
+
         if override_config is None:
             transcribe_cfg = TranscribeConfig(
                 batch_size=batch_size,
@@ -270,9 +272,10 @@ class TranscriptionMixin(ABC):
         # Hold the results here
         results = None  # type: GenericTranscriptionType
 
+        # assert all(param.requires_grad for param in self.parameters())
         try:
             generator = self.transcribe_generator(audio, override_config=transcribe_cfg)
-
+            # assert all(param.requires_grad for param in self.parameters())
             for processed_outputs in generator:
                 # Store results
                 if isinstance(processed_outputs, list):
@@ -362,12 +365,14 @@ class TranscriptionMixin(ABC):
 
         try:
             # Initialize and assert the transcription environment
+            # assert all(param.requires_grad for param in self.parameters())
             self._transcribe_on_begin(audio, transcribe_cfg)
+            # assert all(param.requires_grad for param in self.parameters())
 
             # Work in tmp directory - will store manifest file there
             with tempfile.TemporaryDirectory() as tmpdir:
                 transcribe_cfg._internal.temp_dir = tmpdir
-
+                # assert all(param.requires_grad for param in self.parameters())
                 dataloader = self._transcribe_input_processing(audio, transcribe_cfg)
 
                 if hasattr(transcribe_cfg, 'verbose'):
@@ -377,8 +382,9 @@ class TranscriptionMixin(ABC):
 
                 for test_batch in tqdm(dataloader, desc="Transcribing", disable=not verbose):
                     # Move batch to device
+                    # assert all(param.requires_grad for param in self.parameters())
                     test_batch = move_to_device(test_batch, transcribe_cfg._internal.device)
-
+                    # assert all(param.requires_grad for param in self.parameters())
                     # Run forward pass
                     model_outputs = self._transcribe_forward(test_batch, transcribe_cfg)
                     processed_outputs = self._transcribe_output_processing(model_outputs, transcribe_cfg)
@@ -448,7 +454,9 @@ class TranscriptionMixin(ABC):
                 self.preprocessor.featurizer.pad_to = 0
 
         # Switch model to evaluation mode
+        # assert all(param.requires_grad for param in self.parameters())
         self.eval()
+        # assert all(param.requires_grad for param in self.parameters())
 
         # Disable logging
         trcfg._internal.logging_level = logging.get_verbosity()
@@ -748,15 +756,20 @@ class ASRTranscriptionMixin(TranscriptionMixin):
         """
         super()._transcribe_on_begin(audio, trcfg)
 
+        # assert all(param.requires_grad for param in self.parameters())
+
         # Freeze the encoder and decoder modules
-        if hasattr(self, 'encoder'):
-            self.encoder.freeze()
+        # if hasattr(self, 'encoder'):
+        #     self.encoder.freeze()
 
-        if hasattr(self, 'decoder'):
-            self.decoder.freeze()
+        # if hasattr(self, 'decoder'):
+        #     self.decoder.freeze()
 
-        if hasattr(self, 'joint'):
-            self.joint.freeze()
+        # if hasattr(self, 'joint'):
+        #     self.joint.freeze()
+        # assert all(param.requires_grad for param in self.parameters())
+        # import ipdb; ipdb.set_trace()
+
 
     def _transcribe_on_end(self, trcfg: TranscribeConfig):
         """

--- a/nemo/collections/asr/parts/submodules/multi_head_attention.py
+++ b/nemo/collections/asr/parts/submodules/multi_head_attention.py
@@ -220,13 +220,14 @@ class RelPositionMultiHeadAttention(MultiHeadAttention):
 
         # temporary until we solve this more gracefully
         from contextlib import nullcontext
-        with nullcontext(): # avoid_float16_autocast_context():
+
+        with nullcontext():  # avoid_float16_autocast_context():
             q, k, v = self.forward_qkv(query, key, value)
             q = q.transpose(1, 2)  # (batch, time1, head, d_k)
 
             n_batch_pos = pos_emb.size(0)
             # embedding is not affected by autocast. Ignore for now...
-            
+
             # Could make a custom torch.nn.Module that checks if we're
             # in inference mode, and then caches its own weights'
             # casted versions that way...

--- a/nemo/utils/cast_utils.py
+++ b/nemo/utils/cast_utils.py
@@ -37,7 +37,7 @@ def avoid_float16_autocast_context():
 
     if torch.is_autocast_enabled() and torch.get_autocast_gpu_dtype() == torch.float16:
         if torch.jit.is_scripting() or torch.jit.is_tracing():
-            return torch.cuda.amp.autocast(dtype=torch.float32)
+            return torch.cuda.amp.autocast(enabled=False)
 
         if torch.cuda.is_bf16_supported():
             return torch.cuda.amp.autocast(dtype=torch.bfloat16)


### PR DESCRIPTION
This has been tested only for Parakeet-CTC-1.1B right now. This problem certainly exists elsewhere.

It also is not ina  mergeable state. This is my initial hack to fix the problem.

Automatic mixed precision and inference do not play well together.

Frankly, I do not think we should be using AMP in inference in the first place.

First, automatic mixed precision was created back when neural networks were much simpler. In particular, they did not have softmax and layer norm as frequent operations. In the era of transformers, softmax and layer norm are very common. AMP will uncoditionally output fp32 outputs from these operations, even if their inputs are fp16. See here: https://pytorch.org/docs/stable/amp.html#cuda-ops-that-can-autocast-to-float32

This is no longer necessary, now that layer norm does accumulation in fp32 in pytorch, even if the input is fp16:
https://github.com/pytorch/pytorch/issues/66707

There is a second problem. It is elaborated on in my long comment in nemo/core/classes/module.py. Basically, setting requires_grad=False on a parameter, confusingly enough, disables AMP's caching mechanism, which means we uncoditionally waste time calling cache kernels. Read more here: https://github.com/NVIDIA/NeMo/pull/9086/files#diff-4f86565ac3601ea79395f9d2884c28115c5fd9fe3655894564d71539fe5d8042R58-R90

Both of these problems need to be fixed to prevent inference from constantly casting its intermediate tensors to and from float16 and float32, which is a waste of time that does nothing.

This hacky fix does not suppoer bfloat16 for now.

Again, I recommend simply running model.half() or model.bfloat16() for inference. AMP does not make sense for inference because it wastes memory.

Results from running:

```
batch_size=32
amp=true

echo "GALVEZ: Conformer CTC"
python examples/asr/speech_to_text_eval.py  pretrained_name=nvidia/parakeet-ctc-1.1b dataset_manifest=/home/dgalvez/scratch/data/test_other_sorted_downward.json  batch_size=$batch_size  output_filename=test_clean_decoded.jsonl  amp=$amp  amp_dtype=float16  use_cer=false num_workers=1
\# ctc_decoding.greedy.batched_inference=true
```

RTFx values before my change:

```
922.302270024654
1072.6919226908824
853.5230428014742
1114.2164255498367
1264.829085006686
```

RTFx values after my change:

```
1132.0813676953462
1255.840791955383
838.7445635257388
1389.7852550162668
1479.8061656119771
```

You can see that RTFx gets as high as 1480 after my change. Meanwhile, the highest RTFx before my change is 1264. So it's about a 15% speedup by removing the unnecessary cast kernels.

Forgive the large variance from run-to-run. It is because of the changes made in: https://github.com/NVIDIA/NeMo/pull/8521 There is a huge delay (at least 10 milliseconds) when there is a cache miss for the caching pinned host memory allocator. I'm planning to revert the change since I didn't realize initially how large the cache miss cost was (enough to undue the benefits on reasonably sized workloads).