### PR TITLE
Bugfix missing variables and argument changes to MegatronPretrainingRandomSampler

### DIFF
--- a/nemo/lightning/data.py
+++ b/nemo/lightning/data.py
@@ -103,7 +103,6 @@ def add_megatron_sampler(
         )
     elif dataloader_type == 'cyclic':
         batch_sampler = MegatronPretrainingRandomSampler(
-            dataloader.dataset,
             total_samples=len(dataloader.dataset),
             consumed_samples=consumed_samples,
             micro_batch_size=micro_batch_size,
@@ -259,8 +258,9 @@ class MegatronPretrainingRandomSampler(BaseMegatronSampler):
         assert current_epoch_samples % self.micro_batch_times_data_parallel_size == 0
 
         # data sharding and random sampling
+        data_parallel_size = self.micro_batch_times_data_parallel_size // self.micro_batch_size
         bucket_size = (self.total_samples // self.micro_batch_times_data_parallel_size) * self.micro_batch_size
-        bucket_offset = current_epoch_samples // self.data_parallel_size
+        bucket_offset = current_epoch_samples // data_parallel_size
         start_idx = self.data_parallel_rank * bucket_size
 
         g = torch.Generator()


### PR DESCRIPTION
# What does this PR do ?

Argument changes and non-existent variables are referenced inside of the `MegatronPretrainingRandomSampler` are addressed.

**Collection**: lightning

# Changelog 
- Remove the `dataset` input that was erroneously being passed to `MegatronPretrainingRandomSampler` init.
- Since `self.data_parallel_size` doesn't actually exist inside of `MegatronPretrainingRandomSampler`, infer it from other variables that do exist.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

