### PR TITLE
fix NeMoLogger log -> log_dir rename

### DIFF
--- a/examples/llm/auto_configurator/auto_config.py
+++ b/examples/llm/auto_configurator/auto_config.py
@@ -66,7 +66,7 @@ def train_config(args):
 
         # Run pre-training
         partial = partials[args.run_number - 1]
-        partial.log.dir = os.path.join(args.logs_dir, names[args.run_number - 1])
+        partial.log.log_dir = os.path.join(args.logs_dir, names[args.run_number - 1])
         pretrain = fdl.build(partial)
         pretrain()
     else:


### PR DESCRIPTION
# What does this PR do ?

Renamed log to log_dir recently in NeMoLogger and did not update this.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
