### PR TITLE
Timestamps to transcribe

### DIFF
--- a/docs/source/asr/intro.rst
+++ b/docs/source/asr/intro.rst
@@ -16,10 +16,39 @@ After :ref:`installing NeMo<installation>`, you can transcribe an audio file as 
     asr_model = nemo_asr.models.ASRModel.from_pretrained("stt_en_fastconformer_transducer_large")
     transcript = asr_model.transcribe(["path/to/audio_file.wav"])
 
-Obtain word/segment timestamps
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Obtain timestamps
+^^^^^^^^^^^^^^^^^
 
-You can also obtain timestamps for each word or segment in the transcription as follows:
+Obtaining char(token), word or segment timestamps is also possible with NeMo ASR Models. 
+
+Currently, timestamps are available for Parakeet Models with all types of decoders (CTC/RNNT/TDT). Support for AED models would be added soon.
+
+There are two ways to obtain timestamps:
+1. By using the `timestamps=True` flag in the `transcribe` method.
+2. For more control over the timestamps, you can update the decoding config to mention type of timestamps (char, word, segment) and also specify the segment seperators or word seperator for segment and word level timestamps.
+
+With the `timestamps=True` flag, you can obtain timestamps for each character in the transcription as follows:
+
+.. code-block:: python
+    
+    # import nemo_asr and instantiate asr_model as above
+    import nemo.collections.asr as nemo_asr
+    asr_model = nemo_asr.models.ASRModel.from_pretrained("nvidia/parakeet-tdt_ctc-110m")
+
+    # specify flag `timestamps=True`
+    hypotheses = asr_model.transcribe(["path/to/audio_file.wav"], timestamps=True)
+
+    # by default, timestamps are enabled for char, word and segment level
+    word_timestamps = hypotheses[0][0].timestep['word'] # word level timestamps for first sample
+    segment_timestamps = hypotheses[0][0].timestep['segment'] # segment level timestamps
+    char_timestamps = hypotheses[0][0].timestep['char'] # char level timestamps
+
+    for stamp in segment_timestamps:
+        print(f"{stamp['start']}s - {end['start']}s - {stamp['word']}")
+
+    # segment level timestamps (if model supports Punctuation and Capitalization, segment level timestamps are displayed based on punctuation otherwise complete transcription is considered as a single segment)
+    
+For more control over the timestamps, you can update the decoding config to mention type of timestamps (char, word, segment) and also specify the segment seperators or word seperator for segment and word level timestamps as follows:
 
 .. code-block:: python
 

--- a/docs/source/asr/intro.rst
+++ b/docs/source/asr/intro.rst
@@ -44,7 +44,7 @@ With the `timestamps=True` flag, you can obtain timestamps for each character in
     char_timestamps = hypotheses[0][0].timestep['char'] # char level timestamps
 
     for stamp in segment_timestamps:
-        print(f"{stamp['start']}s - {end['start']}s - {stamp['word']}")
+        print(f"{stamp['start']}s - {stamp['end']}s : {stamp['segment']}")
 
     # segment level timestamps (if model supports Punctuation and Capitalization, segment level timestamps are displayed based on punctuation otherwise complete transcription is considered as a single segment)
     

--- a/examples/asr/asr_chunked_inference/aed/speech_to_text_aed_chunked_infer.py
+++ b/examples/asr/asr_chunked_inference/aed/speech_to_text_aed_chunked_infer.py
@@ -13,11 +13,13 @@
 # limitations under the License.
 
 """
-This script chunks long audios into non-overlapping segments of `chunk_len_in_secs` seconds and performs inference on each 
+This script chunks long audios into non-overlapping segments of `chunk_len_in_secs` 
+seconds and performs inference on each 
 segment individually. The results are then concatenated to form the final output.
 
 Below is an example of how to run this script with the Canary-1b model.
-It's recommended to use manifest input, otherwise the model will perform English ASR with punctuations and capitalizations. 
+It's recommended to use manifest input, otherwise the model will perform English ASR 
+with punctuations and capitalizations. 
 An example manifest line:
 {
     "audio_filepath": "/path/to/audio.wav",  # path to the audio file
@@ -41,11 +43,10 @@ python speech_to_text_aed_chunked_infer.py \
     
 """
 
-import contextlib
 import copy
 import glob
 import os
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass
 from typing import Optional
 
 import pytorch_lightning as pl
@@ -67,6 +68,9 @@ from nemo.utils import logging
 
 @dataclass
 class TranscriptionConfig:
+    """
+    Transcription config 
+    """
     # Required configs
     model_path: Optional[str] = None  # Path to a .nemo file
     pretrained_name: Optional[str] = None  # Name of a pretrained model
@@ -116,6 +120,10 @@ class TranscriptionConfig:
 
 @hydra_runner(config_name="TranscriptionConfig", schema=TranscriptionConfig)
 def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
+    """
+    Transcribes the input audio and can be used to infer long audio files by chunking 
+    them into smaller segments.
+    """
     logging.info(f'Hydra config: {OmegaConf.to_yaml(cfg)}')
     torch.set_grad_enabled(False)
 
@@ -160,7 +168,8 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
 
     if model_cfg.preprocessor.normalize != "per_feature":
         logging.error(
-            "Only EncDecMultiTaskModel models trained with per_feature normalization are supported currently"
+            "Only EncDecMultiTaskModel models trained with per_feature normalization are supported \
+            currently"
         )
 
     # Disable config overwriting

--- a/examples/asr/asr_chunked_inference/aed/speech_to_text_aed_chunked_infer.py
+++ b/examples/asr/asr_chunked_inference/aed/speech_to_text_aed_chunked_infer.py
@@ -69,8 +69,9 @@ from nemo.utils import logging
 @dataclass
 class TranscriptionConfig:
     """
-    Transcription config 
+    Transcription config
     """
+
     # Required configs
     model_path: Optional[str] = None  # Path to a .nemo file
     pretrained_name: Optional[str] = None  # Name of a pretrained model
@@ -121,7 +122,7 @@ class TranscriptionConfig:
 @hydra_runner(config_name="TranscriptionConfig", schema=TranscriptionConfig)
 def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
     """
-    Transcribes the input audio and can be used to infer long audio files by chunking 
+    Transcribes the input audio and can be used to infer long audio files by chunking
     them into smaller segments.
     """
     logging.info(f'Hydra config: {OmegaConf.to_yaml(cfg)}')

--- a/examples/asr/asr_chunked_inference/aed/speech_to_text_aed_chunked_infer.py
+++ b/examples/asr/asr_chunked_inference/aed/speech_to_text_aed_chunked_infer.py
@@ -206,7 +206,7 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
             )
 
     output_filename, pred_text_attr_name = write_transcription(
-        hyps, cfg, model_name, filepaths=filepaths, compute_langs=False, compute_timestamps=False
+        hyps, cfg, model_name, filepaths=filepaths, compute_langs=False, timestamps=False
     )
     logging.info(f"Finished writing predictions to {output_filename}!")
 

--- a/examples/asr/asr_chunked_inference/ctc/speech_to_text_buffered_infer_ctc.py
+++ b/examples/asr/asr_chunked_inference/ctc/speech_to_text_buffered_infer_ctc.py
@@ -67,6 +67,7 @@ class TranscriptionConfig:
     """
     Transcription Configuration for buffered inference.
     """
+
     # Required configs
     model_path: Optional[str] = None  # Path to a .nemo file
     pretrained_name: Optional[str] = None  # Name of a pretrained model
@@ -117,7 +118,7 @@ class TranscriptionConfig:
 @hydra_runner(config_name="TranscriptionConfig", schema=TranscriptionConfig)
 def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
     """
-    Transcribes the input audio and can be used to infer long audio files by chunking 
+    Transcribes the input audio and can be used to infer long audio files by chunking
     them into smaller segments.
     """
     logging.info(f'Hydra config: {OmegaConf.to_yaml(cfg)}')

--- a/examples/asr/asr_chunked_inference/ctc/speech_to_text_buffered_infer_ctc.py
+++ b/examples/asr/asr_chunked_inference/ctc/speech_to_text_buffered_infer_ctc.py
@@ -35,12 +35,11 @@ python speech_to_text_buffered_infer_ctc.py \
     You can use `DEBUG=1 python speech_to_text_buffered_infer_ctc.py ...` to print out the
     predictions of the model, and ground-truth text if presents in manifest.
 """
-import contextlib
 import copy
 import glob
 import math
 import os
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass
 from typing import Optional
 
 import pytorch_lightning as pl
@@ -65,6 +64,9 @@ can_gpu = torch.cuda.is_available()
 
 @dataclass
 class TranscriptionConfig:
+    """
+    Transcription Configuration for buffered inference.
+    """
     # Required configs
     model_path: Optional[str] = None  # Path to a .nemo file
     pretrained_name: Optional[str] = None  # Name of a pretrained model
@@ -114,6 +116,10 @@ class TranscriptionConfig:
 
 @hydra_runner(config_name="TranscriptionConfig", schema=TranscriptionConfig)
 def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
+    """
+    Transcribes the input audio and can be used to infer long audio files by chunking 
+    them into smaller segments.
+    """
     logging.info(f'Hydra config: {OmegaConf.to_yaml(cfg)}')
     torch.set_grad_enabled(False)
 

--- a/examples/asr/asr_chunked_inference/ctc/speech_to_text_buffered_infer_ctc.py
+++ b/examples/asr/asr_chunked_inference/ctc/speech_to_text_buffered_infer_ctc.py
@@ -221,7 +221,7 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
             filepaths,
         )
     output_filename, pred_text_attr_name = write_transcription(
-        hyps, cfg, model_name, filepaths=filepaths, compute_langs=False, compute_timestamps=False
+        hyps, cfg, model_name, filepaths=filepaths, compute_langs=False, timestamps=False
     )
     logging.info(f"Finished writing predictions to {output_filename}!")
 

--- a/examples/asr/asr_chunked_inference/rnnt/speech_to_text_buffered_infer_rnnt.py
+++ b/examples/asr/asr_chunked_inference/rnnt/speech_to_text_buffered_infer_rnnt.py
@@ -61,7 +61,7 @@ import copy
 import glob
 import math
 import os
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass
 from typing import Optional
 
 import pytorch_lightning as pl
@@ -87,6 +87,9 @@ from nemo.utils import logging
 
 @dataclass
 class TranscriptionConfig:
+    """
+    Transcription Configuration for buffered inference.
+    """
     # Required configs
     model_path: Optional[str] = None  # Path to a .nemo file
     pretrained_name: Optional[str] = None  # Name of a pretrained model
@@ -143,6 +146,10 @@ class TranscriptionConfig:
 
 @hydra_runner(config_name="TranscriptionConfig", schema=TranscriptionConfig)
 def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
+    """
+    Transcribes the input audio and can be used to infer long audio files by chunking 
+    them into smaller segments.
+    """
     logging.info(f'Hydra config: {OmegaConf.to_yaml(cfg)}')
     torch.set_grad_enabled(False)
 

--- a/examples/asr/asr_chunked_inference/rnnt/speech_to_text_buffered_infer_rnnt.py
+++ b/examples/asr/asr_chunked_inference/rnnt/speech_to_text_buffered_infer_rnnt.py
@@ -274,7 +274,7 @@ def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
     )
 
     output_filename, pred_text_attr_name = write_transcription(
-        hyps, cfg, model_name, filepaths=filepaths, compute_langs=False, compute_timestamps=False
+        hyps, cfg, model_name, filepaths=filepaths, compute_langs=False, timestamps=False
     )
     logging.info(f"Finished writing predictions to {output_filename}!")
 

--- a/examples/asr/asr_chunked_inference/rnnt/speech_to_text_buffered_infer_rnnt.py
+++ b/examples/asr/asr_chunked_inference/rnnt/speech_to_text_buffered_infer_rnnt.py
@@ -90,6 +90,7 @@ class TranscriptionConfig:
     """
     Transcription Configuration for buffered inference.
     """
+
     # Required configs
     model_path: Optional[str] = None  # Path to a .nemo file
     pretrained_name: Optional[str] = None  # Name of a pretrained model
@@ -147,7 +148,7 @@ class TranscriptionConfig:
 @hydra_runner(config_name="TranscriptionConfig", schema=TranscriptionConfig)
 def main(cfg: TranscriptionConfig) -> TranscriptionConfig:
     """
-    Transcribes the input audio and can be used to infer long audio files by chunking 
+    Transcribes the input audio and can be used to infer long audio files by chunking
     them into smaller segments.
     """
     logging.info(f'Hydra config: {OmegaConf.to_yaml(cfg)}')

--- a/examples/asr/speech_translation/translate_speech.py
+++ b/examples/asr/speech_translation/translate_speech.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import contextlib
 import json
 import os
 from dataclasses import dataclass, is_dataclass

--- a/examples/asr/speech_translation/translate_speech.py
+++ b/examples/asr/speech_translation/translate_speech.py
@@ -64,13 +64,17 @@ python translate_speech.py \
 
 @dataclass
 class ModelChangeConfig:
-
-    # Sub-config for changes specific to the Conformer Encoder
+    """
+    Sub-config for changes specific to the Conformer Encoder
+    """
     conformer: ConformerChangeConfig = ConformerChangeConfig()
 
 
 @dataclass
 class TranslationConfig:
+    """
+    Translation Configuration for audio to text translation.
+    """
     # Required configs
     model_path: Optional[str] = None  # Path to a .nemo file
     pretrained_name: Optional[str] = None  # Name of a pretrained model
@@ -105,6 +109,9 @@ class TranslationConfig:
 
 @hydra_runner(config_name="TranslationConfig", schema=TranslationConfig)
 def main(cfg: TranslationConfig) -> Union[TranslationConfig, List[str]]:
+    """
+    Main function to translate audio to text using a pretrained/finetuned model.
+    """
     logging.info(f'Hydra config: {OmegaConf.to_yaml(cfg)}')
 
     for key in cfg:

--- a/examples/asr/speech_translation/translate_speech.py
+++ b/examples/asr/speech_translation/translate_speech.py
@@ -67,6 +67,7 @@ class ModelChangeConfig:
     """
     Sub-config for changes specific to the Conformer Encoder
     """
+
     conformer: ConformerChangeConfig = ConformerChangeConfig()
 
 
@@ -75,6 +76,7 @@ class TranslationConfig:
     """
     Translation Configuration for audio to text translation.
     """
+
     # Required configs
     model_path: Optional[str] = None  # Path to a .nemo file
     pretrained_name: Optional[str] = None  # Name of a pretrained model

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -47,14 +47,9 @@ Transcribe audio file on a single CPU/GPU. Useful for transcription of moderate 
   model_path: path to .nemo ASR checkpoint
   pretrained_name: name of pretrained ASR model (from NGC registry)
   audio_dir: path to directory with audio files
-  dataset_manifest: path to dataset JSON manifest file (in NeMo format)
-
-  timestamps: Bool to request greedy time stamp information (if the model supports it)
+  dataset_manifest: path to dataset JSON manifest file (in NeMo formats
   compute_langs: Bool to request language ID information (if the model supports it)
-
-  (Optionally: You can limit the type of timestamp computations using below overrides)
-  ctc_decoding.ctc_timestamp_type="all"  # (default all, can be [all, char, word])
-  rnnt_decoding.rnnt_timestamp_type="all"  # (default all, can be [all, char, word])
+  timestamps: Bool to request greedy time stamp information (if the model supports it) by default None 
 
   (Optionally: You can limit the type of timestamp computations using below overrides)
   ctc_decoding.ctc_timestamp_type="all"  # (default all, can be [all, char, word, segment])
@@ -136,10 +131,10 @@ class TranscriptionConfig:
     random_seed: Optional[int] = None  # seed number going to be used in seed_everything()
 
     # Set to True to output greedy timestamp information (only supported models) and returns full alignment hypotheses
-    timestamps: bool = False
+    timestamps: Optional[bool] = None
 
-    # Set to False to return text instead of hypotheses from the transcribe function, so as to save memory
-    return_hypotheses: bool = True
+    # Set to True to return hypotheses instead of text from the transcribe function
+    return_hypotheses: bool = False
 
     # Set to True to output language ID information
     compute_langs: bool = False

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -284,7 +284,6 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
     if hasattr(asr_model, 'change_decoding_strategy') and hasattr(asr_model, 'decoding'):
         if isinstance(asr_model.decoding, MultiTaskDecoding):
             cfg.multitask_decoding.compute_langs = cfg.compute_langs
-            cfg.multitask_decoding.preserve_alignments = cfg.preserve_alignment
             if cfg.extract_nbest:
                 cfg.multitask_decoding.beam.return_best_hypothesis = False
                 cfg.return_hypotheses = True

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -103,13 +103,17 @@ python transcribe_speech.py \
 
 @dataclass
 class ModelChangeConfig:
-
-    # Sub-config for changes specific to the Conformer Encoder
+    """
+    Sub-config for changes specific to the Conformer Encoder
+    """
     conformer: ConformerChangeConfig = field(default_factory=ConformerChangeConfig)
 
 
 @dataclass
 class TranscriptionConfig:
+    """
+    Transcription Configuration for audio to text transcription.
+    """
     # Required configs
     model_path: Optional[str] = None  # Path to a .nemo file
     pretrained_name: Optional[str] = None  # Name of a pretrained model
@@ -166,7 +170,8 @@ class TranscriptionConfig:
     # Implicit single-turn assuming default role='user' (works with Canary-1B)
     #  +prompt.source_lang=en +prompt.target_lang=es +prompt.task=asr +prompt.pnc=yes
     # Explicit single-turn prompt:
-    #  +prompt.role=user +prompt.slots.source_lang=en +prompt.slots.target_lang=es +prompt.slots.task=s2t_translation +prompt.slots.pnc=yes
+    #  +prompt.role=user +prompt.slots.source_lang=en +prompt.slots.target_lang=es 
+    # +prompt.slots.task=s2t_translation +prompt.slots.pnc=yes
     # Explicit multi-turn prompt:
     #  +prompt.turns='[{role:user,slots:{source_lang:en,target_lang:es,task:asr,pnc:yes}}]'
     prompt: dict = field(default_factory=dict)
@@ -200,6 +205,9 @@ class TranscriptionConfig:
 
 @hydra_runner(config_name="TranscriptionConfig", schema=TranscriptionConfig)
 def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis]]:
+    """
+    Transcribes the input audio and can be used to infer with Encoder-Decoder models.
+    """
     logging.info(f'Hydra config: {OmegaConf.to_yaml(cfg)}')
 
     for key in cfg:
@@ -360,7 +368,8 @@ def main(cfg: TranscriptionConfig) -> Union[TranscriptionConfig, List[Hypothesis
                 item = json.loads(line)
                 if "duration" not in item:
                     raise ValueError(
-                        f"Requested calculate_rtfx=True, but line {line} in manifest {cfg.dataset_manifest} lacks a 'duration' field."
+                        f"Requested calculate_rtfx=True, but line {line} in manifest {cfg.dataset_manifest} \
+                            lacks a 'duration' field."
                     )
                 total_duration += item["duration"]
 

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -106,6 +106,7 @@ class ModelChangeConfig:
     """
     Sub-config for changes specific to the Conformer Encoder
     """
+
     conformer: ConformerChangeConfig = field(default_factory=ConformerChangeConfig)
 
 
@@ -114,6 +115,7 @@ class TranscriptionConfig:
     """
     Transcription Configuration for audio to text transcription.
     """
+
     # Required configs
     model_path: Optional[str] = None  # Path to a .nemo file
     pretrained_name: Optional[str] = None  # Name of a pretrained model
@@ -170,7 +172,7 @@ class TranscriptionConfig:
     # Implicit single-turn assuming default role='user' (works with Canary-1B)
     #  +prompt.source_lang=en +prompt.target_lang=es +prompt.task=asr +prompt.pnc=yes
     # Explicit single-turn prompt:
-    #  +prompt.role=user +prompt.slots.source_lang=en +prompt.slots.target_lang=es 
+    #  +prompt.role=user +prompt.slots.source_lang=en +prompt.slots.target_lang=es
     # +prompt.slots.task=s2t_translation +prompt.slots.pnc=yes
     # Explicit multi-turn prompt:
     #  +prompt.turns='[{role:user,slots:{source_lang:en,target_lang:es,task:asr,pnc:yes}}]'

--- a/examples/asr/transcribe_speech.py
+++ b/examples/asr/transcribe_speech.py
@@ -136,11 +136,11 @@ class TranscriptionConfig:
     random_seed: Optional[int] = None  # seed number going to be used in seed_everything()
 
     # Set to True to output greedy timestamp information (only supported models) and returns full alignment hypotheses
-    timestamps: bool = False 
-    
+    timestamps: bool = False
+
     # Set to False to return text instead of hypotheses from the transcribe function, so as to save memory
     return_hypotheses: bool = True
-    
+
     # Set to True to output language ID information
     compute_langs: bool = False
 

--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -485,7 +485,7 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
         """
         if timestamps:
             raise NotImplementedError("Timestamps are not supported for this model yet.")
-        
+
         if override_config is None:
             trcfg = MultiTaskTranscriptionConfig(
                 batch_size=batch_size,
@@ -503,7 +503,9 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
                     f"but got {type(override_config)}"
                 )
             trcfg = override_config
-        import pdb; pdb.set_trace()
+        import pdb
+
+        pdb.set_trace()
         return super().transcribe(audio=audio, override_config=trcfg)
 
     def _setup_dataloader_from_config(self, config: Optional[Dict]):

--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -40,7 +40,6 @@ from nemo.collections.asr.parts.mixins.transcription import (
 from nemo.collections.asr.parts.preprocessing.segment import ChannelSelectorType
 from nemo.collections.asr.parts.submodules.multitask_decoding import MultiTaskDecoding, MultiTaskDecodingConfig
 from nemo.collections.asr.parts.submodules.token_classifier import TokenClassifier
-from nemo.collections.asr.parts.utils import manifest_utils
 from nemo.collections.asr.parts.utils.rnnt_utils import Hypothesis
 from nemo.collections.common import tokenizers
 from nemo.collections.common.data.lhotse.dataloader import get_lhotse_dataloader_from_config
@@ -68,6 +67,9 @@ __all__ = ['EncDecMultiTaskModel']
 
 
 def lens_to_mask(lens, max_length):
+    """
+    Create a mask from a tensor of lengths.
+    """
     batch_size = lens.shape[0]
     mask = torch.arange(max_length).repeat(batch_size, 1).to(lens.device) < lens[:, None]
     return mask
@@ -222,7 +224,8 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
 
         self.val_loss = GlobalAverageLossMetric(dist_sync_on_step=False, take_avg_loss=True)
 
-        # TODO: PytorchMetrics lets you join two metrics together to save compute. But need to make wer and bleu have same outputs first
+        # TODO: PytorchMetrics lets you join two metrics together to save compute. 
+        # But need to make wer and bleu have same outputs first
         self.wer = WER(self.decoding, log_prediction=self.cfg.get("log_prediction"))
         self.bleu = BLEU(
             self.decoding, tokenize=self.cfg.get('bleu_tokenizer', "13a"), log_prediction=False
@@ -270,13 +273,15 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
         prompt_format: Optional[str] = None,
     ):
         """
-        Changes vocabulary used during AED decoding process. Use this method when fine-tuning on from pre-trained model.
-        This method changes only decoder and leaves encoder and pre-processing modules unchanged. For example, you would
-        use it if you want to use pretrained encoder when fine-tuning on data in another language, or when you'd need
-        model to learn capitalization, punctuation and/or special characters.
+        Changes vocabulary used during AED decoding process. Use this method when fine-tuning on 
+        from pre-trained model. This method changes only decoder and leaves encoder and pre-processing
+        modules unchanged. For example, you would use it if you want to use pretrained encoder when 
+        fine-tuning on data in another language, or when you'd need model to learn capitalization, 
+        punctuation and/or special characters.
 
         Args:
-            new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer (if the tokenizer type is `agg`)
+            new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer 
+                (if the tokenizer type is `agg`)
             new_tokenizer_type: Type of tokenizer. Can be either `agg`, `bpe` or `wpe`.
             decoding_cfg: A config for the decoding, which is optional. If the decoding type
                 needs to be changed (from say Greedy to Beam decoding etc), the config can be passed here.
@@ -291,7 +296,8 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
                 new_tokenizer_cfg = new_tokenizer_dir
             else:
                 raise ValueError(
-                    f'New tokenizer dir should be a string unless the tokenizer is `agg`, but this tokenizer type is: {new_tokenizer_type}'
+                    f'New tokenizer dir should be a string unless the tokenizer is `agg`, but this\
+                          tokenizer type is: {new_tokenizer_type}'
                 )
         else:
             new_tokenizer_cfg = None
@@ -464,7 +470,8 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
         """
         Uses greedy decoding to transcribe audio files. Use this method for debugging and prototyping.
         Args:
-            audio: (a single or list) of paths to audio files or a np.ndarray/tensor audio array or path to a manifest file.
+            audio: (a single or list) of paths to audio files or a np.ndarray/tensor audio array or path 
+                to a manifest file.
                 Can also be a dataloader object that provides values that can be consumed by the model.
                 Recommended length per file is between 5 and 25 seconds. \
                 But it is possible to pass a few hours long file if enough GPU memory is available.
@@ -473,16 +480,26 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
             return_hypotheses: (bool) Either return hypotheses or text
                 With hypotheses can do some postprocessing like getting timestamp or rescoring
             num_workers: (int) number of workers for DataLoader
-            channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels from multi-channel audio. If set to `'average'`, it performs averaging across channels. Disabled if set to `None`. Defaults to `None`.
+            channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels 
+                from multi-channel audio. If set to `'average'`, it performs averaging across channels. 
+                Disabled if set to `None`. Defaults to `None`.
             augmentor: (DictConfig): Augment audio samples during transcription if augmentor is applied.
-            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis object (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class for more details. Default is None and would retain the previous state set by using self.change_decoding_strategy(). 
+            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis 
+                object (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class 
+                for more details. Default is None and would retain the previous state set by using 
+                self.change_decoding_strategy(). 
             Note: Currently its not supported for AED models.
             verbose: (bool) whether to display tqdm progress bar
-            override_config: (Optional[MultiTaskTranscriptionConfig]) A config to override the default config.
-            **prompt: Optional input to construct the prompts for the model. Accepted formats are: 1) legacy Canary-1B API source_lang=<lang>, target_lang=<lang>, etc. 2) explicit single-turn role=<role>, slots={<slot>: <value>, ...} 3) explicit multi-turn: turns=[{"role": <role>, "slots": {<slot>: <value>, ...}}]
+            override_config: (Optional[MultiTaskTranscriptionConfig]) A config to override the 
+                default config.
+            **prompt: Optional input to construct the prompts for the model. Accepted formats are: 
+                1) legacy Canary-1B API source_lang=<lang>, target_lang=<lang>, etc. 
+                2) explicit single-turn role=<role>, slots={<slot>: <value>, ...} 
+                3) explicit multi-turn: turns=[{"role": <role>, "slots": {<slot>: <value>, ...}}]
 
         Returns:
-            A list of transcriptions (or raw log probabilities if logprobs is True) in the same order as paths2audio_files
+            A list of transcriptions (or raw log probabilities if logprobs is True) in the same order 
+            as paths2audio_files
         """
         if timestamps:
             raise NotImplementedError("Computing timestamps are not supported for this model yet.")
@@ -895,7 +912,8 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
         )
 
     @deprecated(
-        explanation='The return type of args will be updated in the upcoming release to ensure a consistent output format across all decoder types, such that a Hypothesis object is always returned.'
+        explanation='The return type of args will be updated in the upcoming release to ensure a consistent \
+        output format across all decoder types, such that a Hypothesis object is always returned.'
     )
     def _transcribe_output_processing(self, outputs, trcfg: MultiTaskTranscriptionConfig) -> GenericTranscriptionType:
         """

--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -457,7 +457,7 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
         channel_selector: Optional[ChannelSelectorType] = None,
         augmentor: DictConfig = None,
         verbose: bool = True,
-        timestamps: bool = False,
+        timestamps: Optional[bool] = None,
         override_config: Optional[MultiTaskTranscriptionConfig] = None,
         **prompt,
     ) -> Union[List[str], List[Hypothesis]]:
@@ -475,7 +475,8 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
             num_workers: (int) number of workers for DataLoader
             channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels from multi-channel audio. If set to `'average'`, it performs averaging across channels. Disabled if set to `None`. Defaults to `None`.
             augmentor: (DictConfig): Augment audio samples during transcription if augmentor is applied.
-            timestamps: Bool: whether to provide timestamps along with the transcriptions, currently its not supported for AED models.
+            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis object (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class for more details. Default is None and would retain the previous state set by using self.change_decoding_strategy(). 
+            Note: Currently its not supported for AED models.
             verbose: (bool) whether to display tqdm progress bar
             override_config: (Optional[MultiTaskTranscriptionConfig]) A config to override the default config.
             **prompt: Optional input to construct the prompts for the model. Accepted formats are: 1) legacy Canary-1B API source_lang=<lang>, target_lang=<lang>, etc. 2) explicit single-turn role=<role>, slots={<slot>: <value>, ...} 3) explicit multi-turn: turns=[{"role": <role>, "slots": {<slot>: <value>, ...}}]
@@ -503,9 +504,7 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
                     f"but got {type(override_config)}"
                 )
             trcfg = override_config
-        import pdb
 
-        pdb.set_trace()
         return super().transcribe(audio=audio, override_config=trcfg)
 
     def _setup_dataloader_from_config(self, config: Optional[Dict]):

--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -224,7 +224,7 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
 
         self.val_loss = GlobalAverageLossMetric(dist_sync_on_step=False, take_avg_loss=True)
 
-        # TODO: PytorchMetrics lets you join two metrics together to save compute. 
+        # TODO: PytorchMetrics lets you join two metrics together to save compute.
         # But need to make wer and bleu have same outputs first
         self.wer = WER(self.decoding, log_prediction=self.cfg.get("log_prediction"))
         self.bleu = BLEU(
@@ -273,14 +273,14 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
         prompt_format: Optional[str] = None,
     ):
         """
-        Changes vocabulary used during AED decoding process. Use this method when fine-tuning on 
+        Changes vocabulary used during AED decoding process. Use this method when fine-tuning on
         from pre-trained model. This method changes only decoder and leaves encoder and pre-processing
-        modules unchanged. For example, you would use it if you want to use pretrained encoder when 
-        fine-tuning on data in another language, or when you'd need model to learn capitalization, 
+        modules unchanged. For example, you would use it if you want to use pretrained encoder when
+        fine-tuning on data in another language, or when you'd need model to learn capitalization,
         punctuation and/or special characters.
 
         Args:
-            new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer 
+            new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer
                 (if the tokenizer type is `agg`)
             new_tokenizer_type: Type of tokenizer. Can be either `agg`, `bpe` or `wpe`.
             decoding_cfg: A config for the decoding, which is optional. If the decoding type

--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -475,7 +475,7 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
             num_workers: (int) number of workers for DataLoader
             channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels from multi-channel audio. If set to `'average'`, it performs averaging across channels. Disabled if set to `None`. Defaults to `None`.
             augmentor: (DictConfig): Augment audio samples during transcription if augmentor is applied.
-            timestamps: Bool: whether to provide timestamps along with the transcriptions, currently its not supported.
+            timestamps: Bool: whether to provide timestamps along with the transcriptions, currently its not supported for AED models.
             verbose: (bool) whether to display tqdm progress bar
             override_config: (Optional[MultiTaskTranscriptionConfig]) A config to override the default config.
             **prompt: Optional input to construct the prompts for the model. Accepted formats are: 1) legacy Canary-1B API source_lang=<lang>, target_lang=<lang>, etc. 2) explicit single-turn role=<role>, slots={<slot>: <value>, ...} 3) explicit multi-turn: turns=[{"role": <role>, "slots": {<slot>: <value>, ...}}]
@@ -484,7 +484,7 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
             A list of transcriptions (or raw log probabilities if logprobs is True) in the same order as paths2audio_files
         """
         if timestamps:
-            raise NotImplementedError("Timestamps are not supported for this model yet.")
+            raise NotImplementedError("Computing timestamps are not supported for this model yet.")
 
         if override_config is None:
             trcfg = MultiTaskTranscriptionConfig(

--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -457,6 +457,7 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
         channel_selector: Optional[ChannelSelectorType] = None,
         augmentor: DictConfig = None,
         verbose: bool = True,
+        timestamps: bool = False,
         override_config: Optional[MultiTaskTranscriptionConfig] = None,
         **prompt,
     ) -> Union[List[str], List[Hypothesis]]:
@@ -474,6 +475,7 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
             num_workers: (int) number of workers for DataLoader
             channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels from multi-channel audio. If set to `'average'`, it performs averaging across channels. Disabled if set to `None`. Defaults to `None`.
             augmentor: (DictConfig): Augment audio samples during transcription if augmentor is applied.
+            timestamps: Bool: whether to provide timestamps along with the transcriptions, currently its not supported.
             verbose: (bool) whether to display tqdm progress bar
             override_config: (Optional[MultiTaskTranscriptionConfig]) A config to override the default config.
             **prompt: Optional input to construct the prompts for the model. Accepted formats are: 1) legacy Canary-1B API source_lang=<lang>, target_lang=<lang>, etc. 2) explicit single-turn role=<role>, slots={<slot>: <value>, ...} 3) explicit multi-turn: turns=[{"role": <role>, "slots": {<slot>: <value>, ...}}]
@@ -481,6 +483,9 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
         Returns:
             A list of transcriptions (or raw log probabilities if logprobs is True) in the same order as paths2audio_files
         """
+        if timestamps:
+            raise NotImplementedError("Timestamps are not supported for this model yet.")
+        
         if override_config is None:
             trcfg = MultiTaskTranscriptionConfig(
                 batch_size=batch_size,
@@ -498,7 +503,7 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
                     f"but got {type(override_config)}"
                 )
             trcfg = override_config
-
+        import pdb; pdb.set_trace()
         return super().transcribe(audio=audio, override_config=trcfg)
 
     def _setup_dataloader_from_config(self, config: Optional[Dict]):

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -209,12 +209,14 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
         """
         Changes vocabulary of the tokenizer used during CTC decoding process.
         Use this method when fine-tuning on from pre-trained model.
-        This method changes only decoder and leaves encoder and pre-processing modules unchanged. For example, you would
-        use it if you want to use pretrained encoder when fine-tuning on a data in another language, or when you'd need
-        model to learn capitalization, punctuation and/or special characters.
+        This method changes only decoder and leaves encoder and pre-processing modules unchanged. 
+        For example, you would use it if you want to use pretrained encoder when fine-tuning on a 
+        data in another language, or when you'd need model to learn capitalization, punctuation 
+        and/or special characters.
 
         Args:
-            new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer (if the tokenizer type is `agg`)
+            new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer 
+                (if the tokenizer type is `agg`)
             new_tokenizer_type: Either `agg`, `bpe` or `wpe`. `bpe` is used for SentencePiece tokenizers,
                 whereas `wpe` is used for `BertTokenizer`.
             new_tokenizer_cfg: A config for the new tokenizer. if provided, pre-empts the dir and type
@@ -227,7 +229,8 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
                 new_tokenizer_cfg = new_tokenizer_dir
             else:
                 raise ValueError(
-                    f'New tokenizer dir should be a string unless the tokenizer is `agg`, but this tokenizer type is: {new_tokenizer_type}'
+                    f'New tokenizer dir should be a string unless the tokenizer is `agg`, but this tokenizer \
+                        type is: {new_tokenizer_type}'
                 )
         else:
             new_tokenizer_cfg = None
@@ -380,7 +383,7 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
 
         model = PretrainedModelInfo(
             pretrained_model_name="stt_en_citrinet_256_gamma_0_25",
-            description="For details about this model, please visit https://ngc.nvidia.com/catalog/models/nvidia:nemo:stt_en_citrinet_256_gamma_0_25",
+            description="For details about this model, please visit https://ngc.nvidia.com/catalog/models/nvidia:\nemo:stt_en_citrinet_256_gamma_0_25",
             location="https://api.ngc.nvidia.com/v2/models/nvidia/nemo/stt_en_citrinet_256_gamma_0_25/versions/1.0.0/files/stt_en_citrinet_256_gamma_0_25.nemo",
         )
         results.append(model)

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -307,13 +307,14 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
 
         logging.info(f"Changed tokenizer to {self.decoder.vocabulary} vocabulary.")
 
-    def change_decoding_strategy(self, decoding_cfg: DictConfig):
+    def change_decoding_strategy(self, decoding_cfg: DictConfig, verbose: bool = True):
         """
         Changes decoding strategy used during CTC decoding process.
 
         Args:
             decoding_cfg: A config for the decoder, which is optional. If the decoding type
                 needs to be changed (from say Greedy to Beam decoding etc), the config can be passed here.
+            verbose: Whether to print the new config or not.
         """
         if decoding_cfg is None:
             # Assume same decoding config as before
@@ -343,7 +344,8 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
         with open_dict(self.cfg.decoding):
             self.cfg.decoding = decoding_cfg
 
-        logging.info(f"Changed decoding strategy to \n{OmegaConf.to_yaml(self.cfg.decoding)}")
+        if verbose:
+            logging.info(f"Changed decoding strategy to \n{OmegaConf.to_yaml(self.cfg.decoding)}")
 
     @classmethod
     def list_available_models(cls) -> List[PretrainedModelInfo]:

--- a/nemo/collections/asr/models/ctc_bpe_models.py
+++ b/nemo/collections/asr/models/ctc_bpe_models.py
@@ -209,13 +209,13 @@ class EncDecCTCModelBPE(EncDecCTCModel, ASRBPEMixin):
         """
         Changes vocabulary of the tokenizer used during CTC decoding process.
         Use this method when fine-tuning on from pre-trained model.
-        This method changes only decoder and leaves encoder and pre-processing modules unchanged. 
-        For example, you would use it if you want to use pretrained encoder when fine-tuning on a 
-        data in another language, or when you'd need model to learn capitalization, punctuation 
+        This method changes only decoder and leaves encoder and pre-processing modules unchanged.
+        For example, you would use it if you want to use pretrained encoder when fine-tuning on a
+        data in another language, or when you'd need model to learn capitalization, punctuation
         and/or special characters.
 
         Args:
-            new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer 
+            new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer
                 (if the tokenizer type is `agg`)
             new_tokenizer_type: Either `agg`, `bpe` or `wpe`. `bpe` is used for SentencePiece tokenizers,
                 whereas `wpe` is used for `BertTokenizer`.

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -134,7 +134,8 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         Uses greedy decoding to transcribe audio files. Use this method for debugging and prototyping.
 
         Args:
-            audio: (a single or list) of paths to audio files or a np.ndarray/tensor audio array or path to a manifest file.
+            audio: (a single or list) of paths to audio files or a np.ndarray/tensor audio array or 
+                path to a manifest file.
                 Can also be a dataloader object that provides values that can be consumed by the model.
                 Recommended length per file is between 5 and 25 seconds. \
                 But it is possible to pass a few hours long file if enough GPU memory is available.
@@ -143,22 +144,29 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
             return_hypotheses: (bool) Either return hypotheses or text
                 With hypotheses can do some postprocessing like getting timestamp or rescoring
             num_workers: (int) number of workers for DataLoader
-            channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels from multi-channel audio. If set to `'average'`, it performs averaging across channels. Disabled if set to `None`. Defaults to `None`.
+            channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels 
+                from multi-channel audio. If set to `'average'`, it performs averaging across channels. 
+                Disabled if set to `None`. Defaults to `None`.
             augmentor: (DictConfig): Augment audio samples during transcription if augmentor is applied.
-            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis object (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class for more details. Default is None and would retain the previous state set by using self.change_decoding_strategy().
+            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis 
+                object (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class 
+                for more details. Default is None and would retain the previous state set by 
+                using self.change_decoding_strategy().
             verbose: (bool) whether to display tqdm progress bar
             override_config: (Optional[TranscribeConfig]) override transcription config pre-defined by the user.
                 **Note**: All other arguments in the function will be ignored if override_config is passed.
                 You should call this argument as `model.transcribe(audio, override_config=TranscribeConfig(...))`.
 
         Returns:
-            A list of transcriptions (or raw log probabilities if logprobs is True) in the same order as paths2audio_files
+            A list of transcriptions (or raw log probabilities if logprobs is True) in the same order as 
+            paths2audio_files
         """
         if timestamps is not None:
             # else retain the decoder state (users can set it using change_decoding_strategy)
             if timestamps or (override_config is not None and override_config.timestamps):
                 logging.info(
-                    "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[idx].timestep['word'/'segment'/'char']"
+                    "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, \
+                        with output[idx].timestep['word'/'segment'/'char']"
                 )
                 return_hypotheses = True
                 with open_dict(self.cfg.decoding):
@@ -691,7 +699,8 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         return output
 
     @deprecated(
-        explanation='The return type of args will be updated in the upcoming release to ensure a consistent output format across all decoder types, such that a Hypothesis object is always returned.'
+        explanation='The return type of args will be updated in the upcoming release to ensure a consistent output \
+            format across all decoder types, such that a Hypothesis object is always returned.'
     )
     def _transcribe_output_processing(self, outputs, trcfg: TranscribeConfig) -> GenericTranscriptionType:
         logits = outputs.pop('logits')
@@ -796,7 +805,11 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
 
         model = PretrainedModelInfo(
             pretrained_model_name="QuartzNet15x5Base-En",
-            description="QuartzNet15x5 model trained on six datasets: LibriSpeech, Mozilla Common Voice (validated clips from en_1488h_2019-12-10), WSJ, Fisher, Switchboard, and NSC Singapore English. It was trained with Apex/Amp optimization level O1 for 600 epochs. The model achieves a WER of 3.79% on LibriSpeech dev-clean, and a WER of 10.05% on dev-other. Please visit https://ngc.nvidia.com/catalog/models/nvidia:nemospeechmodels for further details.",
+            description="QuartzNet15x5 model trained on six datasets: LibriSpeech, Mozilla Common Voice \
+                (validated clips from en_1488h_2019-12-10), WSJ, Fisher, Switchboard, and NSC Singapore English. \
+                    It was trained with Apex/Amp optimization level O1 for 600 epochs. The model achieves a WER of \
+                    3.79% on LibriSpeech dev-clean, and a WER of 10.05% on dev-other. Please visit \
+                        https://ngc.nvidia.com/catalog/models/nvidia:nemospeechmodels for further details.",
             location="https://api.ngc.nvidia.com/v2/models/nvidia/nemospeechmodels/versions/1.0.0a5/files/QuartzNet15x5Base-En.nemo",
         )
         results.append(model)

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -156,7 +156,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         """
         if timestamps:
             logging.info("Timestamps requested, setting decoding timestamps to True")
-            return_hypotheses=True
+            return_hypotheses = True
             with open_dict(self.cfg.decoding):
                 self.cfg.decoding.compute_timestamps = True
                 self.cfg.decoding.preserve_alignments = True
@@ -723,8 +723,12 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         del logits, logits_len
 
         if trcfg.timestamps:
-            current_hypotheses = process_timestamp_outputs(current_hypotheses, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride'])
-            all_hyp = process_timestamp_outputs(all_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride'])
+            current_hypotheses = process_timestamp_outputs(
+                current_hypotheses, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
+            )
+            all_hyp = process_timestamp_outputs(
+                all_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
+            )
 
         hypotheses = []
         if all_hyp is None:

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -145,6 +145,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
             num_workers: (int) number of workers for DataLoader
             channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels from multi-channel audio. If set to `'average'`, it performs averaging across channels. Disabled if set to `None`. Defaults to `None`.
             augmentor: (DictConfig): Augment audio samples during transcription if augmentor is applied.
+            timestamps: (Bool): timestamps will be returned if set to True as part of hypothesis object (output.timestep['word']). Refer to `Hypothesis` class for more details.
             verbose: (bool) whether to display tqdm progress bar
             override_config: (Optional[TranscribeConfig]) override transcription config pre-defined by the user.
                 **Note**: All other arguments in the function will be ignored if override_config is passed.
@@ -153,6 +154,19 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         Returns:
             A list of transcriptions (or raw log probabilities if logprobs is True) in the same order as paths2audio_files
         """
+        if timestamps:
+            logging.info("Timestamps requested, setting decoding timestamps to True")
+            return_hypotheses=True
+            with open_dict(self.cfg.decoding):
+                self.cfg.decoding.compute_timestamps = True
+                self.cfg.decoding.preserve_alignments = True
+            self.change_decoding_strategy(self.cfg.decoding, verbose=False)
+        else:  # This is done to ensure the state is preserved when decoding_strategy is set outside
+            with open_dict(self.cfg.decoding):
+                self.cfg.decoding.compute_timestamps = self.cfg.decoding.get('compute_timestamps', False)
+                self.cfg.decoding.preserve_alignments = self.cfg.decoding.get('preserve_alignments', False)
+            self.change_decoding_strategy(self.cfg.decoding, verbose=False)
+
         return super().transcribe(
             audio=audio,
             batch_size=batch_size,
@@ -236,13 +250,14 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
 
             logging.info(f"Changed decoder to output to {self.decoder.vocabulary} vocabulary.")
 
-    def change_decoding_strategy(self, decoding_cfg: DictConfig):
+    def change_decoding_strategy(self, decoding_cfg: DictConfig, verbose: bool = True):
         """
         Changes decoding strategy used during CTC decoding process.
 
         Args:
             decoding_cfg: A config for the decoder, which is optional. If the decoding type
                 needs to be changed (from say Greedy to Beam decoding etc), the config can be passed here.
+            verbose: (bool) whether to display logging information
         """
         if decoding_cfg is None:
             # Assume same decoding config as before
@@ -271,7 +286,8 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         with open_dict(self.cfg.decoding):
             self.cfg.decoding = decoding_cfg
 
-        logging.info(f"Changed decoding strategy to \n{OmegaConf.to_yaml(self.cfg.decoding)}")
+        if verbose:
+            logging.info(f"Changed decoding strategy to \n{OmegaConf.to_yaml(self.cfg.decoding)}")
 
     def _setup_dataloader_from_config(self, config: Optional[Dict]):
         # Automatically inject args from model config to dataloader config

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -154,8 +154,8 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         Returns:
             A list of transcriptions (or raw log probabilities if logprobs is True) in the same order as paths2audio_files
         """
-        if timestamps:
-            logging.info("Timestamps requested, setting decoding timestamps to True")
+        if timestamps or override_config.timestamps:
+            logging.info("Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[idx].timestep['word'/'segment'/'char']")
             return_hypotheses = True
             with open_dict(self.cfg.decoding):
                 self.cfg.decoding.compute_timestamps = True

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -154,7 +154,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
         Returns:
             A list of transcriptions (or raw log probabilities if logprobs is True) in the same order as paths2audio_files
         """
-        if timestamps or override_config.timestamps:
+        if timestamps or (override_config is not None and override_config.timestamps):
             logging.info(
                 "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[idx].timestep['word'/'segment'/'char']"
             )

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -155,7 +155,9 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
             A list of transcriptions (or raw log probabilities if logprobs is True) in the same order as paths2audio_files
         """
         if timestamps or override_config.timestamps:
-            logging.info("Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[idx].timestep['word'/'segment'/'char']")
+            logging.info(
+                "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[idx].timestep['word'/'segment'/'char']"
+            )
             return_hypotheses = True
             with open_dict(self.cfg.decoding):
                 self.cfg.decoding.compute_timestamps = True

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
@@ -415,7 +415,7 @@ class EncDecHybridRNNTCTCBPEModel(EncDecHybridRNNTCTCModel, ASRBPEMixin):
 
             logging.info(f"Changed tokenizer of the CTC decoder to {self.ctc_decoder.vocabulary} vocabulary.")
 
-    def change_decoding_strategy(self, decoding_cfg: DictConfig = None, decoder_type: str = None):
+    def change_decoding_strategy(self, decoding_cfg: DictConfig = None, decoder_type: str = None, verbose: bool = True):
         """
         Changes decoding strategy used during RNNT decoding process.
         Args:
@@ -424,6 +424,7 @@ class EncDecHybridRNNTCTCBPEModel(EncDecHybridRNNTCTCModel, ASRBPEMixin):
             decoder_type: (str) Can be set to 'rnnt' or 'ctc' to switch between appropriate decoder in a
                 model having both RNN-T and CTC decoders. Defaults to None, in which case RNN-T decoder is
                 used. If set to 'ctc', it raises error if 'ctc_decoder' is not an attribute of the model.
+            verbose: bool whether to display change of decoder config or not.
         """
         if decoder_type is None or decoder_type == 'rnnt':
             if decoding_cfg is None:
@@ -466,7 +467,8 @@ class EncDecHybridRNNTCTCBPEModel(EncDecHybridRNNTCTCModel, ASRBPEMixin):
                 self.cfg.decoding = decoding_cfg
 
             self.cur_decoder = "rnnt"
-            logging.info(f"Changed decoding strategy of the RNNT decoder to \n{OmegaConf.to_yaml(self.cfg.decoding)}")
+            if verbose:
+                logging.info(f"Changed decoding strategy of the RNNT decoder to \n{OmegaConf.to_yaml(self.cfg.decoding)}")
 
         elif decoder_type == 'ctc':
             if not hasattr(self, 'ctc_decoding'):
@@ -497,9 +499,10 @@ class EncDecHybridRNNTCTCBPEModel(EncDecHybridRNNTCTCModel, ASRBPEMixin):
                 self.cfg.aux_ctc.decoding = decoding_cfg
 
             self.cur_decoder = "ctc"
-            logging.info(
+            if verbose:
+                logging.info(
                 f"Changed decoding strategy of the CTC decoder to \n{OmegaConf.to_yaml(self.cfg.aux_ctc.decoding)}"
-            )
+                )
         else:
             raise ValueError(f"decoder_type={decoder_type} is not supported. Supported values: [ctc,rnnt]")
 

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
@@ -253,10 +253,10 @@ class EncDecHybridRNNTCTCBPEModel(EncDecHybridRNNTCTCModel, ASRBPEMixin):
         ctc_decoding_cfg: Optional[DictConfig] = None,
     ):
         """
-        Changes vocabulary used during RNNT decoding process. Use this method when fine-tuning on 
-        from pre-trained model. This method changes only decoder and leaves encoder and pre-processing 
-        modules unchanged. For example, you would use it if you want to use pretrained encoder when 
-        fine-tuning on data in another language, or when you'd need model to learn capitalization, 
+        Changes vocabulary used during RNNT decoding process. Use this method when fine-tuning on
+        from pre-trained model. This method changes only decoder and leaves encoder and pre-processing
+        modules unchanged. For example, you would use it if you want to use pretrained encoder when
+        fine-tuning on data in another language, or when you'd need model to learn capitalization,
         punctuation and/or special characters.
 
         Args:

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
@@ -415,7 +415,9 @@ class EncDecHybridRNNTCTCBPEModel(EncDecHybridRNNTCTCModel, ASRBPEMixin):
 
             logging.info(f"Changed tokenizer of the CTC decoder to {self.ctc_decoder.vocabulary} vocabulary.")
 
-    def change_decoding_strategy(self, decoding_cfg: DictConfig = None, decoder_type: str = None, verbose: bool = True):
+    def change_decoding_strategy(
+        self, decoding_cfg: DictConfig = None, decoder_type: str = None, verbose: bool = True
+    ):
         """
         Changes decoding strategy used during RNNT decoding process.
         Args:
@@ -468,7 +470,9 @@ class EncDecHybridRNNTCTCBPEModel(EncDecHybridRNNTCTCModel, ASRBPEMixin):
 
             self.cur_decoder = "rnnt"
             if verbose:
-                logging.info(f"Changed decoding strategy of the RNNT decoder to \n{OmegaConf.to_yaml(self.cfg.decoding)}")
+                logging.info(
+                    f"Changed decoding strategy of the RNNT decoder to \n{OmegaConf.to_yaml(self.cfg.decoding)}"
+                )
 
         elif decoder_type == 'ctc':
             if not hasattr(self, 'ctc_decoding'):
@@ -501,7 +505,7 @@ class EncDecHybridRNNTCTCBPEModel(EncDecHybridRNNTCTCModel, ASRBPEMixin):
             self.cur_decoder = "ctc"
             if verbose:
                 logging.info(
-                f"Changed decoding strategy of the CTC decoder to \n{OmegaConf.to_yaml(self.cfg.aux_ctc.decoding)}"
+                    f"Changed decoding strategy of the CTC decoder to \n{OmegaConf.to_yaml(self.cfg.aux_ctc.decoding)}"
                 )
         else:
             raise ValueError(f"decoder_type={decoder_type} is not supported. Supported values: [ctc,rnnt]")

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models.py
@@ -253,10 +253,11 @@ class EncDecHybridRNNTCTCBPEModel(EncDecHybridRNNTCTCModel, ASRBPEMixin):
         ctc_decoding_cfg: Optional[DictConfig] = None,
     ):
         """
-        Changes vocabulary used during RNNT decoding process. Use this method when fine-tuning on from pre-trained model.
-        This method changes only decoder and leaves encoder and pre-processing modules unchanged. For example, you would
-        use it if you want to use pretrained encoder when fine-tuning on data in another language, or when you'd need
-        model to learn capitalization, punctuation and/or special characters.
+        Changes vocabulary used during RNNT decoding process. Use this method when fine-tuning on 
+        from pre-trained model. This method changes only decoder and leaves encoder and pre-processing 
+        modules unchanged. For example, you would use it if you want to use pretrained encoder when 
+        fine-tuning on data in another language, or when you'd need model to learn capitalization, 
+        punctuation and/or special characters.
 
         Args:
             new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer (if the tokenizer type is `agg`)

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -372,6 +372,8 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         if verbose:
             logging.info(f"Changed decoding strategy to \n{OmegaConf.to_yaml(self.cfg.aux_ctc.decoding)}")
 
+        return None
+
     # PTL-specific methods
     def training_step(self, batch, batch_nb):
         # Reset access registry

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -141,7 +141,7 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         decoding_cfg = self.cfg.aux_ctc.decoding if self.cur_decoder == "ctc" else self.cfg.decoding
 
         if timestamps:
-            logging.info("Timestamps requested, setting decoding timestamps to True")
+            logging.info("Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[idx].timestep['word'/'segment'/'char']")
             return_hypotheses = True
             with open_dict(decoding_cfg):
                 decoding_cfg.decoding.compute_timestamps = True

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -141,7 +141,7 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
                 )
 
             decoding_cfg = self.cfg.aux_ctc.decoding if self.cur_decoder == "ctc" else self.cfg.decoding
-            
+
             logging.info(
                 "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[idx].timestep['word'/'segment'/'char']"
             )

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -221,8 +221,11 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         # if logprobs:
         #     for logit, elen in zip(logits, encoded_len):
         #         logits_list.append(logit[:elen])
-
+        
         if trcfg.timestamps:
+            best_hyp = process_timestamp_outputs(
+                best_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
+            )
             all_hyp = process_timestamp_outputs(
                 all_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
             )

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -142,12 +142,12 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
 
         if timestamps:
             logging.info("Timestamps requested, setting decoding timestamps to True")
-            return_hypotheses=True
+            return_hypotheses = True
             with open_dict(decoding_cfg):
                 decoding_cfg.decoding.compute_timestamps = True
                 decoding_cfg.decoding.preserve_alignments = True
             self.change_decoding_strategy(decoding_cfg, self.cur_decoder, verbose=False)
-        else: # This is done to ensure the timestamps are not computed if not requested
+        else:  # This is done to ensure the timestamps are not computed if not requested
             with open_dict(decoding_cfg):
                 decoding_cfg.compute_timestamps = decoding_cfg.get('compute_timestamps', False)
                 decoding_cfg.preserve_alignments = decoding_cfg.get('preserve_alignments', False)
@@ -221,8 +221,12 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         #         logits_list.append(logit[:elen])
 
         if trcfg.timestamps:
-            hypotheses = process_timestamp_outputs(best_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride'])
-            all_hyp = process_timestamp_outputs(all_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride'])
+            hypotheses = process_timestamp_outputs(
+                best_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
+            )
+            all_hyp = process_timestamp_outputs(
+                all_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
+            )
 
         del logits, encoded_len
 
@@ -318,7 +322,9 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
 
                 logging.info(f"Changed the tokenizer of the CTC decoder to {self.ctc_decoder.vocabulary} vocabulary.")
 
-    def change_decoding_strategy(self, decoding_cfg: DictConfig = None, decoder_type: str = None, verbose: bool = True):
+    def change_decoding_strategy(
+        self, decoding_cfg: DictConfig = None, decoder_type: str = None, verbose: bool = True
+    ):
         """
         Changes decoding strategy used during RNNT decoding process.
 

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -146,8 +146,8 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
             )
             return_hypotheses = True
             with open_dict(decoding_cfg):
-                decoding_cfg.decoding.compute_timestamps = True
-                decoding_cfg.decoding.preserve_alignments = True
+                decoding_cfg.compute_timestamps = True
+                decoding_cfg.preserve_alignments = True
             self.change_decoding_strategy(decoding_cfg, self.cur_decoder, verbose=False)
         else:  # This is done to ensure the timestamps are not computed if not requested
             with open_dict(decoding_cfg):
@@ -223,9 +223,6 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         #         logits_list.append(logit[:elen])
 
         if trcfg.timestamps:
-            hypotheses = process_timestamp_outputs(
-                best_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
-            )
             all_hyp = process_timestamp_outputs(
                 all_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
             )

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -136,10 +136,10 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
 
         if timestamps is not None:
             if self.cur_decoder not in ["ctc", "rnnt"]:
-                    raise ValueError(
-                        f"{self.cur_decoder} is not supported for cur_decoder. Supported values are ['ctc', 'rnnt']"
-                    )
-            decoding_cfg = self.cfg.aux_ctc.decoding if self.cur_decoder == "ctc" else self.cfg.decoding            
+                raise ValueError(
+                    f"{self.cur_decoder} is not supported for cur_decoder. Supported values are ['ctc', 'rnnt']"
+                )
+            decoding_cfg = self.cfg.aux_ctc.decoding if self.cur_decoder == "ctc" else self.cfg.decoding
             if timestamps or (override_config is not None and override_config.timestamps):
                 logging.info(
                     "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[idx].timestep['word'/'segment'/'char']"
@@ -149,7 +149,7 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
                     decoding_cfg.compute_timestamps = True
                     decoding_cfg.preserve_alignments = True
                 self.change_decoding_strategy(decoding_cfg, decoder_type=self.cur_decoder, verbose=False)
-            else: 
+            else:
                 return_hypotheses = False
                 with open_dict(decoding_cfg):
                     decoding_cfg.compute_timestamps = False

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -141,7 +141,9 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         decoding_cfg = self.cfg.aux_ctc.decoding if self.cur_decoder == "ctc" else self.cfg.decoding
 
         if timestamps:
-            logging.info("Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[idx].timestep['word'/'segment'/'char']")
+            logging.info(
+                "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[idx].timestep['word'/'segment'/'char']"
+            )
             return_hypotheses = True
             with open_dict(decoding_cfg):
                 decoding_cfg.decoding.compute_timestamps = True

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -221,7 +221,7 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         # if logprobs:
         #     for logit, elen in zip(logits, encoded_len):
         #         logits_list.append(logit[:elen])
-        
+
         if trcfg.timestamps:
             best_hyp = process_timestamp_outputs(
                 best_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -122,9 +122,13 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
             return_hypotheses: (bool) Either return hypotheses or text
                 With hypotheses can do some postprocessing like getting timestamp or rescoring
             num_workers: (int) number of workers for DataLoader
-            channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels from multi-channel audio. If set to `'average'`, it performs averaging across channels. Disabled if set to `None`. Defaults to `None`. Uses zero-based indexing.
+            channel_selector (int | Iterable[int] | str): select a single channel or a subset of 
+                channels from multi-channel audio. If set to `'average'`, it performs averaging across channels. 
+                Disabled if set to `None`. Defaults to `None`. Uses zero-based indexing.
             augmentor: (DictConfig): Augment audio samples during transcription if augmentor is applied.
-            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis object (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class for more details. Default is None and would retain the previous state set by using self.change_decoding_strategy().
+            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis object 
+                (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class for more details.
+                Default is None and would retain the previous state set by using self.change_decoding_strategy().
             verbose: (bool) whether to display tqdm progress bar
             logprobs: (bool) whether to return ctc logits insted of hypotheses
 
@@ -142,7 +146,8 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
             decoding_cfg = self.cfg.aux_ctc.decoding if self.cur_decoder == "ctc" else self.cfg.decoding
             if timestamps or (override_config is not None and override_config.timestamps):
                 logging.info(
-                    "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[idx].timestep['word'/'segment'/'char']"
+                    "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, \
+                        with output[idx].timestep['word'/'segment'/'char']"
                 )
                 return_hypotheses = True
                 with open_dict(decoding_cfg):
@@ -251,10 +256,11 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         ctc_decoding_cfg: Optional[DictConfig] = None,
     ):
         """
-        Changes vocabulary used during RNNT decoding process. Use this method when fine-tuning a pre-trained model.
-        This method changes only decoder and leaves encoder and pre-processing modules unchanged. For example, you would
-        use it if you want to use pretrained encoder when fine-tuning on data in another language, or when you'd need
-        model to learn capitalization, punctuation and/or special characters.
+        Changes vocabulary used during RNNT decoding process. Use this method when fine-tuning a 
+        pre-trained model. This method changes only decoder and leaves encoder and pre-processing 
+        modules unchanged. For example, you would use it if you want to use pretrained encoder 
+        when fine-tuning on data in another language, or when you'd need model to learn capitalization,
+        punctuation and/or special characters.
 
         Args:
             new_vocabulary: list with new vocabulary. Must contain at least 2 elements. Typically, \

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -31,6 +31,7 @@ from nemo.collections.asr.parts.mixins import ASRBPEMixin, InterCTCMixin, Transc
 from nemo.collections.asr.parts.mixins.transcription import TranscriptionReturnType
 from nemo.collections.asr.parts.preprocessing.segment import ChannelSelectorType
 from nemo.collections.asr.parts.submodules.ctc_decoding import CTCDecoding, CTCDecodingConfig
+from nemo.collections.asr.parts.utils.transcribe_utils import process_timestamp_outputs
 from nemo.core.classes.common import PretrainedModelInfo
 from nemo.core.classes.mixins import AccessMixin
 from nemo.utils import logging, model_utils
@@ -104,6 +105,7 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         channel_selector: Optional[ChannelSelectorType] = None,
         augmentor: DictConfig = None,
         verbose: bool = True,
+        timestamps: bool = False,
         override_config: Optional[TranscribeConfig] = None,
     ) -> TranscriptionReturnType:
         """
@@ -144,6 +146,7 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
             channel_selector=channel_selector,
             augmentor=augmentor,
             verbose=verbose,
+            timestamps=timestamps,
             override_config=override_config,
         )
 
@@ -200,6 +203,10 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
         # if logprobs:
         #     for logit, elen in zip(logits, encoded_len):
         #         logits_list.append(logit[:elen])
+
+        if trcfg.timestamps:
+            hypotheses = process_timestamp_outputs(best_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride'])
+            all_hyp = process_timestamp_outputs(all_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride'])
 
         del logits, encoded_len
 

--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_models.py
@@ -133,14 +133,15 @@ class EncDecHybridRNNTCTCModel(EncDecRNNTModel, ASRBPEMixin, InterCTCMixin):
             * A list of greedy transcript texts / Hypothesis
             * An optional list of beam search transcript texts / Hypothesis / NBestHypothesis.
         """
-        if self.cur_decoder not in ["ctc", "rnnt"]:
-            raise ValueError(
-                f"{self.cur_decoder} is not supported for cur_decoder. Supported values are ['ctc', 'rnnt']"
-            )
 
-        decoding_cfg = self.cfg.aux_ctc.decoding if self.cur_decoder == "ctc" else self.cfg.decoding
+        if timestamps or (override_config is not None and override_config.timestamps):
+            if self.cur_decoder not in ["ctc", "rnnt"]:
+                raise ValueError(
+                    f"{self.cur_decoder} is not supported for cur_decoder. Supported values are ['ctc', 'rnnt']"
+                )
 
-        if timestamps:
+            decoding_cfg = self.cfg.aux_ctc.decoding if self.cur_decoder == "ctc" else self.cfg.decoding
+            
             logging.info(
                 "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[idx].timestep['word'/'segment'/'char']"
             )

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -344,13 +344,15 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
         decoding_cfg: Optional[DictConfig] = None,
     ):
         """
-        Changes vocabulary used during RNNT decoding process. Use this method when fine-tuning on from pre-trained model.
-        This method changes only decoder and leaves encoder and pre-processing modules unchanged. For example, you would
-        use it if you want to use pretrained encoder when fine-tuning on data in another language, or when you'd need
-        model to learn capitalization, punctuation and/or special characters.
+        Changes vocabulary used during RNNT decoding process. Use this method when fine-tuning 
+        on from pre-trained model. This method changes only decoder and leaves encoder and pre-processing 
+        modules unchanged. For example, you would use it if you want to use pretrained encoder when fine-tuning 
+        on data in another language, or when you'd need model to learn capitalization, punctuation 
+        and/or special characters.
 
         Args:
-            new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer (if the tokenizer type is `agg`)
+            new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer 
+                (if the tokenizer type is `agg`)
             new_tokenizer_type: Type of tokenizer. Can be either `agg`, `bpe` or `wpe`.
             decoding_cfg: A config for the decoder, which is optional. If the decoding type
                 needs to be changed (from say Greedy to Beam decoding etc), the config can be passed here.
@@ -363,7 +365,8 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
                 new_tokenizer_cfg = new_tokenizer_dir
             else:
                 raise ValueError(
-                    f'New tokenizer dir should be a string unless the tokenizer is `agg`, but this tokenizer type is: {new_tokenizer_type}'
+                    f'New tokenizer dir should be a string unless the tokenizer is `agg`, but this tokenizer \
+                        type is: {new_tokenizer_type}'
                 )
         else:
             new_tokenizer_cfg = None

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -451,13 +451,14 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
 
         logging.info(f"Changed decoder to output to {self.joint.vocabulary} vocabulary.")
 
-    def change_decoding_strategy(self, decoding_cfg: DictConfig):
+    def change_decoding_strategy(self, decoding_cfg: DictConfig, verbose: bool = True):
         """
         Changes decoding strategy used during RNNT decoding process.
 
         Args:
             decoding_cfg: A config for the decoder, which is optional. If the decoding type
                 needs to be changed (from say Greedy to Beam decoding etc), the config can be passed here.
+            verbose: A flag to enable/disable logging.
         """
         if decoding_cfg is None:
             # Assume same decoding config as before
@@ -498,7 +499,8 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
         with open_dict(self.cfg.decoding):
             self.cfg.decoding = decoding_cfg
 
-        logging.info(f"Changed decoding strategy to \n{OmegaConf.to_yaml(self.cfg.decoding)}")
+        if verbose:
+            logging.info(f"Changed decoding strategy to \n{OmegaConf.to_yaml(self.cfg.decoding)}")
 
     def _setup_dataloader_from_config(self, config: Optional[Dict]):
         if config.get("use_lhotse"):

--- a/nemo/collections/asr/models/rnnt_bpe_models.py
+++ b/nemo/collections/asr/models/rnnt_bpe_models.py
@@ -344,14 +344,14 @@ class EncDecRNNTBPEModel(EncDecRNNTModel, ASRBPEMixin):
         decoding_cfg: Optional[DictConfig] = None,
     ):
         """
-        Changes vocabulary used during RNNT decoding process. Use this method when fine-tuning 
-        on from pre-trained model. This method changes only decoder and leaves encoder and pre-processing 
-        modules unchanged. For example, you would use it if you want to use pretrained encoder when fine-tuning 
-        on data in another language, or when you'd need model to learn capitalization, punctuation 
+        Changes vocabulary used during RNNT decoding process. Use this method when fine-tuning
+        on from pre-trained model. This method changes only decoder and leaves encoder and pre-processing
+        modules unchanged. For example, you would use it if you want to use pretrained encoder when fine-tuning
+        on data in another language, or when you'd need model to learn capitalization, punctuation
         and/or special characters.
 
         Args:
-            new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer 
+            new_tokenizer_dir: Directory path to tokenizer or a config for a new tokenizer
                 (if the tokenizer type is `agg`)
             new_tokenizer_type: Type of tokenizer. Can be either `agg`, `bpe` or `wpe`.
             decoding_cfg: A config for the decoder, which is optional. If the decoding type

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -295,13 +295,6 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
                 self.cfg.decoding.preserve_alignments = self.cfg.decoding.get('preserve_alignments', False)
             self.change_decoding_strategy(self.cfg.decoding, verbose=False)
 
-        self.decoding = RNNTDecoding(
-            decoding_cfg=self.cfg.decoding,
-            decoder=self.decoder,
-            joint=self.joint,
-            vocabulary=self.joint.vocabulary,
-        )
-
         return super().transcribe(
             audio=audio,
             batch_size=batch_size,
@@ -947,6 +940,9 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
         del encoded, encoded_len
 
         if trcfg.timestamps:
+            best_hyp = process_timestamp_outputs(
+                best_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
+            )
             all_hyp = process_timestamp_outputs(
                 all_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
             )

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -281,7 +281,7 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
             * An optional list of beam search transcript texts / Hypothesis / NBestHypothesis.
         """
         if timestamps:
-            logging.info("Timestamps requested, setting decoding timestamps to True")
+            logging.info("Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[0][idx].timestep['word'/'segment'/'char']")
             return_hypotheses = True
             with open_dict(self.cfg.decoding):
                 self.cfg.decoding.compute_timestamps = True

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -280,7 +280,7 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
             * A list of greedy transcript texts / Hypothesis
             * An optional list of beam search transcript texts / Hypothesis / NBestHypothesis.
         """
-        if timestamps:
+        if timestamps or (override_config is not None and override_config.timestamps):
             logging.info(
                 "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[0][idx].timestep['word'/'segment'/'char']"
             )

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -947,9 +947,6 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
         del encoded, encoded_len
 
         if trcfg.timestamps:
-            hypotheses = process_timestamp_outputs(
-                best_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
-            )
             all_hyp = process_timestamp_outputs(
                 all_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
             )

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -255,7 +255,8 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
         Uses greedy decoding to transcribe audio files. Use this method for debugging and prototyping.
 
         Args:
-            audio: (a single or list) of paths to audio files or a np.ndarray/tensor audio array or path to a manifest file.
+            audio: (a single or list) of paths to audio files or a np.ndarray/tensor audio array or path 
+                to a manifest file.
                 Can also be a dataloader object that provides values that can be consumed by the model.
                 Recommended length per file is between 5 and 25 seconds. \
                 But it is possible to pass a few hours long file if enough GPU memory is available.
@@ -267,10 +268,14 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
                 decoding. This is useful for streaming rnnt decoding. If this is not None, then the length of this
                 list should be equal to the length of the audio list.
             num_workers: (int) number of workers for DataLoader
-            channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels from multi-channel audio. If set to `'average'`, it performs averaging across channels. Disabled if set to `None`. Defaults to `None`. Uses zero-based indexing.
+            channel_selector (int | Iterable[int] | str): select a single channel or a subset of channels 
+                from multi-channel audio. If set to `'average'`, it performs averaging across channels. 
+                Disabled if set to `None`. Defaults to `None`. Uses zero-based indexing.
             augmentor: (DictConfig): Augment audio samples during transcription if augmentor is applied.
             verbose: (bool) whether to display tqdm progress bar
-            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis object (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class for more details. Default is None and would retain the previous state set by using self.change_decoding_strategy().
+            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis object 
+                (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class for more details. 
+                Default is None and would retain the previous state set by using self.change_decoding_strategy().
             override_config: (Optional[TranscribeConfig]) override transcription config pre-defined by the user.
                 **Note**: All other arguments in the function will be ignored if override_config is passed.
                 You should call this argument as `model.transcribe(audio, override_config=TranscribeConfig(...))`.
@@ -284,7 +289,8 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
         if timestamps is not None:
             if timestamps or (override_config is not None and override_config.timestamps):
                 logging.info(
-                    "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[0][idx].timestep['word'/'segment'/'char']"
+                    "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, \
+                        with output[0][idx].timestep['word'/'segment'/'char']"
                 )
                 return_hypotheses = True
                 with open_dict(self.cfg.decoding):
@@ -314,10 +320,11 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
 
     def change_vocabulary(self, new_vocabulary: List[str], decoding_cfg: Optional[DictConfig] = None):
         """
-        Changes vocabulary used during RNNT decoding process. Use this method when fine-tuning a pre-trained model.
-        This method changes only decoder and leaves encoder and pre-processing modules unchanged. For example, you would
-        use it if you want to use pretrained encoder when fine-tuning on data in another language, or when you'd need
-        model to learn capitalization, punctuation and/or special characters.
+        Changes vocabulary used during RNNT decoding process. Use this method when fine-tuning a 
+        pre-trained model. This method changes only decoder and leaves encoder and pre-processing 
+        modules unchanged. For example, you would use it if you want to use pretrained encoder when 
+        fine-tuning on data in another language, or when you'd need model to learn capitalization, 
+        punctuation and/or special characters.
 
         Args:
             new_vocabulary: list with new vocabulary. Must contain at least 2 elements. Typically, \
@@ -925,7 +932,8 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
         return output
 
     @deprecated(
-        explanation='The return type of args will be updated in the upcoming release to ensure a consistent output format across all decoder types, such that a "Hypothesis" object is always returned.'
+        explanation='The return type of args will be updated in the upcoming release to ensure a consistent \
+            output format across all decoder types, such that a "Hypothesis" object is always returned.'
     )
     def _transcribe_output_processing(
         self, outputs, trcfg: TranscribeConfig

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -282,7 +282,7 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
         """
         if timestamps:
             logging.info("Timestamps requested, setting decoding timestamps to True")
-            return_hypotheses=True
+            return_hypotheses = True
             with open_dict(self.cfg.decoding):
                 self.cfg.decoding.compute_timestamps = True
                 self.cfg.decoding.preserve_alignments = True
@@ -945,8 +945,12 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
         del encoded, encoded_len
 
         if trcfg.timestamps:
-            hypotheses = process_timestamp_outputs(best_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride'])
-            all_hyp = process_timestamp_outputs(all_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride'])
+            hypotheses = process_timestamp_outputs(
+                best_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
+            )
+            all_hyp = process_timestamp_outputs(
+                all_hyp, self.encoder.subsampling_factor, self.cfg['preprocessor']['window_stride']
+            )
 
         hypotheses = []
         all_hypotheses = []
@@ -958,7 +962,6 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
             all_hypotheses += best_hyp
 
         return (hypotheses, all_hypotheses)
-
 
     def _setup_transcribe_dataloader(self, config: Dict) -> 'torch.utils.data.DataLoader':
         """

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -281,7 +281,9 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
             * An optional list of beam search transcript texts / Hypothesis / NBestHypothesis.
         """
         if timestamps:
-            logging.info("Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[0][idx].timestep['word'/'segment'/'char']")
+            logging.info(
+                "Timestamps requested, setting decoding timestamps to True. Capture them in Hypothesis object, with output[0][idx].timestep['word'/'segment'/'char']"
+            )
             return_hypotheses = True
             with open_dict(self.cfg.decoding):
                 self.cfg.decoding.compute_timestamps = True

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -203,7 +203,9 @@ class ConvASREncoder(NeuralModule, Exportable, AccessMixin):
         return s_input[-1], length
 
     def update_max_sequence_length(self, seq_length: int, device):
-        # Find global max audio length across all nodes
+        """
+        Find global max audio length across all nodes in distributed training and update the max_audio_length
+        """
         if torch.distributed.is_initialized():
             global_max_len = torch.tensor([seq_length], dtype=torch.float32, device=device)
 
@@ -434,7 +436,8 @@ class ConvASRDecoder(NeuralModule, Exportable, adapter_mixins.AdapterModuleMixin
         if vocabulary is not None:
             if num_classes != len(vocabulary):
                 raise ValueError(
-                    f"If vocabulary is specified, it's length should be equal to the num_classes. Instead got: num_classes={num_classes} and len(vocabulary)={len(vocabulary)}"
+                    f"If vocabulary is specified, it's length should be equal to the num_classes. \
+                        Instead got: num_classes={num_classes} and len(vocabulary)={len(vocabulary)}"
                 )
             self.__vocabulary = vocabulary
         self._feat_in = feat_in
@@ -773,8 +776,8 @@ class SpeakerDecoder(NeuralModule, Exportable):
     Args:
         feat_in (int): Number of channels being input to this module
         num_classes (int): Number of unique speakers in dataset
-        emb_sizes (list) : shapes of intermediate embedding layers (we consider speaker embbeddings from 1st of this layers)
-            Defaults to [1024,1024]
+        emb_sizes (list) : shapes of intermediate embedding layers (we consider speaker embbeddings 
+            from 1st of this layers). Defaults to [1024,1024]
         pool_mode (str) : Pooling strategy type. options are 'xvector','tap', 'attention'
             Defaults to 'xvector (mean and variance)'
             tap (temporal average pooling: just mean)

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -133,6 +133,7 @@ class ConvASREncoder(NeuralModule, Exportable, AccessMixin):
         residual_panes = []
         encoder_layers = []
         self.dense_residual = False
+        self._subsampling_factor = 1 
         for layer_idx, lcfg in enumerate(jasper):
             dense_res = []
             if lcfg.get('residual_dense', False):
@@ -181,6 +182,7 @@ class ConvASREncoder(NeuralModule, Exportable, AccessMixin):
                 )
             )
             feat_in = lcfg['filters']
+            self._subsampling_factor *= int(lcfg['stride'][0]) if isinstance(lcfg['stride'], List) else int(lcfg['stride'])
 
         self._feat_out = feat_in
 
@@ -229,6 +231,9 @@ class ConvASREncoder(NeuralModule, Exportable, AccessMixin):
                 elif isinstance(m, SqueezeExcite):
                     m.set_max_len(self.max_audio_length, seq_range=self.seq_range)
 
+    @property
+    def subsampling_factor(self) -> int:
+        return self._subsampling_factor
 
 class ParallelConvASREncoder(NeuralModule, Exportable):
     """

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -776,7 +776,7 @@ class SpeakerDecoder(NeuralModule, Exportable):
     Args:
         feat_in (int): Number of channels being input to this module
         num_classes (int): Number of unique speakers in dataset
-        emb_sizes (list) : shapes of intermediate embedding layers (we consider speaker embbeddings 
+        emb_sizes (list) : shapes of intermediate embedding layers (we consider speaker embbeddings
             from 1st of this layers). Defaults to [1024,1024]
         pool_mode (str) : Pooling strategy type. options are 'xvector','tap', 'attention'
             Defaults to 'xvector (mean and variance)'

--- a/nemo/collections/asr/modules/conv_asr.py
+++ b/nemo/collections/asr/modules/conv_asr.py
@@ -133,7 +133,7 @@ class ConvASREncoder(NeuralModule, Exportable, AccessMixin):
         residual_panes = []
         encoder_layers = []
         self.dense_residual = False
-        self._subsampling_factor = 1 
+        self._subsampling_factor = 1
         for layer_idx, lcfg in enumerate(jasper):
             dense_res = []
             if lcfg.get('residual_dense', False):
@@ -182,7 +182,9 @@ class ConvASREncoder(NeuralModule, Exportable, AccessMixin):
                 )
             )
             feat_in = lcfg['filters']
-            self._subsampling_factor *= int(lcfg['stride'][0]) if isinstance(lcfg['stride'], List) else int(lcfg['stride'])
+            self._subsampling_factor *= (
+                int(lcfg['stride'][0]) if isinstance(lcfg['stride'], List) else int(lcfg['stride'])
+            )
 
         self._feat_out = feat_in
 
@@ -234,6 +236,7 @@ class ConvASREncoder(NeuralModule, Exportable, AccessMixin):
     @property
     def subsampling_factor(self) -> int:
         return self._subsampling_factor
+
 
 class ParallelConvASREncoder(NeuralModule, Exportable):
     """

--- a/nemo/collections/asr/parts/mixins/transcription.py
+++ b/nemo/collections/asr/parts/mixins/transcription.py
@@ -86,7 +86,8 @@ def get_value_from_transcription_config(trcfg, key, default):
         return getattr(trcfg, key)
     else:
         logging.debug(
-            f"Using default value of {default} for {key} because it is not present in the transcription config {trcfg}."
+            f"Using default value of {default} for {key} because it is not present \
+                in the transcription config {trcfg}."
         )
         return default
 
@@ -201,7 +202,9 @@ class TranscriptionMixin(ABC):
                 to `None`. Defaults to `None`. Uses zero-based indexing.
             augmentor: (DictConfig): Augment audio samples during transcription if augmentor is applied.
             verbose: (bool) whether to display tqdm progress bar
-            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis object (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class for more details. Default is None and would retain the previous state set by using self.change_decoding_strategy().
+            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis object 
+                (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class for more details. 
+                Default is None and would retain the previous state set by using self.change_decoding_strategy().
             override_config: (Optional[TranscribeConfig]) override transcription config pre-defined by the user.
                 **Note**: All other arguments in the function will be ignored if override_config is passed.
                 You should call this argument as `model.transcribe(audio, override_config=TranscribeConfig(...))`.

--- a/nemo/collections/asr/parts/mixins/transcription.py
+++ b/nemo/collections/asr/parts/mixins/transcription.py
@@ -16,13 +16,11 @@ import json
 import os
 import tempfile
 from abc import ABC, abstractmethod
-from collections.abc import Iterable
-from dataclasses import dataclass, fields, is_dataclass
+from dataclasses import dataclass
 from functools import partial
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-import omegaconf
 import torch
 from omegaconf import DictConfig
 from torch.utils.data import DataLoader, Dataset

--- a/nemo/collections/asr/parts/mixins/transcription.py
+++ b/nemo/collections/asr/parts/mixins/transcription.py
@@ -62,8 +62,8 @@ class TranscribeConfig:
     num_workers: Optional[int] = None
     channel_selector: ChannelSelectorType = None
     augmentor: Optional[DictConfig] = None
-    timestamps: bool = False # returns timestamps for each word and segments if model supports punctuations
-    verbose: bool = True 
+    timestamps: bool = False  # returns timestamps for each word and segments if model supports punctuations
+    verbose: bool = True
 
     # Utility
     partial_hypothesis: Optional[List[Any]] = None

--- a/nemo/collections/asr/parts/mixins/transcription.py
+++ b/nemo/collections/asr/parts/mixins/transcription.py
@@ -60,7 +60,7 @@ class TranscribeConfig:
     num_workers: Optional[int] = None
     channel_selector: ChannelSelectorType = None
     augmentor: Optional[DictConfig] = None
-    timestamps: bool = False  # returns timestamps for each word and segments if model supports punctuations
+    timestamps: Optional[bool] = None  # returns timestamps for each word and segments if model supports punctuations
     verbose: bool = True
 
     # Utility
@@ -179,7 +179,7 @@ class TranscriptionMixin(ABC):
         channel_selector: Optional[ChannelSelectorType] = None,
         augmentor: DictConfig = None,
         verbose: bool = True,
-        timestamps: bool = False,
+        timestamps: Optional[bool] = None,
         override_config: Optional[TranscribeConfig] = None,
         **config_kwargs,
     ) -> GenericTranscriptionType:
@@ -201,6 +201,7 @@ class TranscriptionMixin(ABC):
                 to `None`. Defaults to `None`. Uses zero-based indexing.
             augmentor: (DictConfig): Augment audio samples during transcription if augmentor is applied.
             verbose: (bool) whether to display tqdm progress bar
+            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis object (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class for more details. Default is None and would retain the previous state set by using self.change_decoding_strategy().
             override_config: (Optional[TranscribeConfig]) override transcription config pre-defined by the user.
                 **Note**: All other arguments in the function will be ignored if override_config is passed.
                 You should call this argument as `model.transcribe(audio, override_config=TranscribeConfig(...))`.

--- a/nemo/collections/asr/parts/mixins/transcription.py
+++ b/nemo/collections/asr/parts/mixins/transcription.py
@@ -441,16 +441,6 @@ class TranscriptionMixin(ABC):
                 trcfg._internal.pad_to_value = self.preprocessor.featurizer.pad_to
                 self.preprocessor.featurizer.pad_to = 0
 
-        # if timestamps option is set
-        if trcfg.timestamps:
-            trcfg.return_hypotheses = True
-            model_decoding_cfg = self.cfg.get('decoding', None)
-            if model_decoding_cfg is not None:
-                with omegaconf.open_dict(model_decoding_cfg):
-                    model_decoding_cfg.compute_timestamps = trcfg.timestamps
-                    model_decoding_cfg.preserve_alignments = trcfg.timestamps
-                self.change_decoding_strategy(model_decoding_cfg)
-
         # Switch model to evaluation mode
         self.eval()
 

--- a/nemo/collections/asr/parts/mixins/transcription.py
+++ b/nemo/collections/asr/parts/mixins/transcription.py
@@ -202,8 +202,8 @@ class TranscriptionMixin(ABC):
                 to `None`. Defaults to `None`. Uses zero-based indexing.
             augmentor: (DictConfig): Augment audio samples during transcription if augmentor is applied.
             verbose: (bool) whether to display tqdm progress bar
-            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis object 
-                (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class for more details. 
+            timestamps: Optional(Bool): timestamps will be returned if set to True as part of hypothesis object
+                (output.timestep['segment']/output.timestep['word']). Refer to `Hypothesis` class for more details.
                 Default is None and would retain the previous state set by using self.change_decoding_strategy().
             override_config: (Optional[TranscribeConfig]) override transcription config pre-defined by the user.
                 **Note**: All other arguments in the function will be ignored if override_config is passed.

--- a/nemo/collections/asr/parts/submodules/ctc_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_decoding.py
@@ -930,7 +930,8 @@ class AbstractCTCDecoding(ConfidenceMixin):
             logging.warning(
                 f"Specified segment seperators are not in supported punctuation {supported_punctuation}. "
                 "If the seperators are not punctuation marks, ignore this warning. "
-                "Otherwise, specify 'segment_gap_threshold' parameter in decoding config to form segments."
+                "Otherwise, specify 'segment_gap_threshold' parameter in decoding config to form segments.",
+                mode=logging_mode.ONCE,
             )
 
         segment_offsets = []

--- a/nemo/collections/asr/parts/submodules/ctc_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_decoding.py
@@ -922,17 +922,16 @@ class AbstractCTCDecoding(ConfidenceMixin):
             A list of dictionaries containing the segment offsets. Each item contains "segment", "start_offset" and
             "end_offset".
         """
-        if (
-            supported_punctuation
-            and not set(segment_delimiter_tokens).intersection(supported_punctuation)
-            and not segment_gap_threshold
-        ):
-            logging.warning(
-                f"Specified segment seperators are not in supported punctuation {supported_punctuation}. "
-                "If the seperators are not punctuation marks, ignore this warning. "
-                "Otherwise, specify 'segment_gap_threshold' parameter in decoding config to form segments.",
-                mode=logging_mode.ONCE,
-            )
+        # if (
+        #     supported_punctuation
+        #     and not set(segment_delimiter_tokens).intersection(supported_punctuation)
+        #     and not segment_gap_threshold
+        # ):
+        #     logging.warning(
+        #         f"Specified segment seperators are not in supported punctuation {supported_punctuation}. "
+        #         "If the seperators are not punctuation marks, ignore this warning. "
+        #         "Otherwise, specify 'segment_gap_threshold' parameter in decoding config to form segments."
+        #     )
 
         segment_offsets = []
         segment_words = []

--- a/nemo/collections/asr/parts/submodules/ctc_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_decoding.py
@@ -922,16 +922,16 @@ class AbstractCTCDecoding(ConfidenceMixin):
             A list of dictionaries containing the segment offsets. Each item contains "segment", "start_offset" and
             "end_offset".
         """
-        # if (
-        #     supported_punctuation
-        #     and not set(segment_delimiter_tokens).intersection(supported_punctuation)
-        #     and not segment_gap_threshold
-        # ):
-        #     logging.warning(
-        #         f"Specified segment seperators are not in supported punctuation {supported_punctuation}. "
-        #         "If the seperators are not punctuation marks, ignore this warning. "
-        #         "Otherwise, specify 'segment_gap_threshold' parameter in decoding config to form segments."
-        #     )
+        if (
+            supported_punctuation
+            and not set(segment_delimiter_tokens).intersection(supported_punctuation)
+            and not segment_gap_threshold
+        ):
+            logging.warning(
+                f"Specified segment seperators are not in supported punctuation {supported_punctuation}. "
+                "If the seperators are not punctuation marks, ignore this warning. "
+                "Otherwise, specify 'segment_gap_threshold' parameter in decoding config to form segments."
+            )
 
         segment_offsets = []
         segment_words = []

--- a/nemo/collections/asr/parts/submodules/rnnt_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_decoding.py
@@ -67,13 +67,15 @@ class AbstractRNNTDecoding(ConfidenceMixin):
 
             rnnt_timestamp_type: A str value, which represents the types of timestamps that should be calculated.
                 Can take the following values - "char" for character/subword time stamps, "word" for word level
-                time stamps, "segment" for segment level time stamps and "all" (default), for character, word and segment level time stamps.
+                time stamps, "segment" for segment level time stamps and "all" (default), for character, 
+                word and segment level time stamps.
 
             word_seperator: Str token representing the seperator between words.
 
             segment_seperators: List containing tokens representing the seperator(s) between segments.
 
-            segment_gap_threshold: The threshold (in frames) that caps the gap between two words necessary for forming the segments.
+            segment_gap_threshold: The threshold (in frames) that caps the gap between two words necessary 
+            for forming the segments.
 
             preserve_frame_confidence: Bool flag which preserves the history of per-frame confidence scores
                 generated during decoding (sample / batched). When set to true, the Hypothesis will contain
@@ -102,10 +104,10 @@ class AbstractRNNTDecoding(ConfidenceMixin):
                     The length of the list corresponds to the number of recognized words.
                 exclude_blank: Bool flag indicating that blank token confidence scores are to be excluded
                     from the `token_confidence`.
-                aggregation: Which aggregation type to use for collapsing per-token confidence into per-word confidence.
-                    Valid options are `mean`, `min`, `max`, `prod`.
-                tdt_include_duration: Bool flag indicating that the duration confidence scores are to be calculated and
-                    attached to the regular frame confidence,
+                aggregation: Which aggregation type to use for collapsing per-token confidence into per-word 
+                    confidence. Valid options are `mean`, `min`, `max`, `prod`.
+                tdt_include_duration: Bool flag indicating that the duration confidence scores are to be calculated 
+                    and attached to the regular frame confidence,
                     making TDT frame confidence element a pair: (`prediction_confidence`, `duration_confidence`).
                 method_cfg: A dict-like object which contains the method name and settings to compute per-frame
                     confidence scores.
@@ -177,22 +179,23 @@ class AbstractRNNTDecoding(ConfidenceMixin):
                 maes_num_steps: Number of adaptive steps to take. From the paper, 2 steps is generally sufficient,
                     and can be reduced to 1 to improve decoding speed while sacrificing some accuracy. int > 0.
 
-                maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to keep this as 1
-                    in order to reduce expensive beam search cost later. int >= 0.
+                maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to 
+                keep this as 1 in order to reduce expensive beam search cost later. int >= 0.
 
                 maes_expansion_beta: Maximum number of prefix expansions allowed, in addition to the beam size.
                     Effectively, the number of hypothesis = beam_size + maes_expansion_beta. Must be an int >= 0,
-                    and affects the speed of inference since large values will perform large beam search in the next step.
+                    and affects the speed of inference since large values will perform large beam search in the 
+                    next step.
 
-                maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when computing the expansions.
-                    The default (2.3) is selected from the paper. It performs a comparison (max_log_prob - gamma <= log_prob[v])
-                    where v is all vocabulary indices in the Vocab set and max_log_prob is the "most" likely token to be
-                    predicted. Gamma therefore provides a margin of additional tokens which can be potential candidates for
-                    expansion apart from the "most likely" candidate.
-                    Lower values will reduce the number of expansions (by increasing pruning-by-value, thereby improving speed
-                    but hurting accuracy). Higher values will increase the number of expansions (by reducing pruning-by-value,
-                    thereby reducing speed but potentially improving accuracy). This is a hyper parameter to be experimentally
-                    tuned on a validation set.
+                maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when computing the 
+                    expansions. The default (2.3) is selected from the paper. It performs a comparison 
+                    (max_log_prob - gamma <= log_prob[v]) where v is all vocabulary indices in the Vocab set 
+                    and max_log_prob is the "most" likely token to be predicted. Gamma therefore provides a margin
+                    of additional tokens which can be potential candidates for expansion apart from the "most likely" 
+                    candidate. Lower values will reduce the number of expansions (by increasing pruning-by-value, 
+                    thereby improving speed but hurting accuracy). Higher values will increase the number of expansions 
+                    (by reducing pruning-by-value, thereby reducing speed but potentially improving accuracy). 
+                    This is a hyper parameter to be experimentally tuned on a validation set.
 
                 softmax_temperature: Scales the logits of the joint prior to computing log_softmax.
 
@@ -950,7 +953,8 @@ class AbstractRNNTDecoding(ConfidenceMixin):
 
             # Check if token is a punctuation mark
             # If so, set its start and end offset as start and end of the previous token
-            # This is done because there was observed a behaviour, when punctuation marks are predicted long after preceding token (i.e. after silence)
+            # This is done because there was observed a behaviour, when punctuation marks are predicted long 
+            # after preceding token (i.e. after silence)
             if offset['char'][0] in supported_punctuation and i > 0:
                 encoded_char_offsets[i]['start_offset'] = offset['start_offset'] = char_offsets[i - 1]['end_offset']
                 encoded_char_offsets[i]['end_offset'] = offset['end_offset'] = offset['start_offset']
@@ -1237,10 +1241,10 @@ class RNNTDecoding(AbstractRNNTDecoding):
                     The length of the list corresponds to the number of recognized words.
                 exclude_blank: Bool flag indicating that blank token confidence scores are to be excluded
                     from the `token_confidence`.
-                aggregation: Which aggregation type to use for collapsing per-token confidence into per-word confidence.
-                    Valid options are `mean`, `min`, `max`, `prod`.
-                tdt_include_duration: Bool flag indicating that the duration confidence scores are to be calculated and
-                    attached to the regular frame confidence,
+                aggregation: Which aggregation type to use for collapsing per-token confidence into per-word 
+                    confidence. Valid options are `mean`, `min`, `max`, `prod`.
+                tdt_include_duration: Bool flag indicating that the duration confidence scores are to be calculated
+                    and attached to the regular frame confidence,
                     making TDT frame confidence element a pair: (`prediction_confidence`, `duration_confidence`).
                 method_cfg: A dict-like object which contains the method name and settings to compute per-frame
                     confidence scores.
@@ -1313,8 +1317,8 @@ class RNNTDecoding(AbstractRNNTDecoding):
                         per timestep of the acoustic model. Larger values will allow longer sentences to be decoded,
                         at increased cost to execution time.
 
-                    alsd_max_target_len: optional int or float, determines the potential maximum target sequence length.
-                        If an integer is provided, it can decode sequences of that particular maximum length.
+                    alsd_max_target_len: optional int or float, determines the potential maximum target sequence 
+                        length. If an integer is provided, it can decode sequences of that particular maximum length.
                         If a float is provided, it can decode sequences of int(alsd_max_target_len * seq_len),
                         where seq_len is the length of the acoustic model output (T).
 
@@ -1326,22 +1330,24 @@ class RNNTDecoding(AbstractRNNTDecoding):
                     maes_num_steps: Number of adaptive steps to take. From the paper, 2 steps is generally sufficient,
                         and can be reduced to 1 to improve decoding speed while sacrificing some accuracy. int > 0.
 
-                    maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to keep this as 1
-                        in order to reduce expensive beam search cost later. int >= 0.
+                    maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to 
+                        keep this as 1 in order to reduce expensive beam search cost later. int >= 0.
 
                     maes_expansion_beta: Maximum number of prefix expansions allowed, in addition to the beam size.
                         Effectively, the number of hypothesis = beam_size + maes_expansion_beta. Must be an int >= 0,
-                        and affects the speed of inference since large values will perform large beam search in the next step.
+                        and affects the speed of inference since large values will perform large beam search in the 
+                        next step.
 
-                    maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when computing the expansions.
-                        The default (2.3) is selected from the paper. It performs a comparison (max_log_prob - gamma <= log_prob[v])
-                        where v is all vocabulary indices in the Vocab set and max_log_prob is the "most" likely token to be
-                        predicted. Gamma therefore provides a margin of additional tokens which can be potential candidates for
-                        expansion apart from the "most likely" candidate.
-                        Lower values will reduce the number of expansions (by increasing pruning-by-value, thereby improving speed
-                        but hurting accuracy). Higher values will increase the number of expansions (by reducing pruning-by-value,
-                        thereby reducing speed but potentially improving accuracy). This is a hyper parameter to be experimentally
-                        tuned on a validation set.
+                    maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when computing the 
+                        expansions.
+                        The default (2.3) is selected from the paper. It performs a comparison 
+                        (max_log_prob - gamma <= log_prob[v]) where v is all vocabulary indices in the Vocab set and 
+                        max_log_prob is the "most" likely token to be predicted. Gamma therefore provides a margin of 
+                        additional tokens which can be potential candidates for expansion apart from the "most likely"
+                        candidate. Lower values will reduce the number of expansions (by increasing pruning-by-value,
+                        thereby improving speed but hurting accuracy). Higher values will increase the number of 
+                        expansions (by reducing pruning-by-value, thereby reducing speed but potentially improving 
+                        accuracy). This is a hyper parameter to be experimentally tuned on a validation set.
 
                     softmax_temperature: Scales the logits of the joint prior to computing log_softmax.
 
@@ -1492,7 +1498,8 @@ class RNNTBPEDecoding(AbstractRNNTDecoding):
 
             segment_seperators: List containing tokens representing the seperator(s) between segments.
 
-            segment_gap_threshold: The threshold (in frames) that caps the gap between two words necessary for forming the segments.
+            segment_gap_threshold: The threshold (in frames) that caps the gap between two words necessary for 
+                forming the segments.
 
             preserve_frame_confidence: Bool flag which preserves the history of per-frame confidence scores
                 generated during decoding (sample / batched). When set to true, the Hypothesis will contain
@@ -1521,10 +1528,10 @@ class RNNTBPEDecoding(AbstractRNNTDecoding):
                     The length of the list corresponds to the number of recognized words.
                 exclude_blank: Bool flag indicating that blank token confidence scores are to be excluded
                     from the `token_confidence`.
-                aggregation: Which aggregation type to use for collapsing per-token confidence into per-word confidence.
-                    Valid options are `mean`, `min`, `max`, `prod`.
-                tdt_include_duration: Bool flag indicating that the duration confidence scores are to be calculated and
-                    attached to the regular frame confidence,
+                aggregation: Which aggregation type to use for collapsing per-token confidence into per-word 
+                    confidence. Valid options are `mean`, `min`, `max`, `prod`.
+                tdt_include_duration: Bool flag indicating that the duration confidence scores are to be 
+                    calculated and attached to the regular frame confidence,
                     making TDT frame confidence element a pair: (`prediction_confidence`, `duration_confidence`).
                 method_cfg: A dict-like object which contains the method name and settings to compute per-frame
                     confidence scores.
@@ -1594,8 +1601,8 @@ class RNNTBPEDecoding(AbstractRNNTDecoding):
                         per timestep of the acoustic model. Larger values will allow longer sentences to be decoded,
                         at increased cost to execution time.
 
-                    alsd_max_target_len: optional int or float, determines the potential maximum target sequence length.
-                        If an integer is provided, it can decode sequences of that particular maximum length.
+                    alsd_max_target_len: optional int or float, determines the potential maximum target sequence 
+                        length. If an integer is provided, it can decode sequences of that particular maximum length.
                         If a float is provided, it can decode sequences of int(alsd_max_target_len * seq_len),
                         where seq_len is the length of the acoustic model output (T).
 
@@ -1607,22 +1614,24 @@ class RNNTBPEDecoding(AbstractRNNTDecoding):
                     maes_num_steps: Number of adaptive steps to take. From the paper, 2 steps is generally sufficient,
                         and can be reduced to 1 to improve decoding speed while sacrificing some accuracy. int > 0.
 
-                    maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to keep this as 1
-                        in order to reduce expensive beam search cost later. int >= 0.
+                    maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to 
+                        keep this as 1 in order to reduce expensive beam search cost later. int >= 0.
 
                     maes_expansion_beta: Maximum number of prefix expansions allowed, in addition to the beam size.
                         Effectively, the number of hypothesis = beam_size + maes_expansion_beta. Must be an int >= 0,
-                        and affects the speed of inference since large values will perform large beam search in the next step.
+                        and affects the speed of inference since large values will perform large beam search in the 
+                        next step.
 
-                    maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when computing the expansions.
-                        The default (2.3) is selected from the paper. It performs a comparison (max_log_prob - gamma <= log_prob[v])
-                        where v is all vocabulary indices in the Vocab set and max_log_prob is the "most" likely token to be
-                        predicted. Gamma therefore provides a margin of additional tokens which can be potential candidates for
-                        expansion apart from the "most likely" candidate.
-                        Lower values will reduce the number of expansions (by increasing pruning-by-value, thereby improving speed
-                        but hurting accuracy). Higher values will increase the number of expansions (by reducing pruning-by-value,
-                        thereby reducing speed but potentially improving accuracy). This is a hyper parameter to be experimentally
-                        tuned on a validation set.
+                    maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when 
+                        computing the expansions. The default (2.3) is selected from the paper. It performs a 
+                        comparison (max_log_prob - gamma <= log_prob[v]) where v is all vocabulary indices in the 
+                        Vocab set and max_log_prob is the "most" likely token to be predicted. Gamma therefore 
+                        provides a margin of additional tokens which can be potential candidates for expansion 
+                        apart from the "most likely" candidate. Lower values will reduce the number of expansions
+                        (by increasing pruning-by-value, thereby improving speed but hurting accuracy). Higher 
+                        values will increase the number of expansions (by reducing pruning-by-value, thereby 
+                        reducing speed but potentially improving accuracy). This is a hyper parameter to be 
+                        experimentally tuned on a validation set.
 
                     softmax_temperature: Scales the logits of the joint prior to computing log_softmax.
 
@@ -1750,7 +1759,8 @@ class RNNTBPEDecoding(AbstractRNNTDecoding):
                     hypotheses[ind].langs_chars = self.decode_ids_to_langs(prediction)
             else:
                 logging.warning(
-                    "Ignoring request for lang output in hypotheses since the model does not use an aggregate tokenizer"
+                    "Ignoring request for lang output in hypotheses since the model does not use an aggregate\
+                          tokenizer"
                 )
 
         return hypotheses

--- a/nemo/collections/asr/parts/submodules/rnnt_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_decoding.py
@@ -67,14 +67,14 @@ class AbstractRNNTDecoding(ConfidenceMixin):
 
             rnnt_timestamp_type: A str value, which represents the types of timestamps that should be calculated.
                 Can take the following values - "char" for character/subword time stamps, "word" for word level
-                time stamps, "segment" for segment level time stamps and "all" (default), for character, 
+                time stamps, "segment" for segment level time stamps and "all" (default), for character,
                 word and segment level time stamps.
 
             word_seperator: Str token representing the seperator between words.
 
             segment_seperators: List containing tokens representing the seperator(s) between segments.
 
-            segment_gap_threshold: The threshold (in frames) that caps the gap between two words necessary 
+            segment_gap_threshold: The threshold (in frames) that caps the gap between two words necessary
             for forming the segments.
 
             preserve_frame_confidence: Bool flag which preserves the history of per-frame confidence scores
@@ -104,9 +104,9 @@ class AbstractRNNTDecoding(ConfidenceMixin):
                     The length of the list corresponds to the number of recognized words.
                 exclude_blank: Bool flag indicating that blank token confidence scores are to be excluded
                     from the `token_confidence`.
-                aggregation: Which aggregation type to use for collapsing per-token confidence into per-word 
+                aggregation: Which aggregation type to use for collapsing per-token confidence into per-word
                     confidence. Valid options are `mean`, `min`, `max`, `prod`.
-                tdt_include_duration: Bool flag indicating that the duration confidence scores are to be calculated 
+                tdt_include_duration: Bool flag indicating that the duration confidence scores are to be calculated
                     and attached to the regular frame confidence,
                     making TDT frame confidence element a pair: (`prediction_confidence`, `duration_confidence`).
                 method_cfg: A dict-like object which contains the method name and settings to compute per-frame
@@ -179,22 +179,22 @@ class AbstractRNNTDecoding(ConfidenceMixin):
                 maes_num_steps: Number of adaptive steps to take. From the paper, 2 steps is generally sufficient,
                     and can be reduced to 1 to improve decoding speed while sacrificing some accuracy. int > 0.
 
-                maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to 
+                maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to
                 keep this as 1 in order to reduce expensive beam search cost later. int >= 0.
 
                 maes_expansion_beta: Maximum number of prefix expansions allowed, in addition to the beam size.
                     Effectively, the number of hypothesis = beam_size + maes_expansion_beta. Must be an int >= 0,
-                    and affects the speed of inference since large values will perform large beam search in the 
+                    and affects the speed of inference since large values will perform large beam search in the
                     next step.
 
-                maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when computing the 
-                    expansions. The default (2.3) is selected from the paper. It performs a comparison 
-                    (max_log_prob - gamma <= log_prob[v]) where v is all vocabulary indices in the Vocab set 
+                maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when computing the
+                    expansions. The default (2.3) is selected from the paper. It performs a comparison
+                    (max_log_prob - gamma <= log_prob[v]) where v is all vocabulary indices in the Vocab set
                     and max_log_prob is the "most" likely token to be predicted. Gamma therefore provides a margin
-                    of additional tokens which can be potential candidates for expansion apart from the "most likely" 
-                    candidate. Lower values will reduce the number of expansions (by increasing pruning-by-value, 
-                    thereby improving speed but hurting accuracy). Higher values will increase the number of expansions 
-                    (by reducing pruning-by-value, thereby reducing speed but potentially improving accuracy). 
+                    of additional tokens which can be potential candidates for expansion apart from the "most likely"
+                    candidate. Lower values will reduce the number of expansions (by increasing pruning-by-value,
+                    thereby improving speed but hurting accuracy). Higher values will increase the number of expansions
+                    (by reducing pruning-by-value, thereby reducing speed but potentially improving accuracy).
                     This is a hyper parameter to be experimentally tuned on a validation set.
 
                 softmax_temperature: Scales the logits of the joint prior to computing log_softmax.
@@ -953,7 +953,7 @@ class AbstractRNNTDecoding(ConfidenceMixin):
 
             # Check if token is a punctuation mark
             # If so, set its start and end offset as start and end of the previous token
-            # This is done because there was observed a behaviour, when punctuation marks are predicted long 
+            # This is done because there was observed a behaviour, when punctuation marks are predicted long
             # after preceding token (i.e. after silence)
             if offset['char'][0] in supported_punctuation and i > 0:
                 encoded_char_offsets[i]['start_offset'] = offset['start_offset'] = char_offsets[i - 1]['end_offset']
@@ -1241,7 +1241,7 @@ class RNNTDecoding(AbstractRNNTDecoding):
                     The length of the list corresponds to the number of recognized words.
                 exclude_blank: Bool flag indicating that blank token confidence scores are to be excluded
                     from the `token_confidence`.
-                aggregation: Which aggregation type to use for collapsing per-token confidence into per-word 
+                aggregation: Which aggregation type to use for collapsing per-token confidence into per-word
                     confidence. Valid options are `mean`, `min`, `max`, `prod`.
                 tdt_include_duration: Bool flag indicating that the duration confidence scores are to be calculated
                     and attached to the regular frame confidence,
@@ -1317,7 +1317,7 @@ class RNNTDecoding(AbstractRNNTDecoding):
                         per timestep of the acoustic model. Larger values will allow longer sentences to be decoded,
                         at increased cost to execution time.
 
-                    alsd_max_target_len: optional int or float, determines the potential maximum target sequence 
+                    alsd_max_target_len: optional int or float, determines the potential maximum target sequence
                         length. If an integer is provided, it can decode sequences of that particular maximum length.
                         If a float is provided, it can decode sequences of int(alsd_max_target_len * seq_len),
                         where seq_len is the length of the acoustic model output (T).
@@ -1330,23 +1330,23 @@ class RNNTDecoding(AbstractRNNTDecoding):
                     maes_num_steps: Number of adaptive steps to take. From the paper, 2 steps is generally sufficient,
                         and can be reduced to 1 to improve decoding speed while sacrificing some accuracy. int > 0.
 
-                    maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to 
+                    maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to
                         keep this as 1 in order to reduce expensive beam search cost later. int >= 0.
 
                     maes_expansion_beta: Maximum number of prefix expansions allowed, in addition to the beam size.
                         Effectively, the number of hypothesis = beam_size + maes_expansion_beta. Must be an int >= 0,
-                        and affects the speed of inference since large values will perform large beam search in the 
+                        and affects the speed of inference since large values will perform large beam search in the
                         next step.
 
-                    maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when computing the 
+                    maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when computing the
                         expansions.
-                        The default (2.3) is selected from the paper. It performs a comparison 
-                        (max_log_prob - gamma <= log_prob[v]) where v is all vocabulary indices in the Vocab set and 
-                        max_log_prob is the "most" likely token to be predicted. Gamma therefore provides a margin of 
+                        The default (2.3) is selected from the paper. It performs a comparison
+                        (max_log_prob - gamma <= log_prob[v]) where v is all vocabulary indices in the Vocab set and
+                        max_log_prob is the "most" likely token to be predicted. Gamma therefore provides a margin of
                         additional tokens which can be potential candidates for expansion apart from the "most likely"
                         candidate. Lower values will reduce the number of expansions (by increasing pruning-by-value,
-                        thereby improving speed but hurting accuracy). Higher values will increase the number of 
-                        expansions (by reducing pruning-by-value, thereby reducing speed but potentially improving 
+                        thereby improving speed but hurting accuracy). Higher values will increase the number of
+                        expansions (by reducing pruning-by-value, thereby reducing speed but potentially improving
                         accuracy). This is a hyper parameter to be experimentally tuned on a validation set.
 
                     softmax_temperature: Scales the logits of the joint prior to computing log_softmax.
@@ -1498,7 +1498,7 @@ class RNNTBPEDecoding(AbstractRNNTDecoding):
 
             segment_seperators: List containing tokens representing the seperator(s) between segments.
 
-            segment_gap_threshold: The threshold (in frames) that caps the gap between two words necessary for 
+            segment_gap_threshold: The threshold (in frames) that caps the gap between two words necessary for
                 forming the segments.
 
             preserve_frame_confidence: Bool flag which preserves the history of per-frame confidence scores
@@ -1528,9 +1528,9 @@ class RNNTBPEDecoding(AbstractRNNTDecoding):
                     The length of the list corresponds to the number of recognized words.
                 exclude_blank: Bool flag indicating that blank token confidence scores are to be excluded
                     from the `token_confidence`.
-                aggregation: Which aggregation type to use for collapsing per-token confidence into per-word 
+                aggregation: Which aggregation type to use for collapsing per-token confidence into per-word
                     confidence. Valid options are `mean`, `min`, `max`, `prod`.
-                tdt_include_duration: Bool flag indicating that the duration confidence scores are to be 
+                tdt_include_duration: Bool flag indicating that the duration confidence scores are to be
                     calculated and attached to the regular frame confidence,
                     making TDT frame confidence element a pair: (`prediction_confidence`, `duration_confidence`).
                 method_cfg: A dict-like object which contains the method name and settings to compute per-frame
@@ -1601,7 +1601,7 @@ class RNNTBPEDecoding(AbstractRNNTDecoding):
                         per timestep of the acoustic model. Larger values will allow longer sentences to be decoded,
                         at increased cost to execution time.
 
-                    alsd_max_target_len: optional int or float, determines the potential maximum target sequence 
+                    alsd_max_target_len: optional int or float, determines the potential maximum target sequence
                         length. If an integer is provided, it can decode sequences of that particular maximum length.
                         If a float is provided, it can decode sequences of int(alsd_max_target_len * seq_len),
                         where seq_len is the length of the acoustic model output (T).
@@ -1614,23 +1614,23 @@ class RNNTBPEDecoding(AbstractRNNTDecoding):
                     maes_num_steps: Number of adaptive steps to take. From the paper, 2 steps is generally sufficient,
                         and can be reduced to 1 to improve decoding speed while sacrificing some accuracy. int > 0.
 
-                    maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to 
+                    maes_prefix_alpha: Maximum prefix length in prefix search. Must be an integer, and is advised to
                         keep this as 1 in order to reduce expensive beam search cost later. int >= 0.
 
                     maes_expansion_beta: Maximum number of prefix expansions allowed, in addition to the beam size.
                         Effectively, the number of hypothesis = beam_size + maes_expansion_beta. Must be an int >= 0,
-                        and affects the speed of inference since large values will perform large beam search in the 
+                        and affects the speed of inference since large values will perform large beam search in the
                         next step.
 
-                    maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when 
-                        computing the expansions. The default (2.3) is selected from the paper. It performs a 
-                        comparison (max_log_prob - gamma <= log_prob[v]) where v is all vocabulary indices in the 
-                        Vocab set and max_log_prob is the "most" likely token to be predicted. Gamma therefore 
-                        provides a margin of additional tokens which can be potential candidates for expansion 
+                    maes_expansion_gamma: Float pruning threshold used in the prune-by-value step when
+                        computing the expansions. The default (2.3) is selected from the paper. It performs a
+                        comparison (max_log_prob - gamma <= log_prob[v]) where v is all vocabulary indices in the
+                        Vocab set and max_log_prob is the "most" likely token to be predicted. Gamma therefore
+                        provides a margin of additional tokens which can be potential candidates for expansion
                         apart from the "most likely" candidate. Lower values will reduce the number of expansions
-                        (by increasing pruning-by-value, thereby improving speed but hurting accuracy). Higher 
-                        values will increase the number of expansions (by reducing pruning-by-value, thereby 
-                        reducing speed but potentially improving accuracy). This is a hyper parameter to be 
+                        (by increasing pruning-by-value, thereby improving speed but hurting accuracy). Higher
+                        values will increase the number of expansions (by reducing pruning-by-value, thereby
+                        reducing speed but potentially improving accuracy). This is a hyper parameter to be
                         experimentally tuned on a validation set.
 
                     softmax_temperature: Scales the logits of the joint prior to computing log_softmax.

--- a/nemo/collections/asr/parts/submodules/rnnt_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_decoding.py
@@ -887,7 +887,7 @@ class AbstractRNNTDecoding(ConfidenceMixin):
 
         # Construct the start and end indices brackets
         end_indices = np.asarray(token_repetitions).cumsum()
-        start_indices = np.concatenate(([start_index], end_indices[:-1]))
+        start_indices = np.concatenate(([int(start_index)], end_indices[:-1]))
 
         # Process the TxU dangling alignment tensor, containing pairs of (logits, label)
         alignment_labels = [al_logits_labels for al_logits_labels in hypothesis.text[1]]

--- a/nemo/collections/asr/parts/utils/streaming_utils.py
+++ b/nemo/collections/asr/parts/utils/streaming_utils.py
@@ -22,7 +22,7 @@ from omegaconf import OmegaConf
 from torch.utils.data import DataLoader
 
 from nemo.collections.asr.data.audio_to_text_lhotse_prompted import PromptedAudioToTextMiniBatch
-from nemo.collections.asr.models.ctc_bpe_models import EncDecCTCModelBPE
+from nemo.collections.asr.models import ASRModel
 from nemo.collections.asr.parts.mixins.streaming import StreamingEncoder
 from nemo.collections.asr.parts.preprocessing.features import normalize_batch
 from nemo.collections.asr.parts.preprocessing.segment import get_samples
@@ -391,7 +391,7 @@ class StreamingFeatureBufferer:
         cfg.preprocessor.dither = 0.0
         cfg.preprocessor.pad_to = 0
         cfg.preprocessor.normalize = "None"
-        self.raw_preprocessor = EncDecCTCModelBPE.from_config_dict(cfg.preprocessor)
+        self.raw_preprocessor = ASRModel.from_config_dict(cfg.preprocessor)
         self.raw_preprocessor.to(asr_model.device)
 
     def reset(self):
@@ -756,7 +756,7 @@ class FrameBatchASR:
         cfg.preprocessor.dither = 0.0
         cfg.preprocessor.pad_to = 0
         cfg.preprocessor.normalize = "None"
-        self.raw_preprocessor = EncDecCTCModelBPE.from_config_dict(cfg.preprocessor)
+        self.raw_preprocessor = ASRModel.from_config_dict(cfg.preprocessor)
         self.raw_preprocessor.to(asr_model.device)
         self.preprocessor = self.raw_preprocessor
 

--- a/nemo/collections/asr/parts/utils/streaming_utils.py
+++ b/nemo/collections/asr/parts/utils/streaming_utils.py
@@ -79,8 +79,8 @@ def longest_common_subsequence_merge(X, Y, filepath=None):
 
     Assumption is that the two chunks are consecutive chunks, and there exists at least small overlap acoustically.
 
-    It is a sub-word token merge algorithm, operating on the abstract notion of integer ids representing the subword ids.
-    It is independent of text or character encoding.
+    It is a sub-word token merge algorithm, operating on the abstract notion of integer ids representing 
+    the subword ids. It is independent of text or character encoding.
 
     Since the algorithm is merge based, and depends on consecutive buffers, the very first buffer is processes using
     the "middle tokens" algorithm.
@@ -292,8 +292,8 @@ def lcs_alignment_merge_buffer(buffer, data, delay, model, max_steps_per_timeste
     Merges the new text from the current frame with the previous text contained in the buffer.
 
     The alignment is based on a Longest Common Subsequence algorithm, with some additional heuristics leveraging
-    the notion that the chunk size is >= the context window. In case this assumptio is violated, the results of the merge
-    will be incorrect (or at least obtain worse WER overall).
+    the notion that the chunk size is >= the context window. In case this assumptio is violated, the results of the
+    merge will be incorrect (or at least obtain worse WER overall).
     """
     # If delay timesteps is 0, that means no future context was used. Simply concatenate the buffer with new data.
     if delay < 1:
@@ -327,8 +327,8 @@ def inplace_buffer_merge(buffer, data, timesteps, model):
     Merges the new text from the current frame with the previous text contained in the buffer.
 
     The alignment is based on a Longest Common Subsequence algorithm, with some additional heuristics leveraging
-    the notion that the chunk size is >= the context window. In case this assumptio is violated, the results of the merge
-    will be incorrect (or at least obtain worse WER overall).
+    the notion that the chunk size is >= the context window. In case this assumptio is violated, the results of 
+    the merge will be incorrect (or at least obtain worse WER overall).
     """
     # If delay timesteps is 0, that means no future context was used. Simply concatenate the buffer with new data.
     if timesteps < 1:
@@ -1091,12 +1091,15 @@ class BatchedFrameASRRNNT(FrameBatchASR):
             -   For all samples, determine if signal has finished.
                 -   If so, skip calculation of mel-specs.
                 -   If not, compute mel spec and length
-            -   Perform Encoder forward over this sub-batch of samples. Maintain the indices of samples that were processed.
-            -   If performing stateful decoding, prior to decoder forward, remove the states of samples that were not processed.
+            -   Perform Encoder forward over this sub-batch of samples. Maintain the indices of samples that 
+                were processed.
+            -   If performing stateful decoding, prior to decoder forward, remove the states of samples that 
+                were not processed.
             -   Perform Decoder + Joint forward for samples that were processed.
             -   For all output RNNT alignment matrix of the joint do:
                 -   If signal has ended previously (this was last buffer of padding), skip alignment
-                -   Otherwise, recalculate global index of this sample from the sub-batch index, and preserve alignment.
+                -   Otherwise, recalculate global index of this sample from the sub-batch index, and preserve 
+                alignment.
             -   Same for preds
             -   Update indices of sub-batch with global index map.
             - Redo steps until all samples were processed (sub-batch size == 0).
@@ -1362,15 +1365,17 @@ class LongestCommonSubsequenceBatchedFrameASRRNNT(BatchedFrameASRRNNT):
 
 class CacheAwareStreamingAudioBuffer:
     """
-    A buffer to be used for cache-aware streaming. It can load a single or multiple audio files/processed signals, split them in chunks and return one on one.
-    It can be used to simulate streaming audio or audios.
+    A buffer to be used for cache-aware streaming. It can load a single or multiple audio 
+    files/processed signals, split them in chunks and return one on one. It can be used to 
+    simulate streaming audio or audios.
     """
 
     def __init__(self, model, online_normalization=None, pad_and_drop_preencoded=False):
         '''
         Args:
             model: An ASR model.
-            online_normalization (bool): whether to perform online normalization per chunk or normalize the whole audio before chunking
+            online_normalization (bool): whether to perform online normalization per chunk or 
+            normalize the whole audio before chunking
             pad_and_drop_preencoded (bool): if true pad first audio chunk and always drop preencoded
         '''
         self.model = model
@@ -1430,7 +1435,8 @@ class CacheAwareStreamingAudioBuffer:
             audio_chunk = self.buffer[:, :, self.buffer_idx : self.buffer_idx + chunk_size]
 
             if self.sampling_frames is not None:
-                # checking to make sure the audio chunk has enough frames to produce at least one output after downsampling
+                # checking to make sure the audio chunk has enough frames to produce at least one output after 
+                # downsampling
                 if self.buffer_idx == 0 and isinstance(self.sampling_frames, list):
                     cur_sampling_frames = self.sampling_frames[0]
                 else:

--- a/nemo/collections/asr/parts/utils/streaming_utils.py
+++ b/nemo/collections/asr/parts/utils/streaming_utils.py
@@ -79,7 +79,7 @@ def longest_common_subsequence_merge(X, Y, filepath=None):
 
     Assumption is that the two chunks are consecutive chunks, and there exists at least small overlap acoustically.
 
-    It is a sub-word token merge algorithm, operating on the abstract notion of integer ids representing 
+    It is a sub-word token merge algorithm, operating on the abstract notion of integer ids representing
     the subword ids. It is independent of text or character encoding.
 
     Since the algorithm is merge based, and depends on consecutive buffers, the very first buffer is processes using
@@ -327,7 +327,7 @@ def inplace_buffer_merge(buffer, data, timesteps, model):
     Merges the new text from the current frame with the previous text contained in the buffer.
 
     The alignment is based on a Longest Common Subsequence algorithm, with some additional heuristics leveraging
-    the notion that the chunk size is >= the context window. In case this assumptio is violated, the results of 
+    the notion that the chunk size is >= the context window. In case this assumptio is violated, the results of
     the merge will be incorrect (or at least obtain worse WER overall).
     """
     # If delay timesteps is 0, that means no future context was used. Simply concatenate the buffer with new data.
@@ -1091,14 +1091,14 @@ class BatchedFrameASRRNNT(FrameBatchASR):
             -   For all samples, determine if signal has finished.
                 -   If so, skip calculation of mel-specs.
                 -   If not, compute mel spec and length
-            -   Perform Encoder forward over this sub-batch of samples. Maintain the indices of samples that 
+            -   Perform Encoder forward over this sub-batch of samples. Maintain the indices of samples that
                 were processed.
-            -   If performing stateful decoding, prior to decoder forward, remove the states of samples that 
+            -   If performing stateful decoding, prior to decoder forward, remove the states of samples that
                 were not processed.
             -   Perform Decoder + Joint forward for samples that were processed.
             -   For all output RNNT alignment matrix of the joint do:
                 -   If signal has ended previously (this was last buffer of padding), skip alignment
-                -   Otherwise, recalculate global index of this sample from the sub-batch index, and preserve 
+                -   Otherwise, recalculate global index of this sample from the sub-batch index, and preserve
                 alignment.
             -   Same for preds
             -   Update indices of sub-batch with global index map.
@@ -1365,8 +1365,8 @@ class LongestCommonSubsequenceBatchedFrameASRRNNT(BatchedFrameASRRNNT):
 
 class CacheAwareStreamingAudioBuffer:
     """
-    A buffer to be used for cache-aware streaming. It can load a single or multiple audio 
-    files/processed signals, split them in chunks and return one on one. It can be used to 
+    A buffer to be used for cache-aware streaming. It can load a single or multiple audio
+    files/processed signals, split them in chunks and return one on one. It can be used to
     simulate streaming audio or audios.
     """
 
@@ -1374,7 +1374,7 @@ class CacheAwareStreamingAudioBuffer:
         '''
         Args:
             model: An ASR model.
-            online_normalization (bool): whether to perform online normalization per chunk or 
+            online_normalization (bool): whether to perform online normalization per chunk or
             normalize the whole audio before chunking
             pad_and_drop_preencoded (bool): if true pad first audio chunk and always drop preencoded
         '''
@@ -1435,7 +1435,7 @@ class CacheAwareStreamingAudioBuffer:
             audio_chunk = self.buffer[:, :, self.buffer_idx : self.buffer_idx + chunk_size]
 
             if self.sampling_frames is not None:
-                # checking to make sure the audio chunk has enough frames to produce at least one output after 
+                # checking to make sure the audio chunk has enough frames to produce at least one output after
                 # downsampling
                 if self.buffer_idx == 0 and isinstance(self.sampling_frames, list):
                     cur_sampling_frames = self.sampling_frames[0]

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -572,6 +572,12 @@ def process_timestamp_outputs(outputs, subsampling_factor: int = 1, window_strid
     """
     Process the timestamps from list of hypothesis to user friendly format.
     Converts the start and end duration from frames to seconds.
+    Args:
+        outputs: List of Hypothesis objects.
+        subsampling_factor: int, Subsampling factor used in the model.
+        window_stride: float, Window stride used in the model. (sometimes referred to as hop length/shift)
+    Returns:
+        List of Hypothesis objects with processed timestamps
 
     """
 
@@ -585,6 +591,10 @@ def process_timestamp_outputs(outputs, subsampling_factor: int = 1, window_strid
         raise ValueError(f"Expected Hypothesis object, got {type(outputs[0])}")
 
     def process_timestamp(timestamp, subsampling_factor, window_stride):
+        """
+        Process the timestamp for a single hypothesis.
+        return the start and end duration in seconds.
+        """
         for idx, val in enumerate(timestamp):
             start_offset = val['start_offset']
             end_offset = val['end_offset']

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -199,7 +199,8 @@ def get_buffered_pred_feat_multitaskAED(
 
     if filepaths:
         logging.info(
-            "Deteced audio files as input, default to English ASR with Punctuation and Capitalization output. Please use manifest input for other options."
+            "Deteced audio files as input, default to English ASR with Punctuation and Capitalization output. \
+                Please use manifest input for other options."
         )
         for audio_file in tqdm(filepaths, desc="Transcribing:", total=len(filepaths), ncols=80):
             meta = {
@@ -281,12 +282,16 @@ def prepare_audio_data(cfg: DictConfig) -> Tuple[List[str], bool]:
             - append_pred (bool): Flag indicating whether to append predictions to an existing dataset.
             - audio_type (str): Type of audio files to consider.
             - dataset_manifest (str): Path to the dataset manifest file.
-            - audio_key (str, optional): Key in the manifest file specifying the audio file path. Defaults to 'audio_filepath'.
-            - presort_manifest (bool, optional): Flag indicating whether to presort the manifest file. Defaults to True.
+            - audio_key (str, optional): Key in the manifest file specifying the audio file path. 
+                Defaults to 'audio_filepath'.
+            - presort_manifest (bool, optional): Flag indicating whether to presort the manifest file. 
+                Defaults to True.
     Returns:
         Tuple[List[str], bool]: A tuple containing the following:
-            - filepaths (List[str]): List of filepaths to the audio files if path to the directory containing audio files is provided.
-            - sorted_manifest_path (bool): Path to the sorted manifest file if path to the dataset manifest file is provided.
+            - filepaths (List[str]): List of filepaths to the audio files if path to the directory 
+                containing audio files is provided.
+            - sorted_manifest_path (bool): Path to the sorted manifest file if path to the dataset 
+                manifest file is provided.
     """
 
     filepaths = None
@@ -308,7 +313,8 @@ def prepare_audio_data(cfg: DictConfig) -> Tuple[List[str], bool]:
                 item[audio_key] = get_full_path(item[audio_key], cfg.dataset_manifest)
                 if item.get("duration") is None and cfg.presort_manifest:
                     raise ValueError(
-                        f"Requested presort_manifest=True, but line {line} in manifest {cfg.dataset_manifest} lacks a 'duration' field."
+                        f"Requested presort_manifest=True, but line {line} in manifest {cfg.dataset_manifest} \
+                            lacks a 'duration' field."
                     )
 
         with NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
@@ -492,10 +498,14 @@ def compute_metrics_per_sample(
 
     Args:
         manifest_path: str, Required - path to dataset JSON manifest file (in NeMo format)
-        reference_field: str, Optional - name of field in .json manifest with the reference text ("text" by default).
-        hypothesis_field: str, Optional - name of field in .json manifest with the hypothesis text ("pred_text" by default).
-        metrics: list[str], Optional - list of metrics to be computed (currently supported "wer", "cer", "punct_er")
-        punctuation_marks: list[str], Optional - list of punctuation marks for computing punctuation error rate ([".", ",", "?"] by default).
+        reference_field: str, Optional - name of field in .json manifest with the reference text 
+            ("text" by default).
+        hypothesis_field: str, Optional - name of field in .json manifest with the hypothesis text 
+            ("pred_text" by default).
+        metrics: list[str], Optional - list of metrics to be computed 
+            (currently supported "wer", "cer", "punct_er")
+        punctuation_marks: list[str], Optional - list of punctuation marks for computing 
+            punctuation error rate ([".", ",", "?"] by default).
         output_manifest_path: str, Optional - path where .json manifest with calculated metrics will be saved.
 
     Returns:
@@ -608,7 +618,8 @@ def process_timestamp_outputs(outputs, subsampling_factor: int = 1, window_strid
     for idx, hyp in enumerate(outputs):
         if not hasattr(hyp, 'timestep'):
             raise ValueError(
-                f"Expected Hypothesis object to have 'timestep' attribute, when compute_timestamps is enabled but got {hyp}"
+                f"Expected Hypothesis object to have 'timestep' attribute, when compute_timestamps is \
+                    enabled but got {hyp}"
             )
         timestep = hyp.timestep
         if 'word' in timestep:

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -586,7 +586,7 @@ def process_timestamp_outputs(outputs, subsampling_factor: int = 1, window_strid
 
     if isinstance(outputs, rnnt_utils.Hypothesis):
         outputs = [outputs]
-    
+
     if not isinstance(outputs[0], rnnt_utils.Hypothesis):
         raise ValueError(f"Expected Hypothesis object, got {type(outputs[0])}")
 
@@ -604,19 +604,23 @@ def process_timestamp_outputs(outputs, subsampling_factor: int = 1, window_strid
             val['end'] = end
 
         return timestamp
-    
+
     for idx, hyp in enumerate(outputs):
         if not hasattr(hyp, 'timestep'):
-            raise ValueError(f"Expected Hypothesis object to have 'timestep' attribute, when compute_timestamps is enabled but got {hyp}")
+            raise ValueError(
+                f"Expected Hypothesis object to have 'timestep' attribute, when compute_timestamps is enabled but got {hyp}"
+            )
         timestep = hyp.timestep
         if 'word' in timestep:
             outputs[idx].timestep['word'] = process_timestamp(timestep['word'], subsampling_factor, window_stride)
         if 'char' in timestep:
             outputs[idx].timestep['char'] = process_timestamp(timestep['char'], subsampling_factor, window_stride)
         if 'segment' in timestep:
-            outputs[idx].timestep['segment'] = process_timestamp(timestep['segment'], subsampling_factor, window_stride)
+            outputs[idx].timestep['segment'] = process_timestamp(
+                timestep['segment'], subsampling_factor, window_stride
+            )
     return outputs
-        
+
 
 class PunctuationCapitalization:
     def __init__(self, punctuation_marks: str):

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -388,7 +388,7 @@ def write_transcription(
     model_name: str,
     filepaths: List[str] = None,
     compute_langs: bool = False,
-    compute_timestamps: bool = False,
+    timestamps: bool = False,
 ) -> Tuple[str, str]:
     """Write generated transcription to output file."""
     if cfg.append_pred:
@@ -433,7 +433,7 @@ def write_transcription(
                 else:  # transcription is Hypothesis
                     item = {'audio_filepath': filepaths[idx], pred_text_attr_name: transcription.text}
 
-                    if compute_timestamps:
+                    if timestamps:
                         timestamps = transcription.timestep
                         if timestamps is not None and isinstance(timestamps, dict):
                             timestamps.pop(
@@ -441,7 +441,7 @@ def write_transcription(
                             )  # Pytorch tensor calculating index of each token, not needed.
                             for key in timestamps.keys():
                                 values = normalize_timestamp_output(timestamps[key])
-                                item[f'timestamps_{key}'] = values
+                                item[f'{key}'] = values
 
                     if compute_langs:
                         item['pred_lang'] = transcription.langs
@@ -458,7 +458,7 @@ def write_transcription(
                     else:  # transcription is Hypothesis
                         item[pred_text_attr_name] = best_hyps[idx].text
 
-                        if compute_timestamps:
+                        if timestamps:
                             timestamps = best_hyps[idx].timestep
                             if timestamps is not None and isinstance(timestamps, dict):
                                 timestamps.pop(
@@ -466,7 +466,7 @@ def write_transcription(
                                 )  # Pytorch tensor calculating index of each token, not needed.
                                 for key in timestamps.keys():
                                     values = normalize_timestamp_output(timestamps[key])
-                                    item[f'timestamps_{key}'] = values
+                                    item[f'{key}'] = values
 
                         if compute_langs:
                             item['pred_lang'] = best_hyps[idx].langs

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -282,15 +282,15 @@ def prepare_audio_data(cfg: DictConfig) -> Tuple[List[str], bool]:
             - append_pred (bool): Flag indicating whether to append predictions to an existing dataset.
             - audio_type (str): Type of audio files to consider.
             - dataset_manifest (str): Path to the dataset manifest file.
-            - audio_key (str, optional): Key in the manifest file specifying the audio file path. 
+            - audio_key (str, optional): Key in the manifest file specifying the audio file path.
                 Defaults to 'audio_filepath'.
-            - presort_manifest (bool, optional): Flag indicating whether to presort the manifest file. 
+            - presort_manifest (bool, optional): Flag indicating whether to presort the manifest file.
                 Defaults to True.
     Returns:
         Tuple[List[str], bool]: A tuple containing the following:
-            - filepaths (List[str]): List of filepaths to the audio files if path to the directory 
+            - filepaths (List[str]): List of filepaths to the audio files if path to the directory
                 containing audio files is provided.
-            - sorted_manifest_path (bool): Path to the sorted manifest file if path to the dataset 
+            - sorted_manifest_path (bool): Path to the sorted manifest file if path to the dataset
                 manifest file is provided.
     """
 
@@ -498,13 +498,13 @@ def compute_metrics_per_sample(
 
     Args:
         manifest_path: str, Required - path to dataset JSON manifest file (in NeMo format)
-        reference_field: str, Optional - name of field in .json manifest with the reference text 
+        reference_field: str, Optional - name of field in .json manifest with the reference text
             ("text" by default).
-        hypothesis_field: str, Optional - name of field in .json manifest with the hypothesis text 
+        hypothesis_field: str, Optional - name of field in .json manifest with the hypothesis text
             ("pred_text" by default).
-        metrics: list[str], Optional - list of metrics to be computed 
+        metrics: list[str], Optional - list of metrics to be computed
             (currently supported "wer", "cer", "punct_er")
-        punctuation_marks: list[str], Optional - list of punctuation marks for computing 
+        punctuation_marks: list[str], Optional - list of punctuation marks for computing
             punctuation error rate ([".", ",", "?"] by default).
         output_manifest_path: str, Optional - path where .json manifest with calculated metrics will be saved.
 

--- a/nemo/collections/asr/parts/utils/transcribe_utils.py
+++ b/nemo/collections/asr/parts/utils/transcribe_utils.py
@@ -568,6 +568,46 @@ def compute_metrics_per_sample(
     return samples_with_metrics
 
 
+def process_timestamp_outputs(outputs, subsampling_factor: int = 1, window_stride: float = 0.01):
+    """
+    Process the timestamps from list of hypothesis to user friendly format.
+    Converts the start and end duration from frames to seconds.
+
+    """
+
+    if outputs is None:
+        return outputs
+
+    if isinstance(outputs, rnnt_utils.Hypothesis):
+        outputs = [outputs]
+    
+    if not isinstance(outputs[0], rnnt_utils.Hypothesis):
+        raise ValueError(f"Expected Hypothesis object, got {type(outputs[0])}")
+
+    def process_timestamp(timestamp, subsampling_factor, window_stride):
+        for idx, val in enumerate(timestamp):
+            start_offset = val['start_offset']
+            end_offset = val['end_offset']
+            start = start_offset * window_stride * subsampling_factor
+            end = end_offset * window_stride * subsampling_factor
+            val['start'] = start
+            val['end'] = end
+
+        return timestamp
+    
+    for idx, hyp in enumerate(outputs):
+        if not hasattr(hyp, 'timestep'):
+            raise ValueError(f"Expected Hypothesis object to have 'timestep' attribute, when compute_timestamps is enabled but got {hyp}")
+        timestep = hyp.timestep
+        if 'word' in timestep:
+            outputs[idx].timestep['word'] = process_timestamp(timestep['word'], subsampling_factor, window_stride)
+        if 'char' in timestep:
+            outputs[idx].timestep['char'] = process_timestamp(timestep['char'], subsampling_factor, window_stride)
+        if 'segment' in timestep:
+            outputs[idx].timestep['segment'] = process_timestamp(timestep['segment'], subsampling_factor, window_stride)
+    return outputs
+        
+
 class PunctuationCapitalization:
     def __init__(self, punctuation_marks: str):
         """

--- a/tests/collections/asr/conftest.py
+++ b/tests/collections/asr/conftest.py
@@ -14,11 +14,12 @@
 
 from dataclasses import dataclass
 from typing import Optional, Type
-from nemo.collections.asr.models import ASRModel
 
 import numpy as np
 import pytest
 import torch
+
+from nemo.collections.asr.models import ASRModel
 
 
 class RNNTTestHelper:
@@ -355,13 +356,16 @@ def rnnt_test_helper() -> Type[RNNTTestHelper]:
 def rnn_loss_sample_data() -> Type[RnntLossSampleData]:
     return RnntLossSampleData
 
+
 @pytest.fixture(scope='session')
 def fast_conformer_transducer_model():
     return ASRModel.from_pretrained("stt_en_fastconformer_transducer_large")
 
+
 @pytest.fixture(scope='session')
 def fast_conformer_ctc_model():
     return ASRModel.from_pretrained("stt_en_fastconformer_ctc_large")
+
 
 @pytest.fixture(scope='session')
 def fast_conformer_hybrid_model():

--- a/tests/collections/asr/conftest.py
+++ b/tests/collections/asr/conftest.py
@@ -14,6 +14,7 @@
 
 from dataclasses import dataclass
 from typing import Optional, Type
+from nemo.collections.asr.models import ASRModel
 
 import numpy as np
 import pytest
@@ -353,3 +354,15 @@ def rnnt_test_helper() -> Type[RNNTTestHelper]:
 @pytest.fixture(scope="session")
 def rnn_loss_sample_data() -> Type[RnntLossSampleData]:
     return RnntLossSampleData
+
+@pytest.fixture(scope='session')
+def fast_conformer_transducer_model():
+    return ASRModel.from_pretrained("stt_en_fastconformer_transducer_large")
+
+@pytest.fixture(scope='session')
+def fast_conformer_ctc_model():
+    return ASRModel.from_pretrained("stt_en_fastconformer_ctc_large")
+
+@pytest.fixture(scope='session')
+def fast_conformer_hybrid_model():
+    return ASRModel.from_pretrained("parakeet-tdt_ctc-110m")

--- a/tests/collections/asr/mixins/test_transcription.py
+++ b/tests/collections/asr/mixins/test_transcription.py
@@ -23,7 +23,6 @@ import torch
 from torch.utils.data import DataLoader, Dataset
 
 from nemo.collections.asr.data.audio_to_text import _speech_collate_fn
-from nemo.collections.asr.models import ASRModel
 from nemo.collections.asr.parts.mixins import TranscribeConfig, TranscriptionMixin
 from nemo.collections.asr.parts.mixins.transcription import GenericTranscriptionType
 from nemo.collections.asr.parts.utils import Hypothesis
@@ -42,6 +41,22 @@ class DummyModel(torch.nn.Module):
         # Input: [1, 1] Output = [1, 1
         out = self.encoder(x)
         return out
+
+
+@pytest.mark.with_downloads()
+@pytest.fixture()
+def audio_files(test_data_dir):
+    """
+    Returns a list of audio files for testing.
+    """
+    import soundfile as sf
+    audio_file1 = os.path.join(test_data_dir, "asr", "train", "an4", "wav", "an46-mmap-b.wav")
+    audio_file2 = os.path.join(test_data_dir, "asr", "train", "an4", "wav", "an104-mrcb-b.wav")
+
+    audio1, _ = sf.read(audio_file1, dtype='float32')
+    audio2, _ = sf.read(audio_file2, dtype='float32')
+
+    return audio1, audio2
 
 
 class TranscribableDummy(DummyModel, TranscriptionMixin):
@@ -295,14 +310,12 @@ class TestTranscriptionMixin:
         assert outputs[0][2] == 3.0
 
     pytest.mark.with_downloads()
-
     @pytest.mark.unit
-    def test_transcribe_return_hypothesis(self, test_data_dir):
-        model = ASRModel.from_pretrained("stt_en_conformer_ctc_small")
+    def test_transcribe_return_hypothesis(self, test_data_dir, fast_conformer_ctc_model):
         audio_file = os.path.join(test_data_dir, "asr", "train", "an4", "wav", "an46-mmap-b.wav")
 
-        # Numpy array test
-        outputs = model.transcribe(audio_file, batch_size=1, return_hypotheses=True)
+        # Audio file test
+        outputs = fast_conformer_ctc_model.transcribe(audio_file, batch_size=1, return_hypotheses=True)
         assert len(outputs) == 1
         assert isinstance(outputs[0], Hypothesis)
 
@@ -313,62 +326,86 @@ class TestTranscriptionMixin:
 
     @pytest.mark.with_downloads()
     @pytest.mark.unit
-    def test_transcribe_tensor(self, test_data_dir):
-        model = ASRModel.from_pretrained("stt_en_conformer_ctc_small")
-
-        # Load audio file
-        import soundfile as sf
-
-        audio_file = os.path.join(test_data_dir, "asr", "train", "an4", "wav", "an46-mmap-b.wav")
-        audio, sr = sf.read(audio_file, dtype='float32')
-
+    def test_transcribe_tensor(self, audio_files, fast_conformer_ctc_model):
+        
+        audio, _ = audio_files
         # Numpy array test
-        outputs = model.transcribe(audio, batch_size=1)
+        outputs = fast_conformer_ctc_model.transcribe(audio, batch_size=1)
         assert len(outputs) == 1
         assert isinstance(outputs[0], str)
 
     @pytest.mark.with_downloads()
     @pytest.mark.unit
-    def test_transcribe_multiple_tensor(self, test_data_dir):
-        model = ASRModel.from_pretrained("stt_en_conformer_ctc_small")
+    def test_transcribe_multiple_tensor(self, audio_files, fast_conformer_ctc_model):
 
-        # Load audio file
-        import soundfile as sf
-
-        audio_file = os.path.join(test_data_dir, "asr", "train", "an4", "wav", "an46-mmap-b.wav")
-        audio, sr = sf.read(audio_file, dtype='float32')
-
-        audio_file_2 = os.path.join(test_data_dir, "asr", "train", "an4", "wav", "an104-mrcb-b.wav")
-        audio_2, sr = sf.read(audio_file_2, dtype='float32')
+        audio, audio_2 = audio_files
         # Mix second audio to torch.tensor()
         audio_2 = torch.tensor(audio_2)
 
         # Numpy array test
-        outputs = model.transcribe([audio, audio_2], batch_size=2)
+        outputs = fast_conformer_ctc_model.transcribe([audio, audio_2], batch_size=2)
         assert len(outputs) == 2
         assert isinstance(outputs[0], str)
         assert isinstance(outputs[1], str)
 
     @pytest.mark.with_downloads()
     @pytest.mark.unit
-    def test_transcribe_dataloader(self, test_data_dir):
-        model = ASRModel.from_pretrained("stt_en_conformer_ctc_small")
+    def test_transcribe_dataloader(self, audio_files, fast_conformer_ctc_model):
 
-        # Load audio file
-        import soundfile as sf
-
-        audio_file = os.path.join(test_data_dir, "asr", "train", "an4", "wav", "an46-mmap-b.wav")
-        audio, sr = sf.read(audio_file, dtype='float32')
-
-        audio_file2 = os.path.join(test_data_dir, "asr", "train", "an4", "wav", "an152-mwhw-b.wav")
-        audio2, sr = sf.read(audio_file2, dtype='float32')
-
+        audio, audio2 = audio_files
+        
         dataset = DummyDataset([audio, audio2])
         collate_fn = lambda x: _speech_collate_fn(x, pad_id=0)
         dataloader = DataLoader(dataset, batch_size=2, shuffle=False, num_workers=0, collate_fn=collate_fn)
 
         # DataLoader test
-        outputs = model.transcribe(dataloader, batch_size=1)
+        outputs = fast_conformer_ctc_model.transcribe(dataloader, batch_size=1)
         assert len(outputs) == 2
         assert isinstance(outputs[0], str)
         assert isinstance(outputs[1], str)
+
+    @pytest.mark.with_downloads()
+    @pytest.mark.unit
+    def test_timestamps_with_transcribe(self, audio_files, fast_conformer_ctc_model):
+        audio1, audio2 = audio_files
+
+        output = fast_conformer_ctc_model.transcribe([audio1,audio2], timestamps=True)
+
+        # check len of output 
+        assert len(output)==2
+
+        # check hypothesis object 
+        assert isinstance(output[0], Hypothesis)
+        # check transcript 
+        assert output[0].text == 'stop'
+        assert output[1].text == 'start'
+
+        # check timestamp
+        assert output[0].timestep['segment'][0]['start'] == pytest.approx(0.4)
+        assert output[0].timestep['segment'][0]['end'] == pytest.approx(0.48)
+
+    
+    @pytest.mark.with_downloads()
+    @pytest.mark.unit
+    def test_timestamps_with_transcribe_hybrid(self, audio_files, fast_conformer_hybrid_model):
+        audio1, audio2 = audio_files
+
+        output = fast_conformer_hybrid_model.transcribe([audio1,audio2], timestamps=True)
+
+        # check len of output 
+        assert len(output)==2
+
+        output = output[1] # Transducer returns tuple
+
+        # check hypothesis object 
+        assert isinstance(output[0], Hypothesis)
+        # check transcript 
+        assert output[0].text == 'Stop?'
+        assert output[1].text == 'Start.'
+
+        # check timestamp
+        assert output[0].timestep['segment'][0]['start'] == pytest.approx(0.48)
+        assert output[0].timestep['segment'][0]['end'] == pytest.approx(0.72)
+
+
+        

--- a/tests/collections/asr/mixins/test_transcription.py
+++ b/tests/collections/asr/mixins/test_transcription.py
@@ -50,6 +50,7 @@ def audio_files(test_data_dir):
     Returns a list of audio files for testing.
     """
     import soundfile as sf
+
     audio_file1 = os.path.join(test_data_dir, "asr", "train", "an4", "wav", "an46-mmap-b.wav")
     audio_file2 = os.path.join(test_data_dir, "asr", "train", "an4", "wav", "an104-mrcb-b.wav")
 
@@ -310,6 +311,7 @@ class TestTranscriptionMixin:
         assert outputs[0][2] == 3.0
 
     pytest.mark.with_downloads()
+
     @pytest.mark.unit
     def test_transcribe_return_hypothesis(self, test_data_dir, fast_conformer_ctc_model):
         audio_file = os.path.join(test_data_dir, "asr", "train", "an4", "wav", "an46-mmap-b.wav")
@@ -327,7 +329,7 @@ class TestTranscriptionMixin:
     @pytest.mark.with_downloads()
     @pytest.mark.unit
     def test_transcribe_tensor(self, audio_files, fast_conformer_ctc_model):
-        
+
         audio, _ = audio_files
         # Numpy array test
         outputs = fast_conformer_ctc_model.transcribe(audio, batch_size=1)
@@ -353,7 +355,7 @@ class TestTranscriptionMixin:
     def test_transcribe_dataloader(self, audio_files, fast_conformer_ctc_model):
 
         audio, audio2 = audio_files
-        
+
         dataset = DummyDataset([audio, audio2])
         collate_fn = lambda x: _speech_collate_fn(x, pad_id=0)
         dataloader = DataLoader(dataset, batch_size=2, shuffle=False, num_workers=0, collate_fn=collate_fn)
@@ -369,14 +371,14 @@ class TestTranscriptionMixin:
     def test_timestamps_with_transcribe(self, audio_files, fast_conformer_ctc_model):
         audio1, audio2 = audio_files
 
-        output = fast_conformer_ctc_model.transcribe([audio1,audio2], timestamps=True)
+        output = fast_conformer_ctc_model.transcribe([audio1, audio2], timestamps=True)
 
-        # check len of output 
-        assert len(output)==2
+        # check len of output
+        assert len(output) == 2
 
-        # check hypothesis object 
+        # check hypothesis object
         assert isinstance(output[0], Hypothesis)
-        # check transcript 
+        # check transcript
         assert output[0].text == 'stop'
         assert output[1].text == 'start'
 
@@ -384,28 +386,24 @@ class TestTranscriptionMixin:
         assert output[0].timestep['segment'][0]['start'] == pytest.approx(0.4)
         assert output[0].timestep['segment'][0]['end'] == pytest.approx(0.48)
 
-    
     @pytest.mark.with_downloads()
     @pytest.mark.unit
     def test_timestamps_with_transcribe_hybrid(self, audio_files, fast_conformer_hybrid_model):
         audio1, audio2 = audio_files
 
-        output = fast_conformer_hybrid_model.transcribe([audio1,audio2], timestamps=True)
+        output = fast_conformer_hybrid_model.transcribe([audio1, audio2], timestamps=True)
 
-        # check len of output 
-        assert len(output)==2
+        # check len of output
+        assert len(output) == 2
 
-        output = output[1] # Transducer returns tuple
+        output = output[1]  # Transducer returns tuple
 
-        # check hypothesis object 
+        # check hypothesis object
         assert isinstance(output[0], Hypothesis)
-        # check transcript 
+        # check transcript
         assert output[0].text == 'Stop?'
         assert output[1].text == 'Start.'
 
         # check timestamp
         assert output[0].timestep['segment'][0]['start'] == pytest.approx(0.48)
         assert output[0].timestep['segment'][0]['end'] == pytest.approx(0.72)
-
-
-        


### PR DESCRIPTION
# What does this PR do ?

Adds support for extracting timestamps to .transcribe() method

**Collection**: ASR

# Changelog 
- Add timestamps=None/True/False to .transcribe() method in mixin
   - None: does nothing, restores state set outside with set_decoding_stratergy (default)
   - True: Enables timestamping with help of return_hypothesis and compute_timestamps setting to decoding_stratergy
   - False: Disables timestamping by disabling return_hypothesis and compute_timestamps to decoding_stratergy
- Adds corresponding support in
   - ctc_models.py
   - rnnt_models.py
   - hybrid_rnnt-ctc_models.py
   - Raise a notimplemented error for AED Based Models (Canary)
- Adds support to transcribe_speech.py
   - merges two variables to one: (compute_timestamps, preserve_alignments  -> timestamps) as both are mutually dependent 
   - cleans much of the code 
- Add optional verbose=True option to change_decoding_strategy method. Default is True
- Move some of model loading to conftest.py to improve setup time for each module
- Add unit test for timestamps option for ctc and hybrid models

# Usage

## From command-line
### with transcribe_speech.py script
```bash
python transcribe_speech.py pretrained_name="nvidia/parakeet-ctc-1.1b.nemo" \
dataset_manifest=<manifest_path> \
output_filename=<output_filename> timestamps=True
```

## From Python Env
### For CTC based models
```python
from nemo.collections.asr.models import ASRModel
ctc_model = ASRModel.from_pretrained('nvidia/parakeet-ctc-1.1b')
output=ctc_model.transcribe(['<file_path>'], timestamps=True) # or manifest instead of individual filepaths
# by default you get timestamps for char, word and segment level. segment level differs based on model you use if it support punctuations and capitalizations natively or not. 
# for word-level timestamps
print(output[0].timestep['word'][:10]) #prints first 10 timestamps *_offset corresponds to frame numbers and start and end are provided in seconds 
# for segment-level timestamps
print(output[0].timestep['segment'][:10])
```

### For RNNT/TDT based models
(currently only difference is output type for both models, will be making it consistent in upcoming PR)
```python
from nemo.collections.asr.models import ASRModel
transducer_model = ASRModel.from_pretrained('nvidia/parakeet-rnnt-1.1b')
output=transducer_model.transcribe(['<file_path>'], timestamps=True)
# for word-level timestamps
print(output[0][0].timestep['word'][:10]) 
# for segment-level timestamps
print(output[0][0].timestep['segment'][:10])
```

### For Hybrid RNNT/TDT-CTC models
Same as above by default decoding would be with transducer (RNNT/TDT), if user wants to change decoder then change decoding strategy before running transcribe()
like: 
```python
from nemo.collections.asr.models import ASRModel
from nemo.collections.asr.parts.submodules.ctc_decoding import CTCDecodingConfig
hybrid_model = ASRModel.from_pretrained('nvidia/parakeet-tdt_ctc-110m')
ctc_cfg = CTCDecodingConfig()
ctc_cfg.decoding = "greedy_batch"
hybrid_model.change_decoding_strategy(decoding_cfg=ctc_cfg, decoder_type="ctc")
output=hybrid_model.transcribe(['<file_path>'], timestamps=True)
# for word-level timestamps
print(output[0].timestep['word'][:10])
# for segment-level timestamps
print(output[0].timestep['segment'][:10])
```

### For AED Models

For AED models like Canary, support would be added soon. 


# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [x] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
