### PR TITLE
Add parameter of embedding_read_fusion for MCoreGPTModel

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -403,6 +403,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                 parallel_output=True,
                 share_embeddings_and_output_weights=self.cfg.get('share_embeddings_and_output_weights', True),
                 position_embedding_type=self.cfg.get('position_embedding_type', 'learned_absolute'),
+                embedding_read_fusion=self.cfg.get('embedding_read_fusion', False),
                 rotary_percent=self.cfg.get('rotary_percentage', 1.0),
                 seq_len_interpolation_factor=self.cfg.get('seq_len_interpolation_factor', None),
                 rotary_base=self.cfg.get('rotary_base', 10000),


### PR DESCRIPTION
# What does this PR do ?

This PR adds the support for embedding_read_fusion parameter in MCoreGPTModel. This new parameter will be added into Megatron-LM.

**Collection**: [Note which collection this PR will affect]

# Changelog 
Add the embedding_read_fusion parameter, which is got from self.cfg.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
