### PR TITLE
[NeMo-UX] fix a version bug in `NeMoLogger`

### DIFF
--- a/nemo/lightning/nemo_logger.py
+++ b/nemo/lightning/nemo_logger.py
@@ -102,14 +102,15 @@ class NeMoLogger(IOMixin):
                 self.name = "default"
 
             version = self.version or os.environ.get(NEMO_ENV_VARNAME_VERSION, None)
-            if is_global_rank_zero():
-                if self.use_datetime_version:
-                    version = time.strftime('%Y-%m-%d_%H-%M-%S')
-            if resume_if_exists:
-                logging.warning(
-                    "No version folders would be created under the log folder as 'resume_if_exists' is enabled."
-                )
-                version = None
+            if not version:
+                if resume_if_exists:
+                    logging.warning(
+                        "No version folders would be created under the log folder as 'resume_if_exists' is enabled."
+                    )
+                    version = None
+                elif is_global_rank_zero():
+                    if self.use_datetime_version:
+                        version = time.strftime('%Y-%m-%d_%H-%M-%S')
             if version:
                 if is_global_rank_zero():
                     os.environ[NEMO_ENV_VARNAME_VERSION] = version


### PR DESCRIPTION
# What does this PR do ?

We only want to ignore the version if `use_datetime_version`  and  `resume_if_exists` are both `True`. If a user sets a version manually, we should include it. Previously, all versions were being ignored when `resume_if_exists` was `True`.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
