### PR TITLE
Fix null/None truncation field with extra generating tokens

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
@@ -364,6 +364,16 @@ class GPTSFTDataset(Dataset):
 
         context_ids = [i for ids in template_ids[:-1] for i in ids]
         label_ids = template_ids[-1]
+        
+        # Leave space for generating tokens.
+        if len(context_ids) + max(len(label_ids), self.tokens_to_generate) > self.max_seq_length:
+            if self.truncation_method == 'left':
+                context_ids = context_ids[-(self.max_seq_length - max(len(label_ids), self.tokens_to_generate)):]
+            elif self.truncation_method == 'right':
+                context_ids = context_ids[:self.max_seq_length - max(len(label_ids), self.tokens_to_generate)]
+            else:
+                raise ValueError(f'{self.truncation_method} is not supported')
+        
         return context_ids, label_ids
 
     def _process_example(self, example):


### PR DESCRIPTION
# What does this PR do ?

When truncation field is None, we will truncate our inputs from right or left. But we need to leave spaces for generating tokens. 

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
