### PR TITLE
Speeds up copying of necessary artifact files with SaveRestoreConnector

### DIFF
--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -1135,7 +1135,9 @@ class NLPSaveRestoreConnector(SaveRestoreConnector):
                 else:
                     # Extract the nemo file into the temporary directory
                     self._unpack_nemo_file(
-                        path2file=restore_path, out_folder=tmpdir, extract_fn=return_config and (lambda name: '.yaml' in name)
+                        path2file=restore_path,
+                        out_folder=tmpdir,
+                        extract_fn=return_config and (lambda name: '.yaml' in name),
                     )
                 checkpoint = {}
                 sharded_state_dict = instance.sharded_state_dict()

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -1135,7 +1135,7 @@ class NLPSaveRestoreConnector(SaveRestoreConnector):
                 else:
                     # Extract the nemo file into the temporary directory
                     self._unpack_nemo_file(
-                        path2file=restore_path, out_folder=tmpdir, extract_config_only=return_config is True
+                        path2file=restore_path, out_folder=tmpdir, extract_fn=return_config and (lambda name: '.yaml' in name)
                     )
                 checkpoint = {}
                 sharded_state_dict = instance.sharded_state_dict()

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -475,43 +475,6 @@ class SaveRestoreConnector:
         if len(tarfile_artifacts) > 0 and len(restoration_paths) == 0:
             # TODO: see cases when this can occur, and if we can fix them
             logging.warning("Model contains registered artifacts, but no restoration paths found")
-        #from torch.distributed import breakpoint
-        #breakpoint()
-        #if len(tarfile_artifacts) > 0 and len(restoration_paths) > 0:
-        #    # Need to step into nemo archive to extract file
-        #    # Get path where the command is executed - the artifacts will be "retrieved" there
-        #    # (original .nemo behavior)
-        #    cwd = os.getcwd()
-        #    # Step into the nemo archive to try and find the file
-        #    # TemporaryDirectory context must always be outer to try-catch chdir otherwise it crashes on Windows
-        #    with tempfile.TemporaryDirectory() as archive_dir:
-        #        try:
-        #            # unpack all restorations paths (nemo checkpoints)
-        #            # in nemo checkpoints all resources contain hash in name, so there should be no collisions
-        #            for path in restoration_paths:
-        #                if self.model_extracted_dir:
-        #                    shutil.copytree(src=path, dst=archive_dir, dirs_exist_ok=True)
-        #                else:
-        #                    self._unpack_nemo_file(path2file=path, out_folder=archive_dir)
-        #            os.chdir(archive_dir)
-        #            for conf_path, artiitem in tarfile_artifacts:
-        #                # Get basename and copy it to nemo_file_folder
-        #                if 'nemo:' in artiitem.path:
-        #                    artifact_base_name = artiitem.path.split('nemo:')[1]
-        #                else:
-        #                    artifact_base_name = os.path.basename(artiitem.path)
-        #                # no need to hash here as we are in tarfile_artifacts which are already hashed
-        #                artifact_uniq_name = artifact_base_name
-        #                shutil.copy2(artifact_base_name, os.path.join(nemo_file_folder, artifact_uniq_name))
-
-        #                # Update artifacts registry
-        #                new_artiitem = model_utils.ArtifactItem()
-        #                new_artiitem.path = "nemo:" + artifact_uniq_name
-        #                new_artiitem.path_type = model_utils.ArtifactPathType.TAR_PATH
-        #                model.artifacts[conf_path] = new_artiitem
-        #        finally:
-        #            # change back working directory
-        #            os.chdir(cwd)
         if len(tarfile_artifacts) > 0 and len(restoration_paths) > 0:
             # Need to step into nemo archive to extract file
             # Get path where the command is executed - the artifacts will be "retrieved" there

--- a/nemo/core/connectors/save_restore_connector.py
+++ b/nemo/core/connectors/save_restore_connector.py
@@ -141,7 +141,9 @@ class SaveRestoreConnector:
                 else:
                     # Extract the nemo file into the temporary directory
                     self._unpack_nemo_file(
-                        path2file=restore_path, out_folder=tmpdir, extract_fn=return_config and (lambda name: '.yaml' in name)
+                        path2file=restore_path,
+                        out_folder=tmpdir,
+                        extract_fn=return_config and (lambda name: '.yaml' in name),
                     )
 
                 # Change current working directory to
@@ -493,9 +495,15 @@ class SaveRestoreConnector:
                 # in nemo checkpoints all resources contain hash in name, so there should be no collisions
                 for path in restoration_paths:
                     if self.model_extracted_dir:
-                        shutil.copy2(os.path.join(path, artifact_base_name), os.path.join(nemo_file_folder, artifact_uniq_name))
+                        shutil.copy2(
+                            os.path.join(path, artifact_base_name), os.path.join(nemo_file_folder, artifact_uniq_name)
+                        )
                     else:
-                        self._unpack_nemo_file(path2file=path, out_folder=nemo_file_folder, extract_fn=lambda name: os.path.basename(name) == artifact_base_name)
+                        self._unpack_nemo_file(
+                            path2file=path,
+                            out_folder=nemo_file_folder,
+                            extract_fn=lambda name: os.path.basename(name) == artifact_base_name,
+                        )
 
                 # Update artifacts registry
                 new_artiitem = model_utils.ArtifactItem()

--- a/tests/core/test_save_restore.py
+++ b/tests/core/test_save_restore.py
@@ -764,7 +764,9 @@ class TestSaveRestore:
             my_connector = MySaveRestoreConnector()
 
             with tempfile.TemporaryDirectory() as config_tmpdir:
-                my_connector._unpack_nemo_file(true_save_path, out_folder=config_tmpdir, extract_fn=lambda name: '.yaml' in name)
+                my_connector._unpack_nemo_file(
+                    true_save_path, out_folder=config_tmpdir, extract_fn=lambda name: '.yaml' in name
+                )
                 current_files = list(os.listdir(config_tmpdir))
 
                 assert len(current_files) == 1  # only config file should have been extracted, no pytorch params

--- a/tests/core/test_save_restore.py
+++ b/tests/core/test_save_restore.py
@@ -764,7 +764,7 @@ class TestSaveRestore:
             my_connector = MySaveRestoreConnector()
 
             with tempfile.TemporaryDirectory() as config_tmpdir:
-                my_connector._unpack_nemo_file(true_save_path, out_folder=config_tmpdir, extract_config_only=True)
+                my_connector._unpack_nemo_file(true_save_path, out_folder=config_tmpdir, extract_fn=lambda name: '.yaml' in name)
                 current_files = list(os.listdir(config_tmpdir))
 
                 assert len(current_files) == 1  # only config file should have been extracted, no pytorch params


### PR DESCRIPTION
# What does this PR do ?

Previously, the SaveRestoreConnector would copy and untar entire
checkpoints just to copy out a tokenizer. For models in the >100GB, this
led to timeouts since only rank=0 did this work, while other ranks moved
on and waited at an all-gather barrier (observed NCCL timeout at 10min).

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
