### PR TITLE
MCore Partial DistOpt Feature

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -195,7 +195,7 @@ class MegatronBaseModel(NLPModel):
             virtual_pipeline_model_parallel_size=vp_size,
             pipeline_model_parallel_split_rank=cfg.get('pipeline_model_parallel_split_rank', 0),
             use_tp_pp_dp_mapping=cfg.get('use_tp_pp_dp_mapping', False),
-            partial_data_parallel_shard_factor = self.cfg.optim.get('partial_data_parallel_shard_factor',1),
+            partial_data_parallel_shard_factor=self.cfg.optim.get('partial_data_parallel_shard_factor', 1),
             context_parallel_size=cfg.get('context_parallel_size', 1),
             micro_batch_size=cfg.get('micro_batch_size'),
             global_batch_size=cfg.get('global_batch_size'),

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -195,6 +195,7 @@ class MegatronBaseModel(NLPModel):
             virtual_pipeline_model_parallel_size=vp_size,
             pipeline_model_parallel_split_rank=cfg.get('pipeline_model_parallel_split_rank', 0),
             use_tp_pp_dp_mapping=cfg.get('use_tp_pp_dp_mapping', False),
+            partial_data_parallel_shard_factor = self.cfg.optim.get('partial_data_parallel_shard_factor',1),
             context_parallel_size=cfg.get('context_parallel_size', 1),
             micro_batch_size=cfg.get('micro_batch_size'),
             global_batch_size=cfg.get('global_batch_size'),

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -195,7 +195,7 @@ class MegatronBaseModel(NLPModel):
             virtual_pipeline_model_parallel_size=vp_size,
             pipeline_model_parallel_split_rank=cfg.get('pipeline_model_parallel_split_rank', 0),
             use_tp_pp_dp_mapping=cfg.get('use_tp_pp_dp_mapping', False),
-            partial_data_parallel_shard_factor=self.cfg.optim.get('partial_data_parallel_shard_factor', 1),
+            num_distributed_optimizer_instances=self.cfg.optim.get('num_distributed_optimizer_instances', 1),
             context_parallel_size=cfg.get('context_parallel_size', 1),
             micro_batch_size=cfg.get('micro_batch_size'),
             global_batch_size=cfg.get('global_batch_size'),

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -574,7 +574,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             ddp_config = DistributedDataParallelConfig(
                 grad_reduce_in_fp32=(self.cfg.optim.get('grad_sync_dtype', 'fp32') == 'fp32'),
                 overlap_grad_reduce=self.cfg.optim.get('overlap_grad_sync', False),
-                partial_data_parallel_shard_factor=self.cfg.optim.get('partial_data_parallel_shard_factor',1),
+                partial_data_parallel_shard_factor=self.cfg.optim.get('partial_data_parallel_shard_factor', 1),
                 use_distributed_optimizer=True,
                 check_for_nan_in_grad=self.cfg.optim.get('check_for_nan_in_grad', False),
                 # mcore bucket_size is based on num of parameters, therefore not

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -574,6 +574,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             ddp_config = DistributedDataParallelConfig(
                 grad_reduce_in_fp32=(self.cfg.optim.get('grad_sync_dtype', 'fp32') == 'fp32'),
                 overlap_grad_reduce=self.cfg.optim.get('overlap_grad_sync', False),
+                partial_data_parallel_shard_factor=self.cfg.optim.get('partial_data_parallel_shard_factor',1),
                 use_distributed_optimizer=True,
                 check_for_nan_in_grad=self.cfg.optim.get('check_for_nan_in_grad', False),
                 # mcore bucket_size is based on num of parameters, therefore not

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -574,7 +574,7 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             ddp_config = DistributedDataParallelConfig(
                 grad_reduce_in_fp32=(self.cfg.optim.get('grad_sync_dtype', 'fp32') == 'fp32'),
                 overlap_grad_reduce=self.cfg.optim.get('overlap_grad_sync', False),
-                partial_data_parallel_shard_factor=self.cfg.optim.get('partial_data_parallel_shard_factor', 1),
+                num_distributed_optimizer_instances=self.cfg.optim.get('num_distributed_optimizer_instances', 1),
                 use_distributed_optimizer=True,
                 check_for_nan_in_grad=self.cfg.optim.get('check_for_nan_in_grad', False),
                 # mcore bucket_size is based on num of parameters, therefore not

--- a/nemo/collections/nlp/modules/common/megatron/megatron_init.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_init.py
@@ -104,6 +104,7 @@ def initialize_model_parallel_for_nemo(
     apex_transformer_log_level=30,
     use_tp_pp_dp_mapping=False,
     use_te_rng_tracker=False,
+    partial_data_parallel_shard_factor = 1,
 ):
 
     if virtual_pipeline_model_parallel_size is not None and not HAVE_INTERLEAVED:
@@ -115,6 +116,7 @@ def initialize_model_parallel_for_nemo(
     app_state.world_size = world_size
     app_state.local_rank = local_rank
     app_state.use_tp_pp_dp_mapping = use_tp_pp_dp_mapping
+    app_state.partial_data_parallel_shard_factor = partial_data_parallel_shard_factor
     app_state.expert_model_parallel_size = expert_model_parallel_size
     app_state.tensor_model_parallel_size = tensor_model_parallel_size
     app_state.pipeline_model_parallel_size = pipeline_model_parallel_size

--- a/nemo/collections/nlp/modules/common/megatron/megatron_init.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_init.py
@@ -104,7 +104,7 @@ def initialize_model_parallel_for_nemo(
     apex_transformer_log_level=30,
     use_tp_pp_dp_mapping=False,
     use_te_rng_tracker=False,
-    partial_data_parallel_shard_factor = 1,
+    partial_data_parallel_shard_factor=1,
 ):
 
     if virtual_pipeline_model_parallel_size is not None and not HAVE_INTERLEAVED:

--- a/nemo/collections/nlp/modules/common/megatron/megatron_init.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_init.py
@@ -104,7 +104,7 @@ def initialize_model_parallel_for_nemo(
     apex_transformer_log_level=30,
     use_tp_pp_dp_mapping=False,
     use_te_rng_tracker=False,
-    partial_data_parallel_shard_factor=1,
+    num_distributed_optimizer_instances=1,
 ):
 
     if virtual_pipeline_model_parallel_size is not None and not HAVE_INTERLEAVED:
@@ -116,7 +116,7 @@ def initialize_model_parallel_for_nemo(
     app_state.world_size = world_size
     app_state.local_rank = local_rank
     app_state.use_tp_pp_dp_mapping = use_tp_pp_dp_mapping
-    app_state.partial_data_parallel_shard_factor = partial_data_parallel_shard_factor
+    app_state.num_distributed_optimizer_instances = num_distributed_optimizer_instances
     app_state.expert_model_parallel_size = expert_model_parallel_size
     app_state.tensor_model_parallel_size = tensor_model_parallel_size
     app_state.pipeline_model_parallel_size = pipeline_model_parallel_size

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -162,6 +162,7 @@ def init_model_parallel(
                 use_sharp=sharp,
                 expert_model_parallel_size=app_state.expert_model_parallel_size,
                 order='tp-pp-dp' if app_state.use_tp_pp_dp_mapping else 'tp-cp-ep-dp-pp',
+                partial_data_parallel_shard_factor=app_state.partial_data_parallel_shard_factor,
                 distributed_timeout_minutes=distributed_timeout_minutes,
             )
 

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -162,7 +162,7 @@ def init_model_parallel(
                 use_sharp=sharp,
                 expert_model_parallel_size=app_state.expert_model_parallel_size,
                 order='tp-pp-dp' if app_state.use_tp_pp_dp_mapping else 'tp-cp-ep-dp-pp',
-                partial_data_parallel_shard_factor=app_state.partial_data_parallel_shard_factor,
+                num_distributed_optimizer_instances=app_state.num_distributed_optimizer_instances,
                 distributed_timeout_minutes=distributed_timeout_minutes,
             )
 

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -56,6 +56,7 @@ class AppState(metaclass=Singleton):
         self._data_parallel_size = None
         self._data_parallel_group = None
         self._use_tp_pp_dp_mapping = False
+        self._partial_data_parallel_shard_factor = 1
         self._megatron_checkpoint_version = None
         self._use_fp8 = False
         self._context_parallel_size = None
@@ -207,6 +208,23 @@ class AppState(metaclass=Singleton):
     @use_tp_pp_dp_mapping.setter
     def use_tp_pp_dp_mapping(self, use_new_mapping):
         self._use_tp_pp_dp_mapping = use_new_mapping
+
+    @property
+    def partial_data_parallel_shard_factor(self):
+        """Property returns the factor by which the Partial DistOpt is sharded.
+        Returns:
+            The partial DistOpt shard factor
+        """
+        return self._partial_data_parallel_shard_factor
+
+    @use_tp_pp_dp_mapping.setter
+    def partial_data_parallel_shard_factor(self, shard_factor):
+        """Property sets the factor by which the Partial DistOpt is sharded.
+        Args:
+            shard_factor (int):  The partial DistOpt shard factor.
+        """
+        self._partial_data_parallel_shard_factor = shard_factor
+
 
     @property
     def virtual_pipeline_model_parallel_size(self):

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -217,7 +217,7 @@ class AppState(metaclass=Singleton):
         """
         return self._partial_data_parallel_shard_factor
 
-    @use_tp_pp_dp_mapping.setter
+    @partial_data_parallel_shard_factor.setter
     def partial_data_parallel_shard_factor(self, shard_factor):
         """Property sets the factor by which the Partial DistOpt is sharded.
         Args:

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -225,7 +225,6 @@ class AppState(metaclass=Singleton):
         """
         self._partial_data_parallel_shard_factor = shard_factor
 
-
     @property
     def virtual_pipeline_model_parallel_size(self):
         """Property returns the number of GPUs in each model parallel group.

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -56,7 +56,7 @@ class AppState(metaclass=Singleton):
         self._data_parallel_size = None
         self._data_parallel_group = None
         self._use_tp_pp_dp_mapping = False
-        self._partial_data_parallel_shard_factor = 1
+        self._num_distributed_optimizer_instances = 1
         self._megatron_checkpoint_version = None
         self._use_fp8 = False
         self._context_parallel_size = None
@@ -210,20 +210,20 @@ class AppState(metaclass=Singleton):
         self._use_tp_pp_dp_mapping = use_new_mapping
 
     @property
-    def partial_data_parallel_shard_factor(self):
+    def num_distributed_optimizer_instances(self):
         """Property returns the factor by which the Partial DistOpt is sharded.
         Returns:
             The partial DistOpt shard factor
         """
-        return self._partial_data_parallel_shard_factor
+        return self._num_distributed_optimizer_instances
 
-    @partial_data_parallel_shard_factor.setter
-    def partial_data_parallel_shard_factor(self, shard_factor):
+    @num_distributed_optimizer_instances.setter
+    def num_distributed_optimizer_instances(self, shard_factor):
         """Property sets the factor by which the Partial DistOpt is sharded.
         Args:
             shard_factor (int):  The partial DistOpt shard factor.
         """
-        self._partial_data_parallel_shard_factor = shard_factor
+        self._num_distributed_optimizer_instances = shard_factor
 
     @property
     def virtual_pipeline_model_parallel_size(self):


### PR DESCRIPTION
# What does this PR do ?

This PR adds an interface argument to support the MCore Partial DistOpt feature. The argument `num_distributed_optimizer_instances` determines the the level of sharding that can be done on the MCore DistOpt across the DP domain.

The setting need to be set as `training.model.optim. num_distributed_optimizer_instances =2` in the configuration YAML file.