### PR TITLE
Upgrade librosa version to fix librosa.display.specshow issue in ASR tutorial notebooks

### DIFF
--- a/requirements/requirements_asr.txt
+++ b/requirements/requirements_asr.txt
@@ -6,7 +6,7 @@ jiwer
 kaldi-python-io
 kaldiio
 lhotse>=1.26.0
-librosa>=0.10.0
+librosa>=0.10.2
 marshmallow
 packaging
 pyannote.core


### PR DESCRIPTION

# What does this PR do ?

Matplotlib removed matplotlib.cm.get_cmap 3.9.0 onwards (deprecated since 3.7.0). This causes an error in our ASR tutorials (ASR_for_telephony_speech.ipynb, Speech_Enhancement_with_NeMo.ipynb, Online_Offline_Microphone_VAD_Demo.ipynb) that use librosa.display.specshow, which internally calls matplotlib.cm.get_cmap(name). Librosa fixed it with this PR: [https://github.com/librosa/librosa/pull/1782](https://github.com/librosa/librosa/pull/1782). 
Hence, lower bounding librosa to 0.10.2 in our requirements.txt to account for the above change. 

**Collection**: [Note which collection this PR will affect]
ASR 

# Changelog 
- Add specific line by line info of high level changes in this PR.
Updated requirements file 


# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
