### PR TITLE
Disable gradients in `swap_tensors()` within `ema.py`

### DIFF
--- a/nemo/collections/common/callbacks/ema.py
+++ b/nemo/collections/common/callbacks/ema.py
@@ -276,6 +276,7 @@ class EMAOptimizer(torch.optim.Optimizer):
             )
             self.thread.start()
 
+    @torch.no_grad()
     def swap_tensors(self, tensor1, tensor2):
         tmp = torch.empty_like(tensor1)
         tmp.copy_(tensor1)

--- a/nemo/collections/common/callbacks/ema.py
+++ b/nemo/collections/common/callbacks/ema.py
@@ -40,7 +40,11 @@ class EMA(Callback):
     """
 
     def __init__(
-        self, decay: float, validate_original_weights: bool = False, every_n_steps: int = 1, cpu_offload: bool = False,
+        self,
+        decay: float,
+        validate_original_weights: bool = False,
+        every_n_steps: int = 1,
+        cpu_offload: bool = False,
     ):
         if not (0 <= decay <= 1):
             raise MisconfigurationException("EMA decay value must be between 0 and 1")
@@ -149,7 +153,9 @@ class EMA(Callback):
 def ema_update(ema_model_tuple, current_model_tuple, decay):
     torch._foreach_mul_(ema_model_tuple, decay)
     torch._foreach_add_(
-        ema_model_tuple, current_model_tuple, alpha=(1.0 - decay),
+        ema_model_tuple,
+        current_model_tuple,
+        alpha=(1.0 - decay),
     )
 
 
@@ -272,7 +278,13 @@ class EMAOptimizer(torch.optim.Optimizer):
 
         if self.device.type == 'cpu':
             self.thread = threading.Thread(
-                target=run_ema_update_cpu, args=(self.ema_params, current_model_state, self.decay, self.stream,),
+                target=run_ema_update_cpu,
+                args=(
+                    self.ema_params,
+                    current_model_state,
+                    self.decay,
+                    self.stream,
+                ),
             )
             self.thread.start()
 


### PR DESCRIPTION
# What does this PR do ?

Disables gradients in `swap_tensors()` within `ema.py` to prevent unintended leaf variable gradient modifications (should they arise). This was found to be necessary in certain projects that use PyTorch Lightning 2+ such as [AlphaFold3-Lightning-Hydra](https://github.com/amorehead/alphafold3-pytorch-lightning-hydra).

**Collection**: [Note which collection this PR will affect]

N/A.

# Changelog 
- Disables gradients in `swap_tensors()` within `ema.py` to prevent unintended leaf variable gradient modifications (should they arise).

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.
