### PR TITLE
use model device for embedding extraction

### DIFF
--- a/nemo/collections/asr/models/clustering_diarizer.py
+++ b/nemo/collections/asr/models/clustering_diarizer.py
@@ -341,7 +341,7 @@ class ClusteringDiarizer(torch.nn.Module, Model, DiarizationMixin):
         self._speaker_model.eval()
         self.time_stamps = {}
 
-        all_embs = torch.empty([0])
+        all_embs = torch.empty([0], device=self._speaker_model.device)
         for test_batch in tqdm(
             self._speaker_model.test_dataloader(),
             desc=f'[{scale_idx+1}/{num_scales}] extract embeddings',
@@ -354,7 +354,7 @@ class ClusteringDiarizer(torch.nn.Module, Model, DiarizationMixin):
                 _, embs = self._speaker_model.forward(input_signal=audio_signal, input_signal_length=audio_signal_len)
                 emb_shape = embs.shape[-1]
                 embs = embs.view(-1, emb_shape)
-                all_embs = torch.cat((all_embs, embs.cpu().detach()), dim=0)
+                all_embs = torch.cat((all_embs, embs.detach()), dim=0)
             del test_batch
 
         with open(manifest_file, 'r', encoding='utf-8') as manifest:


### PR DESCRIPTION

This fixes major slowdowns when running diarization parallel on multiple gpus

Discussion: https://github.com/NVIDIA/NeMo/issues/7101


# What does this PR do ?

Stores embedding extraction on device.

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
