### PR TITLE
use _get_extra_te_kwargs_meta in fabric (call mcore's _get_extra_te_k…

### DIFF
--- a/nemo/lightning/fabric/strategies.py
+++ b/nemo/lightning/fabric/strategies.py
@@ -350,13 +350,21 @@ class FabricMegatronStrategy(DDPStrategy):
 
     @contextmanager
     def megatron_context(self) -> Generator[None, None, None]:
-        def monkey_patched(config):
-            return {"device": "meta"}
-
         from megatron.core.extensions import transformer_engine as _te
 
         original = _te._get_extra_te_kwargs  # noqa: SLF001
-        _te._get_extra_te_kwargs = monkey_patched  # noqa: SLF001
+
+        def _get_extra_te_kwargs_meta(c):
+            """Forces device to meta"""
+            kwargs = original(c)
+            kwargs['device'] = 'meta'
+            return kwargs
+
+        _te._get_extra_te_kwargs = _get_extra_te_kwargs_meta  # noqa: SLF001
+
+
+        _orig_perform_initialization = self.parallelism.perform_initialization
+        _orig_use_cpu_initialization = self.parallelism.use_cpu_initialization
 
         self.parallelism.perform_initialization = False
         self.parallelism.use_cpu_initialization = True
@@ -364,6 +372,8 @@ class FabricMegatronStrategy(DDPStrategy):
         yield
 
         _te._get_extra_te_kwargs = original  # noqa: SLF001
+        self.parallelism.perform_initialization = _orig_perform_initialization
+        self.parallelism.use_cpu_initialization = _orig_use_cpu_initialization
 
     @property
     @override

--- a/nemo/lightning/fabric/strategies.py
+++ b/nemo/lightning/fabric/strategies.py
@@ -362,7 +362,6 @@ class FabricMegatronStrategy(DDPStrategy):
 
         _te._get_extra_te_kwargs = _get_extra_te_kwargs_meta  # noqa: SLF001
 
-
         _orig_perform_initialization = self.parallelism.perform_initialization
         _orig_use_cpu_initialization = self.parallelism.use_cpu_initialization
 


### PR DESCRIPTION
…wargs & overwrite device)

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
