### PR TITLE
fix: cosine annealing linear warmup lr

### DIFF
--- a/nemo/core/optim/lr_scheduler.py
+++ b/nemo/core/optim/lr_scheduler.py
@@ -348,7 +348,7 @@ def _linear_warmup_with_cosine_annealing(max_lr, warmup_steps, step, decay_steps
     assert max_lr > min_lr
     # Use linear warmup for the initial part.
     if warmup_steps > 0 and step <= warmup_steps:
-        return max_lr * float(step) / float(warmup_steps)
+        return max_lr * float(step + 1) / float(warmup_steps + 1)
 
     # For any steps larger than `decay_steps`, use `min_lr`.
     if step > warmup_steps + decay_steps:

--- a/tests/core/test_optimizers_schedulers.py
+++ b/tests/core/test_optimizers_schedulers.py
@@ -638,9 +638,9 @@ class TestOptimizersSchedulers:
 
         for i in range(self.MAX_STEPS):
             if i <= 5:
-                assert policy.get_last_lr()[0] <= self.INITIAL_LR
+                assert 0 < policy.get_last_lr()[0] <= self.INITIAL_LR
             else:
-                assert policy.get_last_lr()[0] < self.INITIAL_LR
+                assert 0 < policy.get_last_lr()[0] < self.INITIAL_LR
 
             opt.step()
             policy.step()
@@ -660,11 +660,11 @@ class TestOptimizersSchedulers:
 
         for i in range(self.MAX_STEPS):
             if i <= 3:
-                assert policy.get_last_lr()[0] <= self.INITIAL_LR + 1e-5
+                assert 0 < policy.get_last_lr()[0] <= self.INITIAL_LR + 1e-5
             elif i > 3 and i <= 8:
-                assert policy.get_last_lr()[0] == policy._get_lr(i)[0]
+                assert 0 < policy.get_last_lr()[0] == policy._get_lr(i)[0]
             else:
-                assert policy.get_last_lr()[0] == self.MIN_LR
+                assert 0 < policy.get_last_lr()[0] == self.MIN_LR
 
             opt.step()
             policy.step()


### PR DESCRIPTION
# What does this PR do ?

`CosineAnnealing` LR with linear warmup and `constant_steps` is `0` on the first step. This causes issues for AdamW optimizer which uses LR for `step_size` in the denominator. This is due to the fact on first step when this method is called `step=0` before the first  optimizer step is complete.

Using the same protection as in:
* https://github.com/NVIDIA/NeMo/blob/d2f3f49aea7b282816063dad5ff2f2c3eedfc6cf/nemo/core/optim/lr_scheduler.py#L81
* https://github.com/NVIDIA/NeMo/blob/d2f3f49aea7b282816063dad5ff2f2c3eedfc6cf/nemo/core/optim/lr_scheduler.py#L315
* https://github.com/NVIDIA/NeMo/blob/d2f3f49aea7b282816063dad5ff2f2c3eedfc6cf/nemo/core/optim/lr_scheduler.py#L611

Updated unit tests not to tolerate LR=0.

**Collection**: [Note which collection this PR will affect]

Core

# Changelog 
- fix cosine annealing linear warmup LR

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
