### PR TITLE
Updating num_weights check in unit_test of RETRO

### DIFF
--- a/tests/collections/nlp/test_retro_model.py
+++ b/tests/collections/nlp/test_retro_model.py
@@ -204,7 +204,7 @@ class TestRETROModel:
 
         num_weights = retro_model.num_weights
         # assert num_weights == 306868224 # using "tokenizer/mt_nlg_plus_multilingual_ja_zh_the_stack_frac_015_256k.model" tokenizer
-        assert num_weights == 113405952  # using "spm_tok_ende_4k/tokenizer.model" tokenizer
+        assert num_weights == 113404416 # using "spm_tok_ende_4k/tokenizer.model" tokenizer
 
     @pytest.mark.unit
     def test_forward(self, retro_model):

--- a/tests/collections/nlp/test_retro_model.py
+++ b/tests/collections/nlp/test_retro_model.py
@@ -204,7 +204,7 @@ class TestRETROModel:
 
         num_weights = retro_model.num_weights
         # assert num_weights == 306868224 # using "tokenizer/mt_nlg_plus_multilingual_ja_zh_the_stack_frac_015_256k.model" tokenizer
-        assert num_weights == 113404416 # using "spm_tok_ende_4k/tokenizer.model" tokenizer
+        assert num_weights == 113404416  # using "spm_tok_ende_4k/tokenizer.model" tokenizer
 
     @pytest.mark.unit
     def test_forward(self, retro_model):


### PR DESCRIPTION
Due to underlying changes in MLM mcore RETRO, the total number of parameters slightly changed.
We update the `assert num_weights ` accordingly in unit test for RETRO.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
