### PR TITLE
Use `get_vocab` method instead of `vocab`

### DIFF
--- a/nemo/collections/common/tokenizers/huggingface/auto_tokenizer.py
+++ b/nemo/collections/common/tokenizers/huggingface/auto_tokenizer.py
@@ -27,7 +27,7 @@ __all__ = [
 
 class AutoTokenizer(TokenizerSpec):
     """
-        Wrapper of HuggingFace AutoTokenizer https://huggingface.co/transformers/model_doc/auto.html#autotokenizer.
+    Wrapper of HuggingFace AutoTokenizer https://huggingface.co/transformers/model_doc/auto.html#autotokenizer.
 
     """
 
@@ -46,15 +46,14 @@ class AutoTokenizer(TokenizerSpec):
         use_fast: Optional[bool] = False,
         trust_remote_code: Optional[bool] = False,
     ):
-
         """
         Args:
-            pretrained_model_name: corresponds to HuggingFace-AutoTokenizer's 'pretrained_model_name_or_path' input argument. 
-                For more details please refer to https://huggingface.co/transformers/_modules/transformers/tokenization_auto.html#AutoTokenizer.from_pretrained. 
+            pretrained_model_name: corresponds to HuggingFace-AutoTokenizer's 'pretrained_model_name_or_path' input argument.
+                For more details please refer to https://huggingface.co/transformers/_modules/transformers/tokenization_auto.html#AutoTokenizer.from_pretrained.
                 The list of all supported models can be found here: ALL_PRETRAINED_CONFIG_ARCHIVE_MAP
             vocab_file: path to file with vocabulary which consists
                 of characters separated by newlines.
-            mask_token: mask token 
+            mask_token: mask token
             bos_token: the beginning of sequence token
             eos_token: the end of sequence token. Usually equal to sep_token
             pad_token: token to use for padding
@@ -132,24 +131,24 @@ class AutoTokenizer(TokenizerSpec):
 
         if len(new_tokens_in_vocab) > 0:
             """
-            Special tokens that were not previously included in the tokenizer's vocabulary file will be added to 
+            Special tokens that were not previously included in the tokenizer's vocabulary file will be added to
             the vocabulary and, as a result, the model should be resized, for example:
-            
+
             # define your model
             pretrained_model_name = 'roberta-base'
             model = nemo_nlp.modules.get_lm_model(pretrained_model_name=pretrained_model_name)
-            
+
             # define pretrained tokenizer
             tokenizer_default = nemo_nlp.modules.get_tokenizer(tokenizer_name=pretrained_model_name)
-            
+
             special_tokens = {'bos_token': '<BOS>',
                               'cls_token': '<CSL>',
                               'additional_special_tokens': ['<MY_NER_TOKEN>', '<ANOTHER_TOKEN>']}
             tokenizer_default.add_special_tokens(special_tokens_dict=special_tokens)
-            
+
             # resize your model so that the embeddings for newly added tokens are updated during training/finetuning
             model.resize_token_embeddings(tokenizer_default.vocab_size)
-            
+
             See NLP_Tokenizers.ipynb for more details.
             """
             logging.warning(

--- a/nemo/collections/common/tokenizers/huggingface/auto_tokenizer.py
+++ b/nemo/collections/common/tokenizers/huggingface/auto_tokenizer.py
@@ -223,7 +223,7 @@ class AutoTokenizer(TokenizerSpec):
 
     @property
     def vocab(self):
-        id2vocab = {v: k for k, v in self.tokenizer.vocab.items()}
+        id2vocab = {v: k for k, v in self.tokenizer.get_vocab().items()}
         return [id2vocab[i] for i in range(len(id2vocab))]
 
     @property


### PR DESCRIPTION
# What does this PR do ?

This PR fixes the issue of missing vocab property for NeMo AutoTokenizer.

Currently, NeMo's AutoTokenizer obtains a list of vocabulary from `tokenizer.vocab`.
However, it can be problematic for the following reasons:

- the property is sometimes missing for certain type of HuggingFace tokenizers.
- the property is not documented in Huggingface Transformers Library.

For example, non-fast version of T5Tokenizer does not seem to have `vocab` as follows:

```
In [8]: assert getattr(AutoTokenizer.from_pretrained('google-t5/t5-base'), "vocab") # This one is OK
In [9]: assert getattr(AutoTokenizer.from_pretrained('google-t5/t5-base', use_fast=False), "vocab") # Not OK
…
---------------------------------------------------------------------------
AttributeError                            Traceback (most recent call last)
Cell In[9], line 1
----> 1 assert getattr(AutoTokenizer.from_pretrained('google-t5/t5-base', use_fast=False), "vocab")

AttributeError: 'T5Tokenizer' object has no attribute 'vocab'
```
This can be a problem for `GPTSFTChatDataset` because it assumes that a given tokenizer has a`vocab` property.

https://github.com/NVIDIA/NeMo/blob/7d3d9ac3b1aecf5786b5978a0c1e574701473c62/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_chat_dataset.py#L313

This PR renames a reference to `vocab`property to `get_vocab` method. 
I believe that this method also returns a list of vocabulary in a same manner as `vocab` property.
Thus, existing tokenizers would not be affected.

**Collection**: [Note which collection this PR will affect]

This PR may affect tokenizer component.

# Changelog 

renamed `vocab` to `get_vocab`

# Usage

n/a

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

n/a
