### PR TITLE
vLLM NemoTokenizerGroup bugfix

### DIFF
--- a/nemo/export/vllm/tokenizer_group.py
+++ b/nemo/export/vllm/tokenizer_group.py
@@ -14,6 +14,7 @@
 
 from typing import List, Optional
 
+from vllm.config import TokenizerPoolConfig
 from vllm.lora.request import LoRARequest
 from vllm.transformers_utils.tokenizer_group.base_tokenizer_group import BaseTokenizerGroup
 
@@ -28,6 +29,10 @@ class NemoTokenizerGroup(BaseTokenizerGroup):
     def __init__(self, tokenizer: SentencePieceTokenizer, add_bos_token: bool = False):
         self.tokenizer = tokenizer
         self.add_bos_token = add_bos_token
+
+    @classmethod
+    def from_config(cls, tokenizer_pool_config: Optional[TokenizerPoolConfig], **init_kwargs) -> None:
+        raise NotImplementedError
 
     def ping(self) -> bool:
         return True


### PR DESCRIPTION
# What does this PR do ?

For `NemoTokenizerGroup` in the base class [BaseTokenizerGroup](https://github.com/vllm-project/vllm/blob/v0.5.3/vllm/transformers_utils/tokenizer_group/base_tokenizer_group.py#L13-L17)  from vLLM there is an abstract `from_config` method that needs to be implemented. This change mocks the implementation to make `scripts/deploy/nlp/deploy_vllm_triton.py` functional.

There error fixed here is:
```
INFO 09-27 15:02:31 llm_engine.py:176] Initializing an LLM engine (v0.5.3) with config: model='/tmp/tmpioclfxxh', speculative_config=None, tokenizer=None, skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, rope_scaling=None, rope_theta=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=512, download_dir=None, load_format=<class 'nemo.export.vllm.model_loader.NemoModelLoader'>, tensor_parallel_size=1, pipeline_parallel_size=1, disable_custom_all_reduce=False, quantization=None, enforce_eager=False, kv_cache_dtype=auto, quantization_param_path=None, device_config=cuda, decoding_config=None, observability_config=None, seed=0, served_model_name=/data/export/LLAMA2-7B-fp8-sft.nemo, use_v2_block_manager=False, enable_prefix_caching=False)
ERROR 09-27 15:02:31 deploy_vllm_triton.py:169] An error has occurred while setting up or serving the model. Error message: An error has occurred during the model export. Error message: Can't instantiate abstract class NemoTokenizerGroup with abstract method from_config
```

CC @apanteleev 

**Collection**: NLP

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to https://github.com/NVIDIA/NeMo/pull/9381
