### PR TITLE
Fix FSDP gradient calculation with orig params

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -999,8 +999,8 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
         """All-reduce gradients of FSDP-sharding-omitted parameters in sharding domain (data-parallel domain)."""
         assert isinstance(self.model, torch.nn.Module)
         grads = []
-        for param in self.model.parameters():
-            if not isinstance(param, torch.distributed.fsdp.FlatParameter) and param.requires_grad:
+        for param in self.model._ignored_params:
+            if param.requires_grad and param.grad is not None:
                 grad = param.grad
                 grads.append(grad.data)
         if len(grads) > 0:


### PR DESCRIPTION
As observed by some users in #8487, FSDP causes differences in loss. This is because gradients are not correctly calculated when `fsdp_use_orig_params=True`. Currently, any non-`FlatParameter` is treated as being unsharded, when in reality they may be sharded when `use_orig_params=True`. This leads to a double reduction of sharded gradients. We thus simply adjust the parameters that are reduced manually. This requires use of a private variable in the FSDP module. Alternatively, the value of `self.kwargs['ignored_states']` in `nlp_overrides.py` could be set as an attribute on the model to avoid this private variable access.

Thanks to @ofivite for suggesting that `use_orig_params=True` could be the cause of the issue, which greatly helped with analysis.

# What does this PR do ?

Fix FSDP gradient calculation when `fsdp_use_orig_params=True`.

**Collection**: nlp

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #8487 (issue)