### PR TITLE
fix FLOPsMeasurementCallback on_train_end when experiment is None

### DIFF
--- a/nemo/collections/common/metrics/perf_metrics.py
+++ b/nemo/collections/common/metrics/perf_metrics.py
@@ -84,7 +84,8 @@ class FLOPsMeasurementCallback(Callback):
             logging.error(f"Failed to calculate TFLOPs per sec per GPU.\n{exc}")
 
         logging.info(f"TFLOPs per sec per GPU={tflops_per_sec_per_gpu:.2f}")
-        pl_module.logger.experiment.add_scalar("tflops_per_sec_per_gpu", tflops_per_sec_per_gpu)
+        if pl_module.logger.experiment is not None:
+            pl_module.logger.experiment.add_scalar("tflops_per_sec_per_gpu", tflops_per_sec_per_gpu)
 
     def eval_tflops_per_sec_per_gpu(self, train_step_time: List | float | int) -> float:
         """


### PR DESCRIPTION
# What does this PR do ?

Fixes basic error in recently introduced #9932 FLOPsMeasurementCallback on_train_end method when `pl_module.logger.experiment` is None.

**Collection**: common

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
