### PR TITLE
Support custom lightning profilers in config

### DIFF
--- a/tests/collections/nlp/test_lightning_profiler.py
+++ b/tests/collections/nlp/test_lightning_profiler.py
@@ -1,0 +1,46 @@
+import pytest
+import pytorch_lightning
+import pytorch_lightning.profilers
+from omegaconf import DictConfig
+
+from nemo.collections.nlp.parts.megatron_trainer_builder import MegatronTrainerBuilder
+
+
+@pytest.fixture()
+def cfg():
+    cfg = {
+        'trainer': {
+            'profiler': {
+                '_target_': 'pytorch_lightning.profilers.PyTorchProfiler',
+                'schedule': {
+                    '_target_': 'torch.profiler.schedule',
+                    'skip_first': 10,
+                    'wait': 5,
+                    'warmup': 1,
+                    'active': 3,
+                    'repeat': 2,
+                },
+            }
+        }
+    }
+    return DictConfig(cfg)
+
+
+class TestLightningProfiler:
+
+    @pytest.mark.unit
+    def test_pytorch_profiler(self, cfg):
+        trainer = MegatronTrainerBuilder(cfg).create_trainer()
+        assert isinstance(trainer.profiler, pytorch_lightning.profilers.PyTorchProfiler)
+        schedule = cfg.trainer.profiler.schedule
+
+        closure = trainer.profiler._schedule._schedule.__closure__
+        captured_values = [cell.cell_contents for cell in closure]
+        captured_names = trainer.profiler._schedule._schedule.__code__.co_freevars
+        captured_dict = dict(zip(captured_names, captured_values))
+
+        assert captured_dict['skip_first'] == schedule.skip_first
+        assert captured_dict['wait'] == schedule.wait
+        assert captured_dict['warmup'] == schedule.warmup
+        assert captured_dict['active'] == schedule.active
+        assert captured_dict['repeat'] == schedule.repeat


### PR DESCRIPTION
# What does this PR do ?

This PR adds support of defining custom lightning profilers

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
To use `PyTorchProfiler` after 100 warm-up steps a user can define trainer.profiler as follows:
```
trainer:
  profiler:
    _target_: pytorch_lightning.profilers.PyTorchProfiler
    schedule:
      _target_: torch.profiler.schedule
      skip_first: 100
      wait: 5
      warmup: 1
      active: 3
      repeat: 2
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?
@MaximumEntropy @ericharper @ekmb @yzhang123 @VahidooX @vladgets @malay-nagda @mikolajblaz @yaoyu-33 @akoumpa

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
