### PR TITLE
Change default parallel_save to False

### DIFF
--- a/nemo/utils/callbacks/dist_ckpt_io.py
+++ b/nemo/utils/callbacks/dist_ckpt_io.py
@@ -205,7 +205,7 @@ class DistributedCheckpointIO(AsyncCompatibleCheckpointIO):
         async_save: bool = False,
         torch_dist_multiproc: Optional[int] = None,
         assume_constant_structure: bool = False,
-        parallel_save: bool = True,
+        parallel_save: bool = False,
         parallel_load: bool = False,
     ):
         super().__init__()
@@ -238,7 +238,7 @@ class DistributedCheckpointIO(AsyncCompatibleCheckpointIO):
             load_directly_on_device=model_cfg.get('dist_ckpt_load_on_device', True),
             async_save=async_save,
             torch_dist_multiproc=model_cfg.get('dist_ckpt_torch_dist_multiproc', None),
-            parallel_save=model_cfg.get('dist_ckpt_parallel_save', True),
+            parallel_save=model_cfg.get('dist_ckpt_parallel_save', False),
             parallel_load=model_cfg.get('dist_ckpt_parallel_load', False),
         )
 


### PR DESCRIPTION
# What does this PR do ?

Parallel save is set to False in the GPT config, but not in the DistributedCheckpointIO constructor. This PR fixes that 

**Collection**: NLP

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
