### PR TITLE
Add MPU rank specifiers for EP & DDP

### DIFF
--- a/examples/nlp/language_modeling/megatron_export.py
+++ b/examples/nlp/language_modeling/megatron_export.py
@@ -115,8 +115,10 @@ def nemo_export(cfg):
                 app_state.tensor_model_parallel_size = cfg.tensor_model_parallel_size
                 app_state.pipeline_model_parallel_size = cfg.pipeline_model_parallel_size
                 (
+                    app_state.data_parallel_rank,
                     app_state.tensor_model_parallel_rank,
                     app_state.pipeline_model_parallel_rank,
+                    app_state.expert_model_parallel_rank,
                     app_state.model_parallel_size,
                     app_state.data_parallel_size,
                     app_state.pipeline_model_parallel_split_rank,

--- a/examples/nlp/language_modeling/megatron_gpt_continue_training.py
+++ b/examples/nlp/language_modeling/megatron_gpt_continue_training.py
@@ -117,7 +117,11 @@ def load_from_checkpoint_dir(cls, cfg, trainer, modify_confg_fn):
     gpt_cfg = modify_confg_fn(hparams_file.cfg, cfg, add_cfg_to_tree=True)
     with tempfile.NamedTemporaryFile(suffix='.yaml') as f:
         OmegaConf.save(config=gpt_cfg, f=f.name)
-        model = cls.load_from_checkpoint(checkpoint_path=checkpoint_path, trainer=trainer, hparams_file=f.name,)
+        model = cls.load_from_checkpoint(
+            checkpoint_path=checkpoint_path,
+            trainer=trainer,
+            hparams_file=f.name,
+        )
         return model
 
 
@@ -147,7 +151,7 @@ def main(cfg) -> None:
         scaler = None
         if cfg.trainer.precision in [16, '16', '16-mixed']:
             scaler = GradScaler(
-                init_scale=cfg.model.get('native_amp_init_scale', 2 ** 32),
+                init_scale=cfg.model.get('native_amp_init_scale', 2**32),
                 growth_interval=cfg.model.get('native_amp_growth_interval', 1000),
                 hysteresis=cfg.model.get('hysteresis', 2),
             )

--- a/examples/nlp/language_modeling/megatron_gpt_continue_training.py
+++ b/examples/nlp/language_modeling/megatron_gpt_continue_training.py
@@ -95,8 +95,10 @@ def load_from_checkpoint_dir(cls, cfg, trainer, modify_confg_fn):
         app_state.tensor_model_parallel_size = cfg.model.tensor_model_parallel_size
         app_state.pipeline_model_parallel_size = cfg.model.pipeline_model_parallel_size
         (
+            app_state.data_parallel_rank,
             app_state.tensor_model_parallel_rank,
             app_state.pipeline_model_parallel_rank,
+            app_state.expert_model_parallel_rank,
             app_state.model_parallel_size,
             app_state.data_parallel_size,
             app_state.pipeline_model_parallel_split_rank,

--- a/examples/nlp/language_modeling/megatron_gpt_eval.py
+++ b/examples/nlp/language_modeling/megatron_gpt_eval.py
@@ -262,6 +262,7 @@ def main(cfg) -> None:
             app_state.pipeline_model_parallel_size = cfg.pipeline_model_parallel_size
             app_state.expert_model_parallel_size = cfg.get('expert_model_parallel_size', 1)
             (
+                app_state.data_parallel_rank,
                 app_state.tensor_model_parallel_rank,
                 app_state.pipeline_model_parallel_rank,
                 app_state.expert_model_parallel_rank,

--- a/examples/nlp/language_modeling/megatron_gpt_validate.py
+++ b/examples/nlp/language_modeling/megatron_gpt_validate.py
@@ -142,7 +142,9 @@ def main(cfg) -> None:
         with tempfile.NamedTemporaryFile(suffix='.yaml') as f:
             OmegaConf.save(config=pretrained_cfg, f=f.name)
             model = MegatronGPTModel.load_from_checkpoint(
-                checkpoint_path=checkpoint_path, trainer=trainer, hparams_file=f.name,
+                checkpoint_path=checkpoint_path,
+                trainer=trainer,
+                hparams_file=f.name,
             )
     else:
         raise ValueError("need at least a nemo file or checkpoint dir")

--- a/examples/nlp/language_modeling/megatron_gpt_validate.py
+++ b/examples/nlp/language_modeling/megatron_gpt_validate.py
@@ -121,8 +121,10 @@ def main(cfg) -> None:
             app_state.pipeline_model_parallel_size = cfg.pipeline_model_parallel_size
             app_state.virtual_pipeline_model_parallel_size = cfg.virtual_pipeline_model_parallel_size
             (
+                app_state.data_parallel_rank,
                 app_state.tensor_model_parallel_rank,
                 app_state.pipeline_model_parallel_rank,
+                app_state.expert_model_parallel_rank,
                 app_state.model_parallel_size,
                 app_state.data_parallel_size,
                 app_state.pipeline_model_parallel_split_rank,

--- a/examples/nlp/language_modeling/megatron_retro_eval.py
+++ b/examples/nlp/language_modeling/megatron_retro_eval.py
@@ -60,7 +60,9 @@ class RequestDataSet(Dataset):
         self.sentences = sentences
         self.neighbors = neighbors
 
-    def __len__(self,):
+    def __len__(
+        self,
+    ):
         return len(self.sentences)
 
     def __getitem__(self, idx):

--- a/examples/nlp/language_modeling/megatron_retro_eval.py
+++ b/examples/nlp/language_modeling/megatron_retro_eval.py
@@ -84,8 +84,10 @@ def main(cfg) -> None:
             app_state.tensor_model_parallel_size = cfg.tensor_model_parallel_size
             app_state.pipeline_model_parallel_size = cfg.pipeline_model_parallel_size
             (
+                app_state.data_parallel_rank,
                 app_state.tensor_model_parallel_rank,
                 app_state.pipeline_model_parallel_rank,
+                app_state.expert_model_parallel_rank,
                 app_state.model_parallel_size,
                 app_state.data_parallel_size,
                 app_state.pipeline_model_parallel_split_rank,

--- a/examples/nlp/language_modeling/megatron_retro_qatask_eval.py
+++ b/examples/nlp/language_modeling/megatron_retro_qatask_eval.py
@@ -63,7 +63,9 @@ class RequestDataSet(Dataset):
         self.sentences = sentences
         self.neighbors = neighbors
 
-    def __len__(self,):
+    def __len__(
+        self,
+    ):
         return len(self.sentences)
 
     def __getitem__(self, idx):

--- a/examples/nlp/language_modeling/megatron_retro_qatask_eval.py
+++ b/examples/nlp/language_modeling/megatron_retro_qatask_eval.py
@@ -116,8 +116,10 @@ def main(cfg) -> None:
             app_state.tensor_model_parallel_size = cfg.tensor_model_parallel_size
             app_state.pipeline_model_parallel_size = cfg.pipeline_model_parallel_size
             (
+                app_state.data_parallel_rank,
                 app_state.tensor_model_parallel_rank,
                 app_state.pipeline_model_parallel_rank,
+                app_state.expert_model_parallel_rank,
                 app_state.model_parallel_size,
                 app_state.data_parallel_size,
                 app_state.pipeline_model_parallel_split_rank,

--- a/examples/nlp/language_modeling/megatron_t5_eval.py
+++ b/examples/nlp/language_modeling/megatron_t5_eval.py
@@ -40,13 +40,22 @@ def main():
         "--tokens_to_generate", type=int, default="16", required=False, help="How many tokens to add to prompt"
     )
     parser.add_argument(
-        "--tensor_model_parallel_size", type=int, default=-1, required=False,
+        "--tensor_model_parallel_size",
+        type=int,
+        default=-1,
+        required=False,
     )
     parser.add_argument(
-        "--pipeline_model_parallel_size", type=int, default=-1, required=False,
+        "--pipeline_model_parallel_size",
+        type=int,
+        default=-1,
+        required=False,
     )
     parser.add_argument(
-        "--pipeline_model_parallel_split_rank", type=int, default=-1, required=False,
+        "--pipeline_model_parallel_split_rank",
+        type=int,
+        default=-1,
+        required=False,
     )
     parser.add_argument("--precision", default="16", type=str, help="PyTorch Lightning Trainer precision flag")
     parser.add_argument("--decoder_starts_with_pad", action="store_true", help="Decoder starts with pad token")

--- a/examples/nlp/language_modeling/megatron_t5_eval.py
+++ b/examples/nlp/language_modeling/megatron_t5_eval.py
@@ -89,8 +89,10 @@ def main():
     if args.tensor_model_parallel_size > 1 or args.pipeline_model_parallel_size > 1:
         app_state.model_parallel_size = args.tensor_model_parallel_size * args.pipeline_model_parallel_size
         (
+            app_state.data_parallel_rank,
             app_state.tensor_model_parallel_rank,
             app_state.pipeline_model_parallel_rank,
+            app_state.expert_model_parallel_rank,
             app_state.model_parallel_size,
             app_state.data_parallel_size,
             app_state.pipeline_model_parallel_split_rank,

--- a/examples/nlp/language_modeling/megatron_t5_seq2seq_finetune.py
+++ b/examples/nlp/language_modeling/megatron_t5_seq2seq_finetune.py
@@ -135,7 +135,11 @@ def load_from_checkpoint_dir(cls, cfg, trainer, modify_confg_fn):
     t5_cfg = modify_confg_fn(hparams_file.cfg, cfg, add_cfg_to_tree=True)
     with tempfile.NamedTemporaryFile(suffix='.yaml') as f:
         OmegaConf.save(config=t5_cfg, f=f.name)
-        model = cls.load_from_checkpoint(checkpoint_path=checkpoint_path, trainer=trainer, hparams_file=f.name,)
+        model = cls.load_from_checkpoint(
+            checkpoint_path=checkpoint_path,
+            trainer=trainer,
+            hparams_file=f.name,
+        )
         return model
 
 
@@ -164,7 +168,7 @@ def main(cfg) -> None:
         scaler = None
         if cfg.trainer.precision in [16, '16', '16-mixed']:
             scaler = GradScaler(
-                init_scale=cfg.model.get('native_amp_init_scale', 2 ** 32),
+                init_scale=cfg.model.get('native_amp_init_scale', 2**32),
                 growth_interval=cfg.model.get('native_amp_growth_interval', 1000),
                 hysteresis=cfg.model.get('hysteresis', 2),
             )

--- a/examples/nlp/language_modeling/megatron_t5_seq2seq_finetune.py
+++ b/examples/nlp/language_modeling/megatron_t5_seq2seq_finetune.py
@@ -113,8 +113,10 @@ def load_from_checkpoint_dir(cls, cfg, trainer, modify_confg_fn):
         app_state.tensor_model_parallel_size = cfg.model.tensor_model_parallel_size
         app_state.pipeline_model_parallel_size = cfg.model.pipeline_model_parallel_size
         (
+            app_state.data_parallel_rank,
             app_state.tensor_model_parallel_rank,
             app_state.pipeline_model_parallel_rank,
+            app_state.expert_model_parallel_rank,
             app_state.model_parallel_size,
             app_state.data_parallel_size,
             app_state.pipeline_model_parallel_split_rank,

--- a/examples/nlp/machine_translation/nmt_transformer_infer_megatron.py
+++ b/examples/nlp/machine_translation/nmt_transformer_infer_megatron.py
@@ -103,13 +103,19 @@ def main(cfg) -> None:
             src_text.append(line.strip())
             if len(src_text) == cfg.batch_size:
                 translations = model.translate(
-                    text=src_text, source_lang=cfg.source_lang, target_lang=cfg.target_lang,
+                    text=src_text,
+                    source_lang=cfg.source_lang,
+                    target_lang=cfg.target_lang,
                 )
                 for translation in translations:
                     tgt_f.write(translation + "\n")
                 src_text = []
         if len(src_text) > 0:
-            translations = model.translate(text=src_text, source_lang=cfg.source_lang, target_lang=cfg.target_lang,)
+            translations = model.translate(
+                text=src_text,
+                source_lang=cfg.source_lang,
+                target_lang=cfg.target_lang,
+            )
             for translation in translations:
                 tgt_f.write(translation + "\n")
 

--- a/examples/nlp/machine_translation/nmt_transformer_infer_megatron.py
+++ b/examples/nlp/machine_translation/nmt_transformer_infer_megatron.py
@@ -58,8 +58,10 @@ def main(cfg) -> None:
     app_state = AppState()
     app_state.model_parallel_size = cfg.tensor_model_parallel_size * cfg.pipeline_model_parallel_size
     (
+        app_state.data_parallel_rank,
         app_state.tensor_model_parallel_rank,
         app_state.pipeline_model_parallel_rank,
+        app_state.expert_model_parallel_rank,
         app_state.model_parallel_size,
         app_state.data_parallel_size,
         app_state.pipeline_model_parallel_split_rank,

--- a/nemo/collections/multimodal/parts/utils.py
+++ b/nemo/collections/multimodal/parts/utils.py
@@ -394,6 +394,7 @@ def create_neva_model_and_processor(cfg):
             app_state.tensor_model_parallel_size = cfg.tensor_model_parallel_size
             app_state.pipeline_model_parallel_size = cfg.pipeline_model_parallel_size
             (
+                _,
                 app_state.tensor_model_parallel_rank,
                 app_state.pipeline_model_parallel_rank,
                 app_state.expert_model_parallel_rank,

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -532,8 +532,6 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                     config,
                     ddp_config,
                     model_chunk,
-                    data_parallel_group=parallel_state.get_data_parallel_group(with_context_parallel=True),
-                    expert_data_parallel_group=parallel_state.get_data_modulo_expert_parallel_group(),
                     # Turn off bucketing for model_chunk 2 onwards, since communication for these
                     # model chunks is overlapped with compute anyway.
                     disable_bucketing=(model_chunk_idx > 0),

--- a/nemo/collections/nlp/modules/common/megatron/megatron_init.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_init.py
@@ -34,6 +34,8 @@ try:
     from megatron.core.parallel_state import (
         RankGenerator,
         get_pipeline_model_parallel_rank,
+        set_data_parallel_rank,
+        set_data_parallel_world_size,
         set_expert_model_parallel_rank,
         set_expert_model_parallel_world_size,
         set_pipeline_model_parallel_rank,
@@ -41,8 +43,6 @@ try:
         set_pipeline_model_parallel_world_size,
         set_tensor_model_parallel_rank,
         set_tensor_model_parallel_world_size,
-        set_data_parallel_world_size,
-        set_data_parallel_rank,
         set_virtual_pipeline_model_parallel_rank,
     )
 

--- a/nemo/collections/nlp/modules/common/megatron/megatron_init.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_init.py
@@ -41,6 +41,8 @@ try:
         set_pipeline_model_parallel_world_size,
         set_tensor_model_parallel_rank,
         set_tensor_model_parallel_world_size,
+        set_data_parallel_world_size,
+        set_data_parallel_rank,
         set_virtual_pipeline_model_parallel_rank,
     )
 
@@ -96,6 +98,7 @@ def initialize_model_parallel_for_nemo(
     app_state.use_fp8 = use_fp8
     app_state.init_mpi_proc_group = init_mpi_proc_group
     (
+        app_state.data_parallel_rank,
         app_state.tensor_model_parallel_rank,
         app_state.pipeline_model_parallel_rank,
         app_state.expert_model_parallel_rank,
@@ -121,6 +124,9 @@ def initialize_model_parallel_for_nemo(
 
     set_expert_model_parallel_world_size(app_state.expert_model_parallel_size)
     set_expert_model_parallel_rank(app_state.expert_model_parallel_rank)
+
+    set_data_parallel_world_size(app_state.data_parallel_size)
+    set_data_parallel_rank(app_state.data_parallel_rank)
 
     set_pipeline_model_parallel_rank(app_state.pipeline_model_parallel_rank)
     if HAVE_INTERLEAVED:
@@ -354,6 +360,7 @@ def fake_initialize_model_parallel(
     logging.info(f'Rank {rank} has embedding rank: {embedding_rank}')
 
     return (
+        data_parallel_rank,
         tensor_model_parallel_rank,
         pipeline_model_parallel_rank,
         expert_model_parallel_rank,

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -31,6 +31,8 @@ from nemo.utils import logging
 try:
     from nemo.collections.nlp.modules.common.megatron.megatron_utils import get_megatron_tokenizer
 
+    from nemo.collections.nlp.modules.common.megatron.megatron_utils import get_megatron_tokenizer
+
     HAVE_MEGATRON_CORE = True
 
 except (ImportError, ModuleNotFoundError):
@@ -91,7 +93,7 @@ def get_tokenizer(
         use_fast: (only for HuggingFace AutoTokenizer) set to True to use fast HuggingFace tokenizer
         bpe_dropout: (experimental) BPE dropout tries to corrupt the standard segmentation
             procedure of BPE to help
-            model better learn word compositionality and become robust to segmentation errors. 
+            model better learn word compositionality and become robust to segmentation errors.
             It has emperically been shown to improve inference time BLEU scores.
     """
     if special_tokens is None:

--- a/nemo/collections/nlp/modules/common/tokenizer_utils.py
+++ b/nemo/collections/nlp/modules/common/tokenizer_utils.py
@@ -31,8 +31,6 @@ from nemo.utils import logging
 try:
     from nemo.collections.nlp.modules.common.megatron.megatron_utils import get_megatron_tokenizer
 
-    from nemo.collections.nlp.modules.common.megatron.megatron_utils import get_megatron_tokenizer
-
     HAVE_MEGATRON_CORE = True
 
 except (ImportError, ModuleNotFoundError):

--- a/scripts/nlp_language_modeling/convert_prompt_learning_ckpt_to_nemo.py
+++ b/scripts/nlp_language_modeling/convert_prompt_learning_ckpt_to_nemo.py
@@ -72,8 +72,10 @@ def main(cfg) -> None:
         if cfg.tensor_model_parallel_size > 1 or cfg.pipeline_model_parallel_size > 1:
             app_state.model_parallel_size = cfg.tensor_model_parallel_size * cfg.pipeline_model_parallel_size
             (
+                app_state.data_parallel_rank,
                 app_state.tensor_model_parallel_rank,
                 app_state.pipeline_model_parallel_rank,
+                app_state.expert_model_parallel_rank,
                 app_state.model_parallel_size,
                 app_state.data_parallel_size,
                 app_state.pipeline_model_parallel_split_rank,

--- a/scripts/nlp_language_modeling/merge_lora_weights/merge.py
+++ b/scripts/nlp_language_modeling/merge_lora_weights/merge.py
@@ -62,7 +62,9 @@ class RequestDataSet(Dataset):
         super().__init__()
         self.sentences = sentences
 
-    def __len__(self,):
+    def __len__(
+        self,
+    ):
         return len(self.sentences)
 
     def __getitem__(self, idx):
@@ -131,9 +133,12 @@ def fix_for_O2(state_dict):
 
 
 def merge(
-    base_model_state_dict: Dict[str, Any], lora_state_dicts: List[Dict], num_layers: int, mcore: bool,
+    base_model_state_dict: Dict[str, Any],
+    lora_state_dicts: List[Dict],
+    num_layers: int,
+    mcore: bool,
 ):
-    """ 
+    """
     Iterate through all the feedforward weights in all the layers.
     Collect the corresponding lora weights for each layer and across tp ranks.
     Computes the "full rank" weight from the two low-rank weights and add it to the feedforward weight.
@@ -213,7 +218,9 @@ def main(cfg) -> None:
 
     if cfg.tensor_model_parallel_size < 0 or cfg.pipeline_model_parallel_size < 0:
         model_config = MegatronGPTModel.restore_from(
-            restore_path=cfg.gpt_model_file, trainer=trainer, return_config=True,
+            restore_path=cfg.gpt_model_file,
+            trainer=trainer,
+            return_config=True,
         )
 
         with open_dict(cfg):

--- a/scripts/nlp_language_modeling/merge_lora_weights/merge.py
+++ b/scripts/nlp_language_modeling/merge_lora_weights/merge.py
@@ -252,10 +252,13 @@ def main(cfg) -> None:
             app_state.tensor_model_parallel_size = cfg.tensor_model_parallel_size
             app_state.pipeline_model_parallel_size = cfg.pipeline_model_parallel_size
             (
+                app_state.data_parallel_rank,
                 app_state.tensor_model_parallel_rank,
                 app_state.pipeline_model_parallel_rank,
+                app_state.expert_model_parallel_rank,
                 app_state.model_parallel_size,
                 app_state.data_parallel_size,
+                app_state.pipeline_model_parallel_split_rank,
                 app_state.virtual_pipeline_model_parallel_rank,
             ) = fake_initialize_model_parallel(
                 world_size=app_state.model_parallel_size,

--- a/tests/collections/nlp/test_initialize.py
+++ b/tests/collections/nlp/test_initialize.py
@@ -117,6 +117,7 @@ def test_fake_initialize(nodes, num_gpu, tp, pp, cp, ep):
     ) = old_fake_initialize_model_parallel(nodes * num_gpu, 0, tp, pp, None, None, ep, cp)
 
     (
+        _,
         m_tensor_model_parallel_rank,
         n_pipeline_model_parallel_rank,
         n_expert_model_parallel_rank,


### PR DESCRIPTION
# What does this PR do ?
I introduced in mcore a config logger, which when enabled dumps to disk configuration options at entry points of mcore. The logger uses the rank as part of the logs filepath & as a result we need a way to specify these when the distributed environment has not yet been setup.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
