### PR TITLE
[NeMo-UX] Handle absolute logger directories in nemo_logger

### DIFF
--- a/nemo/lightning/nemo_logger.py
+++ b/nemo/lightning/nemo_logger.py
@@ -30,11 +30,10 @@ class NeMoLogger(IOMixin):
         log_global_rank_0_only (bool): Log only on global rank 0.
         files_to_copy (Optional[List[str]]): List of files to copy to log directory.
         update_logger_directory (bool): Whether to update logger directory to write to `exp_dir`.
-            If True, the `save_dir` passed to the logger will be treated as a relative path and
-            the logger will be reconfigured to write to `exp_dir / save_dir`. This ensures that
-            all output from an experiment is written to a common directory. If False, the logger's
-            save_dir will not be overwritten. This argument applies only to TensorBoardLogger and
-            WandbLogger instances.
+            If True, the `save_dir` passed to the logger will be reconfigured to write to `exp_dir / save_dir`.
+            This ensures that all output from an experiment is written to a common directory.
+            If False, the logger's save_dir will not be overwritten.
+            This argument applies only to TensorBoardLogger and WandbLogger instances.
         ckpt (Optional[ModelCheckpoint]): Model checkpoint callback.
         tensorboard: (Optional[TensorBoardLogger]): A PyTorch Lightning TensorBoardLogger instance
             to add to the trainer.
@@ -158,7 +157,8 @@ class NeMoLogger(IOMixin):
             for logger in trainer.loggers:
                 if isinstance(logger, TensorBoardLogger):
                     logger._version = version or ""
-                    logger._root_dir = Path(dir) / logger.save_dir
+                    rel_save_dir = os.path.relpath(logger.save_dir)
+                    logger._root_dir = Path(dir) / rel_save_dir
                     trainer.logger._name = self.name
                     logging.warning(
                         f'"update_logger_directory" is True. Overwriting tensorboard logger "save_dir" to {logger._root_dir}'

--- a/nemo/lightning/nemo_logger.py
+++ b/nemo/lightning/nemo_logger.py
@@ -157,8 +157,7 @@ class NeMoLogger(IOMixin):
             for logger in trainer.loggers:
                 if isinstance(logger, TensorBoardLogger):
                     logger._version = version or ""
-                    rel_save_dir = os.path.relpath(logger.save_dir)
-                    logger._root_dir = Path(dir) / rel_save_dir
+                    logger._root_dir = Path(dir) / os.path.relpath(logger.save_dir)
                     trainer.logger._name = self.name
                     logging.warning(
                         f'"update_logger_directory" is True. Overwriting tensorboard logger "save_dir" to {logger._root_dir}'


### PR DESCRIPTION
# What does this PR do ?

This fixes a bug with nemo_logger that arises when the trainer's `logger.save_dir` is absolute, which happens by default. The fix is to convert the absolute path to a relative one before overwriting the logger directory.

**Collection**: LLM

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
