### PR TITLE
Enable specifying alpha for PTQ INT8 SmoothQuant method

### DIFF
--- a/examples/nlp/language_modeling/conf/megatron_quantization.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_quantization.yaml
@@ -26,6 +26,7 @@ quantization:
   calib_dataset: cnn_dailymail # wikitext, cnn_dailymail, or a local dataset
   num_calib_size: 512 # number of samples used for calibration
   awq_block_size: 128 # block size for scaling factors in AWQ algorithm
+  alpha: 1.0 # alpha parameter in SmoothQuant algorithm
 
 export:
   decoder_type: llama # gptnext, gpt2, llama

--- a/nemo/export/quantize/quantizer.py
+++ b/nemo/export/quantize/quantizer.py
@@ -116,6 +116,9 @@ class Quantizer:
                 "axis": None,
                 "enable": enable_quant_kv_cache,
             }
+            if quantization_config.algorithm == "int8_sq":
+                logging.info(f"Using int8_sq alpha = {quantization_config.alpha}")
+                quant_cfg["algorithm"] = {"method": "smoothquant", "alpha": quantization_config.alpha}
 
             self.quant_cfg = quant_cfg
         else:


### PR DESCRIPTION
# What does this PR do ?

Allow users to specifying **alpha** for INT8 SmoothQuant method. For example, setting it to 0.8 improves Llama3 (8b, 70b) MMLU accuracy results compared to default alpha=1.0.

```
| MODEL      |   ALPHA |   MMLU |
|------------|---------|--------|
| LLAMA3-70B |    0    |  0.004 |
| LLAMA3-70B |    0.25 |  0.116 |
| LLAMA3-70B |    0.5  |  0.516 |
| LLAMA3-70B |    0.7  |  0.765 |
| LLAMA3-70B |    0.75 |  0.77  |
| LLAMA3-70B |    0.8  |  0.772 |
| LLAMA3-70B |    0.85 |  0.766 |
| LLAMA3-70B |    0.9  |  0.75  |
| LLAMA3-70B |    1    |  0.728 |
| LLAMA3-8B  |    0    |  0.062 |
| LLAMA3-8B  |    0.25 |  0.227 |
| LLAMA3-8B  |    0.5  |  0.379 |
| LLAMA3-8B  |    0.7  |  0.617 |
| LLAMA3-8B  |    0.75 |  0.624 |
| LLAMA3-8B  |    0.8  |  0.625 |
| LLAMA3-8B  |    0.85 |  0.62  |
| LLAMA3-8B  |    0.9  |  0.619 |
| LLAMA3-8B  |    0.95 |  0.612 |
| LLAMA3-8B  |    1    |  0.594 |
```
**Collection**: NLP

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
python megatron_quantization.py \
    ...   
    quantization.algorithm=int8_sq \
    quantization.alpha=0.5 \
    ....
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
