### PR TITLE
Update s3 checkpoint doc bucket path

### DIFF
--- a/docs/source/common/s3_checkpointing.rst
+++ b/docs/source/common/s3_checkpointing.rst
@@ -35,7 +35,7 @@ Initializing this checkpoint_io requires the dirpath be an S3 dirpath.
 .. code-block:: bash
     
     checkpoint_callback_params:
-    dirpath: s3://mstar-eks-dev-us-east-2/alxzhang/nemo123/1n/checkpoints
+    dirpath: s3://\<bucket\>/\<path\>
     
     ...
 


### PR DESCRIPTION
# What does this PR do ?

Updates the documentation for S3 checkpointing to have a generic bucket path. 
**Collection**: [Note which collection this PR will affect]

# Changelog 
- Updated text in the `s3_checkpointing.rst` file. 

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [x] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
