### PR TITLE
Skip quantization if model is already quantized (QAT resuming)

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -329,6 +329,7 @@ jobs:
            uses: actions/checkout@v4
          - run: |
             python examples/nlp/language_modeling/tuning/megatron_gpt_qat.py \
+            name=llama_ci \
             quantization.algorithm=int4 \
             quantization.num_calib_size=8 \
             trainer.devices=1 \
@@ -344,6 +345,8 @@ jobs:
             model.data.train_ds.file_names=[/home/TestData/nlp/megatron_sft/quarel.jsonl] \
             model.data.train_ds.concat_sampling_probabilities=[1.0] \
             model.data.validation_ds.file_names=[/home/TestData/nlp/megatron_sft/quarel.jsonl]
+
+            tar -tf llama2_qat_results/checkpoints/llama-ci.nemo | grep -q "modelopt_state/" || exit 1
 
             rm -rf llama2_qat_results
          - uses: "NVIDIA/NeMo/.github/actions/cancel-workflow@main"

--- a/docs/source/starthere/intro.rst
+++ b/docs/source/starthere/intro.rst
@@ -102,7 +102,7 @@ This final step involves installing the TensorRT Model Optimizer package.
 
 .. code-block:: bash
 
-    pip install nvidia-modelopt[torch]~=0.13.0 --extra-index-url https://pypi.nvidia.com
+    pip install nvidia-modelopt[torch] --extra-index-url https://pypi.nvidia.com
 
 
 .. code-block:: bash

--- a/nemo/export/quantize/quantizer.py
+++ b/nemo/export/quantize/quantizer.py
@@ -31,6 +31,7 @@ from nemo.utils.model_utils import save_artifacts, unwrap_model
 try:
     import modelopt.torch.quantization as mtq
     from modelopt.torch.export import export_tensorrt_llm_checkpoint
+    from modelopt.torch.quantization.utils import is_quantized
     from modelopt.torch.utils.distributed import set_data_parallel_group, set_tensor_parallel_group
 
     HAVE_MODELOPT = True
@@ -199,6 +200,10 @@ class Quantizer:
         assert self.quant_cfg is not None, "Quantization algorithm is not set"
 
         logging.info(f"Quantizing model to {self.quantization_config.algorithm}...")
+        if is_quantized(model):
+            logging.warning("Model is already quantized. Skipping quantization step.")
+            return model
+
         self._setup(model)
 
         model = mtq.quantize(model, self.quant_cfg, forward_loop)


### PR DESCRIPTION
# What does this PR do ?

When doing QAT for a big model, we often need to resume training. This PR adds a check if model restored from the resume checkpoint is already quantized or not, and if quantized, it skips this step.

**Collection**: N/A

# Changelog 
- Skip quantization if model is already quantized (QAT resuming)

# Usage

- N/A

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation
- [x] Minor improvement

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
