### PR TITLE
Enables megatron parallel move to device inside datastep

### DIFF
--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -29,8 +29,8 @@ from megatron.core import parallel_state
 from megatron.core.distributed import DistributedDataParallel as McoreDDP
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.transformer.transformer_config import TransformerConfig
-from torch import Tensor, nn
 from pytorch_lightning.utilities import move_data_to_device
+from torch import Tensor, nn
 
 DataT = TypeVar("DataT", Tensor, Dict[str, Tensor], Sequence[Tensor])
 
@@ -60,9 +60,10 @@ def default_data_step(dataloader_iter: Iterator[DataT]) -> DataT:
         DataT: The data moved to the device.
     """
     if parallel_state.get_context_parallel_world_size() > 1:
-        raise ValueError("Default data step is being used in a context parallel environment."
-                         "Please define your own data step that appropriately slices the data for context parallel."
-                         )
+        raise ValueError(
+            "Default data step is being used in a context parallel environment."
+            "Please define your own data step that appropriately slices the data for context parallel."
+        )
 
     match next(dataloader_iter):
         # If its wrapped in a tuple, unpack it.
@@ -72,7 +73,7 @@ def default_data_step(dataloader_iter: Iterator[DataT]) -> DataT:
         case batch:
             pass
 
-    return move_data_to_device(batch, torch.cuda.current_device())    
+    return move_data_to_device(batch, torch.cuda.current_device())
 
 
 def default_forward_step(model: nn.Module, batch, *args, **kwargs) -> torch.Tensor:


### PR DESCRIPTION
# What does this PR do ?

We enable the default data step to operate on a wider variety of outputs from the dataloader.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Enables the dataloader to pass a wrapped tuple to the default data step in megatron parallel
- Enables the dataloader to pass any unwrapped item to the default data step

# Usage
* You can potentially add a usage example below


# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
