### PR TITLE
Fix lhotse parsing tarred files with offset field

### DIFF
--- a/nemo/collections/common/data/lhotse/nemo_adapters.py
+++ b/nemo/collections/common/data/lhotse/nemo_adapters.py
@@ -30,7 +30,7 @@ from lhotse.cut import Cut
 from lhotse.dataset.dataloading import resolve_seed
 from lhotse.lazy import LazyIteratorChain, LazyJsonlIterator
 from lhotse.serialization import open_best
-from lhotse.utils import compute_num_samples
+from lhotse.utils import compute_num_samples, ifnone
 
 from nemo.collections.common.parts.preprocessing.manifest import get_full_path
 
@@ -332,14 +332,16 @@ class LazyNeMoTarredIterator:
 
         # Handle NeMo tarred manifests with offsets.
         # They have multiple JSONL entries where audio paths end with '-sub1', '-sub2', etc. for each offset.
-        offset_pattern = re.compile(r'^.+(-sub\d+)$')
+        offset_pattern = re.compile(r'^(?P<stem>.+)(?P<sub>-sub\d+)(?P<ext>\.\w+)?$')
 
         for sid in shard_ids:
             manifest_path = self.paths[sid] if len(self.paths) > 1 else self.paths[0]
 
             def basename(d: dict) -> str:
                 return (
-                    k[: -len(m.group(1))] if (m := offset_pattern.match(k := d["audio_filepath"])) is not None else k
+                    m.group("stem") + ifnone(m.group("ext"), "")
+                    if (m := offset_pattern.match(k := d["audio_filepath"])) is not None
+                    else k
                 )
 
             shard_manifest: dict[str, list[dict]] = groupby(basename, self.shard_id_to_manifest[sid])

--- a/tests/collections/common/test_lhotse_dataloading.py
+++ b/tests/collections/common/test_lhotse_dataloading.py
@@ -1735,10 +1735,14 @@ def nemo_tarred_manifest_path_with_offset(tmp_path_factory) -> Tuple[str, str]:
         TarWriter(f"{root}/audios_0.tar", shard_size=None) as tar_writer,
         SequentialJsonlWriter(root / "tarred_audio_filepaths.jsonl") as mft_writer,
     ):
-        tar_writer.write(recording.id, BytesIO(recording.sources[0].source))
+
+        def audio_path(n: int = None):
+            return recording.id + ("" if n is None else f"-sub{n}") + ".wav"
+
+        tar_writer.write(audio_path(), BytesIO(recording.sources[0].source))
         mft_writer.write(
             {  # segment 0-3s
-                "audio_filepath": recording.id,
+                "audio_filepath": audio_path(),
                 "offset": 0.0,
                 "duration": 3.0,
                 "text": "irrelevant",
@@ -1748,7 +1752,7 @@ def nemo_tarred_manifest_path_with_offset(tmp_path_factory) -> Tuple[str, str]:
         )
         mft_writer.write(
             {  # segment 4-9s
-                "audio_filepath": recording.id + "-sub1",
+                "audio_filepath": audio_path(1),
                 "offset": 4.0,
                 "duration": 5.0,
                 "text": "irrelevant-2",
@@ -1758,7 +1762,7 @@ def nemo_tarred_manifest_path_with_offset(tmp_path_factory) -> Tuple[str, str]:
         )
         mft_writer.write(
             {  # full recording - for reference
-                "audio_filepath": recording.id + "-sub2",
+                "audio_filepath": audio_path(2),
                 "offset": 0.0,
                 "duration": 10.0,
                 "text": "irrelevant irrelevant-2",
@@ -1794,7 +1798,7 @@ def test_dataloader_from_tarred_nemo_manifest_with_offset(nemo_tarred_manifest_p
     assert len(batch) == 3
 
     # Validate example containing full 10s recording.
-    full_cut = batch[-1]
+    full_cut = batch[1]
     assert full_cut.start == 0.0
     assert full_cut.duration == 10.0
     assert full_cut.supervisions[0].text == "irrelevant irrelevant-2"
@@ -1803,7 +1807,7 @@ def test_dataloader_from_tarred_nemo_manifest_with_offset(nemo_tarred_manifest_p
     assert full_audio.shape[1] == full_cut.num_samples == 160000  # 10s * 16kHz
 
     # Validate segment 0-3s.
-    cut = batch[0]
+    cut = batch[2]
     assert cut.start == 0.0
     assert cut.duration == 3.0
     assert cut.supervisions[0].text == "irrelevant"
@@ -1817,7 +1821,7 @@ def test_dataloader_from_tarred_nemo_manifest_with_offset(nemo_tarred_manifest_p
     # Note: LazyNeMoTarredIterator removes the offset information, as it creates a new recording
     # that's a "subset" of the original recording as a memory saving optimization.
     # Hence, we will not see cut.start == 4.0.
-    cut = batch[1]
+    cut = batch[0]
     assert cut.start == 0.0
     assert cut.duration == 5.0
     assert cut.supervisions[0].text == "irrelevant-2"


### PR DESCRIPTION
# What does this PR do ?

Fixes skipping some entries in manifests when using tarred dataset with long-form audio and offset field.

**Collection**: ASR

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
