### PR TITLE
Add the mcore interface for optim arg; overlap param AG with optimizer

### DIFF
--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -618,6 +618,10 @@ class ModelPT(LightningModule, Model):
             overlap_grad_reduce=self.cfg.optim.get('overlap_grad_sync', False),
             overlap_param_gather=self.cfg.optim.get('overlap_param_sync', False),
         )
+        if hasattr(megatron_optim_config, "overlap_param_gather_with_optimizer_step"):
+            megatron_optim_config.overlap_param_gather_with_optimizer_step = (
+                self.cfg.optim.get('overlap_param_gather_with_optimizer_step', False)
+            )
         return megatron_optim_config
 
     def setup_optimization(

--- a/nemo/core/optim/mcore_optim.py
+++ b/nemo/core/optim/mcore_optim.py
@@ -82,7 +82,7 @@ class McoreDistributedOptimizer(torch.optim.Optimizer):
     def load_parameter_state(self, filename: str):
         self.mcore_optimizer.load_parameter_state(filename)
 
-    def finish_param_sync(self, model_index):
+    def finish_param_sync(self, model_index, *unused):
         self.mcore_optimizer.finish_param_sync(model_index)
 
     def disable_pre_hook(self):


### PR DESCRIPTION
# What does this PR do ?

Add the mcore interface for distributed optimizer arg; overlap param AG with optimizer

# Changelog 
- Pass `overlap_param_gather_with_optimizer_step` to megatron-core
- Enable `delay_param_gather` for aligning param AG timing across PP ranks by default
- Fix the input args of `finish_param_sync` func
- Diable embedding param AG bucketing to overlap with optim.step

# Usage
Set `overlap_param_gather_with_optimizer_step=true` to enable param AG chunk overlap with optim.step

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
