### PR TITLE
Update base image for tts asr import check test

### DIFF
--- a/.github/workflows/import-test.yml
+++ b/.github/workflows/import-test.yml
@@ -12,7 +12,7 @@ jobs:
   test-asr-imports:
     runs-on: ubuntu-latest
     container:
-      image: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
+      image: pytorch/pytorch:2.4.0-cuda11.8-cudnn9-runtime
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
@@ -24,7 +24,6 @@ jobs:
       id: nemo-wheel
       run:  |
         pip install Cython
-        sed -i "/torch/d" requirements/requirements.txt
         # install test requirements
         pip install -r requirements/requirements_test.txt
         # Build nemo as a wheel
@@ -44,7 +43,7 @@ jobs:
   test-tts-imports:
     runs-on: ubuntu-latest
     container:
-      image: pytorch/pytorch:2.0.1-cuda11.7-cudnn8-runtime
+      image: pytorch/pytorch:2.4.0-cuda11.8-cudnn9-runtime
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2
@@ -56,7 +55,6 @@ jobs:
       id: nemo-wheel
       run:  |
         pip install Cython
-        sed -i "/torch/d" requirements/requirements.txt
         # install test requirements
         pip install -r requirements/requirements_test.txt
         # Build nemo as a wheel

--- a/.github/workflows/import-test.yml
+++ b/.github/workflows/import-test.yml
@@ -24,6 +24,7 @@ jobs:
       id: nemo-wheel
       run:  |
         pip install Cython
+        sed -i "/torch/d" requirements/requirements.txt
         # install test requirements
         pip install -r requirements/requirements_test.txt
         # Build nemo as a wheel
@@ -36,7 +37,6 @@ jobs:
       run: |
         # Install NeMo Domain
         pip install "${{ steps.nemo-wheel.outputs.DIST_FILE }}[asr]"
-        pip install torch==2.0.1
         # Run import checks
         python tests/core_ptl/check_imports.py --domain "asr"
         # Uninstall NeMo
@@ -56,6 +56,7 @@ jobs:
       id: nemo-wheel
       run:  |
         pip install Cython
+        sed -i "/torch/d" requirements/requirements.txt
         # install test requirements
         pip install -r requirements/requirements_test.txt
         # Build nemo as a wheel
@@ -68,7 +69,6 @@ jobs:
       run: |
         # Install NeMo Domain
         pip install "${{ steps.nemo-wheel.outputs.DIST_FILE }}[tts]"
-        pip install torch==2.0.1
         # Run import checks
         python tests/core_ptl/check_imports.py --domain "tts"
         # Uninstall NeMo

--- a/.github/workflows/import-test.yml
+++ b/.github/workflows/import-test.yml
@@ -36,6 +36,7 @@ jobs:
       run: |
         # Install NeMo Domain
         pip install "${{ steps.nemo-wheel.outputs.DIST_FILE }}[asr]"
+        pip install torch==2.0.1
         # Run import checks
         python tests/core_ptl/check_imports.py --domain "asr"
         # Uninstall NeMo
@@ -67,6 +68,7 @@ jobs:
       run: |
         # Install NeMo Domain
         pip install "${{ steps.nemo-wheel.outputs.DIST_FILE }}[tts]"
+        pip install torch==2.0.1
         # Run import checks
         python tests/core_ptl/check_imports.py --domain "tts"
         # Uninstall NeMo


### PR DESCRIPTION
# What does this PR do ?

Bumped torch version of base container used for tts asr testing as pytorch-lightning>2.2.1 requires torch>=2.1.0


**Collection**: [test]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
