### PR TITLE
[SD] TE-DPA: Disbale TE-DPA In Inference Flow

### DIFF
--- a/nemo/collections/multimodal/models/text_to_image/stable_diffusion/ldm/ddpm.py
+++ b/nemo/collections/multimodal/models/text_to_image/stable_diffusion/ldm/ddpm.py
@@ -2211,6 +2211,9 @@ class MegatronLatentDiffusion(NLPAdapterModelMixin, MegatronBaseModel):
                     cfg.channels_last = True
                 if not cfg.get('capture_cudagraph_iters'):
                     cfg.capture_cudagraph_iters = -1
+                if cfg.get('unet_config') and cfg.get('unet_config').get('use_te_dpa'):
+                    cfg.unet_config.use_te_dpa = False
+                    cfg.unet_config.use_flash_attention = True
 
             # compatibility for stable diffusion old checkpoint tweaks
             first_key = list(checkpoint['state_dict'].keys())[0]
@@ -2242,6 +2245,14 @@ class MegatronLatentDiffusion(NLPAdapterModelMixin, MegatronBaseModel):
                 for key in checkpoint['state_dict'].keys():
                     new_key = key.replace('._orig_mod', '', 1)
                     new_state_dict[new_key] = checkpoint['state_dict'][key]
+                checkpoint['state_dict'] = new_state_dict
+
+            # compatiblity for te-dpa in inference
+            if cfg.get('unet_config') and not cfg.get('unet_config').get('use_te_dpa'):
+                new_state_dict = {}
+                for key in checkpoint['state_dict'].keys():
+                    if "_extra_state" not in key:
+                        new_state_dict[key] = checkpoint['state_dict'][key]
                 checkpoint['state_dict'] = new_state_dict
 
             if cfg.get('megatron_amp_O2', False):


### PR DESCRIPTION
# What does this PR do ?

Specific pattern in SD inference flow can introduce illegal memory access with TE-DPA. We need to disable TE-DPA for eval/inference for now.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
