### PR TITLE
Fixing the UnicodeEncodeError for 'logging'

### DIFF
--- a/nemo/utils/nemo_logging.py
+++ b/nemo/utils/nemo_logging.py
@@ -76,7 +76,7 @@ class Logger(metaclass=Singleton):
         self.rank = 0 if is_global_rank_zero() else "UNK"
 
     def _define_logger(self, capture_warnings=True):
-        """ Creates the logger if not already created. Called in init"""
+        """Creates the logger if not already created. Called in init"""
 
         # Use double-checked locking to avoid taking lock unnecessarily.
         if self._logger is not None:
@@ -126,7 +126,7 @@ class Logger(metaclass=Singleton):
         self._logger.propagate = False
 
     def remove_stream_handlers(self):
-        """ Removes StreamHandler that log to stdout and stderr from the logger."""
+        """Removes StreamHandler that log to stdout and stderr from the logger."""
         if self._logger is None:
             raise RuntimeError("Impossible to set handlers if the Logger is not predefined")
 
@@ -236,7 +236,7 @@ class Logger(metaclass=Singleton):
 
     @contextmanager
     def patch_stderr_handler(self, stream):
-        """ Sends messages that should log to stderr to stream instead. Useful for unittests """
+        """Sends messages that should log to stderr to stream instead. Useful for unittests"""
         if self._logger is not None:
             try:
                 old_stream = self._handlers["stream_stderr"].stream
@@ -268,7 +268,7 @@ class Logger(metaclass=Singleton):
 
     @contextmanager
     def patch_stdout_handler(self, stream):
-        """ Sends messages that should log to stdout to stream instead. Useful for unittests """
+        """Sends messages that should log to stdout to stream instead. Useful for unittests"""
         if self._logger is not None:
             try:
                 old_stream = self._handlers["stream_stdout"].stream

--- a/nemo/utils/nemo_logging.py
+++ b/nemo/utils/nemo_logging.py
@@ -184,7 +184,7 @@ class Logger(metaclass=Singleton):
         if self._logger is None:
             raise RuntimeError("Impossible to set handlers if the Logger is not predefined")
 
-        self._handlers["file"] = _logging.FileHandler(log_file)
+        self._handlers["file"] = _logging.FileHandler(log_file, encoding='utf-8')
         formatter = BaseNeMoFormatter
         self._handlers["file"].setFormatter(formatter())
         self._logger.addHandler(self._handlers["file"])
@@ -201,7 +201,7 @@ class Logger(metaclass=Singleton):
         if self._logger is None:
             raise RuntimeError("Impossible to set handlers if the Logger is not predefined")
 
-        self._handlers["file_err"] = _logging.FileHandler(log_file)
+        self._handlers["file_err"] = _logging.FileHandler(log_file, encoding='utf-8')
         self._handlers["file_err"].addFilter(lambda record: record.levelno > _logging.INFO)
 
         formatter = BaseNeMoFormatter


### PR DESCRIPTION

# What does this PR do ?

Logging is showing UnicodeEncodeError for Spanish (Non-english character) in [tutorials/asr/Multilang_ASR.ipynb](https://github.com/NVIDIA/NeMo/blob/r2.0.0/tutorials/asr/Multilang_ASR.ipynb). Need to specify the encoding scheme to 'utf-8' to avoid that issue. 

**Collection**: [Note which collection this PR will affect]
NeMo/utils

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
