### PR TITLE
build: add ipython to ASR requirements

### DIFF
--- a/requirements/requirements_asr.txt
+++ b/requirements/requirements_asr.txt
@@ -2,6 +2,7 @@ braceexpand
 editdistance
 einops
 g2p_en
+ipython
 jiwer
 kaldi-python-io
 kaldiio


### PR DESCRIPTION
# What does this PR do ?

This should fix the issue with `plot` and `plot_sample_from_rttm` in `nemo/collections/asr/parts/utils/vad_utils.py` 


**Collection**: ASR

# Changelog 
- Add ipython back to ASR Requirements

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* FIXES: #10772
