### PR TITLE
Checkpoint connector bugfixes

### DIFF
--- a/nemo/lightning/ckpt_utils.py
+++ b/nemo/lightning/ckpt_utils.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+# NeMo2 checkpoint structure is a checkpoint directory, with a WEIGHTS_PATH and CONTEXT_PATH subdirectory structure.
+#  WEIGHTS_PATH stores the weights while CONTEXT_PATH stores the hyper-parameters.
+WEIGHTS_PATH: str = "weights"
+CONTEXT_PATH: str = "context"
+
+
+def ckpt_to_weights_subdir(filepath: Union[str, Path]) -> Path:
+    """Given an input checkpoint filepath, clean it using `ckpt_to_dir` and then return the weights subdirectory."""
+    return ckpt_to_dir(filepath=filepath) / WEIGHTS_PATH
+
+
+def ckpt_to_context_subdir(filepath: Union[str, Path]) -> Path:
+    """Given an input checkpoint filepath, clean it using `ckpt_to_dir` and then return the context subdirectory."""
+    return ckpt_to_dir(filepath=filepath) / CONTEXT_PATH
+
+
+def ckpt_to_dir(filepath: Union[str, Path]) -> Path:
+    """PTL considers checkpoints as .ckpt files.
+    This method removes the extension and returns a path
+    to be used as a directory for distributed checkpoints
+    """
+
+    filepath = Path(filepath)
+    if not filepath.suffix == ".ckpt":
+        filepath = filepath.with_suffix(filepath.suffix + ".ckpt")
+
+    # adding this assert because we will later remove directories based on the return value of this method
+    assert filepath.suffix == ".ckpt", f"filepath: {filepath} must have .ckpt extension"
+
+    # create a new path whose name is the original filepath without the .ckpt extension
+    checkpoint_dir = filepath.with_name(filepath.stem)
+
+    return checkpoint_dir

--- a/nemo/lightning/ckpt_utils.py
+++ b/nemo/lightning/ckpt_utils.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Union
 
 # NeMo2 checkpoint structure is a checkpoint directory, with a WEIGHTS_PATH and CONTEXT_PATH subdirectory structure.
 #  WEIGHTS_PATH stores the weights while CONTEXT_PATH stores the hyper-parameters.

--- a/nemo/lightning/io/connector.py
+++ b/nemo/lightning/io/connector.py
@@ -8,7 +8,7 @@ from typing import Generic, Optional, Tuple, TypeVar
 import pytorch_lightning as pl
 from filelock import FileLock, Timeout
 from pytorch_lightning.trainer.states import TrainerFn
-from nemo.utils.model_utils import ckpt_to_context_subdir, ckpt_to_weights_subdir
+from nemo.lightning.ckpt_utils import ckpt_to_context_subdir, ckpt_to_weights_subdir
 
 # Dynamically inherit from the correct Path subclass based on the operating system.
 if os.name == 'nt':

--- a/nemo/lightning/io/connector.py
+++ b/nemo/lightning/io/connector.py
@@ -181,6 +181,7 @@ class ModelConnector(Connector, Generic[SourceT, TargetT]):
         trainer.strategy._init_model_parallel = False
         trainer.strategy.setup(trainer)
         output_path = Path(output_path)
+        output_path.mkdir(parents=True, exist_ok=True)
         trainer.save_checkpoint(ckpt_to_weights_subdir(output_path))
 
         from nemo.lightning.io.pl import TrainerContext

--- a/nemo/lightning/io/connector.py
+++ b/nemo/lightning/io/connector.py
@@ -7,6 +7,8 @@ from typing import Generic, Optional, Tuple, TypeVar
 
 import pytorch_lightning as pl
 from filelock import FileLock, Timeout
+from pytorch_lightning.trainer.states import TrainerFn
+
 
 # Dynamically inherit from the correct Path subclass based on the operating system.
 if os.name == 'nt':
@@ -139,26 +141,25 @@ class ModelConnector(Connector, Generic[SourceT, TargetT]):
         Args:
             model (pl.LightningModule): The model to be set up.
             trainer (Optional[pl.Trainer]): The trainer to be used, if not provided a new one will be created.
-
         Returns
         -------
             pl.Trainer: The trainer configured with the model and strategy.
         """
-        from nemo.lightning import MegatronStrategy, Trainer
-        from nemo.lightning._strategy_lib import megatron_lazy_init_context
+        from nemo.lightning import MegatronStrategy, Trainer, _strategy_lib
 
         _trainer = trainer or Trainer(
-            devices=1, accelerator="cpu", strategy=MegatronStrategy(store_optimizer_states=False)
+            devices=1,
+            accelerator="cpu",
+            strategy=MegatronStrategy(ckpt_save_optimizer=False, always_save_context=True),
         )
-
+        _trainer.state.fn = TrainerFn.FITTING  # needed for proper save.
         _trainer.strategy.connect(model)
         _trainer.strategy.setup_environment()
 
         if not model.state_dict():
             _trainer.strategy.lazy_init = True
-            with _trainer.init_module(), megatron_lazy_init_context(model.config):
+            with _trainer.init_module(), _strategy_lib.megatron_lazy_init_context(model.config):
                 model.configure_model()
-
         return _trainer
 
     def nemo_save(self, output_path: Path, trainer: pl.Trainer, dump_io: bool = True) -> None:
@@ -170,16 +171,20 @@ class ModelConnector(Connector, Generic[SourceT, TargetT]):
             trainer (pl.Trainer): The trainer with the strategy to save the model.
             dump_io (bool): If True, the IO configuration will be saved to the output path.
         """
+        # Import here to avoid circular import
+        from nemo.lightning.pytorch.callbacks.model_checkpoint import ModelCheckpoint
+
         trainer.strategy._setup_optimizers = False
         trainer.strategy._init_model_parallel = False
         trainer.strategy.setup(trainer)
-        trainer.save_checkpoint(output_path)
+        output_path = Path(output_path)
+        trainer.save_checkpoint(output_path / ModelCheckpoint.WEIGHTS_PATH)
 
         from nemo.lightning.io.pl import TrainerContext
         from nemo.utils.get_rank import is_global_rank_zero
 
         if is_global_rank_zero() and dump_io:
-            TrainerContext.from_trainer(trainer).io_dump(output_path)
+            TrainerContext.from_trainer(trainer).io_dump(output_path / ModelCheckpoint.CONTEXT_PATH)
 
     def nemo_load(
         self, path: Path, trainer: Optional[pl.Trainer] = None, cpu: bool = True

--- a/nemo/lightning/io/connector.py
+++ b/nemo/lightning/io/connector.py
@@ -8,7 +8,7 @@ from typing import Generic, Optional, Tuple, TypeVar
 import pytorch_lightning as pl
 from filelock import FileLock, Timeout
 from pytorch_lightning.trainer.states import TrainerFn
-
+from nemo.utils.model_utils import ckpt_to_context_subdir, ckpt_to_weights_subdir
 
 # Dynamically inherit from the correct Path subclass based on the operating system.
 if os.name == 'nt':
@@ -152,7 +152,11 @@ class ModelConnector(Connector, Generic[SourceT, TargetT]):
             accelerator="cpu",
             strategy=MegatronStrategy(ckpt_save_optimizer=False, always_save_context=True),
         )
+        # Note: set trainer to fitting state to avoid the following code path. Feel free to refactor if we no longer
+        #  need to avoid this:
+        #  https://github.com/NVIDIA/NeMo/blob/e35a6592f53ee34b1ec2fc3f1e009dd1ebc79e65/nemo/lightning/pytorch/strategies/megatron_strategy.py#L346-L349
         _trainer.state.fn = TrainerFn.FITTING  # needed for proper save.
+
         _trainer.strategy.connect(model)
         _trainer.strategy.setup_environment()
 
@@ -172,19 +176,18 @@ class ModelConnector(Connector, Generic[SourceT, TargetT]):
             dump_io (bool): If True, the IO configuration will be saved to the output path.
         """
         # Import here to avoid circular import
-        from nemo.lightning.pytorch.callbacks.model_checkpoint import ModelCheckpoint
 
         trainer.strategy._setup_optimizers = False
         trainer.strategy._init_model_parallel = False
         trainer.strategy.setup(trainer)
         output_path = Path(output_path)
-        trainer.save_checkpoint(output_path / ModelCheckpoint.WEIGHTS_PATH)
+        trainer.save_checkpoint(ckpt_to_weights_subdir(output_path))
 
         from nemo.lightning.io.pl import TrainerContext
         from nemo.utils.get_rank import is_global_rank_zero
 
         if is_global_rank_zero() and dump_io:
-            TrainerContext.from_trainer(trainer).io_dump(output_path / ModelCheckpoint.CONTEXT_PATH)
+            TrainerContext.from_trainer(trainer).io_dump(ckpt_to_context_subdir(output_path))
 
     def nemo_load(
         self, path: Path, trainer: Optional[pl.Trainer] = None, cpu: bool = True

--- a/nemo/lightning/io/pl.py
+++ b/nemo/lightning/io/pl.py
@@ -25,6 +25,7 @@ from typing_extensions import Self, override
 
 from nemo.lightning.io.capture import IOProtocol
 from nemo.lightning.io.mixin import IOMixin
+from nemo.utils.model_utils import ckpt_to_dir
 
 try:
     from nemo.utils.callbacks.dist_ckpt_io import AsyncCompatibleCheckpointIO
@@ -267,24 +268,6 @@ def _fix_tensors_device(ckpt: Dict) -> Dict:
         return t
 
     return dict_list_map_outplace(_fix_device, ckpt)
-
-
-def ckpt_to_dir(filepath: Union[str, Path]) -> Path:
-    """PTL considers checkpoints as .ckpt files.
-    This method removes the extension and returns a path
-    to be used as a directory for distributed checkpoints.
-    """
-    filepath = Path(filepath)
-    if not filepath.suffix == ".ckpt":
-        filepath = filepath.with_suffix(filepath.suffix + ".ckpt")
-
-    # adding this assert because we will later remove directories based on the return value of this method
-    assert filepath.suffix == ".ckpt", f"filepath: {filepath} must have .ckpt extension"
-
-    # create a new path whose name is the original filepath without the .ckpt extension
-    checkpoint_dir = filepath.with_name(filepath.stem)
-
-    return checkpoint_dir
 
 
 def is_distributed_ckpt(path) -> bool:

--- a/nemo/lightning/io/pl.py
+++ b/nemo/lightning/io/pl.py
@@ -23,9 +23,9 @@ from megatron.core.parallel_state import get_data_parallel_group
 from torch import nn
 from typing_extensions import Self, override
 
+from nemo.lightning.ckpt_utils import ckpt_to_dir
 from nemo.lightning.io.capture import IOProtocol
 from nemo.lightning.io.mixin import IOMixin
-from nemo.lightning.ckpt_utils import ckpt_to_dir
 
 try:
     from nemo.utils.callbacks.dist_ckpt_io import AsyncCompatibleCheckpointIO

--- a/nemo/lightning/io/pl.py
+++ b/nemo/lightning/io/pl.py
@@ -25,7 +25,7 @@ from typing_extensions import Self, override
 
 from nemo.lightning.io.capture import IOProtocol
 from nemo.lightning.io.mixin import IOMixin
-from nemo.utils.model_utils import ckpt_to_dir
+from nemo.lightning.ckpt_utils import ckpt_to_dir
 
 try:
     from nemo.utils.callbacks.dist_ckpt_io import AsyncCompatibleCheckpointIO

--- a/nemo/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/nemo/lightning/pytorch/callbacks/model_checkpoint.py
@@ -57,8 +57,9 @@ class ModelCheckpoint(PTLModelCheckpoint):
         async_save: Whether to enable asynchronous checkpointing.
     """
 
-    UNFINISHED_CHECKPOINT_SUFFIX = "-unfinished"
-    WEIGHTS_PATH = "weights"
+    UNFINISHED_CHECKPOINT_SUFFIX: str = "-unfinished"
+    WEIGHTS_PATH: str = "weights"
+    CONTEXT_PATH: str = "context"
 
     def __init__(
         self,
@@ -290,7 +291,7 @@ class ModelCheckpoint(PTLModelCheckpoint):
                 else:
                     super()._save_last_checkpoint(trainer, monitor_candidates)
             if self.save_context_on_train_end and not self.always_save_context and is_global_rank_zero():
-                TrainerContext.from_trainer(trainer).io_dump(ckpt_to_dir(self.last_model_path) / "context")
+                TrainerContext.from_trainer(trainer).io_dump(ckpt_to_dir(self.last_model_path) / self.CONTEXT_PATH)
         # Call parent on_train_end() to save the -last checkpoint
         super().on_train_end(trainer, pl_module)
 
@@ -488,7 +489,7 @@ class ModelCheckpoint(PTLModelCheckpoint):
             trainer.save_checkpoint(ckpt_filepath, save_weights_only, storage_options=storage_options)
 
             if self.always_save_context and is_global_rank_zero():
-                TrainerContext.from_trainer(trainer).io_dump(ckpt_to_dir(filepath) / "context")
+                TrainerContext.from_trainer(trainer).io_dump(ckpt_to_dir(filepath) / self.CONTEXT_PATH)
 
             if self.async_save:
                 self._last_checkpoint_saved = filepath

--- a/nemo/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/nemo/lightning/pytorch/callbacks/model_checkpoint.py
@@ -26,10 +26,10 @@ from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint as PTLM
 from pytorch_lightning.callbacks.model_checkpoint import _is_local_file_protocol
 from pytorch_lightning.utilities import rank_zero_info
 
+from nemo.lightning.ckpt_utils import ckpt_to_dir
 from nemo.lightning.io.pl import TrainerContext
 from nemo.utils import logging
 from nemo.utils.app_state import AppState
-from nemo.lightning.ckpt_utils import ckpt_to_dir
 
 
 class ModelCheckpoint(PTLModelCheckpoint):

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -47,6 +47,11 @@ except ModuleNotFoundError:
 MODEL_CONFIG = "model_config.yaml"
 _VAL_TEST_FASTPATH_KEY = 'ds_item'
 
+# NeMo2 checkpoint structure is a checkpoint directory, with a WEIGHTS_PATH and CONTEXT_PATH subdirectory structure.
+#  WEIGHTS_PATH stores the weights while CONTEXT_PATH stores the hyper-parameters.
+WEIGHTS_PATH: str = "weights"
+CONTEXT_PATH: str = "context"
+
 
 class ArtifactPathType(Enum):
     """
@@ -468,7 +473,7 @@ def convert_model_config_to_dict_config(cfg: Union['DictConfig', 'NemoConfig']) 
 
 
 def _convert_config(cfg: 'OmegaConf'):
-    """ Recursive function convertint the configuration from old hydra format to the new one. """
+    """Recursive function convertint the configuration from old hydra format to the new one."""
     if not _HAS_HYDRA:
         logging.error("This function requires Hydra/Omegaconf and it was not installed.")
         exit(1)
@@ -671,9 +676,9 @@ def inject_model_parallel_rank(filepath, fsdp_sharded_ckpt=False):
 
 
 def ckpt_to_dir(filepath: Union[str, Path]) -> Path:
-    """ PTL considers checkpoints as .ckpt files.
-        This method removes the extension and returns a path
-        to be used as a directory for distributed checkpoints
+    """PTL considers checkpoints as .ckpt files.
+    This method removes the extension and returns a path
+    to be used as a directory for distributed checkpoints
     """
 
     filepath = Path(filepath)
@@ -689,6 +694,16 @@ def ckpt_to_dir(filepath: Union[str, Path]) -> Path:
     checkpoint_dir = filepath.with_name(filepath.stem)
 
     return checkpoint_dir
+
+
+def ckpt_to_weights_subdir(filepath: Union[str, Path]) -> Path:
+    """Given an input checkpoint filepath, clean it using `ckpt_to_dir` and then return the weights subdirectory."""
+    return ckpt_to_dir(filepath=filepath) / WEIGHTS_PATH
+
+
+def ckpt_to_context_subdir(filepath: Union[str, Path]) -> Path:
+    """Given an input checkpoint filepath, clean it using `ckpt_to_dir` and then return the context subdirectory."""
+    return ckpt_to_dir(filepath=filepath) / CONTEXT_PATH
 
 
 def save_artifacts(model, output_dir: str, use_abspath: bool = False) -> None:

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -682,13 +682,11 @@ def ckpt_to_dir(filepath: Union[str, Path]) -> Path:
     """
 
     filepath = Path(filepath)
-
-    # if it is already a distributed checkpoint, then return
-    if filepath.suffix != ".ckpt" and filepath.is_dir():
-        return filepath
+    if not filepath.suffix == ".ckpt":
+        filepath = filepath.with_suffix(filepath.suffix + ".ckpt")
 
     # adding this assert because we will later remove directories based on the return value of this method
-    assert filepath.suffix == ".ckpt", f'filepath: {filepath} must have .ckpt extension'
+    assert filepath.suffix == ".ckpt", f"filepath: {filepath} must have .ckpt extension"
 
     # create a new path whose name is the original filepath without the .ckpt extension
     checkpoint_dir = filepath.with_name(filepath.stem)

--- a/nemo/utils/model_utils.py
+++ b/nemo/utils/model_utils.py
@@ -47,11 +47,6 @@ except ModuleNotFoundError:
 MODEL_CONFIG = "model_config.yaml"
 _VAL_TEST_FASTPATH_KEY = 'ds_item'
 
-# NeMo2 checkpoint structure is a checkpoint directory, with a WEIGHTS_PATH and CONTEXT_PATH subdirectory structure.
-#  WEIGHTS_PATH stores the weights while CONTEXT_PATH stores the hyper-parameters.
-WEIGHTS_PATH: str = "weights"
-CONTEXT_PATH: str = "context"
-
 
 class ArtifactPathType(Enum):
     """
@@ -682,8 +677,9 @@ def ckpt_to_dir(filepath: Union[str, Path]) -> Path:
     """
 
     filepath = Path(filepath)
-    if not filepath.suffix == ".ckpt":
-        filepath = filepath.with_suffix(filepath.suffix + ".ckpt")
+    # if it is already a distributed checkpoint, then return
+    if filepath.suffix != ".ckpt" and filepath.is_dir():
+        return filepath
 
     # adding this assert because we will later remove directories based on the return value of this method
     assert filepath.suffix == ".ckpt", f"filepath: {filepath} must have .ckpt extension"
@@ -692,16 +688,6 @@ def ckpt_to_dir(filepath: Union[str, Path]) -> Path:
     checkpoint_dir = filepath.with_name(filepath.stem)
 
     return checkpoint_dir
-
-
-def ckpt_to_weights_subdir(filepath: Union[str, Path]) -> Path:
-    """Given an input checkpoint filepath, clean it using `ckpt_to_dir` and then return the weights subdirectory."""
-    return ckpt_to_dir(filepath=filepath) / WEIGHTS_PATH
-
-
-def ckpt_to_context_subdir(filepath: Union[str, Path]) -> Path:
-    """Given an input checkpoint filepath, clean it using `ckpt_to_dir` and then return the context subdirectory."""
-    return ckpt_to_dir(filepath=filepath) / CONTEXT_PATH
 
 
 def save_artifacts(model, output_dir: str, use_abspath: bool = False) -> None:


### PR DESCRIPTION
# What does this PR do ?

Get checkpoint connector working for bionemo (see https://github.com/NVIDIA/bionemo-fw-ea/pull/180)

# Changelog 
- Use new nemo2 standard `/weights` and `/context` subdirectory scheme so checkpoint loaders work properly with checkpoints created by this method.
- dedup [ckpt_to_dir](https://github.com/NVIDIA/NeMo/pull/10647/files#diff-8b8117bc8b07d1fa52030c25e6a7c7920aafa31780e2665ec5fe63939c11a622L272)
- Other changes necessary to allow checkpoint transformation outside of training resumption.