### PR TITLE
Abstract IOMixin and ability to mutate init parameters.

### DIFF
--- a/nemo/lightning/io/__init__.py
+++ b/nemo/lightning/io/__init__.py
@@ -1,7 +1,7 @@
 from nemo.lightning.io.api import export_ckpt, import_ckpt, load, load_context, model_exporter, model_importer
 from nemo.lightning.io.capture import reinit
 from nemo.lightning.io.connector import Connector, ModelConnector
-from nemo.lightning.io.mixin import ConnectorMixin, IOMixin, track_io
+from nemo.lightning.io.mixin import ConnectorMixin, IOMixin, NeedsIOMixin, track_io
 from nemo.lightning.io.pl import TrainerContext, is_distributed_ckpt
 from nemo.lightning.io.state import TransformCTX, apply_transforms, state_transform
 
@@ -11,6 +11,7 @@ __all__ = [
     "Connector",
     "ConnectorMixin",
     "IOMixin",
+    "NeedsIOMixin",
     "track_io",
     "import_ckpt",
     "is_distributed_ckpt",

--- a/nemo/lightning/io/mixin.py
+++ b/nemo/lightning/io/mixin.py
@@ -86,6 +86,7 @@ class NeedsIOMixin(ABC):
         """
         raise NotImplementedError()
 
+    @classmethod
     @abstractmethod
     def io_artifacts(cls) -> List[Artifact]:
         raise NotImplementedError()

--- a/tests/lightning/io/test_mixin.py
+++ b/tests/lightning/io/test_mixin.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass, field
 from nemo.lightning import io
 
 
@@ -5,6 +6,29 @@ class DummyClass(io.IOMixin):
     def __init__(self, a: int, b: int):
         self.a = a
         self.b = b
+
+
+@dataclass
+class BaseDataClass(io.NeedsIOMixin):
+    a: int = field(default_factory=lambda: 0)
+    b: int = 3
+
+    def lazy_update(self):
+        self.mutate_hparam('b', self.b + 2)
+        # Will update the value of b set later on making use of a future subclass IOMixin
+
+
+@dataclass
+class OverrideModelDataClass1(BaseDataClass, io.IOMixin):
+    a: int = field(default_factory=lambda: 4)
+    c: int = 3
+
+
+@dataclass
+class OverrideModelDataClass2(BaseDataClass, io.IOMixin):
+    a: int = field(default_factory=lambda: 5)  # override default of a
+    # do not define/override b
+    c: int = 4  # new variable
 
 
 class TestIOMixin:
@@ -15,9 +39,42 @@ class TestIOMixin:
         assert copied.a == dummy.a
         assert copied.b == dummy.b
 
+    def test_two_versions(self):
+        v1 = DummyClass(4, 3)
+        v2 = DummyClass(3, 2)
+        coppied_v1 = io.reinit(v1)
+        coppied_v2 = io.reinit(v2)
+        assert v1.a != v2.a
+        assert v1.a == coppied_v1.a
+        assert v2.a == coppied_v2.a
+
     def test_init(self):
         outputs = []
         for i in range(1001):
             outputs.append(DummyClass(i, i))
 
         assert len(outputs) == 1001
+
+    def test_dataclasses_two_versions(self):
+        _ = OverrideModelDataClass1(b=2)
+        v1 = OverrideModelDataClass2(b=4)
+        v1.lazy_update()  # the mutate method allows a variable that matches the init arg to be changed and tracked.
+        coppied_v1 = io.reinit(v1)  # Simulate loading from a checkpoint
+        v2 = OverrideModelDataClass2(a=3, b=1, c=5)
+        coppied_v2 = io.reinit(v2)  # Simulate loading from a checkpoint
+        assert v1.a != v2.a
+        assert v1.a == coppied_v1.a
+        assert v2.a == coppied_v2.a
+        assert v1.b != v2.b
+        assert v1.a == 5
+        assert v1.b == 6
+        assert v1.c == 4
+        assert v2.a == 3
+        assert v2.b == 1
+        assert v2.c == 5
+        assert v1.a == coppied_v1.a
+        assert v1.b == coppied_v1.b
+        assert v1.c == coppied_v1.c
+        assert v2.a == coppied_v2.a
+        assert v2.b == coppied_v2.b
+        assert v2.c == coppied_v2.c


### PR DESCRIPTION
# What does this PR do ?

Adds two helpful items for working with ABCs that eventually get IOMixin:
1. A parent `NeedsIOMixin` ABC that lets you inform a parent class that it will eventually be an IOMixin, and also catches cases where you use it before subclassing and inheriting from iomixin. This has been useful for making parent config types that children implement and extend.
2. A mutate_hparam function that allows you to change the init args that are saved in an iomixin object. This is useful for users who either want to initialize and lazily load configuration, or change configuration based on some other configuration in a way that you want to have saved for later as modified init args. This gives users a path to change a config object in code and save it, as well as have a config set some of it's parameters based on the contents of another config that it loads from a checkpoint, while also being savable itself into a new checkpoint with those modified parameters.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
