### PR TITLE
Allow logging memory profile on interval

### DIFF
--- a/nemo/lightning/pytorch/callbacks/memory_profiler.py
+++ b/nemo/lightning/pytorch/callbacks/memory_profiler.py
@@ -89,10 +89,10 @@ class MemoryProfileCallback(Callback, io.IOMixin):
         # It's disabled
         if self.interval is None or self.interval <= 0:
             return
-        if self.step == self.interval - 1:
+        if self.step % self.interval == 0:
             if self.enable_on_rank():
-                self._dump_memory_snapshot()
-        self.step = (self.step + 1) % self.interval
+                self._dump_memory_snapshot(f"{self.dir}/memory_snapshot-rank{rank}_iter{self.step}.pickle")
+        self.step += 1
 
     def on_train_end(self, trainer, pl_module) -> None:
         """PyTorch Lightning hook:

--- a/nemo/lightning/pytorch/callbacks/memory_profiler.py
+++ b/nemo/lightning/pytorch/callbacks/memory_profiler.py
@@ -44,6 +44,7 @@ class MemoryProfileCallback(Callback, io.IOMixin):
 
         self.dir = dir
         self.ranks = ranks
+        assert isinstance(self.interval, int), "Expected interval to be an integer"
         self.interval = interval
         self.step = 0
 
@@ -87,7 +88,7 @@ class MemoryProfileCallback(Callback, io.IOMixin):
 
     def on_train_batch_start(self, trainer, pl_module, batch, batch_idx, unused=0) -> None:
         # It's disabled
-        if self.interval is None or self.interval <= 0:
+        if self.interval <= 0:
             return
         if self.step % self.interval == 0:
             if self.enable_on_rank():


### PR DESCRIPTION
# What does this PR do ?

Allow logging memory profile via the interval constructor arg.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
