### PR TITLE
Fix for crashes with tensorboard_logger=false and VP + LoRA

### DIFF
--- a/nemo/collections/common/metrics/perf_metrics.py
+++ b/nemo/collections/common/metrics/perf_metrics.py
@@ -85,7 +85,8 @@ class FLOPsMeasurementCallback(Callback):
             logging.error(f"Failed to calculate TFLOPs per sec per GPU.\n{exc}")
 
         logging.info(f"TFLOPs per sec per GPU={tflops_per_sec_per_gpu:.2f}")
-        pl_module.logger.experiment.add_scalar("tflops_per_sec_per_gpu", tflops_per_sec_per_gpu)
+        if pl_module.logger:
+            pl_module.logger.experiment.add_scalar("tflops_per_sec_per_gpu", tflops_per_sec_per_gpu)
 
     def eval_tflops_per_sec_per_gpu(self, train_step_time: List | float | int) -> float:
         """

--- a/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
+++ b/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
@@ -472,7 +472,7 @@ class NLPAdapterModelMixin:
                 use_mcore = (getattr(self, 'mcore_gpt', False)) or (getattr(self, 'mcore_t5', False))
                 if use_mcore:
                     for index, module in enumerate(self.get_model_module_list()):
-                        if parallel_state.get_virtual_pipeline_model_parallel_world_size() is not None:
+                        if parallel_state.get_virtual_pipeline_model_parallel_world_size() is not None and f'model_{index}' in checkpoint['state_dict']:
                             checkpoint_state_dict = checkpoint['state_dict'][f'model_{index}']
                         else:
                             checkpoint_state_dict = checkpoint['state_dict']

--- a/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
+++ b/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py
@@ -472,7 +472,10 @@ class NLPAdapterModelMixin:
                 use_mcore = (getattr(self, 'mcore_gpt', False)) or (getattr(self, 'mcore_t5', False))
                 if use_mcore:
                     for index, module in enumerate(self.get_model_module_list()):
-                        if parallel_state.get_virtual_pipeline_model_parallel_world_size() is not None and f'model_{index}' in checkpoint['state_dict']:
+                        if (
+                            parallel_state.get_virtual_pipeline_model_parallel_world_size() is not None
+                            and f'model_{index}' in checkpoint['state_dict']
+                        ):
                             checkpoint_state_dict = checkpoint['state_dict'][f'model_{index}']
                         else:
                             checkpoint_state_dict = checkpoint['state_dict']


### PR DESCRIPTION
# What does this PR do ?

Two tiny fixes for crashes that can occur with with (1) VP + LoRA and (2) exp_manager.create_tensorboard_logger=false.

**Collection**: nlp

# Changelog 
- With virtual pipeline parallel + lora it is currently possible to encounter:
```
  File "/opt/NeMo/nemo/collections/nlp/parts/mixins/nlp_adapter_mixins.py", line 477, in on_load_checkpoint
    checkpoint_state_dict = checkpoint['state_dict'][f'model_{index}']
KeyError: 'model_0'
```
Sometimes the state_dict is already in the correct format here, so the model_{} keys don't exist.  I've altered this statement to check if that key is present or not first.
- With exp_manager.create_tensorboard_logger=false, adding tflops/sec as a metric raises an exception:
```
  File "/opt/NeMo/nemo/collections/common/metrics/perf_metrics.py", line 87, in on_train_end
    pl_module.logger.experiment.add_scalar("tflops_per_sec_per_gpu", tflops_per_sec_per_gpu)
AttributeError: 'NoneType' object has no attribute 'experiment'
```
I've added a condition to check if the logger exists before adding.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [*] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [*] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
