### PR TITLE
Disable barriers leading to deadlocks in checkpointing with multi-node training

### DIFF
--- a/nemo/utils/callbacks/nemo_model_checkpoint.py
+++ b/nemo/utils/callbacks/nemo_model_checkpoint.py
@@ -84,6 +84,7 @@ class NeMoModelCheckpoint(ModelCheckpoint):
             self.prefix = ""
 
         # Call the parent class constructor with the remaining kwargs.
+        kwargs["enable_version_counter"] = False
         super().__init__(**kwargs)
 
         if self.save_top_k != -1 and n_resume:
@@ -520,7 +521,7 @@ class NeMoModelCheckpoint(ModelCheckpoint):
             return
         # barrier_after=True, so all ranks continue after the unfinished checkpoint marker is placed.
         # if anything goes wrong during removal, we should be able to detect that data is incomplete.
-        self.set_checkpoint_unfinished_marker(filepath, barrier_after=True)
+        self.set_checkpoint_unfinished_marker(filepath, barrier_after=False)
         super()._remove_checkpoint(trainer, filepath)
         ema_callback = self._ema_callback(trainer)
         if ema_callback is not None:
@@ -529,7 +530,7 @@ class NeMoModelCheckpoint(ModelCheckpoint):
             super()._remove_checkpoint(trainer, filepath)
         # barrier_before=True, so all ranks synchronize before removing the unfinished checkpoint marker
         # we don't want to remove the marker until the checkpoint is actually removed.
-        self.remove_checkpoint_unfinished_marker(filepath, barrier_before=True)
+        self.remove_checkpoint_unfinished_marker(filepath, barrier_before=False)
 
     def _ema_format_filepath(self, filepath: str) -> str:
         return filepath.replace(self.FILE_EXTENSION, f'-EMA{self.FILE_EXTENSION}')


### PR DESCRIPTION
# What does this PR do ?

Per internal slack conversation, some multi-node trainings suffered from checkpoints being randomly removed between resumed jobs. After disabling `save_top_k` checkpointing option, the training is then running into deadlocks related to unfinished/last checkpoint logic. I traced down the deadlocks to a number of barriers, that when removed, seem to unblock the training.

**Collection**: All

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
