### PR TITLE
CUDA Memory Profile Analyzer

### DIFF
--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -1864,7 +1864,7 @@ class ModelPT(LightningModule, Model):
         https://pytorch-lightning.readthedocs.io/en/stable/common/lightning_module.html#on-train-batch-start
         We use it here to enable nsys profiling and dynamic freezing.
         """
-        logging.info(f"Training Real batch {self._real_batch_idx} started.")
+        # logging.info(f"Training Real batch {self._real_batch_idx} started.")
         # nsys profiling
         if self.device.type == 'cuda':
             if hasattr(self, '_nsys_profile_enabled'):
@@ -1936,7 +1936,7 @@ class ModelPT(LightningModule, Model):
         https://pytorch-lightning.readthedocs.io/en/stable/common/lightning_module.html#on-train-batch-end
         We use it here to enable nsys profiling.
         """
-        logging.info(f"Training Real batch {self._real_batch_idx} ended.")
+        # logging.info(f"Training Real batch {self._real_batch_idx} ended.")
         if self.device.type == 'cuda':
             if hasattr(self, '_nsys_profile_enabled'):
                 if self._nsys_profile_enabled and not self._nsys_profile_complete:

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -1796,7 +1796,7 @@ class ModelPT(LightningModule, Model):
                 self._memory_profile_weight_enabled = True # Set as True
                 self._memory_profile_oom_enabled = True # Set as True
 
-                if self._memory_profile_weight_enabled and get_rank() == self._memory_profile_rank: # For the weight profile, we record the snapshot from the initialization, and dump it before batch-0 start. 
+                if self._memory_profile_weight_enabled: # For the weight profile, we record the snapshot from the initialization, and dump it before batch-0 start. Note: can't use `get_rank()` during initialization, since nccl_init_group is not called yet. 
                     logging.info(f"====== Rank[{self._memory_profile_rank}], Initialization. Start CUDA memory profiling: Weight ======")
                     torch.cuda.memory._record_memory_history() 
 

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -1787,16 +1787,21 @@ class ModelPT(LightningModule, Model):
                 self._memory_profile_rank = self.cfg.memory_profile.get('rank', 0)
                 self._memory_profile_output_path = self.cfg.memory_profile.get('output_path', None)
                 self._memory_profile_snapshot_file_activation = f'{self._memory_profile_output_path}/memory_profile_rank{self._memory_profile_rank}_act.pickle'    
-                self._memory_profile_snapshot_file_weight = f'{self._memory_profile_output_path}/memory_profile_rank{self._memory_profile_rank}_weight.pickle'    
+                self._memory_profile_snapshot_file_weight = f'{self._memory_profile_output_path}/memory_profile_rank{self._memory_profile_rank}_weight.pickle'
+                self._memory_profile_snapshot_file_oom = f'{self._memory_profile_output_path}/memory_profile_rank{self._memory_profile_rank}_oom.pickle'
                 # CUDA memory profiling options: analysis
                 self._memory_profile_analysis_enabled = self.cfg.memory_profile.get('analysis_enabled', False)
                 self._memory_profile_analysis_path = os.path.join(self._memory_profile_output_path, f"analysis")
-                # CUDA memory profiling options: weight profile
+                # CUDA memory profiling options: weight profile & OOM profile
                 self._memory_profile_weight_enabled = True # Set as True
+                self._memory_profile_oom_enabled = True # Set as True
 
                 if self._memory_profile_weight_enabled and get_rank() == self._memory_profile_rank: # For the weight profile, we record the snapshot from the initialization, and dump it before batch-0 start. 
                     logging.info(f"====== Rank[{self._memory_profile_rank}], Initialization. Start CUDA memory profiling: Weight ======")
                     torch.cuda.memory._record_memory_history() 
+
+                if self._memory_profile_oom_enabled:
+                    torch._C._cuda_attach_out_of_memory_observer(self.oom_observer)
 
                 if type(self._memory_profile_start_step) == int:
                     logging.info(f'CUDA memory profiling (Activation) setup with start_step: {self._memory_profile_start_step}')
@@ -1822,7 +1827,18 @@ class ModelPT(LightningModule, Model):
                         f'Memory profile output path ({self._memory_profile_output_path}) is not set or does not exist.'
                     )
 
-
+    def oom_observer(self, device, alloc, device_alloc, device_free, *args, **kwargs):
+        if get_rank() == self._memory_profile_rank:
+            logging.info(f"====== Rank[{self._memory_profile_rank}]. OOM Profile. End CUDA memory profiling: Out Of Memory. Snapshot saved in {self._memory_profile_snapshot_file_oom} ======")
+            torch.cuda.memory._dump_snapshot(f"{self._memory_profile_snapshot_file_oom}")
+            # if snapshot exists, we call the peak-memory-analyzer and export the csv file
+            # Need to wait a bit after error shows up. It is running the function.
+            if self._memory_profile_oom_enabled and self._memory_profile_analysis_enabled:
+                if os.path.exists(self._memory_profile_snapshot_file_oom):
+                    logging.info(f"===== Memory Profile Analysis: OOM ======")
+                    peak_memory_analysis(self._memory_profile_snapshot_file_oom, self._memory_profile_analysis_path, 'oom', self._memory_profile_rank)
+                else:
+                    raise Exception(f"Snapshot file not found: {self._memory_profile_snapshot_file_oom}")
 
     def on_train_start(self):
         """PyTorch Lightning hook:
@@ -1866,7 +1882,7 @@ class ModelPT(LightningModule, Model):
                         try:
                             logging.info(f"====== Rank[{self._memory_profile_rank}], Batch[{batch_idx}]. End CUDA memory profiling: Weight. Snapshot saved in {self._memory_profile_snapshot_file_weight} ======")
                             torch.cuda.memory._dump_snapshot(f"{self._memory_profile_snapshot_file_weight}")
-                            torch.cuda.memory._record_memory_history(enabled=None)
+                            # torch.cuda.memory._record_memory_history(enabled=None)
                         except Exception as e:
                             logging.error(f"Failed to capture memory snapshot {e}")
                             return
@@ -1887,6 +1903,8 @@ class ModelPT(LightningModule, Model):
                         logging.info(f"====== Rank[{self._memory_profile_rank}], Batch[{batch_idx}]. Start CUDA memory profiling: Activation ======")
                         # Record the current allocated_memory before this training batch. 
                         self._memory_profile_allocated = torch.cuda.memory_allocated() / (1024*1024*1024) # should be weight_memory. # in GB. 
+                        # Restart recording memory history
+                        torch.cuda.memory._record_memory_history(enabled=None)
                         torch.cuda.memory._record_memory_history(max_entries=30000000) # we set a very large max_entries to avoid the truncation that we don't want. Normally a few global batches won't exceed this restriction. This is only to avoid the extremely large file.
                         self._memory_profile_started = True
                         logging.info(f"Before recording activation memory snapshot, allocated memory: {self._memory_profile_allocated} GB")
@@ -1941,7 +1959,7 @@ class ModelPT(LightningModule, Model):
                         if not os.path.exists(self._memory_profile_analysis_path):
                             os.makedirs(self._memory_profile_analysis_path)
                         if os.path.exists(self._memory_profile_snapshot_file_activation):
-                            logging.info(f"====== Memory Profile Analysis: Analyzing the generated memory snapshot file ======")
+                            logging.info(f"====== Memory Profile Analysis: Activation ======")
                             peak_memory_analysis(self._memory_profile_snapshot_file_activation, self._memory_profile_analysis_path, 'act', self._memory_profile_rank)
                         else:
                             raise Exception(f"Snapshot file not found: {self._memory_profile_snapshot_file_activation}")    

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -49,7 +49,6 @@ from nemo.utils.app_state import AppState
 from nemo.utils.debug_hook import register_debug_hooks
 from nemo.utils.exceptions import NeMoBaseException
 from nemo.utils.get_rank import get_rank, is_global_rank_zero
-# from nemo.utils.memory_profile_analyzer import peak_memory_analysis_activation, peak_memory_analysis_weight, peak_memory_analysis_oom
 from nemo.utils.memory_profile_analyzer import peak_memory_analysis
 
 __all__ = ['ModelPT']

--- a/nemo/utils/memory_profile_analyzer.py
+++ b/nemo/utils/memory_profile_analyzer.py
@@ -18,11 +18,10 @@ import pickle
 
 import numpy as np
 import pandas as pd
-from scipy.signal import find_peaks, peak_prominences
-
+from scipy.signal import find_peaks
 from nemo.utils import logging
 
-_all__ = ['peak_memory_analysis']
+__all__ = ['peak_memory_analysis']
 
 GB_SIZE = 1024 * 1024 * 1024
 MB_SIZE = 1024 * 1024
@@ -91,10 +90,7 @@ def find_max_min_alloc_memory(trace):
     """
     Given a trace, find the maximum/minimum alloc memory and the corresponding idx and timestamps.
     """
-    alloc_memory_history = np.zeros(len(trace))  # record the curr_alloc_memory at each timepoint
-    time_us_history = np.zeros(len(trace))  # record the time_us at each timepoint
-
-    curr_alloc_memory = 0  # in GB
+    curr_alloc_memory = 0 # in GB
 
     min_alloc_memory = float('inf')
     max_alloc_memory = float('-inf')
@@ -112,9 +108,6 @@ def find_max_min_alloc_memory(trace):
         elif action == "free_completed":
             curr_alloc_memory -= size
 
-        alloc_memory_history[idx] = curr_alloc_memory
-        time_us_history[idx] = time_us
-
         if curr_alloc_memory > max_alloc_memory:
             max_alloc_memory = curr_alloc_memory
             time_max_alloc = time_us
@@ -125,11 +118,7 @@ def find_max_min_alloc_memory(trace):
             time_min_alloc = time_us
             idx_min = idx
 
-    return (
-        (alloc_memory_history, time_us_history),
-        (idx_min, time_min_alloc, min_alloc_memory),
-        (idx_max, time_max_alloc, max_alloc_memory),
-    )
+    return (idx_min, time_min_alloc, min_alloc_memory), (idx_max, time_max_alloc, max_alloc_memory)
 
 
 class MemoryLife:
@@ -398,11 +387,7 @@ def peak_memory_analysis(mem_snapshot_filepath, mem_snapshot_csv_dir, name_suffi
     # change all the global time_us to the relative time (starting from 0)
     trace = to_relative_time(trace, TIME_OFFSET)
 
-    (
-        (alloc_memory_history, time_us_history),
-        (idx_min, time_min_alloc, min_alloc_memory),
-        (idx_max, time_max_alloc, max_alloc_memory),
-    ) = find_max_min_alloc_memory(trace)
+    (idx_min, time_min_alloc, min_alloc_memory), (idx_max, time_max_alloc, max_alloc_memory) = find_max_min_alloc_memory(trace)
     logging.info(f"===== Global Max and Min Memory =====")
     logging.info(
         f"idx_min: {idx_min}, relative_idx_min: {idx_min/len(trace):.5f}, time_min_alloc: {time_min_alloc}, min_alloc_memory: {min_alloc_memory:.5f} GB"

--- a/nemo/utils/memory_profile_analyzer.py
+++ b/nemo/utils/memory_profile_analyzer.py
@@ -1,0 +1,456 @@
+import pickle
+import os
+import pandas as pd
+import numpy as np
+from scipy.signal import find_peaks, peak_prominences
+from nemo.utils import logging
+
+# __all__ = ['peak_memory_analysis_weight', 'peak_memory_analysis_activation', 'peak_memory_analysis_oom']
+_all__ = ['peak_memory_analysis']
+
+GB_SIZE = 1024*1024*1024
+MB_SIZE = 1024*1024
+KB_SIZE = 1024
+
+def load_pickle_file(filename):
+    with open(filename, "rb") as f:
+        data = pickle.load(f)
+    return data
+
+def make_hashable(obj):
+    """
+    Helper function to make an object hashable. 
+    """
+    if isinstance(obj, dict):
+        return tuple(sorted((k, make_hashable(v)) for k, v in obj.items()))
+    if isinstance(obj, list):
+        return tuple(make_hashable(e) for e in obj)
+    return obj
+
+
+def read_tp(timepoint):
+    time_us = timepoint['time_us']
+    addr = timepoint['addr']
+    action = timepoint['action']
+    size = timepoint['size'] / GB_SIZE
+    frames = timepoint['frames']
+    stream = timepoint['stream']
+    return (time_us, addr, action, size, frames, stream)
+
+
+def first_py_frame(alloc_frames):
+    """
+    Return the frame when it first shows a `.py` file.
+    """
+    # target_string = 'layernorm_linear.py'
+    for frame in alloc_frames:
+        if '.py' in frame['filename']:
+            return frame
+    return None
+
+def alloc_memory_timeline(trace):
+    alloc_memory_history = np.zeros(len(trace)) # record the curr_alloc_memory at each timepoint
+    time_us_history = np.zeros(len(trace)) # record the time_us at each timepoint
+
+    curr_alloc_memory = 0 # in GB
+
+    min_alloc_memory = float('inf')
+    max_alloc_memory = float('-inf')
+
+    time_min_alloc = None
+    time_max_alloc = None
+    idx_min = None
+    idx_max = None
+    
+    for idx, timepoint in enumerate(trace):
+        (time_us, addr, action, size, frames, stream) = read_tp(timepoint)
+
+        if (action == "alloc"):
+            curr_alloc_memory += size
+        elif (action == "free_completed"):
+            curr_alloc_memory -= size
+
+        alloc_memory_history[idx] = curr_alloc_memory
+        time_us_history[idx] = time_us
+
+        if curr_alloc_memory > max_alloc_memory:
+            max_alloc_memory = curr_alloc_memory
+            time_max_alloc = time_us
+            idx_max = idx
+
+        if curr_alloc_memory < min_alloc_memory:
+            min_alloc_memory = curr_alloc_memory
+            time_min_alloc = time_us
+            idx_min = idx
+
+
+    return (alloc_memory_history, time_us_history), (idx_min, time_min_alloc, min_alloc_memory), (idx_max, time_max_alloc, max_alloc_memory)
+
+
+
+def record_alloc_memory_timeline(trace):
+    alloc_memory_history = np.zeros(len(trace)) # record the curr_alloc_memory at each timepoint
+    time_us_history = np.zeros(len(trace)) # record the time_us at each timepoint
+    
+    curr_alloc_memory = 0 # in GB
+
+    min_alloc_memory = float('inf')
+    max_alloc_memory = float('-inf')
+    
+    time_min_alloc = None
+    time_max_alloc = None
+    idx_min = None
+    idx_max = None
+    
+    for idx, timepoint in enumerate(trace):
+        (time_us, addr, action, size, frames, stream) = read_tp(timepoint)
+
+        if (action == "alloc"):
+            curr_alloc_memory += size
+        elif (action == "free_completed"):
+            curr_alloc_memory -= size
+
+        alloc_memory_history[idx] = curr_alloc_memory
+        time_us_history[idx] = time_us
+        
+        
+        if curr_alloc_memory > max_alloc_memory:
+            max_alloc_memory = curr_alloc_memory
+            time_max_alloc = time_us
+            idx_max = idx
+
+        if curr_alloc_memory < min_alloc_memory:
+            min_alloc_memory = curr_alloc_memory
+            time_min_alloc = time_us
+            idx_min = idx
+            
+        # logging.info(f"curr_alloc_memory: {curr_alloc_memory} MB")
+        # logging.info(f"max_alloc_memory: {max_alloc_memory} MB")
+        # logging.info(f"min_alloc_memory: {min_alloc_memory} MB")
+
+    return (alloc_memory_history, time_us_history), (idx_min, time_min_alloc, min_alloc_memory), (idx_max, time_max_alloc, max_alloc_memory)
+
+
+class MemoryLife:
+    """
+    Records one active memory interval. Information includes its lifetime interval (start, end), the size of memory, and related frames (stack trace). 
+    """
+    def __init__(self, start_time_us, end_time_us, size, alloc_frames, free_frames):
+        self.start_time_us = start_time_us
+        self.end_time_us = end_time_us
+        self.size = size
+        self.alloc_frames = alloc_frames
+        self.free_frames = free_frames
+    
+    # the default print function
+    def __str__(self):
+        return f"[{self.start_time_us}, {self.end_time_us}], size: {self.size:.5f} GB"
+    
+    
+
+class MemoryInfo:
+    def __init__(self, addr):
+        self.addr = addr
+        self.history = [] # list of tps
+        self.lifetime = [] # list of MemoryLife
+
+    def add_history(self, tp):
+        self.history.append(tp)
+
+    def add_lifetime_alloc(self, start_time_us, size, alloc_frames):
+        # self.lifetime.append([time_us, None]) # start a new interval
+        self.lifetime.append(MemoryLife(start_time_us, None, size, alloc_frames, None))
+
+    def add_lifetime_free(self, end_time_us, size, frames):
+        # Check exception
+        # 1. if the last lifetime is already freed, then raise exception
+        if self.lifetime[-1].end_time_us is not None:
+            raise Exception(f"Memory at addr {self.addr} is already freed")
+        # 2. check if the alloctaed size == freed size
+        if self.lifetime[-1].size != size:
+            raise Exception(f"Size mismatch (allocated size vs freed size): {self.lifetime[-1].size} vs {size}")
+        # record the end time
+        self.lifetime[-1].end_time_us = end_time_us
+        # record the free frames
+        self.lifetime[-1].free_frames = frames
+    
+    def get_info_if_alive(self, time_us):
+        """
+        Check if the memory is alive at the given time point. We all use relative time point. 
+        Return (start_time_us, size, alloc_frames) if alive, otherwise return None.
+        """
+        for life in self.lifetime:
+            if (life.start_time_us <= time_us) and (life.end_time_us is None or life.end_time_us > time_us):
+                return (life.start_time_us, life.size, life.alloc_frames)
+        return None
+
+
+    def print_info(self):
+        logging.info(f"Addr: {self.addr}, len(lifetime): {len(self.lifetime)}")
+        # print the first 5 lifetimes
+        for idx, life in enumerate(self.lifetime):
+            if idx < 5:
+                logging.info(life)
+
+
+class MemoryTracker:
+    def __init__(self):
+        self.data = {} # key: addr, value: MemoryInfo
+
+    def add_entry(self, tp):
+        (time_us, addr, action, size, frames, stream) = read_tp(tp)
+        
+        if addr not in self.data:
+            self.data[addr] = MemoryInfo(addr)
+
+        self.data[addr].add_history(tp)
+        
+        if action == 'alloc': 
+            # alloc memory
+            self.data[addr].add_lifetime_alloc(time_us, size, frames)
+        elif (action == 'free_completed') and (len(self.data[addr].lifetime)!= 0) :
+            # free memory, but this can't be the first memory op for this addr. There must be an alloc happening before. 
+            self.data[addr].add_lifetime_free(time_us, size, frames)
+        else:
+            # ignore free_requested; or free_completed op before any alloc op, since that is related to some previous alloc ops that are not captured. 
+            # one thing need to keep in mind: we ignore `free_completed` memory that we don't see `alloc` before in this trace. However, these memory activities exist because our trace is not guaranteed to be complete. This may lead to some memory counting mismatch. 
+            pass
+    
+    def check_alive_memory(self, time_us):
+        """
+        Gather all alive memory addresses, their start time, their sizes, and alloc_frames at the given time point. Save it with the order of start time. 
+        """
+        alive_memory = []
+        for addr, memory_info in self.data.items():
+            info = memory_info.get_info_if_alive(time_us) # info = (start_time_us, size, alloc_frames)
+            if info is not None:
+                alive_memory.append((addr, info[0], info[1], info[2]))
+        alive_memory.sort(key=lambda x: x[1]) # sort by start time
+        return alive_memory
+
+'''
+Data structure for memory grouped by alloc_frames. 
+It includes alloc_frames, a list of memory that shares the same alloc_frames, the total count, the total size of memory. 
+'''
+class MemoryGroupByAllocFrames:
+    def __init__(self, alloc_frames, memory_list):
+        self.alloc_frames = alloc_frames
+        self.memory_list = memory_list
+        self.count = len(memory_list)
+        self.total_size = sum([x[2] for x in memory_list])
+        self.frame_string = self.first_py_frame()
+    
+    def add_memory(self, memory):
+        self.memory_list.append(memory) # memory = (addr, start_time_us, size, alloc_frames)
+        self.count += 1
+        self.total_size += memory[2]
+    
+    def first_py_frame(self):
+        """
+        Return the frame when it first shows a `.py` file.
+        """
+        # target_string = 'layernorm_linear.py'
+        for frame in self.alloc_frames:
+            if '.py' in frame['filename']:
+                return frame
+        return None
+
+
+    def __str__(self):
+        # return f"Alloc Frames: {self.alloc_frames}, Count: {self.count}, Total Size: {self.total_size:.5f} GB"a
+        # return f"Count: {self.count}, Total Size: {self.total_size:.5f} GB"
+        return f"First Py Frame: {self.frame_string}, Count: {self.count}, Total Size: {self.total_size:.5f} GB"
+
+
+class MemoryAnalyzer:
+    def __init__(self, memory_list):
+        """
+        memory_list: list of (addr, start_time_us, size, alloc_frames)
+        """
+        self.memory_list = memory_list
+        self.alloc_frames_group = dict() # key: alloc_frames_tuple, value: MemoryGroupByAllocFrames
+
+    def group_memory_by_alloc_frames(self):
+        for addr, start_time_us, size, alloc_frames in self.memory_list:
+            alloc_frames_tuple = make_hashable(alloc_frames) # make it hashable so that it can be used as a key
+            
+            if alloc_frames_tuple not in self.alloc_frames_group:
+                self.alloc_frames_group[alloc_frames_tuple] = MemoryGroupByAllocFrames(alloc_frames, [])
+
+            self.alloc_frames_group[alloc_frames_tuple].add_memory((addr, start_time_us, size, alloc_frames))
+        
+        # sort the alloc_frames_group by total_size
+        self.alloc_frames_group = dict(sorted(self.alloc_frames_group.items(), key=lambda x: x[1].total_size, reverse=True))
+    
+    def print_info(self):
+        for frames, group in self.alloc_frames_group.items():
+            logging.info(f"{group}")
+    
+    def save_as_list(self):
+        """
+        Save as a list of tuple (frame_string, count, total_size, alloc_frames)
+        """
+        memory_group_by_alloc_frames = []
+        for frames, group in self.alloc_frames_group.items():
+            one_layer = group.frame_string, group.count, group.total_size, group.alloc_frames
+            memory_group_by_alloc_frames.append(one_layer)
+        return memory_group_by_alloc_frames
+
+
+def find_prominence_peak(history, prominence, distance=1000):
+    """
+    Find peaks/valleys with prominence. 
+    After checking the definition of prominence, seems like in our case, prominence is close to the memory_gap. So we use a 0.8*memory_gap as prominence. 
+    Note that this is kind of heuristic, and can be broken in some cases (?)
+
+    Return: prominence_peaks and prominence_valleys
+        (peaks, valleys)
+    """
+    peaks, properties_peak = find_peaks(x=history, prominence=prominence, distance=distance)  # looks like prominence is close to memory_gap   ## we set a very small distance, since we find a case that two peaks are very close to each other.
+    # Find local minima (inverted peaks)
+    inverted_history = -history
+    valleys, properties_valleys = find_peaks(inverted_history, prominence=prominence, distance=distance)
+    return (peaks, properties_peak), (valleys, properties_valleys)
+
+def find_paired_peak_valley(peaks, valleys):
+    """
+    Ensure each trough is paired with the next peak
+    """
+    paired_peaks = []
+    paired_valleys = []
+
+    for valley in valleys:
+        # Find the next peak after this trough
+        next_peak_candidates = peaks[peaks > valley]
+        if next_peak_candidates.size > 0:
+            next_peak = next_peak_candidates[0]
+            paired_valleys.append(valley)
+            paired_peaks.append(next_peak)
+    return paired_peaks, paired_valleys
+
+def to_relative_time(trace, TIME_OFFSET):
+    """
+    Change the absolute time to the relative time for all the timepoints in this trace. The absolute time is too large, which is not readable. 
+    """
+    for timepoint in trace:
+        timepoint['time_us'] -= TIME_OFFSET
+    return trace
+
+
+# ===== Function: for two time points, check the corresponding alive memory, and compare them to see: what's new, what's gone, what's unchanged.
+def compare_alive_memory(tracker, time_us_1, time_us_2):
+    alive_memory_1 = tracker.check_alive_memory(time_us_1)
+    alive_memory_2 = tracker.check_alive_memory(time_us_2)
+
+    # 1. what's new
+    new_memory = [x for x in alive_memory_2 if x not in alive_memory_1]
+    # 2. what's gone
+    gone_memory = [x for x in alive_memory_1 if x not in alive_memory_2]
+    # 3. what's unchanged
+    unchanged_memory = [x for x in alive_memory_2 if x in alive_memory_1]
+    # 4. new_memory and gone_memory could overlap a lot, but they only differ on the addr or start_time_us. We compare them to show real_new_memory and real_gone_memory. 
+    # This time when we compare `in`, we compare (size, alloc_frames) instead of (addr, start_time_us, size, alloc_frames)
+    real_new_memory = [x for x in new_memory if (x[2], x[3]) not in [(y[2], y[3]) for y in gone_memory]]
+    real_gone_memory = [x for x in gone_memory if (x[2], x[3]) not in [(y[2], y[3]) for y in new_memory]]
+
+    return (new_memory, gone_memory), (real_new_memory, real_gone_memory), unchanged_memory
+
+def print_memory_list_summary(memory_list, name):
+    total_size = sum([x[2] for x in memory_list])
+    print(f"len({name}): {len(memory_list)}, Total memory size: {total_size:.5f} GB")
+
+def prune_frames(frames):
+    """
+    The stack trace is too long, and include many not-so-useful frame. We prune those frames with '??' in the filename. 
+    """
+    return [frame for frame in frames if '??' not in frame['filename']]
+
+
+
+
+
+
+def peak_memory_analysis(mem_snapshot_filepath, mem_snapshot_csv_dir):
+    """
+    Key and Entry Function for peak memory analysis. 
+    Find the global peak of the trace. 
+    1. Check alive memory at global peak, and export to CSV with their stack traces. 
+    2. Group the alive memory by its alloc_frames. Export to CSV. 
+    """
+    
+    # ===== Loading =====
+    snapshot = load_pickle_file(mem_snapshot_filepath)
+    traces = snapshot['device_traces']
+    trace = traces[0] # useful trace. Device 0. 
+
+    # remove the last timepoint, if it is an oom action
+    if trace[-1]['action'] == 'oom':
+        trace = trace[:-1]
+
+    min_time_us, max_time_us = trace[0]['time_us'], trace[-1]['time_us']
+    TIME_OFFSET = min_time_us
+    min_time_us -= TIME_OFFSET
+    max_time_us -= TIME_OFFSET
+
+    # change all the global time_us to the relative time (starting from 0)
+    trace = to_relative_time(trace, TIME_OFFSET)
+
+    (alloc_memory_history, time_us_history), (idx_min, time_min_alloc, min_alloc_memory), (idx_max, time_max_alloc, max_alloc_memory) = alloc_memory_timeline(trace)
+    logging.info(f"===== Global Max and Min Memory =====")
+    logging.info(f"idx_min: {idx_min}, relative_idx_min: {idx_min/len(trace):.5f}, time_min_alloc: {time_min_alloc}, min_alloc_memory: {min_alloc_memory:.5f} GB")
+    logging.info(f"idx_max: {idx_max}, relative_idx_max: {idx_max/len(trace):.5f}, time_max_alloc: {time_max_alloc}, max_alloc_memory: {max_alloc_memory:.5f} GB")
+
+    # track the lifetime of each memory address
+    tracker = MemoryTracker()
+    for tp in trace:
+        tracker.add_entry(tp)
+    
+    # ======== 1. Global Peak Alive Memory Analsysis ========
+    logging.info(f"======== 1. Global Peak Alive Memory Analysis ========")
+    logging.info(f"===== Check Alive Memory at Global Peak: time_max_alloc (relative time): {time_max_alloc/max_time_us:.5f} =====") # need to be the time here
+
+    alive_memory_max = tracker.check_alive_memory(time_max_alloc)
+    # the accumulated memory size at time_max_alloc
+    total_memory_max = sum([x[2] for x in alive_memory_max])
+    logging.info(f"Number of alive memory addresses: {len(alive_memory_max)}, Total memory size: {total_memory_max:.5f} GB")
+    
+    logging.info(f"===== Export to CSV: alive memory with its stack traces =====")
+    # 1. export this alive_memory_max to a csv file, with pandas
+    alive_memory_max_short = [(x[0], x[1], x[2], first_py_frame(x[3])) for x in alive_memory_max]
+    data = {
+        "Addr (Decimal)": [x[0] for x in alive_memory_max],
+        "Time of Allocation (us)": [x[1] for x in alive_memory_max],
+        "Size (GB)": [x[2] for x in alive_memory_max],
+        "First Python Frame": [x[3] for x in alive_memory_max_short], # this is the first frame that shows a `.py` file
+        "Full Stack Trace": [x[3] for x in alive_memory_max], 
+        "Pruned Stack Trace": [prune_frames(x[3]) for x in alive_memory_max], # prune the stack trace
+    }
+    df = pd.DataFrame(data)
+    csv_1_path = os.path.join(mem_snapshot_csv_dir, "alive_memory.csv")
+    df.to_csv(csv_1_path, index=False) # this generates a big csv file, since the alloc_frames are huge. 
+    logging.info(f"1: Exported to {csv_1_path}")
+
+
+    # ======== 2. group memory by alloc_frames at global peak ========
+    logging.info(f"======== 2. Group Global Peak Alive Memory by Alloc Frames ========")
+    analyzer = MemoryAnalyzer(alive_memory_max)
+    analyzer.group_memory_by_alloc_frames()
+    # analyzer.print_info()
+    memory_group_by_alloc_frames = analyzer.save_as_list()
+
+    # logging.info(memory_group_by_alloc_frames)
+    # export as csv
+    logging.info(f"===== Export to CSV: grouped memory by alloc_frames =====")
+    data_group = {
+        "First Python Frame": [x[0] for x in memory_group_by_alloc_frames],
+        "Repeat": [x[1] for x in memory_group_by_alloc_frames],
+        "Total Size (GB)": [x[2] for x in memory_group_by_alloc_frames], 
+        "Pruned Stack Trace": [prune_frames(x[3]) for x in memory_group_by_alloc_frames] # prune the stack trace
+    }
+    df_group = pd.DataFrame(data_group)
+    csv_2_path = os.path.join(mem_snapshot_csv_dir, "group_by_alloc_frames.csv")
+    df_group.to_csv(csv_2_path, index=False)
+    logging.info(f"2: Exported to {csv_2_path}")   
+
+
+

--- a/nemo/utils/memory_profile_analyzer.py
+++ b/nemo/utils/memory_profile_analyzer.py
@@ -90,7 +90,7 @@ def find_max_min_alloc_memory(trace):
     """
     Given a trace, find the maximum/minimum alloc memory and the corresponding idx and timestamps.
     """
-    curr_alloc_memory = 0 # in GB
+    curr_alloc_memory = 0  # in GB
 
     min_alloc_memory = float('inf')
     max_alloc_memory = float('-inf')
@@ -387,7 +387,9 @@ def peak_memory_analysis(mem_snapshot_filepath, mem_snapshot_csv_dir, name_suffi
     # change all the global time_us to the relative time (starting from 0)
     trace = to_relative_time(trace, TIME_OFFSET)
 
-    (idx_min, time_min_alloc, min_alloc_memory), (idx_max, time_max_alloc, max_alloc_memory) = find_max_min_alloc_memory(trace)
+    (idx_min, time_min_alloc, min_alloc_memory), (idx_max, time_max_alloc, max_alloc_memory) = (
+        find_max_min_alloc_memory(trace)
+    )
     logging.info(f"===== Global Max and Min Memory =====")
     logging.info(
         f"idx_min: {idx_min}, relative_idx_min: {idx_min/len(trace):.5f}, time_min_alloc: {time_min_alloc}, min_alloc_memory: {min_alloc_memory:.5f} GB"

--- a/nemo/utils/memory_profile_analyzer.py
+++ b/nemo/utils/memory_profile_analyzer.py
@@ -54,6 +54,8 @@ def get_printed_frames(alive_memory):
     Get the printed frames for the alive_memory.
     prune_frames to get rid of '??' in the filename.
     Add `\n` in between each frame for the readability.
+
+    alive_memory: list of (addr, start_time_us, size, alloc_frames)
     """
     # Prune Frames. x: [addr, start_time_us, size, alloc_frames]. x[3]: alloc_frames.
     after_prune_frames = [prune_frames(x[3]) for x in alive_memory]
@@ -63,6 +65,11 @@ def get_printed_frames(alive_memory):
 
 
 def read_tp(timepoint):
+    """
+    Read the timepoint and return the time_us, addr, action, size, frames, stream.
+
+    timepoint: a dictionary with keys: 'time_us', 'addr', 'action', 'size', 'frames', 'stream'
+    """
     time_us = timepoint['time_us']
     addr = timepoint['addr']
     action = timepoint['action']

--- a/nemo/utils/memory_profile_analyzer.py
+++ b/nemo/utils/memory_profile_analyzer.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import pickle
 import os
 import csv
@@ -6,7 +20,6 @@ import numpy as np
 from scipy.signal import find_peaks, peak_prominences
 from nemo.utils import logging
 
-# __all__ = ['peak_memory_analysis_weight', 'peak_memory_analysis_activation', 'peak_memory_analysis_oom']
 _all__ = ['peak_memory_analysis']
 
 GB_SIZE = 1024*1024*1024

--- a/nemo/utils/memory_profile_analyzer.py
+++ b/nemo/utils/memory_profile_analyzer.py
@@ -16,7 +16,6 @@ import csv
 import os
 import pickle
 
-import numpy as np
 import pandas as pd
 from scipy.signal import find_peaks
 from nemo.utils import logging
@@ -24,8 +23,6 @@ from nemo.utils import logging
 __all__ = ['peak_memory_analysis']
 
 GB_SIZE = 1024 * 1024 * 1024
-MB_SIZE = 1024 * 1024
-KB_SIZE = 1024
 
 
 def load_pickle_file(filename):


### PR DESCRIPTION
# What does this PR do ?
- Collect CUDA memory snapshot based on the previous commit (#9096 ), and further analyze which parts of the model contribute to the total memory footprint. 
- The memory profile will generate two `pickle file`, one for weight, one for activation. The user can load the file in the below page: https://pytorch.org/memory_viz
- If out-of-memory (CUDA OOM) occurs, the tool will capture the snapshot before OOM occurs, and generate the `pickle file`.
- With knobs `analysis_enabled: True`, the memory profile analyzer will generate two csv files each for weight/activation/OOM. The output csv files includes:
  1. Weight
      - `alive_memory_weight.csv`
      - `group_by_alloc_frames_weight.csv`
  2. Activation
      - `alive_memory_memory.csv`
      - `group_by_alloc_frames_memory.csv`
  3. OOM
      - `alive_memory_oom.csv`
      - `group_by_alloc_frames_oom.csv`


# Changelog 
- Fix some issues of previous memory profile
    - `batch_idx` mismatch issue.
    - `max_entries` is too small, which makes the generated snapshot easily truncated.
- Add weight memory capturing.
- Add OOM case support.
- Added the option to enable further analysis to the generated memory snapshot file. The analyzer finds the peak memory of the snapshot, and generate two csv files, including
    1. All the alive memory buffers at that peak moment
    2. Group them by allocation frames, showing the relationship between model layer and its corresponding memory footprint.

# Usage
- Add the below knobs to the yaml run config.

```python
# Memory Profile
memory_profile:                                                                      
   enabled: true                                                                      
   start_step: 1                                                                      
   end_step: 3                                                                        
   rank: 0                                                                            
   output_path: <path/to/out_file>
   analysis_enabled: true
```



# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
