### PR TITLE
Add return type hint to from_pretrained method

### DIFF
--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -35,6 +35,7 @@ from huggingface_hub import HfApi
 from huggingface_hub import get_token as get_hf_token
 from huggingface_hub import hf_hub_download, snapshot_download
 from omegaconf import DictConfig, OmegaConf
+from typing_extensions import Self
 
 import nemo
 from nemo.core.classes.mixins.hf_io_mixin import HuggingFaceFileIO
@@ -718,7 +719,7 @@ class Model(Typing, Serialization, FileIO, HuggingFaceFileIO):
         trainer: Optional['Trainer'] = None,
         save_restore_connector: SaveRestoreConnector = None,
         return_model_file: Optional[bool] = False,
-    ):
+    ) -> Self:
         """
         Instantiates an instance of NeMo from NVIDIA NGC cloud
         Use restore_from() to instantiate from a local .nemo file.


### PR DESCRIPTION
# What does this PR do ?

Add a type hint.

**Collection**: [core]

# Changelog 
Add return type hint to the `Model`'s `from_pretrained` method.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.
