### PR TITLE
enabling data parallel comm backend arg

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -196,6 +196,7 @@ class MegatronBaseModel(NLPModel):
             pipeline_model_parallel_split_rank=cfg.get('pipeline_model_parallel_split_rank', 0),
             use_tp_pp_dp_mapping=cfg.get('use_tp_pp_dp_mapping', False),
             context_parallel_size=cfg.get('context_parallel_size', 1),
+            data_parallel_comm_backend=cfg.get('data_parallel_comm_backend', 'nccl'),
             micro_batch_size=cfg.get('micro_batch_size'),
             global_batch_size=cfg.get('global_batch_size'),
             rampup_batch_size=cfg.get('rampup_batch_size', None),

--- a/nemo/collections/nlp/modules/common/megatron/megatron_init.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_init.py
@@ -95,6 +95,7 @@ def initialize_model_parallel_for_nemo(
     virtual_pipeline_model_parallel_size=None,
     pipeline_model_parallel_split_rank=None,
     context_parallel_size=1,
+    data_parallel_comm_backend='nccl',
     micro_batch_size=None,
     global_batch_size=None,
     rampup_batch_size=None,
@@ -120,6 +121,7 @@ def initialize_model_parallel_for_nemo(
     app_state.pipeline_model_parallel_size = pipeline_model_parallel_size
     app_state.virtual_pipeline_model_parallel_size = virtual_pipeline_model_parallel_size
     app_state.context_parallel_size = context_parallel_size
+    app_state.data_parallel_comm_backend = data_parallel_comm_backend
     app_state.use_fp8 = use_fp8
     app_state.init_mpi_proc_group = init_mpi_proc_group
     (

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -158,6 +158,7 @@ def init_model_parallel(
                 virtual_pipeline_model_parallel_size=app_state.virtual_pipeline_model_parallel_size,
                 pipeline_model_parallel_split_rank=app_state.pipeline_model_parallel_split_rank,
                 context_parallel_size=app_state.context_parallel_size,
+                data_parallel_comm_backend=app_state.data_parallel_comm_backend,
                 nccl_communicator_config_path=nccl_communicator_config_path,
                 use_sharp=sharp,
                 expert_model_parallel_size=app_state.expert_model_parallel_size,

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -52,6 +52,7 @@ class AppState(metaclass=Singleton):
         self._virtual_pipeline_model_parallel_size = None
         self._pipeline_model_parallel_group = None
         self._pipeline_model_parallel_split_rank = None
+        self.data_parallel_comm_backend = None
         self._is_megatron_initialized = False
         self._data_parallel_size = None
         self._data_parallel_group = None
@@ -151,6 +152,22 @@ class AppState(metaclass=Singleton):
             size (int):  Number of GPUs in each model parallel group.
         """
         self._tensor_model_parallel_size = size
+
+    @property
+    def data_parallel_comm_backend(self):
+        """Property returns the backend communication library of data parallel communication.
+        Returns:
+            Backend communication library of data parallel communication.
+        """
+        return self._data_parallel_comm_backend
+
+    @data_parallel_comm_backend.setter
+    def data_parallel_comm_backend(self, backend):
+        """Property sets the backend communication library of data parallel communication.
+        Args:
+            backend (str): Backend communication library of data parallel communication.
+        """
+        self._data_parallel_comm_backend = backend
 
     @property
     def expert_model_parallel_rank(self):


### PR DESCRIPTION
# What does this PR do ?

+training.model.data_parallel_comm_backend=ucc

set CUDA_DEVICE_MAX_CONNECTIONS=8
which is in NeMo-Launcher `launcher/launcher_scripts/nemo_launcher/core/stages.py:_cuda_device_max_connections()`

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
