### PR TITLE
Enabling bias_dropout_add_fused with no bias term

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/fused_bias_dropout_add.py
+++ b/nemo/collections/nlp/modules/common/megatron/fused_bias_dropout_add.py
@@ -47,12 +47,12 @@ def bias_dropout_add_fused_train_(
     # type: (Tensor, Tensor, Tensor, float) -> Tensor
     return bias_dropout_add(x, bias, residual, prob, True)
 
+
 @torch.jit.script
-def dropout_add_fused_train_(
-    x: torch.Tensor, bias: torch.Tensor, residual: torch.Tensor, prob: float
-) -> torch.Tensor:
+def dropout_add_fused_train_(x: torch.Tensor, bias: torch.Tensor, residual: torch.Tensor, prob: float) -> torch.Tensor:
     # type: (Tensor, None, Tensor, float) -> Tensor
     return dropout_add(x, bias, residual, prob, True)
+
 
 def bias_dropout_add_fused_train(x, bias, residual, prob):
     # re-enable torch grad to enable fused optimization.

--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -453,7 +453,7 @@ class ParallelTransformerLayer_(MegatronModule, adapter_mixins.AdapterModuleMixi
         if transformer_block_type == 'normformer' and position_after == 'attention':
             bias_dropout_add_func = get_dropout_add(self.training)
         # Bias dropout add fused kernel
-        elif self.bias and self.bias_dropout_add_fusion:
+        elif self.bias_dropout_add_fusion:
             if self.training:
                 bias_dropout_add_func = bias_dropout_add_fused_train
             else:


### PR DESCRIPTION
# What does this PR do ?

Specific LLM/VLM hang when using specific PP settings and with the bias term is set to false hang. By enabling a fused dropout_add_fused we should fix this problem as well as speed up training of LLM/VLM that do not have the bias term 

**Collection**:  nlp

# Changelog 
- Add specific line by line info of high level changes in this PR.
- nemo/collections/nlp/modules/common/megatron/transformer.py - Enabling the bias_dropout_add_fusion to be used for both bias and non bias enabled
- nemo/collections/nlp/modules/common/megatron/fused_bias_dropout_add.py - Check whether the bias term is there and choose relevant fused function

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [N/A] Did you write any new necessary tests?
- [ X] Did you add or update any necessary documentation?
- [N/A] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [N/A] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [N/A] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #6396
