### PR TITLE
vLLM Export Improvements

### DIFF
--- a/nemo/export/vllm/engine.py
+++ b/nemo/export/vllm/engine.py
@@ -48,7 +48,7 @@ class NemoLLMEngine(LLMEngine):
                 )
 
                 # Update the HF config fields that come from the tokenizer in NeMo
-                self.model_config.hf_config.vocab_size = tokenizer_group.tokenizer.vocab_size
+                self.model_config.hf_config.vocab_size = len(tokenizer_group.tokenizer.vocab) # this may be greater than vocab_size
                 self.model_config.hf_config.bos_token_id = tokenizer_group.tokenizer.bos_token_id
                 self.model_config.hf_config.eos_token_id = tokenizer_group.tokenizer.eos_token_id
                 self.model_config.hf_config.pad_token_id = tokenizer_group.tokenizer.pad_token_id

--- a/nemo/export/vllm/engine.py
+++ b/nemo/export/vllm/engine.py
@@ -48,7 +48,9 @@ class NemoLLMEngine(LLMEngine):
                 )
 
                 # Update the HF config fields that come from the tokenizer in NeMo
-                self.model_config.hf_config.vocab_size = len(tokenizer_group.tokenizer.vocab) # this may be greater than vocab_size
+                self.model_config.hf_config.vocab_size = len(
+                    tokenizer_group.tokenizer.vocab
+                )  # this may be greater than vocab_size
                 self.model_config.hf_config.bos_token_id = tokenizer_group.tokenizer.bos_token_id
                 self.model_config.hf_config.eos_token_id = tokenizer_group.tokenizer.eos_token_id
                 self.model_config.hf_config.pad_token_id = tokenizer_group.tokenizer.pad_token_id

--- a/scripts/deploy/nlp/deploy_vllm_triton.py
+++ b/scripts/deploy/nlp/deploy_vllm_triton.py
@@ -64,7 +64,9 @@ def get_args(argv):
         type=str,
         help="dtype of the model on TensorRT-LLM or vLLM",
     )
-    parser.add_argument("-mml", "--max_model_len", default=512, type=int, help="Max input + ouptut length of the model")
+    parser.add_argument(
+        "-mml", "--max_model_len", default=512, type=int, help="Max input + ouptut length of the model"
+    )
     parser.add_argument("-mbs", "--max_batch_size", default=8, type=int, help="Max batch size of the model")
     parser.add_argument(
         "-es", '--enable_streaming', default=False, action='store_true', help="Enables streaming sentences."
@@ -138,7 +140,7 @@ def nemo_deploy(argv):
     LOGGER.info(args)
 
     triton_deployable = get_vllm_deployable(args)
-    
+
     try:
         nm = DeployPyTriton(
             model=triton_deployable,

--- a/scripts/deploy/nlp/deploy_vllm_triton.py
+++ b/scripts/deploy/nlp/deploy_vllm_triton.py
@@ -17,7 +17,6 @@ import logging
 import os
 import sys
 import tempfile
-from pathlib import Path
 
 from nemo.deploy import DeployPyTriton
 
@@ -55,7 +54,7 @@ def get_args(argv):
     parser.add_argument(
         "-tmr", "--triton_model_repository", default=None, type=str, help="Folder for the vLLM conversion"
     )
-    parser.add_argument("-ng", "--num_gpus", default=1, type=int, help="Number of GPUs for the deployment")
+    parser.add_argument("-tps", "--tensor_parallelism_size", default=1, type=int, help="Tensor parallelism size")
     parser.add_argument(
         "-dt",
         "--dtype",
@@ -113,7 +112,7 @@ def get_vllm_deployable(args):
             nemo_checkpoint=args.nemo_checkpoint,
             model_dir=model_dir,
             model_type=args.model_type,
-            tensor_parallel_size=args.num_gpus,
+            tensor_parallel_size=args.tensor_parallelism_size,
             max_model_len=args.max_model_len,
             dtype=args.dtype,
             weight_storage=args.weight_storage,

--- a/scripts/deploy/nlp/deploy_vllm_triton.py
+++ b/scripts/deploy/nlp/deploy_vllm_triton.py
@@ -1,0 +1,171 @@
+# Copyright (c) 2023-2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import logging
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+from nemo.deploy import DeployPyTriton
+
+LOGGER = logging.getLogger("NeMo")
+
+try:
+    from nemo.export.vllm_exporter import vLLMExporter
+except Exception as e:
+    LOGGER.error(f"Cannot import the vLLM exporter. {type(e).__name__}: {e}")
+    sys.exit(1)
+
+
+def get_args(argv):
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        description=f"Export NeMo models to vLLM and deploy them on Triton",
+    )
+    parser.add_argument("-nc", "--nemo_checkpoint", type=str, help="Source .nemo file")
+    parser.add_argument(
+        "-mt",
+        "--model_type",
+        type=str,
+        required=False,
+        choices=["llama", "mistral", "mixtral", "starcoder2", "gemma"],
+        help="Type of the model",
+    )
+    parser.add_argument("-tmn", "--triton_model_name", required=True, type=str, help="Name for the service")
+    parser.add_argument("-tmv", "--triton_model_version", default=1, type=int, help="Version for the service")
+    parser.add_argument(
+        "-trp", "--triton_port", default=8000, type=int, help="Port for the Triton server to listen for requests"
+    )
+    parser.add_argument(
+        "-tha", "--triton_http_address", default="0.0.0.0", type=str, help="HTTP address for the Triton server"
+    )
+    parser.add_argument(
+        "-tmr", "--triton_model_repository", default=None, type=str, help="Folder for the vLLM conversion"
+    )
+    parser.add_argument("-ng", "--num_gpus", default=1, type=int, help="Number of GPUs for the deployment")
+    parser.add_argument(
+        "-dt",
+        "--dtype",
+        choices=["bfloat16", "float16", "fp8", "int8"],
+        default="bfloat16",
+        type=str,
+        help="dtype of the model on TensorRT-LLM or vLLM",
+    )
+    parser.add_argument("-mml", "--max_model_len", default=512, type=int, help="Max input + ouptut length of the model")
+    parser.add_argument("-mbs", "--max_batch_size", default=8, type=int, help="Max batch size of the model")
+    parser.add_argument(
+        "-es", '--enable_streaming', default=False, action='store_true', help="Enables streaming sentences."
+    )
+    parser.add_argument("-dm", "--debug_mode", default=False, action='store_true', help="Enable debug mode")
+    parser.add_argument(
+        '-ws',
+        '--weight_storage',
+        default='auto',
+        choices=['auto', 'cache', 'file', 'memory'],
+        help='Strategy for storing converted weights for vLLM: "file" - always write weights into a file, '
+        '"memory" - always do an in-memory conversion, "cache" - reuse existing files if they are '
+        'newer than the nemo checkpoint, "auto" - use "cache" for multi-GPU runs and "memory" '
+        'for single-GPU runs.',
+    )
+    parser.add_argument(
+        "-gmu",
+        '--gpu_memory_utilization',
+        default=0.9,
+        type=float,
+        help="GPU memory utilization percentage for vLLM.",
+    )
+    args = parser.parse_args(argv)
+    return args
+
+
+def get_vllm_deployable(args):
+    tempdir = None
+    model_dir = args.triton_model_repository
+    if model_dir is None:
+        tempdir = tempfile.TemporaryDirectory()
+        model_dir = tempdir.name
+        LOGGER.info(
+            f"{model_dir} path will be used as the vLLM intermediate folder. "
+            + "Please set the --triton_model_repository parameter if you'd like to use a path that already "
+            + "includes the vLLM model files."
+        )
+    elif not os.path.exists(model_dir):
+        os.makedirs(model_dir)
+
+    try:
+        exporter = vLLMExporter()
+        exporter.export(
+            nemo_checkpoint=args.nemo_checkpoint,
+            model_dir=model_dir,
+            model_type=args.model_type,
+            tensor_parallel_size=args.num_gpus,
+            max_model_len=args.max_model_len,
+            dtype=args.dtype,
+            weight_storage=args.weight_storage,
+            gpu_memory_utilization=args.gpu_memory_utilization,
+        )
+        return exporter
+    except Exception as error:
+        raise RuntimeError("An error has occurred during the model export. Error message: " + str(error))
+    finally:
+        if tempdir is not None:
+            tempdir.cleanup()
+
+
+def nemo_deploy(argv):
+    args = get_args(argv)
+
+    if args.debug_mode:
+        loglevel = logging.DEBUG
+    else:
+        loglevel = logging.INFO
+
+    LOGGER.setLevel(loglevel)
+    LOGGER.info("Logging level set to {}".format(loglevel))
+    LOGGER.info(args)
+
+    triton_deployable = get_vllm_deployable(args)
+    
+    try:
+        nm = DeployPyTriton(
+            model=triton_deployable,
+            triton_model_name=args.triton_model_name,
+            triton_model_version=args.triton_model_version,
+            max_batch_size=args.max_batch_size,
+            port=args.triton_port,
+            address=args.triton_http_address,
+            streaming=args.enable_streaming,
+        )
+
+        LOGGER.info("Triton deploy function will be called.")
+        nm.deploy()
+    except Exception as error:
+        LOGGER.error("Error message has occurred during deploy function. Error message: " + str(error))
+        return
+
+    try:
+        LOGGER.info("Model serving on Triton is will be started.")
+        nm.serve()
+    except Exception as error:
+        LOGGER.error("Error message has occurred during deploy function. Error message: " + str(error))
+        return
+
+    LOGGER.info("Model serving will be stopped.")
+    nm.stop()
+
+
+if __name__ == '__main__':
+    nemo_deploy(sys.argv[1:])

--- a/tests/export/nemo_export.py
+++ b/tests/export/nemo_export.py
@@ -42,7 +42,9 @@ in_framework_supported = True
 try:
     from nemo.deploy.nlp import MegatronLLMDeployable
 except Exception as e:
-    LOGGER.warning(f"Cannot import MegatronLLMDeployable, in-framework inference will not be available. {type(e).__name__}: {e}")
+    LOGGER.warning(
+        f"Cannot import MegatronLLMDeployable, in-framework inference will not be available. {type(e).__name__}: {e}"
+    )
     in_framework_supported = False
 
 trt_llm_supported = True
@@ -273,7 +275,7 @@ def run_inference(
                 tensor_parallel_size=tp_size,
                 pipeline_parallel_size=pp_size,
                 max_model_len=max_input_len + max_output_len,
-                gpu_memory_utilization=args.gpu_memory_utilization
+                gpu_memory_utilization=args.gpu_memory_utilization,
             )
         else:
             exporter = TensorRTLLM(model_dir, lora_ckpt_list, load_model=False)
@@ -706,7 +708,7 @@ def get_args():
     parser.add_argument(
         "-gmu",
         '--gpu_memory_utilization',
-        default=0.95, # 0.95 is needed to run Mixtral-8x7B on 2x48GB GPUs
+        default=0.95,  # 0.95 is needed to run Mixtral-8x7B on 2x48GB GPUs
         type=float,
         help="GPU memory utilization percentage for vLLM.",
     )
@@ -740,7 +742,7 @@ def run_inference_tests(args):
 
     if args.use_vllm and not vllm_supported:
         raise UsageError("vLLM engine is not supported in this environment.")
-    
+
     if args.in_framework and not in_framework_supported:
         raise UsageError("In-framework inference is not supported in this environment.")
 
@@ -752,14 +754,15 @@ def run_inference_tests(args):
 
     if args.run_accuracy and args.test_data_path is None:
         raise UsageError("Accuracy testing requires the --test_data_path argument.")
-    
-    
+
     if args.max_tps is None:
         args.max_tps = args.min_tps
 
     if args.use_vllm and args.min_tps != args.max_tps:
-        raise UsageError("vLLM doesn't support changing tensor parallel group size without relaunching the process. "
-                         "Use the same value for --min_tps and --max_tps.")
+        raise UsageError(
+            "vLLM doesn't support changing tensor parallel group size without relaunching the process. "
+            "Use the same value for --min_tps and --max_tps."
+        )
 
     result_dic: Dict[int, Tuple[FunctionalResult, Optional[AccuracyResult]]] = {}
 

--- a/tests/export/nemo_export.py
+++ b/tests/export/nemo_export.py
@@ -26,17 +26,24 @@ import torch
 
 # Import infer_data_path from the parent folder assuming that the 'tests' package is not installed.
 sys.path.append(str(Path(__file__).parent.parent))
-from tests.infer_data_path import get_infer_test_data
+from infer_data_path import get_infer_test_data
 
 LOGGER = logging.getLogger("NeMo")
 
 triton_supported = True
 try:
     from nemo.deploy import DeployPyTriton
-    from nemo.deploy.nlp import MegatronLLMDeployable, NemoQueryLLM
+    from nemo.deploy.nlp import NemoQueryLLM
 except Exception as e:
     LOGGER.warning(f"Cannot import Triton, deployment will not be available. {type(e).__name__}: {e}")
     triton_supported = False
+
+in_framework_supported = True
+try:
+    from nemo.deploy.nlp import MegatronLLMDeployable
+except Exception as e:
+    LOGGER.warning(f"Cannot import MegatronLLMDeployable, in-framework inference will not be available. {type(e).__name__}: {e}")
+    in_framework_supported = False
 
 trt_llm_supported = True
 try:
@@ -266,6 +273,7 @@ def run_inference(
                 tensor_parallel_size=tp_size,
                 pipeline_parallel_size=pp_size,
                 max_model_len=max_input_len + max_output_len,
+                gpu_memory_utilization=args.gpu_memory_utilization
             )
         else:
             exporter = TensorRTLLM(model_dir, lora_ckpt_list, load_model=False)
@@ -311,10 +319,11 @@ def run_inference(
         functional_result = FunctionalResult()
 
         # Check non-deployed funcitonal correctness
-        functional_result.regular_pass = True
-        # if not check_model_outputs(streaming, output, expected_outputs):
-        #    LOGGER.warning("Model outputs don't match the expected result.")
-        #    functional_result.regular_pass = False
+        if args.functional_test:
+            functional_result.regular_pass = True
+            if not check_model_outputs(streaming, output, expected_outputs):
+                LOGGER.warning("Model outputs don't match the expected result.")
+                functional_result.regular_pass = False
 
         output_cpp = ""
         if test_cpp_runtime and not use_lora_plugin and not ptuning and not use_vllm:
@@ -359,10 +368,11 @@ def run_inference(
             output_deployed = list(output_deployed)
 
             # Check deployed funcitonal correctness
-            functional_result.deployed_pass = True
-            # if not check_model_outputs(streaming, output_deployed, expected_outputs):
-            #    LOGGER.warning("Deployed model outputs don't match the expected result.")
-            #    functional_result.deployed_pass = False
+            if args.functional_test:
+                functional_result.deployed_pass = True
+                if not check_model_outputs(streaming, output_deployed, expected_outputs):
+                    LOGGER.warning("Deployed model outputs don't match the expected result.")
+                    functional_result.deployed_pass = False
 
         if debug or functional_result.regular_pass == False or functional_result.deployed_pass == False:
             print("")
@@ -664,6 +674,11 @@ def get_args():
         default="False",
     )
     parser.add_argument(
+        "--functional_test",
+        type=str,
+        default="False",
+    )
+    parser.add_argument(
         "--debug",
         default=False,
         action='store_true',
@@ -688,6 +703,13 @@ def get_args():
         type=str,
         default="False",
     )
+    parser.add_argument(
+        "-gmu",
+        '--gpu_memory_utilization',
+        default=0.95, # 0.95 is needed to run Mixtral-8x7B on 2x48GB GPUs
+        type=float,
+        help="GPU memory utilization percentage for vLLM.",
+    )
 
     args = parser.parse_args()
 
@@ -702,6 +724,7 @@ def get_args():
 
     args.test_cpp_runtime = str_to_bool("test_cpp_runtime", args.test_cpp_runtime)
     args.test_deployment = str_to_bool("test_deployment", args.test_deployment)
+    args.functional_test = str_to_bool("functional_test", args.functional_test)
     args.save_trt_engine = str_to_bool("save_trt_engin", args.save_trt_engine)
     args.run_accuracy = str_to_bool("run_accuracy", args.run_accuracy)
     args.use_vllm = str_to_bool("use_vllm", args.use_vllm)
@@ -717,6 +740,9 @@ def run_inference_tests(args):
 
     if args.use_vllm and not vllm_supported:
         raise UsageError("vLLM engine is not supported in this environment.")
+    
+    if args.in_framework and not in_framework_supported:
+        raise UsageError("In-framework inference is not supported in this environment.")
 
     if args.use_vllm and (args.ptuning or args.lora):
         raise UsageError("The vLLM integration currently does not support P-tuning or LoRA.")
@@ -726,13 +752,19 @@ def run_inference_tests(args):
 
     if args.run_accuracy and args.test_data_path is None:
         raise UsageError("Accuracy testing requires the --test_data_path argument.")
+    
+    
+    if args.max_tps is None:
+        args.max_tps = args.min_tps
+
+    if args.use_vllm and args.min_tps != args.max_tps:
+        raise UsageError("vLLM doesn't support changing tensor parallel group size without relaunching the process. "
+                         "Use the same value for --min_tps and --max_tps.")
 
     result_dic: Dict[int, Tuple[FunctionalResult, Optional[AccuracyResult]]] = {}
 
     if args.existing_test_models:
         tps = args.min_tps
-        if args.max_tps is None:
-            args.max_tps = args.min_tps
 
         while tps <= args.max_tps:
             result_dic[tps] = run_existing_checkpoints(
@@ -760,8 +792,6 @@ def run_inference_tests(args):
         prompts = ["The capital of France is", "Largest animal in the sea is"]
         expected_outputs = ["Paris", "blue whale"]
         tps = args.min_tps
-        if args.max_tps is None:
-            args.max_tps = args.min_tps
 
         while tps <= args.max_tps:
             if args.in_framework:
@@ -827,9 +857,9 @@ def run_inference_tests(args):
                 return "N/A"
             return "PASS" if b else "FAIL"
 
-        print(f"Number of tps:                  {num_tps}")
+        print(f"Tensor Parallelism:              {num_tps}")
 
-        if functional_result is not None:
+        if args.functional_test and functional_result is not None:
             print(f"Functional Test:                 {optional_bool_to_pass_fail(functional_result.regular_pass)}")
             print(f"Deployed Functional Test:        {optional_bool_to_pass_fail(functional_result.deployed_pass)}")
 
@@ -838,7 +868,7 @@ def run_inference_tests(args):
             if functional_result.deployed_pass == False:
                 functional_test_result = "FAIL"
 
-        if accuracy_result is not None:
+        if args.run_accuracy and accuracy_result is not None:
             print(f"Model Accuracy:                  {accuracy_result.accuracy:.4f}")
             print(f"Relaxed Model Accuracy:          {accuracy_result.accuracy_relaxed:.4f}")
             print(f"Deployed Model Accuracy:         {accuracy_result.deployed_accuracy:.4f}")
@@ -848,7 +878,8 @@ def run_inference_tests(args):
                 accuracy_test_result = "FAIL"
 
     print("=======================================")
-    print(f"Functional: {functional_test_result}")
+    if args.functional_test:
+        print(f"Functional: {functional_test_result}")
     if args.run_accuracy:
         print(f"Acccuracy: {accuracy_test_result}")
 


### PR DESCRIPTION
# What does this PR do ?

Adds support for LLAMA3 and fixes a few other issues with vLLM.

**Collection**: NLP

# Changelog 
- Separated the vLLM export functionality from the common deployment script into deploy_vllm_triton.py.
- Fixed LLAMA3 exprot (wrong vocab_size)
- Improved the export test.

**PR Type**:
- [X] Bugfix
