### PR TITLE
Adding controls for Transformer (native NeMo) 

### DIFF
--- a/nemo/collections/nlp/modules/common/megatron/transformer.py
+++ b/nemo/collections/nlp/modules/common/megatron/transformer.py
@@ -802,6 +802,9 @@ class AutocastTransformerLayer(TransformerLayer):
         ub_bulk_dgrad: bool = True,
         autocast_dtype: Any = 16,
         zero_centered_gamma: bool = False,
+        bias: bool = True,
+        activation: str = 'gelu',
+        normalization: str = "LayerNorm",
         device: str = 'cuda',
         **kwargs,
     ) -> None:
@@ -836,6 +839,9 @@ class AutocastTransformerLayer(TransformerLayer):
             "ub_bulk_wgrad": ub_bulk_wgrad,
             "ub_bulk_dgrad": ub_bulk_dgrad,
             "device": device,
+            "bias": bias,
+            "activation": activation,
+            "normalization": normalization,
         }
         te_version = packaging.version.Version(version("transformer-engine"))
         if te_version > packaging.version.Version("1.5.0"):
@@ -1107,6 +1113,9 @@ class ParallelTransformer(MegatronModule):
                     "ub_bulk_dgrad": config.tp_comm_bulk_dgrad,
                     "zero_centered_gamma": normalization == 'layernorm1p',
                     "device": 'cpu' if config.use_cpu_initialization else 'cuda',
+                    "bias": bias,
+                    "activation": activation,
+                    "normalization": {"layernorm": "LayerNorm", "rmsnorm": "RMSNorm"}[normalization],
                 }
                 te_version = packaging.version.Version(version("transformer-engine"))
                 if te_version > packaging.version.Version("1.5.0"):


### PR DESCRIPTION
Oleg Sudakov finds that these arguments (bias, activation, normalization) are not currently controllable for native NeMo model, and suggest fix (https://github.com/NVIDIA/NeMo/pull/8845/files).
NVBug: https://github.com/NVIDIA/NeMo/pull/8845/files



# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
