### PR TITLE
ci: Fix release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,12 @@ jobs:
           PAYLOAD=$(jq \
                       -n \
                       -c \
+                      --arg TAG_NAME "v${VERSION}" \
                       --arg CI_COMMIT_BRANCH "${{ inputs.branch }}" \
                       --arg NAME "$NAME" \
                       --arg BODY "$CHANGELOG" \
                       '{
-                        "tag_name": $CI_COMMIT_BRANCH,
+                        "tag_name": $TAG_NAME,
                         "target_commitish": $CI_COMMIT_BRANCH,
                         "name": $NAME,
                         "body": $BODY,


### PR DESCRIPTION
# What does this PR do ?

Release tags should start with `v` and not with `r`

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
