### PR TITLE
Remove max_num_tokens heuristic from test scripts

### DIFF
--- a/nemo/export/trt_llm/qnemo/qnemo_to_tensorrt_llm.py
+++ b/nemo/export/trt_llm/qnemo/qnemo_to_tensorrt_llm.py
@@ -105,7 +105,7 @@ def qnemo_to_tensorrt_llm(
     if max_seq_len:
         build_cmd += f"--max_seq_len {max_seq_len} "
 
-    if max_num_tokens:
+    if max_num_tokens is not None:
         build_cmd += f"--max_num_tokens {max_num_tokens} "
     else:
         build_cmd += f"--max_num_tokens {max_batch_size * max_input_len} "

--- a/tests/deploy/nemo_deploy.py
+++ b/tests/deploy/nemo_deploy.py
@@ -164,6 +164,7 @@ def run_trt_llm_inference(
     use_embedding_sharing=False,
     max_input_len=128,
     max_output_len=128,
+    max_num_tokens=None,
     ptuning=False,
     p_tuning_checkpoint=None,
     lora=False,
@@ -249,7 +250,7 @@ def run_trt_llm_inference(
             max_prompt_embedding_table_size=max_prompt_embedding_table_size,
             use_lora_plugin=use_lora_plugin,
             lora_target_modules=lora_target_modules,
-            max_num_tokens=int(max_input_len * max_batch_size * 0.2),
+            max_num_tokens=max_num_tokens,
             opt_num_tokens=60,
             use_embedding_sharing=use_embedding_sharing,
         )
@@ -424,6 +425,7 @@ def run_existing_checkpoints(
             use_embedding_sharing=use_embedding_sharing,
             max_input_len=512,
             max_output_len=model_info["max_output_len"],
+            max_num_tokens=None,
             ptuning=ptuning,
             p_tuning_checkpoint=p_tuning_checkpoint,
             lora=lora,
@@ -448,7 +450,6 @@ def get_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description=f"Deploy nemo models to Triton and benchmark the models",
     )
-
     parser.add_argument(
         "--model_name",
         type=str,
@@ -498,6 +499,10 @@ def get_args():
         "--max_output_len",
         type=int,
         default=128,
+    )
+    parser.add_argument(
+        "--max_num_tokens",
+        type=int,
     )
     parser.add_argument(
         "--p_tuning_checkpoint",
@@ -646,6 +651,7 @@ def run_inference_tests(args):
                     max_batch_size=args.max_batch_size,
                     max_input_len=args.max_input_len,
                     max_output_len=args.max_output_len,
+                    max_num_tokens=args.max_num_tokens,
                     ptuning=args.ptuning,
                     p_tuning_checkpoint=args.p_tuning_checkpoint,
                     lora=args.lora,

--- a/tests/export/nemo_export.py
+++ b/tests/export/nemo_export.py
@@ -223,6 +223,7 @@ def run_inference(
     use_embedding_sharing=False,
     max_input_len=128,
     max_output_len=128,
+    max_num_tokens=None,
     use_parallel_embedding=False,
     ptuning=False,
     p_tuning_checkpoint=None,
@@ -322,7 +323,7 @@ def run_inference(
                 max_prompt_embedding_table_size=max_prompt_embedding_table_size,
                 use_lora_plugin=use_lora_plugin,
                 lora_target_modules=lora_target_modules,
-                max_num_tokens=int(max_input_len * max_batch_size * 0.2),
+                max_num_tokens=max_num_tokens,
                 use_embedding_sharing=use_embedding_sharing,
             )
 
@@ -511,6 +512,7 @@ def run_existing_checkpoints(
             use_parallel_embedding=use_parallel_embedding,
             max_input_len=512,
             max_output_len=model_info["max_output_len"],
+            max_num_tokens=None,
             ptuning=ptuning,
             p_tuning_checkpoint=p_tuning_checkpoint,
             lora=lora,
@@ -596,7 +598,6 @@ def get_args():
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description=f"Deploy nemo models to Triton and benchmark the models",
     )
-
     parser.add_argument(
         "--model_name",
         type=str,
@@ -651,6 +652,10 @@ def get_args():
         "--max_output_len",
         type=int,
         default=128,
+    )
+    parser.add_argument(
+        "--max_num_tokens",
+        type=int,
     )
     parser.add_argument(
         "--use_parallel_embedding",
@@ -856,6 +861,7 @@ def run_inference_tests(args):
                     max_batch_size=args.max_batch_size,
                     max_input_len=args.max_input_len,
                     max_output_len=args.max_output_len,
+                    max_num_tokens=args.max_num_tokens,
                     use_parallel_embedding=args.use_parallel_embedding,
                     ptuning=args.ptuning,
                     p_tuning_checkpoint=args.p_tuning_checkpoint,


### PR DESCRIPTION
# What does this PR do ?

Removing heuristic setting `max_num_tokens=int(max_input_len * max_batch_size * 0.2)` that may be too strict. This is to produce an engine that can be used beyond the test scripts (e.g. subsequent benchmarking or other evaluations).

**Collection**: NLP

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
