### PR TITLE
[NeMo-UX] make progress bar easier to parse

### DIFF
--- a/nemo/lightning/pytorch/callbacks/progress.py
+++ b/nemo/lightning/pytorch/callbacks/progress.py
@@ -22,7 +22,7 @@ class MegatronProgressBar(TQDMProgressBar):
         Override bar_format to not have 's/it'.
         """
         self.bar = super().init_train_tqdm()
-        self.bar.bar_format = "{desc}: {percentage:3.0f}%|{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}{postfix}]"
+        self.bar.bar_format = "{desc} {n_fmt}/{total_fmt}{postfix}"
         return self.bar
 
     def on_train_epoch_start(self, trainer, *_):


### PR DESCRIPTION
# What does this PR do ?
This is a minor update to the NeMo 2.0 progress bar that make the metrics slightly easier to parse. Rather than the progress being logged like this:
```
Epoch 0: :   0%|          | 0/80 [00:00<?]
Epoch 0: :   1%|▏         | 1/80 [00:00<00:45]
Epoch 0: :   1%|▏         | 1/80 [00:00<00:45, global_step=0.000, reduced_train_loss=11.00, train_step_timing in s=0.543]
Epoch 0: :   2%|▎         | 2/80 [00:00<00:30, global_step=0.000, reduced_train_loss=11.00, train_step_timing in s=0.543]
Epoch 0: :   2%|▎         | 2/80 [00:00<00:30, global_step=1.000, reduced_train_loss=10.10, train_step_timing in s=0.166]
Epoch 0: :   4%|▍         | 3/80 [00:00<00:24, global_step=1.000, reduced_train_loss=10.10, train_step_timing in s=0.166]
Epoch 0: :   4%|▍         | 3/80 [00:00<00:24, global_step=2.000, reduced_train_loss=9.840, train_step_timing in s=0.167]
```
The progress now look like this:
```
Epoch 0:  1/80, global_step=0.000, reduced_train_loss=11.00, train_step_timing in s=0.510
Epoch 0:  2/80, global_step=0.000, reduced_train_loss=11.00, train_step_timing in s=0.510
Epoch 0:  2/80, global_step=1.000, reduced_train_loss=10.10, train_step_timing in s=0.166
Epoch 0:  3/80, global_step=1.000, reduced_train_loss=10.10, train_step_timing in s=0.166
Epoch 0:  3/80, global_step=2.000, reduced_train_loss=9.840, train_step_timing in s=0.166
```
This is a temporary update while we work on a more permanent solution. 

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
