### PR TITLE
Fix the dictionary  format returned by the `scheduler` method

### DIFF
--- a/nemo/lightning/pytorch/optim/lr_scheduler.py
+++ b/nemo/lightning/pytorch/optim/lr_scheduler.py
@@ -48,9 +48,11 @@ class WarmupPolicyScheduler(LRSchedulerModule):
         )
         return {
             "optimizer": optimizer,
-            "scheduler": lr_scheduler,
-            "interval": self.interval,
-            "frequency": self.frequency,
+            "lr_scheduler": {
+                "scheduler": lr_scheduler,
+                "interval": self.interval,
+                "frequency": self.frequency,
+            },
             "monitor": self.monitor,
         }
 
@@ -93,9 +95,11 @@ class WarmupHoldPolicyScheduler(LRSchedulerModule):
         )
         return {
             "optimizer": optimizer,
-            "scheduler": lr_scheduler,
-            "interval": self.interval,
-            "frequency": self.frequency,
+            "lr_scheduler": {
+                "scheduler": lr_scheduler,
+                "interval": self.interval,
+                "frequency": self.frequency,
+            },
             "monitor": self.monitor,
         }
 
@@ -122,9 +126,11 @@ class SquareAnnealingScheduler(LRSchedulerModule):
         lr_scheduler = SquareAnnealing(optimizer, max_steps=self.max_steps, min_lr=self.min_lr)
         return {
             "optimizer": optimizer,
-            "scheduler": lr_scheduler,
-            "interval": self.interval,
-            "frequency": self.frequency,
+            "lr_scheduler": {
+                "scheduler": lr_scheduler,
+                "interval": self.interval,
+                "frequency": self.frequency,
+            },
             "monitor": self.monitor,
         }
 
@@ -151,9 +157,11 @@ class SquareRootAnnealingScheduler(LRSchedulerModule):
         lr_scheduler = SquareRootAnnealing(optimizer, max_steps=self.max_steps, min_lr=self.min_lr)
         return {
             "optimizer": optimizer,
-            "scheduler": lr_scheduler,
-            "interval": self.interval,
-            "frequency": self.frequency,
+            "lr_scheduler": {
+                "scheduler": lr_scheduler,
+                "interval": self.interval,
+                "frequency": self.frequency,
+            },
             "monitor": self.monitor,
         }
 
@@ -193,9 +201,11 @@ class NoamAnnealingScheduler(LRSchedulerModule):
         )
         return {
             "optimizer": optimizer,
-            "scheduler": lr_scheduler,
-            "interval": self.interval,
-            "frequency": self.frequency,
+            "lr_scheduler": {
+                "scheduler": lr_scheduler,
+                "interval": self.interval,
+                "frequency": self.frequency,
+            },
             "monitor": self.monitor,
         }
 
@@ -226,9 +236,11 @@ class NoamHoldAnnealingScheduler(LRSchedulerModule):
         )
         return {
             "optimizer": optimizer,
-            "scheduler": lr_scheduler,
-            "interval": self.interval,
-            "frequency": self.frequency,
+            "lr_scheduler": {
+                "scheduler": lr_scheduler,
+                "interval": self.interval,
+                "frequency": self.frequency,
+            },
             "monitor": self.monitor,
         }
 
@@ -255,9 +267,11 @@ class WarmupAnnealingScheduler(LRSchedulerModule):
         lr_scheduler = WarmupAnnealing(optimizer, max_steps=self.max_steps, min_lr=self.min_lr)
         return {
             "optimizer": optimizer,
-            "scheduler": lr_scheduler,
-            "interval": self.interval,
-            "frequency": self.frequency,
+            "lr_scheduler": {
+                "scheduler": lr_scheduler,
+                "interval": self.interval,
+                "frequency": self.frequency,
+            },
             "monitor": self.monitor,
         }
 
@@ -284,9 +298,11 @@ class InverseSquareRootAnnealingScheduler(LRSchedulerModule):
         lr_scheduler = InverseSquareRootAnnealing(optimizer, max_steps=self.max_steps, min_lr=self.min_lr)
         return {
             "optimizer": optimizer,
-            "scheduler": lr_scheduler,
-            "interval": self.interval,
-            "frequency": self.frequency,
+            "lr_scheduler": {
+                "scheduler": lr_scheduler,
+                "interval": self.interval,
+                "frequency": self.frequency,
+            },
             "monitor": self.monitor,
         }
 
@@ -313,9 +329,11 @@ class T5InverseSquareRootAnnealingScheduler(LRSchedulerModule):
         lr_scheduler = T5InverseSquareRootAnnealing(optimizer, max_steps=self.max_steps, min_lr=self.min_lr)
         return {
             "optimizer": optimizer,
-            "scheduler": lr_scheduler,
-            "interval": self.interval,
-            "frequency": self.frequency,
+            "lr_scheduler": {
+                "scheduler": lr_scheduler,
+                "interval": self.interval,
+                "frequency": self.frequency,
+            },
             "monitor": self.monitor,
         }
 
@@ -348,9 +366,11 @@ class PolynomialDecayAnnealingScheduler(LRSchedulerModule):
         )
         return {
             "optimizer": optimizer,
-            "scheduler": lr_scheduler,
-            "interval": self.interval,
-            "frequency": self.frequency,
+            "lr_scheduler": {
+                "scheduler": lr_scheduler,
+                "interval": self.interval,
+                "frequency": self.frequency,
+            },
             "monitor": self.monitor,
         }
 
@@ -383,9 +403,11 @@ class PolynomialHoldDecayAnnealingScheduler(LRSchedulerModule):
         )
         return {
             "optimizer": optimizer,
-            "scheduler": lr_scheduler,
-            "interval": self.interval,
-            "frequency": self.frequency,
+            "lr_scheduler": {
+                "scheduler": lr_scheduler,
+                "interval": self.interval,
+                "frequency": self.frequency,
+            },
             "monitor": self.monitor,
         }
 
@@ -423,16 +445,19 @@ class CosineAnnealingScheduler(LRSchedulerModule):
 
         return {
             "optimizer": optimizer,
-            # REQUIRED: The scheduler instance
             "scheduler": lr_scheduler,
-            # The unit of the scheduler's step size, could also be 'step'.
-            # 'epoch' updates the scheduler on epoch end whereas 'step'
-            # updates it after a optimizer update.
-            "interval": self.interval,
-            # How many epochs/steps should pass between calls to
-            # `scheduler.step()`. 1 corresponds to updating the learning
-            # rate after every epoch/step.
-            "frequency": self.frequency,
+            "lr_scheduler": {
+                # REQUIRED: The scheduler instance
+                "scheduler": lr_scheduler,
+                # The unit of the scheduler's step size, could also be 'step'.
+                # 'epoch' updates the scheduler on epoch end whereas 'step'
+                # updates it after a optimizer update.
+                "interval": self.interval,
+                # How many epochs/steps should pass between calls to
+                # `scheduler.step()`. 1 corresponds to updating the learning
+                # rate after every epoch/step.
+                "frequency": self.frequency,
+            },
             # Metric to to monitor for schedulers like `ReduceLROnPlateau`
             "monitor": self.monitor,
         }


### PR DESCRIPTION
# What does this PR do ?

I am changing the dict format returned by `scheduler` method in the new `lightning/optim` module. 

I followed the example of `LRSchedulerModule` to create a custom cosine annealing scheduler. My scheduler was returning the dict format: 
```
        return {
            "optimizer": optimizers,
            # REQUIRED: The scheduler instance
            # `interval` is the unit of the scheduler's step size, could also be 'step'.
            # 'epoch' updates the scheduler on epoch end whereas 'step'
            # updates it after a optimizer update.
            "scheduler": lr_scheduler,
            "interval": self.interval,
             "frequency": self.frequency,
            # Metric to monitor for schedulers like `ReduceLROnPlateau`
            "monitor": self.monitor,
        }
```

With this format, I was getting a warning: 
```
[NeMo W 2024-07-03 16:27:38 nemo_logging:349] /usr/local/lib/python3.10/dist-packages/pytorch_lightning/core/optimizer.py:376: Found unsupported keys in the optimizer configuration: {'scheduler', 'frequency', 'interval'}
```
and the learning rate was not decreasing (which is wrong)

changing it to the following format fixed the issue: 
```
        return {
            "optimizer": optimizers,
            # REQUIRED: The scheduler instance
            # `interval` is the unit of the scheduler's step size, could also be 'step'.
            # 'epoch' updates the scheduler on epoch end whereas 'step'
            # updates it after a optimizer update.
            "lr_scheduler": {
                "scheduler": lr_scheduler,
                "interval": self.interval,
                "frequency": self.frequency,
            },
            # Metric to monitor for schedulers like `ReduceLROnPlateau`
            "monitor": self.monitor,
        }
```

![image](https://github.com/NVIDIA/NeMo/assets/17721108/186599df-8ab1-4c74-8848-1896aaf0b13e)

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
