### PR TITLE
Add option to convert PyTriton response to OpenAI format

### DIFF
--- a/nemo/deploy/nlp/query_llm.py
+++ b/nemo/deploy/nlp/query_llm.py
@@ -15,6 +15,7 @@
 from abc import ABC, abstractmethod
 
 import numpy as np
+import time
 
 from nemo.deploy.utils import str_list2numpy
 
@@ -172,6 +173,7 @@ class NemoQueryLLM(NemoQueryLLMBase):
         compute_logprob: bool = None,
         end_strings=None,
         init_timeout=60.0,
+        openai_format_response: bool = False
     ):
         """
         Query the Triton server synchronously and return a list of responses.
@@ -259,7 +261,20 @@ class NemoQueryLLM(NemoQueryLLMBase):
                     return "Unknown output keyword."
 
                 sentences = np.char.decode(output.astype("bytes"), "utf-8")
-                return sentences
+                if openai_format_response:
+                    openai_response = {
+                        "id": f"cmpl-{int(time.time())}",
+                        "object": "text_completion",
+                        "created": int(time.time()),
+                        "model": self.model_name,
+                        "choices": [{
+                            "text": str(sentences)
+                        }
+                        ]
+                    }
+                    return openai_response
+                else:
+                    return sentences
             else:
                 return result_dict["outputs"]
 

--- a/nemo/deploy/nlp/query_llm.py
+++ b/nemo/deploy/nlp/query_llm.py
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 from abc import ABC, abstractmethod
 
 import numpy as np
-import time
 
 from nemo.deploy.utils import str_list2numpy
 
@@ -173,7 +173,7 @@ class NemoQueryLLM(NemoQueryLLMBase):
         compute_logprob: bool = None,
         end_strings=None,
         init_timeout=60.0,
-        openai_format_response: bool = False
+        openai_format_response: bool = False,
     ):
         """
         Query the Triton server synchronously and return a list of responses.
@@ -267,10 +267,7 @@ class NemoQueryLLM(NemoQueryLLMBase):
                         "object": "text_completion",
                         "created": int(time.time()),
                         "model": self.model_name,
-                        "choices": [{
-                            "text": str(sentences)
-                        }
-                        ]
+                        "choices": [{"text": str(sentences)}],
                     }
                     return openai_response
                 else:

--- a/nemo/deploy/service/config.json
+++ b/nemo/deploy/service/config.json
@@ -1,6 +1,0 @@
-{
-    "triton_service_port": 8000,
-    "triton_service_ip": "0.0.0.0",
-    "triton_request_timeout": 60,
-    "openai_format_response": true
-  }

--- a/nemo/deploy/service/config.json
+++ b/nemo/deploy/service/config.json
@@ -1,5 +1,6 @@
 {
     "triton_service_port": 8000,
     "triton_service_ip": "0.0.0.0",
-    "triton_request_timeout": 60
+    "triton_request_timeout": 60,
+    "openai_format_response": true
   }

--- a/nemo/deploy/service/rest_model_api.py
+++ b/nemo/deploy/service/rest_model_api.py
@@ -59,6 +59,7 @@ class TritonSettings(BaseSettings):
         """
         return self._openai_format_response
 
+
 app = FastAPI()
 triton_settings = TritonSettings()
 
@@ -73,6 +74,7 @@ class CompletionRequest(BaseModel):
     stream: bool = False
     stop: str | None = None
     frequency_penalty: float = 1.0
+
 
 @app.get("/triton_health")
 async def check_triton_health():
@@ -90,6 +92,7 @@ async def check_triton_health():
     except requests.RequestException as e:
         raise HTTPException(status_code=503, detail=f"Cannot reach Triton server: {str(e)}")
 
+
 @app.post("/v1/completions/")
 def completions_v1(request: CompletionRequest):
     try:
@@ -102,7 +105,7 @@ def completions_v1(request: CompletionRequest):
             top_p=request.top_p,
             temperature=request.temperature,
             init_timeout=triton_settings.triton_request_timeout,
-            openai_format_response=triton_settings.openai_format_response
+            openai_format_response=triton_settings.openai_format_response,
         )
         if triton_settings.openai_format_response:
             return output

--- a/nemo/deploy/service/rest_model_api.py
+++ b/nemo/deploy/service/rest_model_api.py
@@ -12,8 +12,9 @@
 import json
 import os
 from pathlib import Path
+import requests
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 from pydantic_settings import BaseSettings
 
@@ -33,6 +34,7 @@ class TritonSettings(BaseSettings):
                 self._triton_service_port = config_json["triton_service_port"]
                 self._triton_service_ip = config_json["triton_service_ip"]
                 self._triton_request_timeout = config_json["triton_request_timeout"]
+                self._openai_format_response = config_json["openai_format_response"]
         except Exception as error:
             print("An exception occurred:", error)
             return
@@ -49,6 +51,13 @@ class TritonSettings(BaseSettings):
     def triton_request_timeout(self):
         return self._triton_request_timeout
 
+    @property
+    def openai_format_response(self):
+        """
+        Retuns the response from Triton server in OpenAI compatible formar if set to True,
+        default set in config.json is false.
+        """
+        return self._openai_format_response
 
 app = FastAPI()
 triton_settings = TritonSettings()
@@ -65,6 +74,21 @@ class CompletionRequest(BaseModel):
     stop: str | None = None
     frequency_penalty: float = 1.0
 
+@app.get("/triton_health")
+async def check_triton_health():
+    """
+    This method exposes endpoint "/triton_health" which can be used to verify if Triton server is accessible while running the REST or FastAPI application.
+    Verify by running: curl http://service_http_address:service_port/triton_health and the returned status should inform if the server is accessible.
+    """
+    triton_url = f"triton_settings.triton_service_ip:str(triton_settings.triton_service_port)/v2/health/ready"
+    try:
+        response = requests.get(triton_url, timeout=5)
+        if response.status_code == 200:
+            return {"status": "Triton server is reachable and ready"}
+        else:
+            raise HTTPException(status_code=503, detail="Triton server is not ready")
+    except requests.RequestException as e:
+        raise HTTPException(status_code=503, detail=f"Cannot reach Triton server: {str(e)}")
 
 @app.post("/v1/completions/")
 def completions_v1(request: CompletionRequest):
@@ -78,10 +102,14 @@ def completions_v1(request: CompletionRequest):
             top_p=request.top_p,
             temperature=request.temperature,
             init_timeout=triton_settings.triton_request_timeout,
+            openai_format_response=triton_settings.openai_format_response
         )
-        return {
-            "output": output[0][0],
-        }
+        if triton_settings.openai_format_response:
+            return output
+        else:
+            return {
+                "output": output[0][0],
+            }
     except Exception as error:
         print("An exception occurred:", error)
         return {"error": "An exception occurred"}

--- a/scripts/deploy/nlp/deploy_triton.py
+++ b/scripts/deploy/nlp/deploy_triton.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 import argparse
+import json
 import logging
 import os
 import sys
 from pathlib import Path
+
 import uvicorn
-import json
 
 from nemo.deploy import DeployPyTriton
 
@@ -186,10 +187,17 @@ def get_args(argv):
         "-sha", "--service_http_address", default="0.0.0.0", type=str, help="HTTP address for the REST Service"
     )
     parser.add_argument("-sp", "--service_port", default=8080, type=int, help="Port for the REST Service")
-    parser.add_argument("-ofr", "--openai_format_response", default=False, type=bool, help="Return the response from PyTriton server in OpenAI compatible format")
+    parser.add_argument(
+        "-ofr",
+        "--openai_format_response",
+        default=False,
+        type=bool,
+        help="Return the response from PyTriton server in OpenAI compatible format",
+    )
     parser.add_argument("-dm", "--debug_mode", default=False, action='store_true', help="Enable debug mode")
     args = parser.parse_args(argv)
     return args
+
 
 def store_args_to_json(args):
     """
@@ -200,10 +208,11 @@ def store_args_to_json(args):
         "triton_service_ip": args.triton_http_address,
         "triton_service_port": args.triton_port,
         "triton_request_timeout": args.triton_request_timeout,
-        "openai_format_response": args.openai_format_response
+        "openai_format_response": args.openai_format_response,
     }
     with open("nemo/deploy/service/config.json", "w") as f:
         json.dump(args_dict, f)
+
 
 def get_trtllm_deployable(args):
     if args.triton_model_repository is None:

--- a/scripts/deploy/nlp/deploy_triton.py
+++ b/scripts/deploy/nlp/deploy_triton.py
@@ -241,6 +241,9 @@ def get_trtllm_deployable(args):
         if args.service_port == args.triton_port:
             logging.error("REST service port and Triton server port cannot use the same port.")
             return
+        logging.warning("When using REST service to expose endpoints, the REST application uses Triton IP, Triton Port and other endpoint specific" \
+                     " parameter values from nemo/deploy/service/config.json to call NeMoQueryLLM. Please make sure args.triton_http_address and" \
+                     " args.triton_port match the values in config.json.")
 
     trt_llm_exporter = TensorRTLLM(
         model_dir=trt_llm_path,


### PR DESCRIPTION
# What does this PR do ?

1. Adds option to convert responses from PyTriton server to OpenAI compatible format. 
2. Also adds `triton_request_timeout` and `openai_format_response` as user defined args which are then written to a json file along with `triton IP` and `triton port` to be accessed by `rest_model_api.py` (Deletes the existing `nemo/deploy/service/config.json` favor of these changes)

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
