### PR TITLE
[NeMo-UX] Fix a minor bug with async checkpointing

### DIFF
--- a/nemo/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/nemo/lightning/pytorch/callbacks/model_checkpoint.py
@@ -380,6 +380,8 @@ class ModelCheckpoint(PTLModelCheckpoint, IOMixin):
         self.set_checkpoint_unfinished_marker(filepath, barrier_after=True)
         ema_callback = self._ema_callback(trainer)
 
+        self._last_global_step_saved = trainer.global_step
+
         if ema_callback is not None:
             if self.async_save:
                 raise ValueError('async_save with EMA not supported')
@@ -422,7 +424,6 @@ class ModelCheckpoint(PTLModelCheckpoint, IOMixin):
 
         def _cb():
             logging.debug(f'Finalize callback called for step {global_step}, filepath {filepath}')
-            self._last_global_step_saved = global_step
             self._last_checkpoint_saved = filepath
 
             from nemo.utils.get_rank import is_global_rank_zero


### PR DESCRIPTION
Because `self._last_global_step_saved` is being set within the finalize fn, it is only updated when a checkpoint is finalized. This causes an erroneous mismatch between `self._last_global_step_saved` and `trainer.global_step`, so [this PTL check](https://github.com/Lightning-AI/pytorch-lightning/blob/abcac663232f5a0fd47442a0c782e81fccbf0174/src/lightning/pytorch/callbacks/model_checkpoint.py#L420) returns `False` when it should return `True`. This causes some checkpoints to get saved twice, once `on_train_batch_end` and once `on_validation_end`. This fixes the problem by updating `self._last_global_step_saved` outside of the finalize function. 

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
