### PR TITLE
ci: Toggle pre-release

### DIFF
--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -40,7 +40,7 @@ jobs:
           
           VERSION=$(python -c 'import nemo; print(nemo.__version__)')
           
-          if [[ "${{ inputs.is_prerelease }}" == "false" ]]; then
+          if [[ "${{ inputs.is_prelease }}" == "false" ]]; then
             sed -i '/^PRE_RELEASE/c\PRE_RELEASE =  '\''' nemo/package_info.py 
           fi
 

--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -7,6 +7,11 @@ on:
         description: 'MAJOR.MINOR.PATCH[rcN] (Example: 2.0.0rc1, or 2.1.0)'
         required: true
         type: string
+      is_prelease:
+        description: Whether to keep and bump the pre-release label
+        required: false
+        default: false
+        type: boolean
       mcore_version:
         description: 'Version of MCore to use (must be a valid git ref)'
         required: true
@@ -34,7 +39,12 @@ jobs:
           cd ${{ github.run_id }}
           
           VERSION=$(python -c 'import nemo; print(nemo.__version__)')
-                    echo "Release version r$VERSION" > version
+          
+          if [[ "${{ inputs.is_prerelease }}" == "false" ]]; then
+            sed -i '/^PRE_RELEASE/c\PRE_RELEASE =  '\''' nemo/package_info.py 
+          fi
+
+          echo "Release version r$VERSION" > version
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Pin branch name in Notebooks


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
