### PR TITLE
Call teardown even when something fails.

### DIFF
--- a/examples/multimodal/text_to_image/stable_diffusion/sd_train.py
+++ b/examples/multimodal/text_to_image/stable_diffusion/sd_train.py
@@ -25,6 +25,7 @@ from nemo.core.config import hydra_runner
 from nemo.utils import logging
 from nemo.utils.callbacks import CUDAGraphCallback
 from nemo.utils.exp_manager import exp_manager
+from nemo.lightning.base import teardown
 
 
 class MegatronStableDiffusionTrainerBuilder(MegatronTrainerBuilder):
@@ -107,8 +108,10 @@ def main(cfg) -> None:
         else:
             logging.info(f"Running full finetuning since no peft scheme is given.\n{model.summarize()}")
 
-    trainer.fit(model)
-
+    try:
+        trainer.fit(model)
+    finally:
+        teardown(trainer)
 
 if __name__ == '__main__':
     main()

--- a/examples/multimodal/text_to_image/stable_diffusion/sd_train.py
+++ b/examples/multimodal/text_to_image/stable_diffusion/sd_train.py
@@ -22,10 +22,10 @@ from nemo.collections.nlp.parts.megatron_trainer_builder import MegatronTrainerB
 from nemo.collections.nlp.parts.nlp_overrides import NLPDDPStrategy
 from nemo.collections.nlp.parts.peft_config import PEFT_CONFIG_MAP
 from nemo.core.config import hydra_runner
+from nemo.lightning.base import teardown
 from nemo.utils import logging
 from nemo.utils.callbacks import CUDAGraphCallback
 from nemo.utils.exp_manager import exp_manager
-from nemo.lightning.base import teardown
 
 
 class MegatronStableDiffusionTrainerBuilder(MegatronTrainerBuilder):
@@ -75,7 +75,11 @@ def main(cfg) -> None:
             n, c, h = cfg.model.micro_batch_size, cfg.model.channels, cfg.model.image_size
             x = torch.randn((n, c, h, h), dtype=torch.float32, device="cuda")
             t = torch.randint(77, (n,), device="cuda")
-            cc = torch.randn((n, 77, cfg.model.unet_config.context_dim), dtype=torch.float32, device="cuda",)
+            cc = torch.randn(
+                (n, 77, cfg.model.unet_config.context_dim),
+                dtype=torch.float32,
+                device="cuda",
+            )
             if cfg.model.precision in [16, '16']:
                 x = x.type(torch.float16)
                 cc = cc.type(torch.float16)
@@ -112,6 +116,7 @@ def main(cfg) -> None:
         trainer.fit(model)
     finally:
         teardown(trainer)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
# What does this PR do ?

Avoid tons of terminal spam such as:
```
[rank0]:[W528 18:14:19.086678488 ProcessGroupNCCL.cpp:1122] WARNING: process group has NOT been destroyed before it is being destructed. On normal program exit, the application should call destroy_process_group to ensure that any pending NCCL data transfers have finished in this process. In rare cases this process can exit before this point and block the progress of another member of the process group. This constraint has always been present,  but this warning has only been added since PyTorch 2.4
```

when an error occurs, which can obscure the real error.

**Collection**: Stable diffusion

# Changelog 
- stable diffusion: Clean up process groups after an error occurs.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- - Are any necessary for this?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] Bugfix

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.