### PR TITLE
Expose drop_last in MegatronDataSampler

### DIFF
--- a/nemo/lightning/pytorch/plugins/data_sampler.py
+++ b/nemo/lightning/pytorch/plugins/data_sampler.py
@@ -75,7 +75,7 @@ class MegatronDataSampler(DataSampler):
             rampup_batch_size=self.rampup_batch_size,
             consumed_samples=self.init_consumed_samples if mode == 'train' else 0,
             dataloader_type=self.dataloader_type,
-            drop_last=self.drop_last
+            drop_last=self.drop_last,
         )
 
     def compute_consumed_samples(self, steps_since_resume=0) -> int:

--- a/nemo/lightning/pytorch/plugins/data_sampler.py
+++ b/nemo/lightning/pytorch/plugins/data_sampler.py
@@ -44,6 +44,7 @@ class MegatronDataSampler(DataSampler):
         init_consumed_samples: int = 0,
         init_global_step: int = 0,
         output_log: bool = True,
+        drop_last: bool = True,
     ):
         self.seq_len = seq_len
         self.output_log = output_log
@@ -56,6 +57,7 @@ class MegatronDataSampler(DataSampler):
         self.if_first_step = 0
         self.prev_global_batch_size = None
         self.init_global_step = init_global_step
+        self.drop_last = drop_last
 
     def setup(self, global_rank: int) -> None:
         from nemo.lightning.data import setup_microbatch_calculator
@@ -73,6 +75,7 @@ class MegatronDataSampler(DataSampler):
             rampup_batch_size=self.rampup_batch_size,
             consumed_samples=self.init_consumed_samples if mode == 'train' else 0,
             dataloader_type=self.dataloader_type,
+            drop_last=self.drop_last
         )
 
     def compute_consumed_samples(self, steps_since_resume=0) -> int:


### PR DESCRIPTION
# What does this PR do ?

This PR exposes the `drop_last` argument in `MegatronDataSampler` which we use in our BioNeMo datamodules to run inference for complete/partial batches of data.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
