### PR TITLE
Fix GreedyBatchedCTCInfer regression from GreedyCTCInfer.

### DIFF
--- a/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
@@ -394,7 +394,15 @@ class GreedyBatchedCTCInfer(Typing, ConfidenceMethodMixin):
 
         if decoder_lengths is None:
             logging.warning(_DECODER_LENGTHS_NONE_WARNING, mode=logging_mode.ONCE)
-            decoder_lengths = torch.tensor([decoder_output.shape[1]], dtype=torch.long).expand(decoder_output.shape[0])
+            decoder_lengths = torch.tensor([decoder_output.shape[1]], dtype=torch.long, device=decoder_output.device).expand(decoder_output.shape[0])
+
+        # GreedyCTCInfer::forward(), by accident, works with
+        # decoder_lengths on either CPU or GPU when decoder_output is
+        # on GPU. For the sake of backwards compatibility, we also
+        # allow decoder_lengths to be on the CPU device. In this case,
+        # we simply copy the decoder_lengths from CPU to GPU. If both
+        # tensors are already on the same device, this is a no-op.
+        decoder_lengths = decoder_lengths.to(decoder_output.device)
 
         if decoder_output.ndim == 2:
             hypotheses = self._greedy_decode_labels_batched(decoder_output, decoder_lengths)

--- a/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_greedy_decoding.py
@@ -394,7 +394,9 @@ class GreedyBatchedCTCInfer(Typing, ConfidenceMethodMixin):
 
         if decoder_lengths is None:
             logging.warning(_DECODER_LENGTHS_NONE_WARNING, mode=logging_mode.ONCE)
-            decoder_lengths = torch.tensor([decoder_output.shape[1]], dtype=torch.long, device=decoder_output.device).expand(decoder_output.shape[0])
+            decoder_lengths = torch.tensor(
+                [decoder_output.shape[1]], dtype=torch.long, device=decoder_output.device
+            ).expand(decoder_output.shape[0])
 
         # GreedyCTCInfer::forward(), by accident, works with
         # decoder_lengths on either CPU or GPU when decoder_output is

--- a/tests/collections/asr/decoding/test_ctc_decoding.py
+++ b/tests/collections/asr/decoding/test_ctc_decoding.py
@@ -200,8 +200,28 @@ class TestCTCDecoding:
     @pytest.mark.parametrize('timestamps', [False, True])
     @pytest.mark.parametrize('preserve_frame_confidence', [False, True])
     @pytest.mark.parametrize('length_is_none', [False, True])
+    @pytest.mark.parametrize(
+        "logprobs_device",
+        [
+            torch.device("cpu"),
+            pytest.param(
+                torch.device("cuda"),
+                marks=pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required for test.',),
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "length_device",
+        [
+            torch.device("cpu"),
+            pytest.param(
+                torch.device("cuda"),
+                marks=pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required for test.',),
+            ),
+        ],
+    )
     def test_batched_decoding_logprobs(
-        self, tmp_tokenizer, alignments, timestamps, preserve_frame_confidence, length_is_none
+        self, tmp_tokenizer, alignments, timestamps, preserve_frame_confidence, length_is_none, logprobs_device, length_device
     ):
         cfg = CTCBPEDecodingConfig(
             strategy='greedy',
@@ -217,7 +237,7 @@ class TestCTCDecoding:
         torch.manual_seed(1)
         B, T = 4, 20
         V = unbatched_decoding.tokenizer.tokenizer.vocab_size + 1
-        input_signal = torch.randn(size=(B, T, V))
+        input_signal = torch.randn(size=(B, T, V), device=logprobs_device)
         # Set the blank index to a very high probability to make sure
         # that we always handle at least a few blanks.
         input_signal[:, 0, unbatched_decoding.tokenizer.tokenizer.vocab_size] = 1000
@@ -225,7 +245,7 @@ class TestCTCDecoding:
         if length_is_none:
             length = None
         else:
-            length = torch.randint(low=1, high=T, size=[B])
+            length = torch.randint(low=1, high=T, size=[B], device=length_device)
 
         with torch.inference_mode():
             hyps, _ = unbatched_decoding.ctc_decoder_predictions_tensor(
@@ -249,7 +269,27 @@ class TestCTCDecoding:
     @pytest.mark.unit
     @pytest.mark.parametrize('timestamps', [False, True])
     @pytest.mark.parametrize('length_is_none', [False, True])
-    def test_batched_decoding_labels(self, tmp_tokenizer, timestamps, length_is_none):
+    @pytest.mark.parametrize(
+        "labels_device",
+        [
+            torch.device("cpu"),
+            pytest.param(
+                torch.device("cuda"),
+                marks=pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required for test.',),
+            ),
+        ],
+    )
+    @pytest.mark.parametrize(
+        "length_device",
+        [
+            torch.device("cpu"),
+            pytest.param(
+                torch.device("cuda"),
+                marks=pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required for test.',),
+            ),
+        ],
+    )
+    def test_batched_decoding_labels(self, tmp_tokenizer, timestamps, length_is_none, labels_device, length_device):
         cfg = CTCBPEDecodingConfig(strategy='greedy', compute_timestamps=timestamps)
         unbatched_decoding = CTCBPEDecoding(decoding_cfg=cfg, tokenizer=tmp_tokenizer)
         cfg.strategy = 'greedy_batched'
@@ -258,7 +298,7 @@ class TestCTCDecoding:
         torch.manual_seed(1)
         B, T = 4, 20
         V = unbatched_decoding.tokenizer.tokenizer.vocab_size + 1
-        input_labels = torch.randint(V, size=(B, T))
+        input_labels = torch.randint(V, size=(B, T), device=labels_device)
         # Set some indices to blank to make sure that we always handle
         # at least a few blanks.
         input_labels[:, 0] = unbatched_decoding.tokenizer.tokenizer.vocab_size
@@ -266,7 +306,7 @@ class TestCTCDecoding:
         if length_is_none:
             length = None
         else:
-            length = torch.randint(low=1, high=T, size=[B])
+            length = torch.randint(low=1, high=T, size=[B], device=length_device)
 
         with torch.inference_mode():
             hyps, _ = unbatched_decoding.ctc_decoder_predictions_tensor(

--- a/tests/collections/asr/decoding/test_ctc_decoding.py
+++ b/tests/collections/asr/decoding/test_ctc_decoding.py
@@ -206,7 +206,10 @@ class TestCTCDecoding:
             torch.device("cpu"),
             pytest.param(
                 torch.device("cuda"),
-                marks=pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required for test.',),
+                marks=pytest.mark.skipif(
+                    not torch.cuda.is_available(),
+                    reason='CUDA required for test.',
+                ),
             ),
         ],
     )
@@ -216,12 +219,22 @@ class TestCTCDecoding:
             torch.device("cpu"),
             pytest.param(
                 torch.device("cuda"),
-                marks=pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required for test.',),
+                marks=pytest.mark.skipif(
+                    not torch.cuda.is_available(),
+                    reason='CUDA required for test.',
+                ),
             ),
         ],
     )
     def test_batched_decoding_logprobs(
-        self, tmp_tokenizer, alignments, timestamps, preserve_frame_confidence, length_is_none, logprobs_device, length_device
+        self,
+        tmp_tokenizer,
+        alignments,
+        timestamps,
+        preserve_frame_confidence,
+        length_is_none,
+        logprobs_device,
+        length_device,
     ):
         cfg = CTCBPEDecodingConfig(
             strategy='greedy',
@@ -275,7 +288,10 @@ class TestCTCDecoding:
             torch.device("cpu"),
             pytest.param(
                 torch.device("cuda"),
-                marks=pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required for test.',),
+                marks=pytest.mark.skipif(
+                    not torch.cuda.is_available(),
+                    reason='CUDA required for test.',
+                ),
             ),
         ],
     )
@@ -285,7 +301,10 @@ class TestCTCDecoding:
             torch.device("cpu"),
             pytest.param(
                 torch.device("cuda"),
-                marks=pytest.mark.skipif(not torch.cuda.is_available(), reason='CUDA required for test.',),
+                marks=pytest.mark.skipif(
+                    not torch.cuda.is_available(),
+                    reason='CUDA required for test.',
+                ),
             ),
         ],
     )


### PR DESCRIPTION
# What does this PR do ?

decoder_lengths is allowed to be on CPU even when decoder_output is on GPU. This matches the behavior of GreedyCTCInfer. Even though that behavior is unintentional, there is code depending on that behavior, including our jupyter notebooks.

# Testing

I tested in the following way. I ran:

```
pytest -k test_batched_decoding_ tests/collections/asr/decoding/test_ctc_decoding.py
CUDA_VISIBLE_DEVICES="" pytest -k test_batched_decoding_ tests/collections/asr/decoding/test_ctc_decoding.py
```

CUDA_VISIBLE_DEVICES="" ensures that the test runs when on CPU-only machines, as well as on machines with GPU. My previous PR related to this failed to test on GPU, which caused the crash we see today when we run with lengths on CPU but logprobs on GPU.

I also manually ran examples/notebooks/asr/ASR_with_Subword_Tokenization.ipynb and examples/notebooks/asr/ASR_with_NeMo.ipynb manually. These run to completion. I had to comment out the part that install NeMo from pypi, which would overwrite my local installation.

**Collection**: ASR

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to NVBug 4647443 and 4647231
