### PR TITLE
Fix missing runtime_gather_output arg in gemma 2 output layer

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron/gemma2/gemma2_modules.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron/gemma2/gemma2_modules.py
@@ -274,7 +274,7 @@ class TERowParallelLinearLayerNorm(TERowParallelLinear):
 
 
 class Gemma2OutputLayer(ColumnParallelLinear):
-    def forward(self, input_: torch.Tensor, weight: Optional[torch.Tensor] = None):
-        output, bias = super().forward(input_, weight)
+    def forward(self, input_: torch.Tensor, weight: Optional[torch.Tensor] = None, runtime_gather_output: Optional[bool] = None):
+        output, bias = super().forward(input_, weight, runtime_gather_output)
         output = logit_softcapping(output, self.config.final_logit_softcapping)
         return output, bias


### PR DESCRIPTION
# What does this PR do ?

* The forward pass in Gemma 2 passes runtime_gather_output
* Leads to unexpected keyword arg error while finetuning gemma 2 2b without it

**Collection**: nlp/models/language_modeling/megatron/gemma2

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
