### PR TITLE
Add option for mutex timeout in distributed optimizer backward hook

### DIFF
--- a/nemo/core/optim/distributed_adam.py
+++ b/nemo/core/optim/distributed_adam.py
@@ -171,9 +171,7 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
                         self._lock.release()
                     else:
                         # Failed to acquire lock before timeout
-                        raise RuntimeError(
-                            f'MegatronDistributedFusedAdam: Failed to acquire lock within {lock_timeout} seconds.'
-                        )
+                        print(f'MegatronDistributedFusedAdam: Failed to acquire lock within {lock_timeout} seconds.')
 
             self._lock_with_timeout = lock_with_timeout
 

--- a/nemo/core/optim/distributed_adam.py
+++ b/nemo/core/optim/distributed_adam.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import collections
+import contextlib
 import itertools
 from typing import Callable, Dict, Iterable, Optional, Union
 
@@ -108,6 +109,8 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
             but requires larger memory than distributing within all
             ranks, especially for pure data parallel models.
             (default: False).
+        lock_timeout (float, optional): timeout for callback mutex in
+            seconds.
         **kwargs: keyword arguments to pass to Apex
             DistributedFusedAdam.
 
@@ -118,6 +121,7 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
         params: Union[Iterable[torch.nn.Parameter], Iterable[dict]],
         disable_distributed_parameters: bool = False,
         distribute_within_nodes: bool = False,
+        lock_timeout: Optional[float] = None,
         **kwargs,
     ):
 
@@ -152,6 +156,21 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
         # Construct distributed optimizer
         super().__init__(param_groups, **kwargs)
 
+        # Create mutex with timeout
+        self._lock_with_timeout = None
+        if lock_timeout is not None:
+
+            @contextlib.contextmanager
+            def lock_with_timeout():
+                result = self._lock.acquire(timeout=lock_timeout)
+                try:
+                    yield result
+                finally:
+                    if result:
+                        self._lock.release()
+
+            self._lock_with_timeout = lock_with_timeout
+
     def _broadcast_params(self) -> None:
         # Assume params have already been synchronized
         pass
@@ -166,7 +185,10 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
                     'before the forward pass (e.g. by calling data_ptr) '
                     'or run DistributedFusedAdam with overlap_param_sync=False.'
                 )
-            with self._lock:
+            lock = self._lock
+            if self._lock_with_timeout is not None:
+                lock = self._lock_with_timeout()
+            with lock:
                 need_to_initialize = 'fragments' not in self.state[param]
                 if need_to_initialize:
                     self._init_param_state(param, param_group_id, param_id)

--- a/nemo/core/optim/distributed_adam.py
+++ b/nemo/core/optim/distributed_adam.py
@@ -15,6 +15,7 @@
 import collections
 import contextlib
 import itertools
+import threading
 from typing import Callable, Dict, Iterable, Optional, Union
 
 import torch
@@ -156,20 +157,20 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
         # Construct distributed optimizer
         super().__init__(param_groups, **kwargs)
 
-        # Create mutex with timeout
-        self._lock_with_timeout = None
+        # Replace lock if timeout is provided
         if lock_timeout is not None:
+            self._lock_with_timeout: threading.Lock = threading.Lock()
 
             @contextlib.contextmanager
             def lock_with_timeout():
-                result = self._lock.acquire(timeout=lock_timeout)
+                result = self._lock_with_timeout.acquire(timeout=lock_timeout)
                 try:
                     yield result
                 finally:
                     if result:
-                        self._lock.release()
+                        self._lock_with_timeout.release()
 
-            self._lock_with_timeout = lock_with_timeout
+            self._lock = lock_with_timeout()
 
     def _broadcast_params(self) -> None:
         # Assume params have already been synchronized
@@ -185,10 +186,7 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
                     'before the forward pass (e.g. by calling data_ptr) '
                     'or run DistributedFusedAdam with overlap_param_sync=False.'
                 )
-            lock = self._lock
-            if self._lock_with_timeout is not None:
-                lock = self._lock_with_timeout()
-            with lock:
+            with self._lock:
                 need_to_initialize = 'fragments' not in self.state[param]
                 if need_to_initialize:
                     self._init_param_state(param, param_group_id, param_id)

--- a/nemo/core/optim/distributed_adam.py
+++ b/nemo/core/optim/distributed_adam.py
@@ -167,7 +167,13 @@ class MegatronDistributedFusedAdam(DistributedFusedAdam):
                     yield result
                 finally:
                     if result:
+                        # Acquired lock before timeout
                         self._lock.release()
+                    else:
+                        # Failed to acquire lock before timeout
+                        raise RuntimeError(
+                            f'MegatronDistributedFusedAdam: Failed to acquire lock within {lock_timeout} seconds.'
+                        )
 
             self._lock_with_timeout = lock_with_timeout
 


### PR DESCRIPTION
# What does this PR do ?

Modified version of https://github.com/NVIDIA/NeMo/pull/9084, to debug a hang at https://github.com/NVIDIA/NeMo/blob/f658b6f0445403c338c7371941b1fe644832df48/nemo/core/optim/distributed_adam.py#L131

**Collection**: NLP

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
Run GPT, e.g. with the config at https://github.com/NVIDIA/NeMo/blob/main/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml.

Enable the distributed optimizer with `model.optim.name=distributed_fused_adam` and set the timeout with `model.optim.lock_timeout=<seconds>`.

# Jenkins CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

There's no need to comment `jenkins` on the PR to trigger Jenkins CI.
The GitHub Actions CI will run automatically when the PR is opened.
To run CI on an untrusted fork, a NeMo user with write access must click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
