### PR TITLE
Fix: When training ASR models, it saves .nemo 2 times in a row when save_last is True

### DIFF
--- a/nemo/utils/callbacks/nemo_model_checkpoint.py
+++ b/nemo/utils/callbacks/nemo_model_checkpoint.py
@@ -215,6 +215,11 @@ class NeMoModelCheckpoint(ModelCheckpoint):
         else:
             maybe_injected_best_model_path = self.best_model_path
 
+        if self.save_last:
+            if self.best_model_path == self.last_model_path.replace('-last', ''):
+                logging.debug(f'Last checkpoint {self.last_model_path} already saved (avoiding unnecessary overwrite)')
+                return output
+
         if self.save_best_model:
             if not os.path.exists(maybe_injected_best_model_path):
                 return


### PR DESCRIPTION
# What does this PR do ?

It fixes a minor bug mentioned in #10798 where it saves the .nemo 2 times when save_last and always_save_nemo are True. When it saves the best checkpoint and when it saves the last checkpoint.

**Collection**: 

# Changelog 
- Fix unnecessary checkpointing to .nemo

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
- [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #10798
