### PR TITLE
[NeMo-UX[ Move nemotron imports inline

### DIFF
--- a/nemo/collections/llm/gpt/model/nemotron.py
+++ b/nemo/collections/llm/gpt/model/nemotron.py
@@ -11,11 +11,11 @@ from nemo.collections.llm.utils import Config
 from nemo.lightning import OptimizerModule, io, teardown
 
 if TYPE_CHECKING:
-    from nemo.collections.common.tokenizers.tokenizer_spec import TokenizerSpec
-    from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
     from transformers import NemotronConfig as HFNemotronConfig
     from transformers import NemotronForCausalLM
-    
+
+    from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
+    from nemo.collections.common.tokenizers.tokenizer_spec import TokenizerSpec
 
 
 @dataclass
@@ -125,7 +125,7 @@ class HFNemotronImporter(io.ModelConnector["NemotronForCausalLM", NemotronModel]
 
     def apply(self, output_path: Path) -> Path:
         from transformers import NemotronForCausalLM
-        
+
         source = NemotronForCausalLM.from_pretrained(str(self))
         target = self.init()
         trainer = self.nemo_setup(target)
@@ -165,7 +165,7 @@ class HFNemotronImporter(io.ModelConnector["NemotronForCausalLM", NemotronModel]
     @property
     def config(self) -> NemotronConfig:
         from transformers import NemotronConfig as HFNemotronConfig
-        
+
         source = HFNemotronConfig.from_pretrained(str(self))
 
         def make_vocab_size_divisible_by(vocab_size):
@@ -232,7 +232,7 @@ class HFNemotronExporter(io.ModelConnector[NemotronModel, "NemotronForCausalLM"]
     @property
     def config(self) -> "HFNemotronConfig":
         from transformers import NemotronConfig as HFNemotronConfig
-        
+
         source: NemotronConfig = io.load_context(str(self)).model.config
 
         return HFNemotronConfig(

--- a/nemo/collections/llm/gpt/model/nemotron.py
+++ b/nemo/collections/llm/gpt/model/nemotron.py
@@ -4,10 +4,7 @@ from typing import TYPE_CHECKING, Annotated, Callable, Optional
 
 import torch
 from torch import nn
-from transformers import NemotronConfig as HFNemotronConfig
-from transformers import NemotronForCausalLM
 
-from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
 from nemo.collections.llm.fn.activation import squared_relu
 from nemo.collections.llm.gpt.model.base import GPTConfig, GPTModel
 from nemo.collections.llm.utils import Config
@@ -15,6 +12,10 @@ from nemo.lightning import OptimizerModule, io, teardown
 
 if TYPE_CHECKING:
     from nemo.collections.common.tokenizers.tokenizer_spec import TokenizerSpec
+    from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
+    from transformers import NemotronConfig as HFNemotronConfig
+    from transformers import NemotronForCausalLM
+    
 
 
 @dataclass
@@ -123,6 +124,8 @@ class HFNemotronImporter(io.ModelConnector["NemotronForCausalLM", NemotronModel]
         return NemotronModel(self.config, tokenizer=self.tokenizer)
 
     def apply(self, output_path: Path) -> Path:
+        from transformers import NemotronForCausalLM
+        
         source = NemotronForCausalLM.from_pretrained(str(self))
         target = self.init()
         trainer = self.nemo_setup(target)
@@ -155,10 +158,14 @@ class HFNemotronImporter(io.ModelConnector["NemotronForCausalLM", NemotronModel]
 
     @property
     def tokenizer(self) -> "AutoTokenizer":
+        from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
+
         return AutoTokenizer(str(self))
 
     @property
     def config(self) -> NemotronConfig:
+        from transformers import NemotronConfig as HFNemotronConfig
+        
         source = HFNemotronConfig.from_pretrained(str(self))
 
         def make_vocab_size_divisible_by(vocab_size):
@@ -224,6 +231,8 @@ class HFNemotronExporter(io.ModelConnector[NemotronModel, "NemotronForCausalLM"]
 
     @property
     def config(self) -> "HFNemotronConfig":
+        from transformers import NemotronConfig as HFNemotronConfig
+        
         source: NemotronConfig = io.load_context(str(self)).model.config
 
         return HFNemotronConfig(


### PR DESCRIPTION
# What does this PR do ?

This PR moves the imports for nemotron of transformers & tokenizer inline. This is needed for pip-installs where we don't want to throw an import error when someone doesn't have transformers installed. 

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
