### PR TITLE
Akoumparouli/nemo ux moe loss logging

### DIFF
--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -1514,3 +1514,18 @@ def masked_token_loss_context_parallel(tensor: Tensor, mask: Tensor, num_valid_t
     torch.distributed.all_reduce(loss, group=parallel_state.get_context_parallel_group())
 
     return loss
+
+def reduce_loss_across_pipeline(loss):
+    from megatron.core import parallel_state
+
+    from nemo.collections.nlp.parts.utils_funcs import get_last_rank
+
+    # When using pipeline parallelism, loss is calculated only in the last pipeline stage and
+    # it should be casted to other pipeline stages for logging.
+    # we can avoid this broadcast by updating the PTL log function to accept specific ranks
+    if parallel_state.get_pipeline_model_parallel_world_size() > 1:
+        if torch.distributed.get_rank() == get_last_rank():
+            torch.distributed.send(loss, 0)
+        elif torch.distributed.get_rank() == 0:
+            torch.distributed.recv(loss, get_last_rank())
+    return loss

--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -1516,22 +1516,6 @@ def masked_token_loss_context_parallel(tensor: Tensor, mask: Tensor, num_valid_t
     return loss
 
 
-def reduce_loss_across_pipeline(loss):
-    from megatron.core import parallel_state
-
-    from nemo.collections.nlp.parts.utils_funcs import get_last_rank
-
-    # When using pipeline parallelism, loss is calculated only in the last pipeline stage and
-    # it should be casted to other pipeline stages for logging.
-    # we can avoid this broadcast by updating the PTL log function to accept specific ranks
-    if parallel_state.get_pipeline_model_parallel_world_size() > 1:
-        if torch.distributed.get_rank() == get_last_rank():
-            torch.distributed.send(loss, 0)
-        elif torch.distributed.get_rank() == 0:
-            torch.distributed.recv(loss, get_last_rank())
-    return loss
-
-
 @contextmanager
 def moe_loss_tracker_ctx():
     from megatron.core.transformer.moe.moe_utils import (

--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -1540,8 +1540,10 @@ def moe_loss_tracker_ctx():
     )
 
     reduce_aux_losses_tracker_across_ranks()
-    yield
-    clear_aux_losses_tracker()
+    try:
+        yield
+    finally:
+        clear_aux_losses_tracker()
 
 
 @torch.no_grad()

--- a/nemo/lightning/pytorch/strategies/megatron_strategy.py
+++ b/nemo/lightning/pytorch/strategies/megatron_strategy.py
@@ -481,7 +481,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
             for opt in self.optimizers:
                 opt.zero_grad()
 
-            out = self.model(dataloader_iter, forward_only=False, *args, **kwargs)
+            loss = self.model(dataloader_iter, forward_only=False, *args, **kwargs)
 
             if torch.is_tensor(out):
                 reduced_train_loss = out

--- a/nemo/lightning/pytorch/strategies/megatron_strategy.py
+++ b/nemo/lightning/pytorch/strategies/megatron_strategy.py
@@ -529,6 +529,10 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
                 self.lightning_module.log(
                     "reduced_train_loss", reduced_train_loss, prog_bar=True, batch_size=1, sync_dist=False
                 )
+                # Log any MoE losses.
+                # TODO(@akoumparouli): loss_scale depends on the GBS.
+                for loss_name, loss_value in aggregate_moe_loss_stats(loss_scale=1.0).items():
+                    self.lightning_module.log(loss_name, loss_value, prog_bar=True, rank_zero_only=True, batch_size=1)
 
             return out
 

--- a/nemo/lightning/pytorch/strategies/megatron_strategy.py
+++ b/nemo/lightning/pytorch/strategies/megatron_strategy.py
@@ -58,7 +58,7 @@ from typing_extensions import override
 from nemo.core.optim.mcore_optim import McoreDistributedOptimizer
 from nemo.lightning import _strategy_lib, io
 from nemo.lightning.ckpt_utils import ckpt_to_weights_subdir
-from nemo.lightning.megatron_parallel import CallbackConnector, MegatronParallel, _ModuleStepFunction
+from nemo.lightning.megatron_parallel import CallbackConnector, MegatronParallel, _ModuleStepFunction, aggregate_moe_loss_stats
 from nemo.lightning.pytorch.callbacks import ModelTransform
 from nemo.lightning.pytorch.strategies.utils import (
     RestoreConfig,
@@ -481,7 +481,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
             for opt in self.optimizers:
                 opt.zero_grad()
 
-            loss = self.model(dataloader_iter, forward_only=False, *args, **kwargs)
+            out = self.model(dataloader_iter, forward_only=False, *args, **kwargs)
 
             if torch.is_tensor(out):
                 reduced_train_loss = out

--- a/nemo/lightning/pytorch/strategies/megatron_strategy.py
+++ b/nemo/lightning/pytorch/strategies/megatron_strategy.py
@@ -58,7 +58,12 @@ from typing_extensions import override
 from nemo.core.optim.mcore_optim import McoreDistributedOptimizer
 from nemo.lightning import _strategy_lib, io
 from nemo.lightning.ckpt_utils import ckpt_to_weights_subdir
-from nemo.lightning.megatron_parallel import CallbackConnector, MegatronParallel, _ModuleStepFunction, aggregate_moe_loss_stats
+from nemo.lightning.megatron_parallel import (
+    CallbackConnector,
+    MegatronParallel,
+    _ModuleStepFunction,
+    aggregate_moe_loss_stats,
+)
 from nemo.lightning.pytorch.callbacks import ModelTransform
 from nemo.lightning.pytorch.strategies.utils import (
     RestoreConfig,


### PR DESCRIPTION
# What does this PR do ?
Without this PR

```
Training epoch 0, iteration 0/9 | lr: 0.0006 | consumed_samples: 32 | global_batch_size: 32 | global_step: 0 | reduced_train_loss: 11.02
Training epoch 0, iteration 1/9 | lr: 0.0006 | consumed_samples: 64 | global_batch_size: 32 | global_step: 1 | reduced_train_loss: 9.761
Training epoch 0, iteration 2/9 | lr: 0.0006 | consumed_samples: 96 | global_batch_size: 32 | global_step: 2 | reduced_train_loss: 9.21
Training epoch 0, iteration 3/9 | lr: 0.0006 | consumed_samples: 128 | global_batch_size: 32 | global_step: 3 | reduced_train_loss: 8.595
Training epoch 0, iteration 4/9 | lr: 0.0006 | consumed_samples: 160 | global_batch_size: 32 | global_step: 4 | reduced_train_loss: 8.675
Training epoch 0, iteration 5/9 | lr: 0.0006 | consumed_samples: 192 | global_batch_size: 32 | global_step: 5 | reduced_train_loss: 7.918
Training epoch 0, iteration 6/9 | lr: 0.0006 | consumed_samples: 224 | global_batch_size: 32 | global_step: 6 | reduced_train_loss: 7.319
Training epoch 0, iteration 7/9 | lr: 0.0006 | consumed_samples: 256 | global_batch_size: 32 | global_step: 7 | reduced_train_loss: 7.889
Training epoch 0, iteration 8/9 | lr: 0.0006 | consumed_samples: 288 | global_batch_size: 32 | global_step: 8 | reduced_train_loss: 7.113
Training epoch 0, iteration 9/9 | lr: 0.0006 | consumed_samples: 320 | global_batch_size: 32 | global_step: 9 | reduced_train_loss: 6.909
```


With this PR:

```
Training epoch 0, iteration 0/9 | lr: 0.0006 | consumed_samples: 32 | global_batch_size: 32 | global_step: 0 | reduced_train_loss: 11.02 | load_balancing_loss: 9.812
Training epoch 0, iteration 1/9 | lr: 0.0006 | consumed_samples: 64 | global_batch_size: 32 | global_step: 1 | reduced_train_loss: 9.763 | load_balancing_loss: 9.919
Training epoch 0, iteration 2/9 | lr: 0.0006 | consumed_samples: 96 | global_batch_size: 32 | global_step: 2 | reduced_train_loss: 9.232 | load_balancing_loss: 13.04
Training epoch 0, iteration 3/9 | lr: 0.0006 | consumed_samples: 128 | global_batch_size: 32 | global_step: 3 | reduced_train_loss: 8.579 | load_balancing_loss: 16.77
Training epoch 0, iteration 4/9 | lr: 0.0006 | consumed_samples: 160 | global_batch_size: 32 | global_step: 4 | reduced_train_loss: 8.661 | load_balancing_loss: 17.5
Training epoch 0, iteration 5/9 | lr: 0.0006 | consumed_samples: 192 | global_batch_size: 32 | global_step: 5 | reduced_train_loss: 7.909 | load_balancing_loss: 13.16
Training epoch 0, iteration 6/9 | lr: 0.0006 | consumed_samples: 224 | global_batch_size: 32 | global_step: 6 | reduced_train_loss: 7.358 | load_balancing_loss: 13.96
Training epoch 0, iteration 7/9 | lr: 0.0006 | consumed_samples: 256 | global_batch_size: 32 | global_step: 7 | reduced_train_loss: 7.994 | load_balancing_loss: 14.74
Training epoch 0, iteration 8/9 | lr: 0.0006 | consumed_samples: 288 | global_batch_size: 32 | global_step: 8 | reduced_train_loss: 6.796 | load_balancing_loss: 15.49
Training epoch 0, iteration 9/9 | lr: 0.0006 | consumed_samples: 320 | global_batch_size: 32 | global_step: 9 | reduced_train_loss: 6.789 | load_balancing_loss: 16.16
```

```
config = llm.MixtralConfig8x7B(
        num_layers=2,
        hidden_size=768,
        ffn_hidden_size=3072,
        num_attention_heads=8,
        seq_length=seq_length,
        init_method_std=0.023,
        hidden_dropout=0.1,
        attention_dropout=0.1,
        layernorm_epsilon=1e-5,
        make_vocab_size_divisible_by=128,
        masked_softmax_fusion=args.masked_softmax_fusion,
        # Moe,
        num_moe_experts=8,
        moe_aux_loss_coeff=0.01,
        moe_router_topk=2,
        moe_router_pre_softmax=True,
        moe_token_dispatcher_type="alltoall",
        moe_router_load_balancing_type='aux_loss',
    )
```
**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
