### PR TITLE
Add model_downsampling_factor to NFA cfg

### DIFF
--- a/tools/nemo_forced_aligner/align.py
+++ b/tools/nemo_forced_aligner/align.py
@@ -88,6 +88,9 @@ Arguments:
     total_buffer_in_secs: float  Length of buffer (chunk + left and right padding) in seconds
     chunk_batch_size: int batch size for buffered chunk inference,
                       which will cut one audio into segments and do inference on chunk_batch_size segments at a time
+    model_downsample_factor: int interval at which the model processes overlapping segments of audio input, impacting 
+                      its ability to capture temporal features in speech (8 for Citrinet and FasConformer models and 
+                      4 for Conformer models).
 
     simulate_cache_aware_streaming: False, if set True, using cache aware streaming to do get the logits for alignment
 
@@ -143,6 +146,7 @@ class AlignmentConfig:
     chunk_len_in_secs: float = 1.6
     total_buffer_in_secs: float = 4.0
     chunk_batch_size: int = 32
+    model_downsample_factor: int = 8
 
     # Cache aware streaming configs
     simulate_cache_aware_streaming: Optional[bool] = False

--- a/tools/nemo_forced_aligner/align.py
+++ b/tools/nemo_forced_aligner/align.py
@@ -319,7 +319,14 @@ def main(cfg: AlignmentConfig):
     for start, end in zip(starts, ends):
         manifest_lines_batch = get_manifest_lines_batch(cfg.manifest_filepath, start, end)
 
-        (log_probs_batch, y_batch, T_batch, U_batch, utt_obj_batch, output_timestep_duration,) = get_batch_variables(
+        (
+            log_probs_batch,
+            y_batch,
+            T_batch,
+            U_batch,
+            utt_obj_batch,
+            output_timestep_duration,
+        ) = get_batch_variables(
             manifest_lines_batch,
             model,
             cfg.additional_segment_grouping_separator,
@@ -338,13 +345,18 @@ def main(cfg: AlignmentConfig):
             utt_obj = add_t_start_end_to_utt_obj(utt_obj, alignment_utt, output_timestep_duration)
 
             if "ctm" in cfg.save_output_file_formats:
-                utt_obj = make_ctm_files(utt_obj, cfg.output_dir, cfg.ctm_file_config,)
+                utt_obj = make_ctm_files(
+                    utt_obj,
+                    cfg.output_dir,
+                    cfg.ctm_file_config,
+                )
 
             if "ass" in cfg.save_output_file_formats:
                 utt_obj = make_ass_files(utt_obj, cfg.output_dir, cfg.ass_file_config)
 
             write_manifest_out_line(
-                f_manifest_out, utt_obj,
+                f_manifest_out,
+                utt_obj,
             )
 
     f_manifest_out.close()


### PR DESCRIPTION
The `model_downsampling_factor` parameter was missing in the configuration, which caused the `use_buffered_chunked_streaming` option to malfunction. This PR adds the missing parameter and updates the documentation accordingly.