### PR TITLE
refactored energon datamodule to remove image_processor and task encoder passed through init

### DIFF
--- a/tests/collections/multimodal/data/energon/test_data_module.py
+++ b/tests/collections/multimodal/data/energon/test_data_module.py
@@ -32,9 +32,7 @@ class TestSimpleMultiModalDataModuleWithDummyData(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.processor = AutoProcessor.from_pretrained("llava-hf/llava-1.5-7b-hf")
-        cls.tokenizer = cls.processor.tokenizer
-        cls.image_processor = cls.processor.image_processor
+        cls.hf_model_id = "llava-hf/llava-1.5-7b-hf"
 
     def setUp(self):
         self.config = MultiModalSampleConfig(
@@ -49,13 +47,15 @@ class TestSimpleMultiModalDataModuleWithDummyData(unittest.TestCase):
 
         self.data_module = SimpleMultiModalDataModule(
             path=str(self.dataset_path),
-            tokenizer=self.tokenizer,
-            image_processor=self.image_processor,
+            hf_model_id=self.hf_model_id,
             num_workers=0,
             micro_batch_size=1,
             global_batch_size=2,
             multimodal_sample_config=self.config,
         )
+        self.data_module.setup(stage='train')
+        self.tokenizer = self.data_module.tokenizer
+        self.image_processor = self.data_module.image_processor
 
     def tearDown(self):
         self.temp_dir.cleanup()


### PR DESCRIPTION
refactored energon datamodule to remove image_processor and task encoder passed through init

**Collection**: 
Multimodal

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
data_module = SimpleMultiModalDataModule(
    path=dataset_path,
    hf_model_id=hf_model_id,
    seq_length=512,  
    micro_batch_size=8,  
    global_batch_size=32, 
    num_workers=4, 
    pin_memory=True,  
    task_encoder_class=CustomTaskEncoder
)
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
