### PR TITLE
nemo-ux: run checkpoint conversion only on rank=0 if invoked with tor…

### DIFF
--- a/nemo/lightning/io/mixin.py
+++ b/nemo/lightning/io/mixin.py
@@ -11,6 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Type, TypeVar, Union
 
 import fiddle as fdl
 import fiddle._src.experimental.dataclasses as fdl_dc
+import torch
 from cloudpickle import dump, load
 from fiddle._src.experimental import serialization
 from typing_extensions import Self
@@ -291,11 +292,17 @@ class ConnectorMixin:
         ------
             FileNotFoundError: If the checkpoint file does not exist at the specified path.
         """
+        import os
+
         connector = self._get_connector(path)
         ckpt_path: Path = connector.local_path(base_path=base_path)
-        ckpt_path = connector(ckpt_path, overwrite=overwrite)
-
-        connector.on_import_ckpt(self)
+        # If already in multiproc environment (e.g. due to torchrun invocation) run only on RANK = 0
+        is_distributed = 'LOCAL_WORLD_SIZE' in os.environ
+        if (is_distributed and int(os.environ['LOCAL_RANK']) == 0) or not 'LOCAL_WORLD_SIZE' in os.environ:
+            ckpt_path = connector(ckpt_path, overwrite=overwrite)
+            connector.on_import_ckpt(self)
+            if is_distributed:
+                torch.distributed.barrier()
 
         return ckpt_path
 


### PR DESCRIPTION
importing any model with torchrun --nproc_per_node=8 will fail (to reproduce the conversion has to run, make sure to remove any cached models to reproduce).

The solution is to detect whether in multiproc and run conversion only on rank=0.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
