### PR TITLE
Allow users to pass HF via local-path: model_cls.import_ckpt("hf:///p…

### DIFF
--- a/nemo/lightning/io/connector.py
+++ b/nemo/lightning/io/connector.py
@@ -2,7 +2,7 @@ import inspect
 import logging
 import os
 import shutil
-from pathlib import Path, PosixPath, WindowsPath
+from pathlib import Path, PosixPath, PurePath, WindowsPath
 from typing import Generic, Optional, Tuple, TypeVar
 
 import pytorch_lightning as pl
@@ -212,6 +212,10 @@ class ModelConnector(Connector, Generic[SourceT, TargetT]):
 
             _base = Path(NEMO_MODELS_CACHE)
 
+        # If the useu supplied `hf:///path/to/downloaded/my-model/`
+        # then extract the last dir-name (i.e. my-model) and append it to _base
+        if str(self).startswith('/'):
+            return _base / PurePath((str(self))).name
         return _base / str(self).replace("://", "/")
 
     def on_import_ckpt(self, model: pl.LightningModule):


### PR DESCRIPTION
Want to enable the following
`
    model = llm.MixtralModel(llm.MixtralConfig8x22B())
    hf_ckpt_path = "hf://mistralai/Mixtral-8x22B-v0.1"
    hf_ckpt_path = 'hf:///mnt/4tb/mixtral_8x22b/mixtral-8x22B-hf/'
    ckpt_path = model.import_ckpt(hf_ckpt_path)
`

- pass via hf identifier, ie: `hf_ckpt_path = "hf://mistralai/Mixtral-8x22B-v0.1"`
- pass via local path, ie: `hf_ckpt_path = 'hf:///mnt/4tb/mixtral_8x22b/mixtral-8x22B-hf/"`


This is mainly useful when the user has already downloaded to their local disk a large checkpoint (e.g. > 200B parameters).

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
