### PR TITLE
[NeMo-UX] Update default PTL logging `save_dir`

### DIFF
--- a/nemo/lightning/nemo_logger.py
+++ b/nemo/lightning/nemo_logger.py
@@ -30,7 +30,12 @@ class NeMoLogger(IOMixin):
         log_local_rank_0_only (bool): Log only on local rank 0.
         log_global_rank_0_only (bool): Log only on global rank 0.
         files_to_copy (Optional[List[str]]): List of files to copy to log directory.
-        update_logger_directory (bool): Whether to update logger directory.
+        update_logger_directory (bool): Whether to update logger directory to write to `exp_dir`.
+            If True, the `save_dir` passed to the logger will be treated as a relative path and
+            the logger will be reconfigured to write to `exp_dir / save_dir`. This ensures that
+            all output from an experiment is written to a common directory. If False, the logger's
+            save_dir will not be overwritten. This argument applies only to TensorBoardLogger and
+            WandbLogger instances.
         ckpt (Optional[ModelCheckpoint]): Model checkpoint callback.
     """
 

--- a/nemo/lightning/nemo_logger.py
+++ b/nemo/lightning/nemo_logger.py
@@ -147,12 +147,14 @@ class NeMoLogger(IOMixin):
         if self.update_logger_directory:
             for logger in trainer.loggers:
                 if isinstance(logger, TensorBoardLogger):
+                    logger._version = version or ""
                     logger._root_dir = Path(dir) / logger.save_dir
                     trainer.logger._name = self.name
                     logging.warning(
                         f'"update_logger_directory" is True. Overwriting tensorboard logger "save_dir" to {logger._root_dir}'
                     )
                 elif isinstance(logger, WandbLogger):
+                    logger._id = version or ""
                     logger._save_dir = Path(dir) / logger.save_dir
                     logger._wandb_init["dir"] = Path(dir) / logger.save_dir
                     logger._wandb_init["name"] = self.name

--- a/tests/lightning/test_nemo_logger.py
+++ b/tests/lightning/test_nemo_logger.py
@@ -21,7 +21,7 @@ class TestNeMoLogger:
         trainer = nl.Trainer(accelerator="cpu")
         logger = nl.NeMoLogger(
             update_logger_directory=True,
-            wandb=WandbLogger(save_dir="test", offline=True),
+            wandb=WandbLogger(save_dir="wandb_logs", offline=True),
         )
 
         logger.setup(trainer)
@@ -29,7 +29,7 @@ class TestNeMoLogger:
         assert len(logger.extra_loggers) == 0
         assert len(trainer.loggers) == 2
         assert isinstance(trainer.loggers[1], WandbLogger)
-        assert str(trainer.loggers[1].save_dir).endswith("nemo_experiments")
+        assert str(trainer.loggers[1].save_dir).endswith("nemo_experiments/wandb_logs")
         assert trainer.loggers[1]._name == "default"
 
     def test_explicit_log_dir(self, trainer):


### PR DESCRIPTION
# What does this PR do ?

If a user passes a `save_dir` to a PTL logger, by default we write the logs to `<log_dir> / save_dir`, where `<log_dir>` is determined by NeMoLogger. Previously, `save_dir` was ignored, and the logs would be written to `<log_dir>`. 

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
