### PR TITLE
replace `SIGKILL` with `SIGTERM`

### DIFF
--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -167,7 +167,7 @@ class FaultToleranceParams:
     rank_heartbeat_timeout: Optional[float] = 45.0 * 60.0
     calculate_timeouts: bool = True
     safety_factor: float = 5.0
-    rank_termination_signal: signal.Signals = signal.SIGKILL
+    rank_termination_signal: signal.Signals = signal.SIGTERM
     log_level: str = 'INFO'
     max_rank_restarts: int = 0
     max_subsequent_job_failures: int = 0


### PR DESCRIPTION
# What does this PR do ?

`signal.SIGKILL` is used but it's not supported in windows, it was introduced in #9352 

**Collection**: Core

# Changelog 
- Replace `signal.SIGKILL` with `signal.SIGTERM` as it is not supported in windows, I know windows is supposed to be used along with WSL, but most of the inference functionality does work without WSL, so if this PR doesn't break the functionality, there is no need to break what is left of windows compatibility

# Usage
`from nemo.collections.asr.models.msdd_models import NeuralDiarizer`
or
`from nemo.utils import exp_manager`

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

@ericharper @titu1994 @blisc @okuchaiev 
