### PR TITLE
NeVa::forward - remove device syncs (torch.where) and vectorize over batch dimensions

### DIFF
--- a/nemo/utils/__init__.py
+++ b/nemo/utils/__init__.py
@@ -13,6 +13,9 @@
 # limitations under the License.
 
 
+from collections.abc import Callable
+
+from nemo.constants import NEMO_ENV_VARNAME_TESTING
 from nemo.utils.app_state import AppState
 from nemo.utils.cast_utils import (
     CastToFloat,
@@ -24,6 +27,7 @@ from nemo.utils.cast_utils import (
     monkeypatched,
 )
 from nemo.utils.dtype import str_to_dtype
+from nemo.utils.env_var_parsing import get_envbool
 from nemo.utils.nemo_logging import Logger as _Logger
 from nemo.utils.nemo_logging import LogMode as logging_mode
 
@@ -34,3 +38,12 @@ try:
     add_memory_handlers_to_pl_logger()
 except ModuleNotFoundError:
     pass
+
+
+def run_if_testing(f: Callable):
+    """Helper function that invokes the input callable `f`
+    if the environment variable `NEMO_TESTING` is set.
+    """
+
+    if get_envbool(NEMO_ENV_VARNAME_TESTING, False):
+        f()


### PR DESCRIPTION
The following patch modifies the forward of the NeVa model (the `replace_media_embeddings` method) by introducing the following improvements:

- Elimination of `torch.where` with a single argument. That call introduces device synchronizations when run on GPUs.
- Media index selection manipulation in the construction of `padded_media_indices` can be done  in a single vectorized call.
- Reduction in the overall number of kernel launches.
- Elimination of calls to `all`. This also causes device syncs. We can leave it, or run it in debug mode only. It is best to have a dedicated test instead of that assert, imho.