### PR TITLE
Set TE flag in legacy -> mcore conversion script

### DIFF
--- a/scripts/checkpoint_converters/convert_gpt_nemo_to_mcore.py
+++ b/scripts/checkpoint_converters/convert_gpt_nemo_to_mcore.py
@@ -128,9 +128,9 @@ def build_key_mapping(nemo_cfg):
         f"{model_str}.decoder.final_layernorm.weight": "model.language_model.encoder.final_layernorm.weight",
     }
     if has_layernorm_bias:
-        mcore_to_nemo_mapping[
-            f"{model_str}.decoder.final_layernorm.bias"
-        ] = "model.language_model.encoder.final_layernorm.bias"
+        mcore_to_nemo_mapping[f"{model_str}.decoder.final_layernorm.bias"] = (
+            "model.language_model.encoder.final_layernorm.bias"
+        )
 
     if not nemo_cfg.get("share_embeddings_and_output_weights", True):
         mcore_to_nemo_mapping[f"{model_str}.output_layer.weight"] = "model.language_model.output_layer.weight"
@@ -138,9 +138,9 @@ def build_key_mapping(nemo_cfg):
     if nemo_cfg.get("position_embedding_type", 'learned_absolute') == 'rope':
         mcore_to_nemo_mapping[f"{model_str}.rotary_pos_emb.inv_freq"] = "model.language_model.rotary_pos_emb.inv_freq"
     else:
-        mcore_to_nemo_mapping[
-            f"{model_str}.embedding.position_embeddings.weight"
-        ] = "model.language_model.embedding.position_embeddings.weight"
+        mcore_to_nemo_mapping[f"{model_str}.embedding.position_embeddings.weight"] = (
+            "model.language_model.embedding.position_embeddings.weight"
+        )
 
     nemo_prefix = "model.language_model.encoder.layers"
     mcore_prefix = f"{model_str}.decoder.layers"
@@ -338,5 +338,7 @@ if __name__ == '__main__':
     try:
         run_sanity_checks(input_nemo_file, output_nemo_file, cpu_only=cpu_only, ignore_if_missing=ignore_if_missing)
     except torch.cuda.OutOfMemoryError:
-        logging.info("✅ Conversion was successful, but could not run sanity check due to torch.cuda.OutOfMemoryError.")
+        logging.info(
+            "✅ Conversion was successful, but could not run sanity check due to torch.cuda.OutOfMemoryError."
+        )
         logging.info("Please run the script with the same command again to run sanity check.")

--- a/scripts/checkpoint_converters/convert_gpt_nemo_to_mcore.py
+++ b/scripts/checkpoint_converters/convert_gpt_nemo_to_mcore.py
@@ -88,6 +88,9 @@ def get_mcore_model_from_nemo_file(nemo_restore_from_path, cpu_only=False):
     model_cfg.mcore_gpt = True
     model_cfg.use_cpu_initialization = cpu_only
 
+    # The key mappings use TE spec, hence set the TE flag to True
+    model_cfg.transformer_engine = True
+
     logging.info("*** initializing mcore model with the following config")
     logging.info(OmegaConf.to_yaml(model_cfg))
     trainer = Trainer(devices=1, accelerator='cpu', strategy=NLPDDPStrategy())


### PR DESCRIPTION
# What does this PR do ?

Fix TE flag in response to recent change where mcore models now default to mcore local specs unless `transformer_engine` flag is set to true. Previously, it always used TE specs.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
