### PR TITLE
Support enabling inference server only in megatron_gpt_eval.py

### DIFF
--- a/examples/nlp/language_modeling/megatron_gpt_eval.py
+++ b/examples/nlp/language_modeling/megatron_gpt_eval.py
@@ -312,36 +312,37 @@ def main(cfg) -> None:
     }
 
     fp8_enabled = hasattr(model.cfg, "fp8") and (model.cfg.fp8 == True)
-    if fp8_enabled:
+    if fp8_enabled and isinstance(cfg.prompts, list):
         nb_paddings = 0
         while len(cfg.prompts) % 8 != 0:
             cfg.prompts.append("")
             nb_paddings += 1
 
-    # First method of running text generation, call model.generate method
-    response = model.generate(
-        inputs=OmegaConf.to_container(cfg.prompts), length_params=length_params, sampling_params=sampling_params
-    )
+    if isinstance(cfg.prompts, list) and len(cfg.prompts) > 0:
+        # First method of running text generation, call model.generate method
+        response = model.generate(
+            inputs=OmegaConf.to_container(cfg.prompts), length_params=length_params, sampling_params=sampling_params
+        )
 
-    if fp8_enabled:
-        response = remove_padded_prompts(response, nb_paddings)
-    print("***************************")
-    print(response)
-    print("***************************")
+        if fp8_enabled:
+            response = remove_padded_prompts(response, nb_paddings)
+        print("***************************")
+        print(response)
+        print("***************************")
 
-    # Second method of running text generation, call trainer.predict [recommended]
-    bs = 8 if fp8_enabled else 2
-    ds = RequestDataSet(OmegaConf.to_container(cfg.prompts))
-    request_dl = DataLoader(dataset=ds, batch_size=bs)
-    config = OmegaConf.to_container(cfg.inference)
-    model.set_inference_config(config)
-    response = trainer.predict(model, request_dl)
+        # Second method of running text generation, call trainer.predict [recommended]
+        bs = 8 if fp8_enabled else 2
+        ds = RequestDataSet(OmegaConf.to_container(cfg.prompts))
+        request_dl = DataLoader(dataset=ds, batch_size=bs)
+        config = OmegaConf.to_container(cfg.inference)
+        model.set_inference_config(config)
+        response = trainer.predict(model, request_dl)
 
-    if fp8_enabled:
-        response[-1] = remove_padded_prompts(response[-1], nb_paddings)
-    print("***************************")
-    print(response)
-    print("***************************")
+        if fp8_enabled:
+            response[-1] = remove_padded_prompts(response[-1], nb_paddings)
+        print("***************************")
+        print(response)
+        print("***************************")
 
     # Third method of running text generation, use inference server
     if cfg.server:


### PR DESCRIPTION
# What does this PR do ?

Support enabling inference server only in megatron_gpt_eval.py, thus overriding the first and second examples if `cfg.prompts` is empty. 

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
