### PR TITLE
[NeMo-UX] Fixes to make PreemptionCallback work

### DIFF
--- a/nemo/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/nemo/lightning/pytorch/callbacks/model_checkpoint.py
@@ -249,7 +249,9 @@ class ModelCheckpoint(PTLModelCheckpoint, IOMixin):
             if isinstance(trainer.val_check_interval, int) and trainer.global_step % trainer.val_check_interval != 0:
                 should_save_last_checkpoint = True
             if any(map(lambda callback: isinstance(callback, PreemptionCallback), trainer.callbacks)):
-                preemption_callback: PreemptionCallback = next(filter(lambda callback: isinstance(callback, PreemptionCallback), trainer.callbacks))
+                preemption_callback: PreemptionCallback = next(
+                    filter(lambda callback: isinstance(callback, PreemptionCallback), trainer.callbacks)
+                )
                 if preemption_callback.preemption_supported:
                     should_save_last_checkpoint = True
             if should_save_last_checkpoint:

--- a/nemo/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/nemo/lightning/pytorch/callbacks/model_checkpoint.py
@@ -28,7 +28,6 @@ from pytorch_lightning.utilities import rank_zero_info
 
 from nemo.lightning.io.mixin import IOMixin
 from nemo.lightning.io.pl import TrainerContext
-from nemo.lightning.pytorch.callbacks.preemption import PreemptionCallback
 from nemo.utils import logging
 from nemo.utils.app_state import AppState
 from nemo.utils.model_utils import ckpt_to_dir
@@ -248,12 +247,6 @@ class ModelCheckpoint(PTLModelCheckpoint, IOMixin):
                 should_save_last_checkpoint = True
             if isinstance(trainer.val_check_interval, int) and trainer.global_step % trainer.val_check_interval != 0:
                 should_save_last_checkpoint = True
-            if any(map(lambda callback: isinstance(callback, PreemptionCallback), trainer.callbacks)):
-                preemption_callback: PreemptionCallback = next(
-                    filter(lambda callback: isinstance(callback, PreemptionCallback), trainer.callbacks)
-                )
-                if preemption_callback.preemption_supported:
-                    should_save_last_checkpoint = True
             if should_save_last_checkpoint:
                 monitor_candidates = self._monitor_candidates(trainer)
                 if self.last_model_path == self.format_checkpoint_name(monitor_candidates, self.CHECKPOINT_NAME_LAST):

--- a/nemo/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/nemo/lightning/pytorch/callbacks/model_checkpoint.py
@@ -28,6 +28,7 @@ from pytorch_lightning.utilities import rank_zero_info
 
 from nemo.lightning.io.mixin import IOMixin
 from nemo.lightning.io.pl import TrainerContext
+from nemo.lightning.pytorch.callbacks.preemption import PreemptionCallback
 from nemo.utils import logging
 from nemo.utils.app_state import AppState
 from nemo.utils.model_utils import ckpt_to_dir
@@ -247,6 +248,10 @@ class ModelCheckpoint(PTLModelCheckpoint, IOMixin):
                 should_save_last_checkpoint = True
             if isinstance(trainer.val_check_interval, int) and trainer.global_step % trainer.val_check_interval != 0:
                 should_save_last_checkpoint = True
+            if any(map(lambda callback: isinstance(callback, PreemptionCallback), trainer.callbacks)):
+                preemption_callback: PreemptionCallback = next(filter(lambda callback: isinstance(callback, PreemptionCallback), trainer.callbacks))
+                if preemption_callback.preemption_supported:
+                    should_save_last_checkpoint = True
             if should_save_last_checkpoint:
                 monitor_candidates = self._monitor_candidates(trainer)
                 if self.last_model_path == self.format_checkpoint_name(monitor_candidates, self.CHECKPOINT_NAME_LAST):

--- a/nemo/lightning/pytorch/callbacks/preemption.py
+++ b/nemo/lightning/pytorch/callbacks/preemption.py
@@ -45,14 +45,14 @@ class PreemptionCallback(Callback, IOMixin):
         self._preemption_supported = None
 
     def on_train_start(self, trainer: Trainer, pl_module) -> None:
-        if self._preemption_supported:
+        if self.preemption_supported:
             self._handler_context = self._preemption_handler()
             self._handler_context.__enter__()
 
     def on_train_batch_start(self, trainer: Trainer, pl_module, batch, batch_idx: int) -> None:
-        if not self._preemption_supported:
+        if not self.preemption_supported:
             self._preemption_supported = self._check_preemption_support()
-            if self._preemption_supported:
+            if self.preemption_supported:
                 self._handler_context = self._preemption_handler()
                 self._handler_context.__enter__()
 
@@ -72,7 +72,7 @@ class PreemptionCallback(Callback, IOMixin):
 
     @contextlib.contextmanager
     def _preemption_handler(self):
-        if not self._preemption_supported:
+        if not self.preemption_supported:
             logging.warning("Preemption requires torch distributed to be initialized, preemption may be disabled")
             yield
             return
@@ -105,7 +105,7 @@ class PreemptionCallback(Callback, IOMixin):
 
     @property
     def interrupted(self) -> bool:
-        if not self._preemption_supported:
+        if not self.preemption_supported:
             return False
         interrupted = torch.tensor(self._interrupted, device=torch.cuda.current_device(), dtype=torch.int32)
         torch.distributed.broadcast(interrupted, 0)

--- a/nemo/lightning/pytorch/callbacks/preemption.py
+++ b/nemo/lightning/pytorch/callbacks/preemption.py
@@ -20,10 +20,11 @@ import torch
 from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.trainer.trainer import Trainer
 
+from nemo.lightning.io.mixin import IOMixin
 from nemo.utils import logging
 
 
-class PreemptionCallback(Callback):
+class PreemptionCallback(Callback, IOMixin):
     """
     PreemptionCallback checks for preemption during training at the end of every step.
     Upon preemption, it signals the trainer to stop gracefully.

--- a/nemo/lightning/pytorch/callbacks/preemption.py
+++ b/nemo/lightning/pytorch/callbacks/preemption.py
@@ -42,17 +42,17 @@ class PreemptionCallback(Callback, IOMixin):
         self.sig = sig if sig is not None else signal.SIGTERM
         self._interrupted = False
         self._handler_context = None
-        self.preemption_supported = None
+        self._preemption_supported = None
 
     def on_train_start(self, trainer: Trainer, pl_module) -> None:
-        if self.preemption_supported:
+        if self._preemption_supported:
             self._handler_context = self._preemption_handler()
             self._handler_context.__enter__()
 
     def on_train_batch_start(self, trainer: Trainer, pl_module, batch, batch_idx: int) -> None:
-        if not self.preemption_supported:
-            self.preemption_supported = self._check_preemption_support()
-            if self.preemption_supported:
+        if not self._preemption_supported:
+            self._preemption_supported = self._check_preemption_support()
+            if self._preemption_supported:
                 self._handler_context = self._preemption_handler()
                 self._handler_context.__enter__()
 
@@ -72,7 +72,7 @@ class PreemptionCallback(Callback, IOMixin):
 
     @contextlib.contextmanager
     def _preemption_handler(self):
-        if not self.preemption_supported:
+        if not self._preemption_supported:
             logging.warning("Preemption requires torch distributed to be initialized, preemption may be disabled")
             yield
             return
@@ -96,16 +96,16 @@ class PreemptionCallback(Callback, IOMixin):
 
     @property
     def preemption_supported(self) -> bool:
-        if self.preemption_supported is None:
-            self.preemption_supported = self._check_preemption_support()
-        return self.preemption_supported
+        if self._preemption_supported is None:
+            self._preemption_supported = self._check_preemption_support()
+        return self._preemption_supported
 
     def _check_preemption_support(self) -> bool:
         return torch.distributed.is_available() and torch.distributed.is_initialized()
 
     @property
     def interrupted(self) -> bool:
-        if not self.preemption_supported:
+        if not self._preemption_supported:
             return False
         interrupted = torch.tensor(self._interrupted, device=torch.cuda.current_device(), dtype=torch.int32)
         torch.distributed.broadcast(interrupted, 0)

--- a/nemo/lightning/pytorch/callbacks/preemption.py
+++ b/nemo/lightning/pytorch/callbacks/preemption.py
@@ -42,7 +42,7 @@ class PreemptionCallback(Callback, IOMixin):
         self.sig = sig if sig is not None else signal.SIGTERM
         self._interrupted = False
         self._handler_context = None
-        self._preemption_supported = None
+        self.preemption_supported = None
 
     def on_train_start(self, trainer: Trainer, pl_module) -> None:
         if self.preemption_supported:
@@ -51,7 +51,7 @@ class PreemptionCallback(Callback, IOMixin):
 
     def on_train_batch_start(self, trainer: Trainer, pl_module, batch, batch_idx: int) -> None:
         if not self.preemption_supported:
-            self._preemption_supported = self._check_preemption_support()
+            self.preemption_supported = self._check_preemption_support()
             if self.preemption_supported:
                 self._handler_context = self._preemption_handler()
                 self._handler_context.__enter__()
@@ -96,9 +96,9 @@ class PreemptionCallback(Callback, IOMixin):
 
     @property
     def preemption_supported(self) -> bool:
-        if self._preemption_supported is None:
-            self._preemption_supported = self._check_preemption_support()
-        return self._preemption_supported
+        if self.preemption_supported is None:
+            self.preemption_supported = self._check_preemption_support()
+        return self.preemption_supported
 
     def _check_preemption_support(self) -> bool:
         return torch.distributed.is_available() and torch.distributed.is_initialized()

--- a/nemo/lightning/pytorch/callbacks/preemption.py
+++ b/nemo/lightning/pytorch/callbacks/preemption.py
@@ -14,6 +14,7 @@
 
 import contextlib
 import signal
+import sys
 from typing import Optional
 
 import torch
@@ -21,6 +22,7 @@ from pytorch_lightning.callbacks import Callback
 from pytorch_lightning.trainer.trainer import Trainer
 
 from nemo.lightning.io.mixin import IOMixin
+from nemo.lightning.pytorch.callbacks.model_checkpoint import ModelCheckpoint
 from nemo.utils import logging
 
 
@@ -62,13 +64,15 @@ class PreemptionCallback(Callback, IOMixin):
 
     def on_train_batch_end(self, trainer: Trainer, pl_module, outputs, batch, batch_idx: int) -> None:
         if self.interrupted:
-            logging.info("Preemption detected, signaling trainer to stop")
+            logging.info("Preemption detected, saving checkpoint and exiting")
             trainer.should_stop = True
-
-    def on_exception(self, trainer: Trainer, pl_module, exception: BaseException) -> None:
-        if isinstance(exception, PreemptionException):
-            logging.info("Handling PreemptionException")
-            trainer.should_stop = True
+            if any(map(lambda callback: isinstance(callback, ModelCheckpoint), trainer.callbacks)):
+                checkpoint_callback: ModelCheckpoint = next(
+                    filter(lambda callback: isinstance(callback, ModelCheckpoint), trainer.callbacks)
+                )
+                monitor_candidates = checkpoint_callback._monitor_candidates(trainer)
+                checkpoint_callback._save_last_checkpoint(trainer, monitor_candidates)
+                sys.exit(0)
 
     @contextlib.contextmanager
     def _preemption_handler(self):
@@ -82,7 +86,6 @@ class PreemptionCallback(Callback, IOMixin):
         def master_handler(signum, frame):
             logging.info(f"Received signal {signum}, initiating graceful stop")
             self._interrupted = True
-            raise PreemptionException("Preemption signal received")
 
         def ignoring_handler(signum, frame):
             logging.debug(f"Received signal {signum} on non-master rank, ignoring")
@@ -110,7 +113,3 @@ class PreemptionCallback(Callback, IOMixin):
         interrupted = torch.tensor(self._interrupted, device=torch.cuda.current_device(), dtype=torch.int32)
         torch.distributed.broadcast(interrupted, 0)
         return bool(interrupted.item())
-
-
-class PreemptionException(Exception):
-    """Custom exception for preemption events."""

--- a/nemo/lightning/pytorch/callbacks/preemption.py
+++ b/nemo/lightning/pytorch/callbacks/preemption.py
@@ -66,12 +66,9 @@ class PreemptionCallback(Callback, IOMixin):
         if self.interrupted:
             logging.info("Preemption detected, saving checkpoint and exiting")
             trainer.should_stop = True
-            if any(map(lambda callback: isinstance(callback, ModelCheckpoint), trainer.callbacks)):
-                checkpoint_callback: ModelCheckpoint = next(
-                    filter(lambda callback: isinstance(callback, ModelCheckpoint), trainer.callbacks)
-                )
-                monitor_candidates = checkpoint_callback._monitor_candidates(trainer)
-                checkpoint_callback._save_last_checkpoint(trainer, monitor_candidates)
+            if trainer.checkpoint_callback:
+                monitor_candidates = trainer.checkpoint_callback._monitor_candidates(trainer)
+                trainer.checkpoint_callback._save_last_checkpoint(trainer, monitor_candidates)
                 sys.exit(0)
 
     @contextlib.contextmanager

--- a/nemo/lightning/resume.py
+++ b/nemo/lightning/resume.py
@@ -139,7 +139,9 @@ class AutoResume(Resume, io.IOMixin):
                     checkpoint = last_checkpoints[0]
                     checkpoint = uninject_model_parallel_rank(checkpoint)
                 else:
-                    raise ValueError(f"Multiple checkpoints {last_checkpoints} that matches *last.ckpt.")
+                    # Select the checkpoint with the latest modified time
+                    checkpoint = sorted(last_checkpoints, key=lambda pth: pth.lstat().st_mtime, reverse=True)[0]
+                    logging.warning(f"Multiple checkpoints {last_checkpoints} matches *last.ckpt. Selecting one with the latest modified time.")
             else:
                 checkpoint = last_checkpoints[0]
 

--- a/nemo/lightning/resume.py
+++ b/nemo/lightning/resume.py
@@ -141,7 +141,9 @@ class AutoResume(Resume, io.IOMixin):
                 else:
                     # Select the checkpoint with the latest modified time
                     checkpoint = sorted(last_checkpoints, key=lambda pth: pth.lstat().st_mtime, reverse=True)[0]
-                    logging.warning(f"Multiple checkpoints {last_checkpoints} matches *last.ckpt. Selecting one with the latest modified time.")
+                    logging.warning(
+                        f"Multiple checkpoints {last_checkpoints} matches *last.ckpt. Selecting one with the latest modified time."
+                    )
             else:
                 checkpoint = last_checkpoints[0]
 

--- a/tests/lightning/pytorch/callbacks/test_preemption.py
+++ b/tests/lightning/pytorch/callbacks/test_preemption.py
@@ -1,4 +1,3 @@
-import logging
 import signal
 from unittest.mock import MagicMock, PropertyMock, patch
 
@@ -6,7 +5,7 @@ import pytest
 import torch
 from pytorch_lightning import Trainer
 
-from nemo.lightning.pytorch.callbacks.preemption import PreemptionCallback, PreemptionException
+from nemo.lightning.pytorch.callbacks.preemption import PreemptionCallback
 
 
 class TestPreemptionCallback:
@@ -102,13 +101,3 @@ class TestPreemptionCallback:
         with patch.object(PreemptionCallback, 'interrupted', new_callable=lambda: property(lambda self: interrupted)):
             callback.on_train_batch_end(mock_trainer, None, None, None, 0)
             assert mock_trainer.should_stop == interrupted
-
-    def test_on_exception_preemption(self, callback, mock_trainer):
-        exception = PreemptionException("Test preemption")
-        callback.on_exception(mock_trainer, None, exception)
-        assert mock_trainer.should_stop
-
-    def test_on_exception_other(self, callback, mock_trainer):
-        exception = ValueError("Some other exception")
-        callback.on_exception(mock_trainer, None, exception)
-        assert not mock_trainer.should_stop

--- a/tests/lightning/pytorch/callbacks/test_preemption.py
+++ b/tests/lightning/pytorch/callbacks/test_preemption.py
@@ -99,5 +99,9 @@ class TestPreemptionCallback:
     @pytest.mark.parametrize("interrupted", [True, False])
     def test_on_train_batch_end(self, callback, mock_trainer, interrupted):
         with patch.object(PreemptionCallback, 'interrupted', new_callable=lambda: property(lambda self: interrupted)):
-            callback.on_train_batch_end(mock_trainer, None, None, None, 0)
+            if interrupted:
+                with pytest.raises(SystemExit):
+                    callback.on_train_batch_end(mock_trainer, None, None, None, 0)
+            else:
+                callback.on_train_batch_end(mock_trainer, None, None, None, 0)
             assert mock_trainer.should_stop == interrupted


### PR DESCRIPTION
# What does this PR do ?

Adds IOMixin to PreemptionCallback to make it serializable

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
