### PR TITLE
Fix passing options to TransformerEngine layers and MCore

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron/gpt_full_te_layer_autocast_spec.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/gpt_full_te_layer_autocast_spec.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Optional
 import torch
 from pkg_resources import packaging
 
-from nemo.collections.nlp.modules.common.megatron.utils import ApexGuardDefaults
+from nemo.collections.nlp.modules.common.megatron.utils import ApexGuardDefaults, get_te_normalization
 from nemo.collections.nlp.parts import utils_funcs
 
 try:
@@ -83,12 +83,15 @@ class AutocastTransformerLayer(TransformerLayer):
         ub_bulk_dgrad: bool = True,
         autocast_dtype: Any = 16,
         zero_centered_gamma: bool = False,
+        normalization: str = 'layernorm',
+        bias: bool = True,
         device: str = 'cuda',
         **kwargs,
     ) -> None:
         if not HAVE_MEGATRON_CORE or not HAVE_TE:
             raise ImportError(IMPORT_ERROR)
 
+        normalization = get_te_normalization(normalization)
         transformer_layer_args = {
             "hidden_size": hidden_size,
             "ffn_hidden_size": ffn_hidden_size,
@@ -116,6 +119,8 @@ class AutocastTransformerLayer(TransformerLayer):
             "set_parallel_mode": tp_size > 1,
             "fuse_qkv_params": True,
             "zero_centered_gamma": zero_centered_gamma,
+            "normalization": normalization,
+            "bias": bias,
             "ub_tp_comm_overlap": ub_tp_comm_overlap,
             "ub_bulk_wgrad": ub_bulk_wgrad,
             "ub_bulk_dgrad": ub_bulk_dgrad,

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -52,6 +52,7 @@ from nemo.collections.nlp.modules.common.megatron.utils import (
     get_all_params_for_weight_decay_optimization,
     get_ltor_masks_and_position_ids,
     get_params_for_weight_decay_optimization,
+    get_te_normalization,
 )
 from nemo.collections.nlp.modules.common.text_generation_strategy import TextGenerationStrategy
 from nemo.collections.nlp.modules.common.text_generation_utils import (
@@ -1989,18 +1990,9 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
 
         normalization = self.cfg.get('normalization', 'layernorm').lower()
         layernorm_zero_centered_gamma = self.cfg.get('normalization', 'layernorm') == 'layernorm1p'
-        if normalization == 'layernorm':
-            normalization = 'LayerNorm'
-        elif normalization == 'rmsnorm':
-            normalization = 'RMSNorm'
-        elif normalization == 'layernorm1p':
-            normalization = 'LayerNorm'
+        normalization = get_te_normalization(normalization)
+        if normalization == 'layernorm1p':
             layernorm_zero_centered_gamma = True
-        else:
-            logging.warning(
-                f"The normalization type: {normalization} might not be supported in megatron core."
-                f"Supported types are LayerNorm and RMSNorm."
-            )
 
         ub_tp_comm_overlap = self.cfg.get('ub_tp_comm_overlap', False)
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -2017,6 +2017,10 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             'gated_linear_unit': gated_linear_unit,
             'fp8': fp8,
             'tp_comm_overlap': ub_tp_comm_overlap,
+            # Bias related
+            'add_bias_linear': self.cfg.get('bias', True),
+            'bias_activation_fusion': self.cfg.get('bias_activation_fusion', True),
+            'bias_dropout_fusion': self.cfg.get('bias_dropout_add_fusion', True),
             # MoE related
             'num_moe_experts': self.cfg.get('num_moe_experts', None),
             'moe_router_load_balancing_type': self.cfg.get('moe_router_load_balancing_type', 'aux_loss'),

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -53,6 +53,7 @@ from nemo.collections.nlp.modules.common.megatron.utils import (
     get_ltor_masks_and_position_ids,
     get_params_for_weight_decay_optimization,
     get_te_normalization,
+    is_glu_activation,
 )
 from nemo.collections.nlp.modules.common.text_generation_strategy import TextGenerationStrategy
 from nemo.collections.nlp.modules.common.text_generation_utils import (
@@ -1994,6 +1995,9 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         if normalization == 'layernorm1p':
             layernorm_zero_centered_gamma = True
 
+        activation = self.cfg.get('activation', 'gelu').lower()
+        gated_linear_unit = is_glu_activation(activation)
+
         ub_tp_comm_overlap = self.cfg.get('ub_tp_comm_overlap', False)
 
         if not self.cfg.get('fp8', False):
@@ -2009,6 +2013,8 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         model_specific_configs = {
             'layernorm_zero_centered_gamma': layernorm_zero_centered_gamma,
             'normalization': normalization,
+            'activation_func': activation_to_func(activation),
+            'gated_linear_unit': gated_linear_unit,
             'fp8': fp8,
             'tp_comm_overlap': ub_tp_comm_overlap,
             # MoE related

--- a/nemo/collections/nlp/modules/common/megatron/mlp.py
+++ b/nemo/collections/nlp/modules/common/megatron/mlp.py
@@ -27,7 +27,7 @@ from nemo.collections.nlp.modules.common.megatron.fused_layer_norm import get_la
 from nemo.collections.nlp.modules.common.megatron.layer_norm_1p import LayerNorm1P
 from nemo.collections.nlp.modules.common.megatron.module import MegatronModule
 from nemo.collections.nlp.modules.common.megatron.utils import ApexGuardDefaults, ApproxGELUActivation, erf_gelu
-from nemo.collections.nlp.modules.common.megatron.utils import openai_gelu as openai_gelu_func
+from nemo.collections.nlp.modules.common.megatron.utils import is_glu_activation, openai_gelu as openai_gelu_func
 from nemo.collections.nlp.modules.common.megatron.utils import squared_relu
 from nemo.core import adapter_mixins
 
@@ -144,14 +144,7 @@ class ParallelMLP(MegatronModule, adapter_mixins.AdapterModuleMixin):
                 bias=bias,
             )
 
-        self.glu_activation_family = activation in [
-            'geglu',
-            'reglu',
-            'swiglu',
-            'fast-geglu',
-            'fast-reglu',
-            'fast-swiglu',
-        ]
+        self.glu_activation_family = is_glu_activation(activation)
         bias_activation_fusion_unavailable = activation in ['reglu', 'swiglu']
 
         if bias_activation_fusion_unavailable and bias_activation_fusion:

--- a/nemo/collections/nlp/modules/common/megatron/mlp.py
+++ b/nemo/collections/nlp/modules/common/megatron/mlp.py
@@ -26,8 +26,13 @@ from nemo.collections.nlp.modules.common.megatron.fused_bias_gelu import fused_b
 from nemo.collections.nlp.modules.common.megatron.fused_layer_norm import get_layer_norm
 from nemo.collections.nlp.modules.common.megatron.layer_norm_1p import LayerNorm1P
 from nemo.collections.nlp.modules.common.megatron.module import MegatronModule
-from nemo.collections.nlp.modules.common.megatron.utils import ApexGuardDefaults, ApproxGELUActivation, erf_gelu
-from nemo.collections.nlp.modules.common.megatron.utils import is_glu_activation, openai_gelu as openai_gelu_func
+from nemo.collections.nlp.modules.common.megatron.utils import (
+    ApexGuardDefaults,
+    ApproxGELUActivation,
+    erf_gelu,
+    is_glu_activation,
+)
+from nemo.collections.nlp.modules.common.megatron.utils import openai_gelu as openai_gelu_func
 from nemo.collections.nlp.modules.common.megatron.utils import squared_relu
 from nemo.core import adapter_mixins
 

--- a/nemo/collections/nlp/modules/common/megatron/mlp.py
+++ b/nemo/collections/nlp/modules/common/megatron/mlp.py
@@ -126,9 +126,9 @@ class ParallelMLP(MegatronModule, adapter_mixins.AdapterModuleMixin):
         # Project to 4h.
         self.dense_h_to_4h = tensor_parallel.ColumnParallelLinear(
             hidden_size,
-            ffn_hidden_size * 2
-            if self.fast_glu_activation
-            else ffn_hidden_size,  # NOTE: When using geglu, divide ffn dim by 2/3 to keep overall params the same.
+            (
+                ffn_hidden_size * 2 if self.fast_glu_activation else ffn_hidden_size
+            ),  # NOTE: When using geglu, divide ffn dim by 2/3 to keep overall params the same.
             config=config,
             gather_output=False,
             init_method=init_method,
@@ -276,7 +276,7 @@ class ParallelMLP(MegatronModule, adapter_mixins.AdapterModuleMixin):
 
 class SwitchMLP(MegatronModule):
     """Top-1 MoE
-    
+
     Curently supports Sinkhorn based expert routing."""
 
     def __init__(

--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -41,7 +41,11 @@ from nemo.collections.nlp.modules.common.megatron.layer_norm_1p import LayerNorm
 from nemo.collections.nlp.modules.common.megatron.layer_type import LayerType
 from nemo.collections.nlp.modules.common.megatron.mlp import ParallelMLP, SwitchMLP
 from nemo.collections.nlp.modules.common.megatron.module import MegatronModule
-from nemo.collections.nlp.modules.common.megatron.utils import ApexGuardDefaults, get_te_normalization
+from nemo.collections.nlp.modules.common.megatron.utils import (
+    ApexGuardDefaults,
+    get_te_activation,
+    get_te_normalization,
+)
 from nemo.collections.nlp.parts import utils_funcs
 from nemo.core import adapter_mixins
 from nemo.utils import logging
@@ -802,11 +806,13 @@ class AutocastTransformerLayer(TransformerLayer):
         ub_bulk_dgrad: bool = True,
         autocast_dtype: Any = 16,
         zero_centered_gamma: bool = False,
+        activation: str = 'gelu',
         normalization: str = 'layernorm',
         bias: bool = True,
         device: str = 'cuda',
         **kwargs,
     ) -> None:
+        activation = get_te_activation(activation)
         normalization = get_te_normalization(normalization)
         transformer_layer_args = {
             "hidden_size": hidden_size,
@@ -835,6 +841,7 @@ class AutocastTransformerLayer(TransformerLayer):
             "set_parallel_mode": tp_size > 1,
             "fuse_qkv_params": True,
             "zero_centered_gamma": zero_centered_gamma,
+            "activation": activation,
             "normalization": normalization,
             "bias": bias,
             "ub_tp_comm_overlap": ub_tp_comm_overlap,
@@ -1111,6 +1118,7 @@ class ParallelTransformer(MegatronModule):
                     "ub_bulk_wgrad": config.tp_comm_bulk_wgrad,
                     "ub_bulk_dgrad": config.tp_comm_bulk_dgrad,
                     "zero_centered_gamma": normalization == 'layernorm1p',
+                    "activation": activation,
                     "normalization": normalization,
                     "bias": bias,
                     "device": 'cpu' if config.use_cpu_initialization else 'cuda',

--- a/nemo/collections/nlp/modules/common/megatron/utils.py
+++ b/nemo/collections/nlp/modules/common/megatron/utils.py
@@ -160,7 +160,7 @@ def attention_mask_func(attention_scores, attention_mask):
 
 def get_te_activation(activation: str) -> str:
     """Return the string for the desired activation converted for usage
-    with TransformerEngine and/or Megatron-LM core.
+    with TransformerEngine.
 
     Log an error if it cannot be converted.
     """

--- a/nemo/collections/nlp/modules/common/megatron/utils.py
+++ b/nemo/collections/nlp/modules/common/megatron/utils.py
@@ -158,6 +158,50 @@ def attention_mask_func(attention_scores, attention_mask):
     return attention_scores
 
 
+def get_te_activation(activation: str) -> str:
+    """Return the string for the desired activation converted for usage
+    with TransformerEngine and/or Megatron-LM core.
+
+    Log an error if it cannot be converted.
+    """
+    activations = {
+        'gelu': 'gelu',
+        'geglu': 'geglu',
+        'reglu': 'reglu',
+        'swiglu': 'swiglu',
+        # Documented in TransformerEngine, but not implemented.
+        # 'squared-relu': 'squared_relu',
+        'fast-geglu': 'geglu',
+        'fast-swiglu': 'swiglu',
+        'fast-reglu': 'reglu',
+        'approx-gelu': 'qgelu',
+    }
+    if activation in activations:
+        activation = activations[activation]
+    else:
+        logging.warning(
+            f"The normalization type: {activation} might not be supported "
+            f"in Megatron-LM core or TransformerEngine."
+            f"Supported types are {list(sorted(set(activations.values())))} "
+            f"(converted from {list(activations.keys())})."
+        )
+    return activation
+
+
+def is_glu_activation(activation: str) -> bool:
+    """Return whether the given activation config string maps to an
+    activation with a gated linear unit.
+    """
+    return activation in [
+        'geglu',
+        'reglu',
+        'swiglu',
+        'fast-geglu',
+        'fast-reglu',
+        'fast-swiglu',
+    ]
+
+
 def get_te_normalization(normalization: str) -> str:
     """Return the string for the desired normalization converted for
     usage with TransformerEngine and/or Megatron-LM core.

--- a/nemo/collections/nlp/modules/common/megatron/utils.py
+++ b/nemo/collections/nlp/modules/common/megatron/utils.py
@@ -158,6 +158,33 @@ def attention_mask_func(attention_scores, attention_mask):
     return attention_scores
 
 
+def get_te_normalization(normalization: str) -> str:
+    """Return the string for the desired normalization converted for
+    usage with TransformerEngine and/or Megatron-LM core.
+
+    Log an error if it cannot be converted. Note that other options,
+    such as `zero_centered_gamma=True` or
+    `layernorm_zero_centered_gamma=True` (for TransformerEngine and
+    Megatron-LM core respectively) for "layernorm1p" need to be adjusted
+    separately.
+    """
+    normalizations = {
+        'layernorm': 'LayerNorm',
+        'layernorm1p': 'LayerNorm',
+        'rmsnorm': 'RMSNorm',
+    }
+    if normalization in normalizations:
+        normalization = normalizations[normalization]
+    else:
+        logging.warning(
+            f"The normalization type: {normalization} might not be supported "
+            f"in Megatron-LM core or TransformerEngine. "
+            f"Supported types are {list(sorted(set(normalizations.values())))} "
+            f"(converted from {list(normalizations.keys())})."
+        )
+    return normalization
+
+
 def get_linear_layer(rows, columns, init_method):
     """Simple linear layer with weight initialization."""
     layer = torch.nn.Linear(rows, columns)


### PR DESCRIPTION
This affects the NeMo TransformerEngine layers (`AutocastTransformerLayer`) and MCore `TransformerConfig`, which previously did not correctly receive the settings for
- `activation: str`: custom activation, including the GLU property,
- `normalization: str`: custom normalization layers,
- `bias: bool`: optional bias,
- (MCore only) `bias_dropout_add_fusion: bool`: whether to fuse **bias add+dropout+residual add** via JIT-compilation (we could even enable this for TransformerEngine by setting `os.environ["NVTE_BIAS_DROPOUT_FUSION"] = "1"`. Note that Megatron-LM also does not do this), and
- (MCore only) `bias_activation_fusion: bool`: whether to fuse **bias add+activation** via JIT-compilation.

# What does this PR do ?

Fix passing normalization and bias options to TransformerEngine layers. Previously, with `mcore=False, transformer_engine=True`, the mentioned model settings would not be reproduced correctly.

**Collection**: NLP

# Changelog 
- We refactor the functions to convert the NeMo normalization and activation config option to its TransformerEngine/Megatron-LM core equivalent, saving on duplicate code and improving maintainability.
- We refactor the query for whether an activation function uses a GLU layer.
- These refactored functions are now used for creating the TransformerEngine and MCore configs.
- We pass two additional values to the `AutocastTransformerLayer` and its superclass constructor, namely `activation`, `normalization`, and `bias`. 
- We pass five additional values to the MCore `TransformerConfig`, namely `activation_func`, `gated_linear_unit`, `add_bias_linear`, `bias_activation_fusion`, and `bias_dropout_fusion`.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? – There were no existing tests for `AutocastTransformerLayer`, so I did not bother.
- [ ] Did you add or update any necessary documentation? – I do not think this is necessary, we just fix the incorrect behavior.
- [X] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc) – Yes, it implicitly affects behavior in TransformerEngine and Megatron-LM.
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
