### PR TITLE
bionemo: bn2/add pipelineparallel dtype

### DIFF
--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -69,7 +69,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         ckpt_include_optimizer: bool = False,
         ddp: Union[DDPLiteral, DistributedDataParallelConfig] = "megatron",
         lazy_init: bool = False,
-        pipeline_dtype: Optional[torch.dtype]: None
+        pipeline_dtype: Optional[torch.dtype] = None,
         **kwargs,
     ) -> None:
         super().__init__(

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -508,7 +508,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
             tensor_model_parallel_size=self.tensor_model_parallel_size,
             pipeline_model_parallel_size=self.pipeline_model_parallel_size,
             virtual_pipeline_model_parallel_size=self.virtual_pipeline_model_parallel_size,
-            pipeline_dtype=self.pipeline_dtype
+            pipeline_dtype=self.pipeline_dtype,
         )
 
 

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -69,6 +69,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         ckpt_include_optimizer: bool = False,
         ddp: Union[DDPLiteral, DistributedDataParallelConfig] = "megatron",
         lazy_init: bool = False,
+        pipeline_dtype: Optional[torch.dtype]: None
         **kwargs,
     ) -> None:
         super().__init__(
@@ -89,6 +90,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         self.ckpt_type = ckpt_type
         self.lazy_init = lazy_init
         self.ckpt_include_optimizer = ckpt_include_optimizer
+        self.pipeline_dtype = pipeline_dtype
 
         if ddp == "megatron":
             self.ddp_config = DistributedDataParallelConfig(use_distributed_optimizer=True)
@@ -506,6 +508,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
             tensor_model_parallel_size=self.tensor_model_parallel_size,
             pipeline_model_parallel_size=self.pipeline_model_parallel_size,
             virtual_pipeline_model_parallel_size=self.virtual_pipeline_model_parallel_size,
+            pipeline_dtype=self.pipeline_dtype
         )
 
 


### PR DESCRIPTION
Fixes a bug from `parallel_dtype` not being correctly passed in the `parallelism` method.