### PR TITLE
remove redundant temp-file handling

### DIFF
--- a/nemo/utils/callbacks/s3_checkpoint_io.py
+++ b/nemo/utils/callbacks/s3_checkpoint_io.py
@@ -136,7 +136,7 @@ class S3CheckpointIO(CheckpointIO):
             except Exception as e:
                 logging.error(f'Failed to upload {item[2]} to {item[1]}, exception: {e}')
                 raise e
-            
+
         self._futures = in_progress_futures
         logging.debug(
             f'Time elapsed checking uploading future results: {(time.perf_counter() - start_time):.2f} seconds'
@@ -209,7 +209,6 @@ class S3CheckpointIO(CheckpointIO):
             start_time = time.perf_counter()
             self._executor.shutdown(wait=True)
             logging.info(f'executor shut down after {(time.perf_counter() - start_time):.2f} seconds, rank {rank}')
-
 
 
 def _clean_up_conflicting_checkpoint(filepath: str) -> None:


### PR DESCRIPTION
# What does this PR do ?

The s3_checkpoint_io tracks tempfiles created to handle cleanup during teardown when saving is asynchronous, but does so redundantly and can be removed due to `self._executor.shutdown(wait=True)` already handling it. 

**Collection**: [Note which collection this PR will affect]
nlp

# Changelog 
- Removed tracking of tempfiles in the S3CheckpointIO 

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
