### PR TITLE
[NeMo-UX] Removing default_path from ModelConnector

### DIFF
--- a/nemo/collections/llm/gpt/model/mistral_7b.py
+++ b/nemo/collections/llm/gpt/model/mistral_7b.py
@@ -42,7 +42,7 @@ class Mistral7BModel(GPTModel):
         super().__init__(config or Mistral7BConfig(), _tokenizer)
 
 
-@io.model_importer(Mistral7BModel, "hf", default_path="mistralai/Mistral-7B-v0.1")
+@io.model_importer(Mistral7BModel, "hf")
 class HFMistral7BImporter(io.ModelConnector["MistralForCausalLM", Mistral7BModel]):
     def init(self) -> Mistral7BModel:
         return Mistral7BModel(self.config, tokenizer=self.tokenizer)

--- a/nemo/lightning/io/api.py
+++ b/nemo/lightning/io/api.py
@@ -64,9 +64,7 @@ def load_ckpt(path: Path) -> TrainerCheckpoint:
     return load(path, output_type=TrainerCheckpoint)
 
 
-def model_importer(
-    target: Type[ConnectorMixin], ext: str
-) -> Callable[[Type[ConnT]], Type[ConnT]]:
+def model_importer(target: Type[ConnectorMixin], ext: str) -> Callable[[Type[ConnT]], Type[ConnT]]:
     """
     Registers an importer for a model with a specified file extension and an optional default path.
 
@@ -88,9 +86,7 @@ def model_importer(
     return target.register_importer(ext)
 
 
-def model_exporter(
-    target: Type[ConnectorMixin], ext: str
-) -> Callable[[Type[ConnT]], Type[ConnT]]:
+def model_exporter(target: Type[ConnectorMixin], ext: str) -> Callable[[Type[ConnT]], Type[ConnT]]:
     """
     Registers an exporter for a model with a specified file extension and an optional default path.
 

--- a/nemo/lightning/io/api.py
+++ b/nemo/lightning/io/api.py
@@ -65,7 +65,7 @@ def load_ckpt(path: Path) -> TrainerCheckpoint:
 
 
 def model_importer(
-    target: Type[ConnectorMixin], ext: str, default_path: Optional[str] = None
+    target: Type[ConnectorMixin], ext: str
 ) -> Callable[[Type[ConnT]], Type[ConnT]]:
     """
     Registers an importer for a model with a specified file extension and an optional default path.
@@ -81,15 +81,15 @@ def model_importer(
         to the model class.
 
     Example:
-        @model_importer(MyModel, "hf", default_path="path/to/default")
+        @model_importer(MyModel, "hf")
         class MyModelHfImporter(io.ModelConnector):
             ...
     """
-    return target.register_importer(ext, default_path=default_path)
+    return target.register_importer(ext)
 
 
 def model_exporter(
-    target: Type[ConnectorMixin], ext: str, default_path: Optional[str] = None
+    target: Type[ConnectorMixin], ext: str
 ) -> Callable[[Type[ConnT]], Type[ConnT]]:
     """
     Registers an exporter for a model with a specified file extension and an optional default path.
@@ -105,11 +105,11 @@ def model_exporter(
         to the model class.
 
     Example:
-        @model_exporter(MyModel, "hf", default_path="path/to/default")
+        @model_exporter(MyModel, "hf")
         class MyModelHFExporter(io.ModelConnector):
             ...
     """
-    return target.register_exporter(ext, default_path=default_path)
+    return target.register_exporter(ext)
 
 
 def import_ckpt(
@@ -161,7 +161,7 @@ def import_ckpt(
 
     Example:
         model = Mistral7BModel()
-        imported_path = import_ckpt(model, "hf")
+        imported_path = import_ckpt(model, "hf://mistralai/Mistral-7B-v0.1")
     """
     if not isinstance(model, ConnectorMixin):
         raise ValueError("Model must be an instance of ConnectorMixin")


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
