### PR TITLE
Fix metric logging

### DIFF
--- a/nemo/lightning/_strategy_lib.py
+++ b/nemo/lightning/_strategy_lib.py
@@ -532,7 +532,8 @@ def _sync_from_last_pipeline_stage(value: torch.Tensor, broadcast: bool = False)
         src_rank = parallel_state.get_pipeline_model_parallel_last_rank()
 
         if not broadcast:
-            if torch.distributed.get_rank() == src_rank:
+            pp_ranks = torch.distributed.get_process_group_ranks(parallel_state.get_pipeline_model_parallel_group())
+            if torch.distributed.get_rank() == src_rank and 0 in pp_ranks:
                 torch.distributed.send(value, 0)
             elif torch.distributed.get_rank() == 0:
                 torch.distributed.recv(value, src_rank)

--- a/nemo/lightning/_strategy_lib.py
+++ b/nemo/lightning/_strategy_lib.py
@@ -526,6 +526,16 @@ def load_model_state_dict(megatron_parallel, checkpoint: Mapping[str, Any], stri
 
 
 def _sync_from_last_pipeline_stage(value: torch.Tensor, broadcast: bool = False):
+    """
+    When pipeline parallelism is enabled, casts a tensor defined on the last pipeline stage to other ranks.
+
+        Args:
+            value (torch.Tensor): A tensor to be casted from the final pipeline stage of a pipeline parallelism group (e.g. loss).
+                Note that this tensor should already be defined on the target rank(s) to fill with received data.
+            broadcast (bool): When True, broadcasts value from the final pipeline stage rank to all ranks in its group.
+                When False, only rank zero receives value from the final pipeline stage rank in its group.
+                This mode exists to avoid slow one-to-many communication when not necessary. Defaults to False.
+    """
     from megatron.core import parallel_state
 
     if parallel_state.get_pipeline_model_parallel_world_size() > 1:

--- a/nemo/lightning/_strategy_lib.py
+++ b/nemo/lightning/_strategy_lib.py
@@ -525,7 +525,7 @@ def load_model_state_dict(megatron_parallel, checkpoint: Mapping[str, Any], stri
         module.load_state_dict(_state_dict, strict=strict)
 
 
-def _sync_from_last_pipeline_stage(value, broadcast=False):  # TODO add type annotation
+def _sync_from_last_pipeline_stage(value: torch.Tensor, broadcast: bool = False):
     from megatron.core import parallel_state
 
     if parallel_state.get_pipeline_model_parallel_world_size() > 1:

--- a/nemo/lightning/_strategy_lib.py
+++ b/nemo/lightning/_strategy_lib.py
@@ -523,3 +523,22 @@ def load_model_state_dict(megatron_parallel, checkpoint: Mapping[str, Any], stri
                 _state_dict[key] = value
 
         module.load_state_dict(_state_dict, strict=strict)
+
+
+def _sync_from_last_pipeline_stage(value, broadcast=False):  # TODO add type annotation
+    from megatron.core import parallel_state
+
+    if parallel_state.get_pipeline_model_parallel_world_size() > 1:
+        src_rank = parallel_state.get_pipeline_model_parallel_last_rank()
+
+        if not broadcast:
+            if torch.distributed.get_rank() == src_rank:
+                torch.distributed.send(value, 0)
+            elif torch.distributed.get_rank() == 0:
+                torch.distributed.recv(value, src_rank)
+        else:
+            torch.distributed.broadcast(
+                value,
+                src_rank,
+                group=parallel_state.get_pipeline_model_parallel_group(),
+            )

--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -286,16 +286,10 @@ class MegatronParallel(nn.ModuleList, Generic[ModelT]):
             self.callbacks.event("on_megatron_reduce_microbatches_end", **context)
         else:
             # we're not on the last pipeline stage so no losses
-            if forward_only:
-                loss_mean = cast(torch.Tensor, [])
-            else:
-                loss_mean = torch.tensor(0.0, device=torch.cuda.current_device())
+            loss_mean = torch.tensor(0.0, device=torch.cuda.current_device())
 
         self.callbacks.event("on_megatron_log_step_end", **context)
         self.callbacks.event("on_megatron_step_end", **context)
-
-        if loss_mean == []:
-            loss_mean = None
 
         return loss_mean
 

--- a/nemo/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/nemo/lightning/pytorch/callbacks/model_checkpoint.py
@@ -393,21 +393,20 @@ class ModelCheckpoint(PTLModelCheckpoint):
         exists = self._fs.exists(filepath) or (check_dist_ckpt and self._fs.exists(ckpt_to_dir(filepath)))
         return trainer.strategy.broadcast(exists)
 
-    def format_checkpoint_name(
-        self, metrics: Dict[str, torch.Tensor], filename: Optional[str] = None, ver: Optional[int] = None
-    ) -> str:
+    def _monitor_candidates(self, trainer: "pl.Trainer") -> Dict[str, torch.Tensor]:
         """Broadcast loss from last pipeline stage."""
+        monitor_candidates = super().monitor_candidates(trainer)
 
         from nemo.lightning._strategy_lib import _sync_from_last_pipeline_stage
 
-        keys = re.findall(r"[\{](.*?)[:\}]", filename)
-        for loss in ['reduced_train_loss', 'val_loss']:
-            if loss in keys:
-                if loss not in metrics:
-                    metrics[loss] = torch.tensor(0.0, device=torch.cuda.current_device())
-                _sync_from_last_pipeline_stage(metrics[loss], broadcast=True)
+        keys = re.findall(r"[\{](.*?)[:\}]", self.filename)
+        for loss_name in ['reduced_train_loss', 'val_loss']:
+            if loss_name in keys or loss_name == self.monitor:
+                if loss_name not in monitor_candidates:
+                    monitor_candidates[loss_name] = torch.tensor(0.0, device=torch.cuda.current_device())
+                _sync_from_last_pipeline_stage(monitor_candidates[loss_name], broadcast=True)
 
-        return super().format_checkpoint_name(metrics, filename, ver)
+        return monitor_candidates
 
     def _save_checkpoint(self, trainer: 'pytorch_lightning.Trainer', filepath: str) -> None:
         # barrier_after=True, so all ranks continue after the unfinished checkpoint marker is placed.

--- a/nemo/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/nemo/lightning/pytorch/callbacks/model_checkpoint.py
@@ -401,10 +401,11 @@ class ModelCheckpoint(PTLModelCheckpoint):
         from nemo.lightning._strategy_lib import _sync_from_last_pipeline_stage
 
         keys = re.findall(r"[\{](.*?)[:\}]", filename)
-        if 'reduced_train_loss' in keys:
-            _sync_from_last_pipeline_stage(metrics['reduced_train_loss'], broadcast=True)
-        if 'val_loss' in keys:
-            _sync_from_last_pipeline_stage(metrics['val_loss'], broadcast=True)
+        for loss in ['reduced_train_loss', 'val_loss']:
+            if loss in keys:
+                if loss not in metrics:
+                    metrics[loss] = torch.tensor(0.0, device=torch.cuda.current_device())
+                _sync_from_last_pipeline_stage(metrics[loss], broadcast=True)
 
         return super().format_checkpoint_name(metrics, filename, ver)
 

--- a/nemo/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/nemo/lightning/pytorch/callbacks/model_checkpoint.py
@@ -400,7 +400,7 @@ class ModelCheckpoint(PTLModelCheckpoint):
         from nemo.lightning._strategy_lib import _sync_from_last_pipeline_stage
 
         keys = re.findall(r"[\{](.*?)[:\}]", self.filename)
-        for loss_name in ['reduced_train_loss', 'val_loss']:
+        for loss_name in ['reduced_train_loss']:
             if loss_name in keys or loss_name == self.monitor:
                 if loss_name not in monitor_candidates:
                     monitor_candidates[loss_name] = torch.tensor(0.0, device=torch.cuda.current_device())

--- a/nemo/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/nemo/lightning/pytorch/callbacks/model_checkpoint.py
@@ -395,7 +395,7 @@ class ModelCheckpoint(PTLModelCheckpoint):
 
     def _monitor_candidates(self, trainer: "pl.Trainer") -> Dict[str, torch.Tensor]:
         """Broadcast loss from last pipeline stage."""
-        monitor_candidates = super().monitor_candidates(trainer)
+        monitor_candidates = super()._monitor_candidates(trainer)
 
         from nemo.lightning._strategy_lib import _sync_from_last_pipeline_stage
 

--- a/nemo/lightning/pytorch/optim/base.py
+++ b/nemo/lightning/pytorch/optim/base.py
@@ -152,7 +152,7 @@ class OptimizerModule(L.Callback, CallbackMethods, IOMixin, ABC):
     def on_train_batch_start(self, trainer, pl_module, batch, batch_idx) -> None:
         if self._optimizers is not None:
             lr = self._optimizers[0].param_groups[0]['lr']
-            pl_module.log('lr', lr, rank_zero_only=True, batch_size=1, prog_bar=True)
+            pl_module.log('lr', lr, batch_size=1, prog_bar=True)
 
     def __call__(self, model: L.LightningModule, megatron_parallel=None) -> OptimizerLRScheduler:
         """Calls the setup and optimizers methods.

--- a/nemo/lightning/pytorch/plugins/data_sampler.py
+++ b/nemo/lightning/pytorch/plugins/data_sampler.py
@@ -99,7 +99,6 @@ class MegatronDataSampler(DataSampler):
             'consumed_samples',
             consumed_samples,
             prog_bar=True,
-            rank_zero_only=True,
             batch_size=1,
         )
 
@@ -113,7 +112,6 @@ class MegatronDataSampler(DataSampler):
             "global_batch_size",
             self.current_global_batch_size,
             prog_bar=True,
-            rank_zero_only=True,
             batch_size=1,
         )
         self.if_first_step = 1

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -487,7 +487,8 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
 
             pp_size = parallel_state.get_pipeline_model_parallel_world_size()
             if pp_size > 1:
-                # ranks that are not final pp stage have 0 for loss, and out will be reduced
+                # ranks that are not final pp stage have 0 for loss, and out will be mean-reduced over pp
+                # groups (due to sync_dist), which divides val_loss by pp_size. so we multiply by pp_size to cancel out
                 self.lightning_module.log(
                     'val_loss',
                     out * pp_size,

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -151,6 +151,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         ckpt_load_directly_on_device: bool = True,
         setup_optimizers: bool = True,
         init_model_parallel: bool = True,
+        broadcast_loss_with_pipeline_parallel: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -187,6 +188,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         self.parallel_load = ckpt_parallel_load
         self.parallel_save_optim = ckpt_parallel_save_optim
         self.load_directly_on_device = ckpt_load_directly_on_device
+        self.broadcast_loss_with_pipeline_parallel = broadcast_loss_with_pipeline_parallel
 
         self._ddp = ddp
         if ddp == "megatron":
@@ -465,19 +467,12 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
                 )
 
             if self.log_train_loss:
-                from megatron.core import parallel_state
-
-                from nemo.collections.nlp.parts.utils_funcs import get_last_rank
-
-                # When using pipeline parallelism, loss is calculated only in the last pipeline stage and
-                # it should be casted to other pipeline stages for logging.
-                # we can avoid this broadcast by updating the PTL log function to accept specific ranks
-                if parallel_state.get_pipeline_model_parallel_world_size() > 1:
-                    if torch.distributed.get_rank() == get_last_rank():
-                        torch.distributed.send(out, 0)
-                    elif torch.distributed.get_rank() == 0:
-                        torch.distributed.recv(out, get_last_rank())
-                self.lightning_module.log('reduced_train_loss', out, prog_bar=True, rank_zero_only=True, batch_size=1)
+                _log_loss(
+                    self.lightning_module,
+                    'reduced_train_loss',
+                    out,
+                    broadcast=self.broadcast_loss_with_pipeline_parallel,
+                )
 
             return out
 
@@ -489,7 +484,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
 
         with self.precision_plugin.val_step_context():  # TODO: Do we need this?
             out = self.model(dataloader_iter, forward_only=True, *args, **kwargs)
-            self.lightning_module.log('val_loss', out, rank_zero_only=True, batch_size=1)
+            _log_loss(self.lightning_module, 'val_loss', out, broadcast=self.broadcast_loss_with_pipeline_parallel)
             return out
 
     @override
@@ -757,6 +752,30 @@ def _data_fetcher_wrapper(fn):
             return _DataLoaderIterDataFetcher()
 
     return wrapped
+
+
+def _log_loss(lightning_module, name, value, broadcast=True):  # TODO add type annotation
+    from megatron.core import parallel_state
+
+    if parallel_state.get_pipeline_model_parallel_world_size() > 1:
+        src_rank = parallel_state.get_pipeline_model_parallel_last_rank()
+
+        if not broadcast:
+            if torch.distributed.get_rank() == src_rank:
+                torch.distributed.send(value, 0)
+            elif torch.distributed.get_rank() == 0:
+                torch.distributed.recv(value, src_rank)
+                lightning_module.log(name, value, prog_bar=True, rank_zero_only=True, batch_size=1)
+            return
+
+        else:
+            torch.distributed.broadcast(
+                value,
+                src_rank,
+                group=parallel_state.get_pipeline_model_parallel_group(),
+            )
+
+    lightning_module.log(name, value, prog_bar=True, batch_size=1)
 
 
 class _MegatronAutomaticOptimization(_AutomaticOptimization):

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -187,6 +187,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         self.parallel_load = ckpt_parallel_load
         self.parallel_save_optim = ckpt_parallel_save_optim
         self.load_directly_on_device = ckpt_load_directly_on_device
+        self._validation_step_outputs = None
 
         self._ddp = ddp
         if ddp == "megatron":
@@ -474,6 +475,26 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
 
             return out
 
+    @property
+    def validation_step_outputs(self):
+        """
+        Cached outputs of validation_step. It can be a list of items (for single data loader) or a list of lists
+        (for multiple data loaders).
+
+        Returns:
+            List of outputs of validation_step.
+        """
+        if self._validation_step_outputs is not None:
+            return self._validation_step_outputs
+
+        # Initialize new output list
+        self._validation_step_outputs = []
+        return self._validation_step_outputs
+
+    @validation_step_outputs.setter
+    def validation_step_outputs(self, value):
+        self._validation_step_outputs = value
+
     @override
     def validation_step(self, dataloader_iter, *args: Any, **kwargs: Any) -> STEP_OUTPUT:
         assert self.lightning_module is not None
@@ -482,9 +503,23 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
 
         with self.precision_plugin.val_step_context():  # TODO: Do we need this?
             out = self.model(dataloader_iter, forward_only=True, *args, **kwargs)
-            _strategy_lib._sync_from_last_pipeline_stage(out, broadcast=True)
-            self.lightning_module.log('val_loss', out, prog_bar=True, batch_size=1)
+            self.validation_step_outputs.append(out)
             return out
+
+    @override
+    def on_validation_end(self):
+        from megatron.core import parallel_state
+
+        if parallel_state.is_pipeline_last_stage():
+            total_loss_and_total_samples = torch.vstack(self.validation_step_outputs).sum(axis=0)
+            avg_loss = total_loss_and_total_samples[0] / total_loss_and_total_samples[1]
+            averaged_loss = avg_loss.type(torch.float32).cuda()
+        else:
+            averaged_loss = torch.tensor(0.0, dtype=torch.float32).cuda()
+
+        _strategy_lib._sync_from_last_pipeline_stage(averaged_loss, broadcast=True)
+        self.lightning_module.log('val_loss', averaged_loss, prog_bar=True, batch_size=1)
+        self.validation_step_outputs.clear()  # free memory
 
     @override
     def test_step(self, dataloader_iter, *args: Any, **kwargs: Any) -> STEP_OUTPUT:

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -484,7 +484,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
             out = self.model(dataloader_iter, forward_only=True, *args, **kwargs)
             _strategy_lib._sync_from_last_pipeline_stage(out, broadcast=False)  # p2p now, broadcast later at ckpt
             if torch.distributed.get_rank() == 0:
-                self.lightning_module.log('val_loss', out, rank_zero_only=True, batch_size=1)
+                self.lightning_module.log('val_loss', out, prog_bar=True, rank_zero_only=True, batch_size=1)
             return out
 
     @override

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -467,10 +467,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
             if self.log_train_loss:
                 # p2p now, broadcast later at ckpt
                 _strategy_lib._sync_from_last_pipeline_stage(out, broadcast=False)
-                if torch.distributed.get_rank() == 0:
-                    self.lightning_module.log(
-                        'reduced_train_loss', out, prog_bar=True, rank_zero_only=True, batch_size=1
-                    )
+                self.lightning_module.log('reduced_train_loss', out, prog_bar=True, batch_size=1)
 
             return out
 
@@ -483,8 +480,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         with self.precision_plugin.val_step_context():  # TODO: Do we need this?
             out = self.model(dataloader_iter, forward_only=True, *args, **kwargs)
             _strategy_lib._sync_from_last_pipeline_stage(out, broadcast=False)  # p2p now, broadcast later at ckpt
-            if torch.distributed.get_rank() == 0:
-                self.lightning_module.log('val_loss', out, rank_zero_only=True, batch_size=1)
+            self.lightning_module.log('val_loss', out, batch_size=1)
             return out
 
     @override

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -511,9 +511,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         from megatron.core import parallel_state
 
         if parallel_state.is_pipeline_last_stage():
-            total_loss_and_total_samples = torch.vstack(self.validation_step_outputs).sum(axis=0)
-            avg_loss = total_loss_and_total_samples[0] / total_loss_and_total_samples[1]
-            averaged_loss = avg_loss.type(torch.float32).cuda()
+            averaged_loss = torch.stack(self.validation_step_outputs).mean()
         else:
             averaged_loss = torch.tensor(0.0, dtype=torch.float32).cuda()
 

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -440,7 +440,6 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
                 'global_step',
                 self.trainer.global_step,
                 prog_bar=True,
-                rank_zero_only=True,
                 batch_size=1,
             )
 
@@ -456,14 +455,12 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
                     "peak_memory_usage",
                     max_memory_reserved,
                     prog_bar=True,
-                    rank_zero_only=True,
                     batch_size=1,
                 )
                 self.lightning_module.log(
                     "memory_allocated",
                     memory_allocated,
                     prog_bar=True,
-                    rank_zero_only=True,
                     batch_size=1,
                 )
 

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -486,7 +486,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
             from megatron.core import parallel_state
 
             pp_size = parallel_state.get_pipeline_model_parallel_world_size()
-            if parallel_state.get_pipeline_model_parallel_world_size() > 1:
+            if pp_size > 1:
                 # ranks that are not final pp stage have 0 for loss, and out will be reduced
                 self.lightning_module.log(
                     'val_loss',

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -482,9 +482,8 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
 
         with self.precision_plugin.val_step_context():  # TODO: Do we need this?
             out = self.model(dataloader_iter, forward_only=True, *args, **kwargs)
-            _strategy_lib._sync_from_last_pipeline_stage(out, broadcast=False)  # p2p now, broadcast later at ckpt
-            if torch.distributed.get_rank() == 0:
-                self.lightning_module.log('val_loss', out, prog_bar=True, rank_zero_only=True, batch_size=1)
+            _strategy_lib._sync_from_last_pipeline_stage(out, broadcast=True)
+            self.lightning_module.log('val_loss', out, prog_bar=True, batch_size=1)
             return out
 
     @override

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -151,7 +151,6 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         ckpt_load_directly_on_device: bool = True,
         setup_optimizers: bool = True,
         init_model_parallel: bool = True,
-        broadcast_loss_with_pipeline_parallel: bool = True,
         **kwargs,
     ) -> None:
         super().__init__(
@@ -188,7 +187,6 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         self.parallel_load = ckpt_parallel_load
         self.parallel_save_optim = ckpt_parallel_save_optim
         self.load_directly_on_device = ckpt_load_directly_on_device
-        self.broadcast_loss_with_pipeline_parallel = broadcast_loss_with_pipeline_parallel
 
         self._ddp = ddp
         if ddp == "megatron":
@@ -467,12 +465,12 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
                 )
 
             if self.log_train_loss:
-                _log_loss(
-                    self.lightning_module,
-                    'reduced_train_loss',
-                    out,
-                    broadcast=self.broadcast_loss_with_pipeline_parallel,
-                )
+                # p2p now, broadcast later at ckpt
+                _strategy_lib._sync_from_last_pipeline_stage(out, broadcast=False)
+                if torch.distributed.get_rank() == 0:
+                    self.lightning_module.log(
+                        'reduced_train_loss', out, prog_bar=True, rank_zero_only=True, batch_size=1
+                    )
 
             return out
 
@@ -484,7 +482,9 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
 
         with self.precision_plugin.val_step_context():  # TODO: Do we need this?
             out = self.model(dataloader_iter, forward_only=True, *args, **kwargs)
-            _log_loss(self.lightning_module, 'val_loss', out, broadcast=self.broadcast_loss_with_pipeline_parallel)
+            _strategy_lib._sync_from_last_pipeline_stage(out, broadcast=False)  # p2p now, broadcast later at ckpt
+            if torch.distributed.get_rank() == 0:
+                self.lightning_module.log('val_loss', out, rank_zero_only=True, batch_size=1)
             return out
 
     @override
@@ -752,30 +752,6 @@ def _data_fetcher_wrapper(fn):
             return _DataLoaderIterDataFetcher()
 
     return wrapped
-
-
-def _log_loss(lightning_module, name, value, broadcast=True):  # TODO add type annotation
-    from megatron.core import parallel_state
-
-    if parallel_state.get_pipeline_model_parallel_world_size() > 1:
-        src_rank = parallel_state.get_pipeline_model_parallel_last_rank()
-
-        if not broadcast:
-            if torch.distributed.get_rank() == src_rank:
-                torch.distributed.send(value, 0)
-            elif torch.distributed.get_rank() == 0:
-                torch.distributed.recv(value, src_rank)
-                lightning_module.log(name, value, prog_bar=True, rank_zero_only=True, batch_size=1)
-            return
-
-        else:
-            torch.distributed.broadcast(
-                value,
-                src_rank,
-                group=parallel_state.get_pipeline_model_parallel_group(),
-            )
-
-    lightning_module.log(name, value, prog_bar=True, batch_size=1)
 
 
 class _MegatronAutomaticOptimization(_AutomaticOptimization):

--- a/nemo/lightning/pytorch/strategies.py
+++ b/nemo/lightning/pytorch/strategies.py
@@ -467,7 +467,10 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
             if self.log_train_loss:
                 # p2p now, broadcast later at ckpt
                 _strategy_lib._sync_from_last_pipeline_stage(out, broadcast=False)
-                self.lightning_module.log('reduced_train_loss', out, prog_bar=True, batch_size=1)
+                if torch.distributed.get_rank() == 0:
+                    self.lightning_module.log(
+                        'reduced_train_loss', out, prog_bar=True, rank_zero_only=True, batch_size=1
+                    )
 
             return out
 
@@ -480,7 +483,8 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         with self.precision_plugin.val_step_context():  # TODO: Do we need this?
             out = self.model(dataloader_iter, forward_only=True, *args, **kwargs)
             _strategy_lib._sync_from_last_pipeline_stage(out, broadcast=False)  # p2p now, broadcast later at ckpt
-            self.lightning_module.log('val_loss', out, batch_size=1)
+            if torch.distributed.get_rank() == 0:
+                self.lightning_module.log('val_loss', out, rank_zero_only=True, batch_size=1)
             return out
 
     @override


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Remove `rank_zero_only=True` flag, unless used as [documented](https://lightning.ai/docs/pytorch/stable/visualize/logging_advanced.html#rank-zero-only)
- Refactor train and val loss logging

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
