### PR TITLE
Fix partial audio transcription

### DIFF
--- a/examples/asr/asr_cache_aware_streaming/speech_to_text_cache_aware_streaming_infer.py
+++ b/examples/asr/asr_cache_aware_streaming/speech_to_text_cache_aware_streaming_infer.py
@@ -96,6 +96,10 @@ from nemo.collections.asr.parts.utils.rnnt_utils import Hypothesis
 from nemo.collections.asr.parts.utils.streaming_utils import CacheAwareStreamingAudioBuffer
 from nemo.utils import logging
 
+import sys
+sys.path.append('/disk1/NVIDIA/repos/open_asr_leaderboard/')
+
+from normalizer import data_utils
 
 def extract_transcriptions(hyps):
     """
@@ -412,8 +416,14 @@ def main():
                 )
                 all_streaming_tran.extend(streaming_tran)
                 if args.compare_vs_offline:
+                    offline_tran = data_utils.normalizer(offline_tran)
                     all_offline_tran.extend(offline_tran)
                 streaming_buffer.reset_buffer()
+
+        for i, (ref, hyp) in enumerate(zip(all_refs_text, all_streaming_tran)):
+            # normalize ref text and straming text
+            all_refs_text[i] = data_utils.normalizer(ref)
+            all_streaming_tran[i] = data_utils.normalizer(hyp)
 
         if args.compare_vs_offline and len(all_refs_text) == len(all_offline_tran):
             offline_wer = word_error_rate(hypotheses=all_offline_tran, references=all_refs_text)
@@ -431,7 +441,7 @@ def main():
                 "streaming_out_"
                 + os.path.splitext(os.path.basename(args.asr_model))[0]
                 + "_"
-                + os.path.splitext(os.path.basename(args.test_manifest))[0]
+                + os.path.splitext(os.path.basename(args.manifest_file))[0]
                 + ".json"
             )
 

--- a/examples/asr/asr_cache_aware_streaming/speech_to_text_cache_aware_streaming_infer.py
+++ b/examples/asr/asr_cache_aware_streaming/speech_to_text_cache_aware_streaming_infer.py
@@ -84,6 +84,7 @@ python speech_to_text_streaming_infer.py \
 import contextlib
 import json
 import os
+import sys
 import time
 from argparse import ArgumentParser
 
@@ -96,15 +97,15 @@ from nemo.collections.asr.parts.utils.rnnt_utils import Hypothesis
 from nemo.collections.asr.parts.utils.streaming_utils import CacheAwareStreamingAudioBuffer
 from nemo.utils import logging
 
-import sys
 sys.path.append('/disk1/NVIDIA/repos/open_asr_leaderboard/')
 
 from normalizer import data_utils
 
+
 def extract_transcriptions(hyps):
     """
-        The transcribed_texts returned by CTC and RNNT models are different.
-        This method would extract and return the text section of the hypothesis.
+    The transcribed_texts returned by CTC and RNNT models are different.
+    This method would extract and return the text section of the hypothesis.
     """
     if isinstance(hyps[0], Hypothesis):
         transcriptions = []
@@ -214,7 +215,10 @@ def perform_streaming(
 def main():
     parser = ArgumentParser()
     parser.add_argument(
-        "--asr_model", type=str, required=True, help="Path to an ASR model .nemo file or name of a pretrained model.",
+        "--asr_model",
+        type=str,
+        required=True,
+        help="Path to an ASR model .nemo file or name of a pretrained model.",
     )
     parser.add_argument(
         "--device", type=str, help="The device to load the model onto and perform the streaming", default="cuda"

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -296,8 +296,8 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
     else:  # rnnt model, there could be other models needs to be addressed.
         if cfg.decoder_type and cfg.decoder_type != 'rnnt':
             raise ValueError('RNNT model only support rnnt decoding!')
-    
-    if hasattr(asr_model.encoder,'att_context_style') and asr_model.encoder.att_context_style == 'chunked_limited':
+
+    if hasattr(asr_model.encoder, 'att_context_style') and asr_model.encoder.att_context_style == 'chunked_limited':
         if cfg.att_context_size is None:
             logging.info(f"Using default att_context_size={asr_model.encoder.att_context_size}")
         else:

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -460,7 +460,7 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
 
     if cfg.dataset_manifest is not None:
         logging.info(f"Finished transcribing from manifest file: {cfg.dataset_manifest}")
-        if cfg.presort_manifest:
+        if cfg.presort_manifest and not partial_audio:
             transcriptions = restore_transcription_order(cfg.dataset_manifest, transcriptions)
     else:
         logging.info(f"Finished transcribing {len(filepaths)} files !")

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -300,7 +300,7 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
     if hasattr(asr_model.encoder,'att_context_style') and asr_model.encoder.att_context_style == 'chunked_limited':
         if cfg.att_context_size is None:
             logging.info(f"Using default att_context_size={asr_model.encoder.att_context_size}")
-        else :
+        else:
             logging.info(f"Setting provided att_context_size={cfg.att_context_size} for chunkaware encoder")
             asr_model.encoder.set_default_att_context_size(cfg.att_context_size)
 

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -296,9 +296,13 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
     else:  # rnnt model, there could be other models needs to be addressed.
         if cfg.decoder_type and cfg.decoder_type != 'rnnt':
             raise ValueError('RNNT model only support rnnt decoding!')
-
-    if cfg.decoder_type and hasattr(asr_model.encoder, 'set_default_att_context_size'):
-        asr_model.encoder.set_default_att_context_size(cfg.att_context_size)
+    
+    if asr_model.encoder.att_context_style == 'chunked_limited':
+        if cfg.att_context_size is None:
+            logging.info(f"Using default att_context_size={asr_model.encoder.att_context_size}")
+        else :
+            logging.info(f"Setting provided att_context_size={cfg.att_context_size} for chunkaware encoder")
+            asr_model.encoder.set_default_att_context_size(cfg.att_context_size)
 
     # Setup decoding strategy
     if hasattr(asr_model, 'change_decoding_strategy') and hasattr(asr_model, 'decoding'):

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -297,7 +297,7 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
         if cfg.decoder_type and cfg.decoder_type != 'rnnt':
             raise ValueError('RNNT model only support rnnt decoding!')
     
-    if asr_model.encoder.att_context_style == 'chunked_limited':
+    if hasattr(asr_model.encoder,'att_context_style') and asr_model.encoder.att_context_style == 'chunked_limited':
         if cfg.att_context_size is None:
             logging.info(f"Using default att_context_size={asr_model.encoder.att_context_size}")
         else :


### PR DESCRIPTION
# What does this PR do ?

Temp fix. Removes reording for partial audio, as it was not enabled for it. 

But need to understand why presorting of manifest is only enabled for EncDecMultiTask @pzelasko 


**Collection**: ASR

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```bash
python transcribe_speech.py model_path=<.nemo file> dataset_manifest=<manifest_file> allow_partial_transcribe=True
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
