### PR TITLE
Replace usage of np.sctypes with np.issubdtype

### DIFF
--- a/nemo/collections/asr/parts/preprocessing/feature_loader.py
+++ b/nemo/collections/asr/parts/preprocessing/feature_loader.py
@@ -50,10 +50,10 @@ class ExternalFeatureLoader(object):
         Integers will be scaled to [-1, 1] in float32.
         """
         float32_samples = samples.astype('float32')
-        if samples.dtype in np.sctypes['int']:
+        if np.issubdtype(samples.dtype, np.integer):
             bits = np.iinfo(samples.dtype).bits
             float32_samples *= 1.0 / 2 ** (bits - 1)
-        elif samples.dtype in np.sctypes['float']:
+        elif np.issubdtype(samples.dtype, np.floating):
             pass
         else:
             raise TypeError("Unsupported sample type: %s." % samples.dtype)

--- a/nemo/collections/asr/parts/preprocessing/feature_loader.py
+++ b/nemo/collections/asr/parts/preprocessing/feature_loader.py
@@ -18,12 +18,13 @@ import torch
 
 
 class ExternalFeatureLoader(object):
-    """Feature loader that load external features store in certain format. 
+    """Feature loader that load external features store in certain format.
     Currently support pickle, npy and npz format.
     """
 
     def __init__(
-        self, augmentor: Optional["nemo.collections.asr.parts.perturb.FeatureAugmentor"] = None,
+        self,
+        augmentor: Optional["nemo.collections.asr.parts.perturb.FeatureAugmentor"] = None,
     ):
         """
         Feature loader

--- a/nemo/collections/asr/parts/preprocessing/segment.py
+++ b/nemo/collections/asr/parts/preprocessing/segment.py
@@ -260,10 +260,10 @@ class AudioSegment(object):
         Integers will be scaled to [-1, 1] in float32.
         """
         float32_samples = samples.astype('float32')
-        if samples.dtype in np.sctypes['int']:
+        if np.issubdtype(samples.dtype, np.integer):
             bits = np.iinfo(samples.dtype).bits
             float32_samples *= 1.0 / 2 ** (bits - 1)
-        elif samples.dtype in np.sctypes['float']:
+        elif np.issubdtype(samples.dtype, np.floating):
             pass
         else:
             raise TypeError("Unsupported sample type: %s." % samples.dtype)


### PR DESCRIPTION
# What does this PR do ?

Remove usage of np.sctypes that is not supported anymore with Numpy 2.x. ASR inference from scripts such as transcribe_speech.py was broken because of this. this is a duplicate of #10180 because it was closed

**Collection**: ASR
# Changelog 
- Replace usage of `np.sctypes` with `np.issubdtype` for `numpy>=2` compatibility

# Usage
NA

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?
@titu1994 , @redoctopus, @jbalam-nv, or @okuchaiev

