### PR TITLE
enables default data step in megatron parallel to operate on a wider variety of tensors

### DIFF
--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -25,9 +25,11 @@ from typing import (
 
 import torch
 import torch.distributed
+from megatron.core import parallel_state
 from megatron.core.distributed import DistributedDataParallel as McoreDDP
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.transformer.transformer_config import TransformerConfig
+from pytorch_lightning.utilities import move_data_to_device
 from torch import Tensor, nn
 from typing_extensions import override
 
@@ -43,15 +45,36 @@ class PrecisionPluginProtocol(Protocol[DataT]):
 
 
 def default_data_step(dataloader_iter: Iterator[DataT]) -> DataT:
-    batch = next(dataloader_iter)
+    """
+    Moves the data to a device.
 
-    if isinstance(batch, tuple) and len(batch) == 3:
-        batch = batch[0]
+    In this case we utilize the match function to unpack the dataloader iterator. There may be a wrapper on the dataloader
+    iter from here: https://github.com/NVIDIA/NeMo/blob/main/nemo/lightning/fabric/strategies.py#L441.
 
-    if isinstance(batch, dict):
-        batch = {k: v.cuda(non_blocking=True) for k, v in batch.items()}
+    This will not subset the data for your with context parallel so please override this function if you
+    want to use context parallel.
 
-    return batch
+    Examples:
+        If the dataloader_iter returns: [Tuple[<tensor>, <int>, <int>]] -> move to device
+        If the dataloader_iter returns: [<tensor>, <tensor>] -> move to device
+
+    Returns:
+        DataT: The data moved to the device.
+    """
+    if parallel_state.get_context_parallel_world_size() > 1:
+        raise ValueError("Default data step is being used in a context parallel environment."
+                         "Please define your own data step that appropriately slices the data for context parallel."
+                         )
+
+    match next(dataloader_iter):
+        # If its wrapped in a tuple, unpack it.
+        case (batch, int(_), int(_)):
+            pass
+        # Canonical case.
+        case batch:
+            pass
+
+    return move_data_to_device(batch, torch.cuda.current_device())  
 
 
 def default_forward_step(model: nn.Module, batch, *args, **kwargs) -> torch.Tensor:

--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -62,9 +62,10 @@ def default_data_step(dataloader_iter: Iterator[DataT]) -> DataT:
         DataT: The data moved to the device.
     """
     if parallel_state.get_context_parallel_world_size() > 1:
-        raise ValueError("Default data step is being used in a context parallel environment."
-                         "Please define your own data step that appropriately slices the data for context parallel."
-                         )
+        raise ValueError(
+            "Default data step is being used in a context parallel environment."
+            "Please define your own data step that appropriately slices the data for context parallel."
+        )
 
     match next(dataloader_iter):
         # If its wrapped in a tuple, unpack it.
@@ -76,9 +77,9 @@ def default_data_step(dataloader_iter: Iterator[DataT]) -> DataT:
         # If the dataloader_iter is empty, return None.
         case _:
             batch = None
-    
+
     if batch is not None:
-        return move_data_to_device(batch, torch.cuda.current_device())  
+        return move_data_to_device(batch, torch.cuda.current_device())
     else:
         raise ValueError("No valid batch found from dataloader_iter.")
 

--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -74,14 +74,14 @@ def default_data_step(dataloader_iter: Iterator[DataT]) -> DataT:
         # Canonical case.
         case batch:
             pass
-        # If the dataloader_iter is empty, return None.
+        # If the dataloader_iter is empty, return a ValueError.
         case _:
             batch = None
 
     if batch is not None:
         return move_data_to_device(batch, torch.cuda.current_device())
     else:
-        raise ValueError("No valid batch found from dataloader_iter.")
+        raise ValueError("None returned from dataloader.")
 
 
 def default_forward_step(model: nn.Module, batch, *args, **kwargs) -> torch.Tensor:

--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -73,8 +73,14 @@ def default_data_step(dataloader_iter: Iterator[DataT]) -> DataT:
         # Canonical case.
         case batch:
             pass
-
-    return move_data_to_device(batch, torch.cuda.current_device())  
+        # If the dataloader_iter is empty, return None.
+        case _:
+            batch = None
+    
+    if batch is not None:
+        return move_data_to_device(batch, torch.cuda.current_device())  
+    else:
+        raise ValueError("No valid batch found from dataloader_iter.")
 
 
 def default_forward_step(model: nn.Module, batch, *args, **kwargs) -> torch.Tensor:


### PR DESCRIPTION
…variety of tensors coming out of the dataloader

Add more flexibility to the default data step inside megatron parallel.

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Megatron parallel's default data step can operate on wrapped tuples and unwrapped items coming directly out of the dataloader

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
