### PR TITLE
Fix exp_manager.wandb_logger_kwargs.config type

### DIFF
--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -999,7 +999,7 @@ def configure_loggers(
         if wandb_kwargs.get('save_dir', None) is None:
             wandb_kwargs['save_dir'] = exp_dir
         os.makedirs(wandb_kwargs['save_dir'], exist_ok=True)
-        wandb_logger = WandbLogger(version=version, **wandb_kwargs)
+        wandb_logger = WandbLogger(version=version, **OmegaConf.to_container(wandb_kwargs, resolve=True))
 
         logger_list.append(wandb_logger)
         logging.info("WandBLogger has been set up")


### PR DESCRIPTION
# What does this PR do ?
Fixed exp_manager.wandb_logger_kwargs.config

Configuring wandb.config using hydra configuration file and/or its cli overrides is useful, it allows adding metadata to wandb run without modifying python code.

Currently passing wandb 'config' in exp_manager.wandb_logger_kwargs won't work because wandb.init() expects 'config' value to be a plain dict instead of an omegaconf.DictConfig instance, this patch converts wandb_kwargs to plain python dict before passing in to pytorch_lightning.loggers.WandbLogger() (eventually calls wandb.init())

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
