### PR TITLE
Add filepaths to pretty_errors' stacktraces; pretty_errors is installed by PL

### DIFF
--- a/nemo/__init__.py
+++ b/nemo/__init__.py
@@ -14,17 +14,18 @@
 
 
 import pretty_errors
+
 pretty_errors.configure(
-    separator_character = '*',
-    filename_display    = pretty_errors.FILENAME_FULL,
-    line_number_first   = True,
-    display_link        = True,
-    lines_before        = 5,
-    lines_after         = 2,
-    line_color          = pretty_errors.RED + '> ' + pretty_errors.default_config.line_color,
-    code_color          = '  ' + pretty_errors.default_config.line_color,
-    truncate_code       = True,
-    display_locals      = True
+    separator_character='*',
+    filename_display=pretty_errors.FILENAME_FULL,
+    line_number_first=True,
+    display_link=True,
+    lines_before=5,
+    lines_after=2,
+    line_color=pretty_errors.RED + '> ' + pretty_errors.default_config.line_color,
+    code_color='  ' + pretty_errors.default_config.line_color,
+    truncate_code=True,
+    display_locals=True,
 )
 
 from nemo.package_info import (

--- a/nemo/__init__.py
+++ b/nemo/__init__.py
@@ -13,6 +13,20 @@
 # limitations under the License.
 
 
+import pretty_errors
+pretty_errors.configure(
+    separator_character = '*',
+    filename_display    = pretty_errors.FILENAME_FULL,
+    line_number_first   = True,
+    display_link        = True,
+    lines_before        = 5,
+    lines_after         = 2,
+    line_color          = pretty_errors.RED + '> ' + pretty_errors.default_config.line_color,
+    code_color          = '  ' + pretty_errors.default_config.line_color,
+    truncate_code       = True,
+    display_locals      = True
+)
+
 from nemo.package_info import (
     __contact_emails__,
     __contact_names__,

--- a/nemo/__init__.py
+++ b/nemo/__init__.py
@@ -12,21 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+try:
+    import pretty_errors
 
-import pretty_errors
-
-pretty_errors.configure(
-    separator_character='*',
-    filename_display=pretty_errors.FILENAME_FULL,
-    line_number_first=True,
-    display_link=True,
-    lines_before=5,
-    lines_after=2,
-    line_color=pretty_errors.RED + '> ' + pretty_errors.default_config.line_color,
-    code_color='  ' + pretty_errors.default_config.line_color,
-    truncate_code=True,
-    display_locals=True,
-)
+    pretty_errors.configure(
+        separator_character='*',
+        filename_display=pretty_errors.FILENAME_FULL,
+        line_number_first=True,
+        display_link=True,
+        lines_before=5,
+        lines_after=2,
+        line_color=pretty_errors.RED + '> ' + pretty_errors.default_config.line_color,
+        code_color='  ' + pretty_errors.default_config.line_color,
+        truncate_code=True,
+        display_locals=True,
+    )
+except ImportError:
+    pass
 
 from nemo.package_info import (
     __contact_emails__,


### PR DESCRIPTION
PL installs pretty_errors which alters `sys.excepthook` from `sys.__excepthook__` to a text formatting function the pretty_errors library defines. However, the format used is incomplete as it misses filepaths, which hinders debugging.

This PR includes pretty_errors and configures it so that we get filepaths in the stacktraces, for example:

Before:
```
-------------------------------------------------------------------------------
megatron_gpt_finetuning.py 18 <module>
from nemo.utils import logging

__init__.py 31 <module>
from nemo.utils.lightning_logger_patch import add_memory_handlers_to_pl_logger

lightning_logger_patch.py 19 <module>
q()

NameError:
name 'q' is not defined
```


After:
```
*******************************************************************************
18 <module> ...examples/nlp/language_modeling/tuning/megatron_gpt_finetuning.py"/opt/NeMo/examples/nlp/language_modeling/tuning/megatron_gpt_finetuning.py", line 18
> from nemo.utils import logging

31 <module> /opt/NeMo/nemo/utils/__init__.py
"/opt/NeMo/nemo/utils/__init__.py", line 31
> from nemo.utils.lightning_logger_patch import add_memory_handlers_to_pl_logger...

19 <module> /opt/NeMo/nemo/utils/lightning_logger_patch.py
"/opt/NeMo/nemo/utils/lightning_logger_patch.py", line 19

  import logging as _logging
  from logging.handlers import MemoryHandler

  import pytorch_lightning as pl
> q()

  HANDLERS = {}

_logging: <module 'logging' from '/usr/lib/python3.10/logging/__init__.py'>
MemoryHandler: <class 'logging.handlers.MemoryHandler'>
pl: <module 'pytorch_lightning' from '/usr/local/lib/python3.10/dist-p... [105]
NameError:
name 'q' is not defined
```



# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
