### PR TITLE
Akoumparouli/hf lit module peft ckpt bugfix

### DIFF
--- a/nemo/collections/llm/peft/lora.py
+++ b/nemo/collections/llm/peft/lora.py
@@ -113,16 +113,6 @@ class LinearAdapter(nn.Module):
             lora_res = self.dropout(lora_res)
         return res + lora_res
 
-    def sharded_state_dict(
-        self, prefix: str = '', sharded_offsets: tuple = (), metadata: Optional[dict] = None
-    ) -> ShardedStateDict:
-        sharded_state_dict = {}
-        sharded_state_dict.update(self.lora_a.sharded_state_dict(f"{prefix}lora_a.", sharded_offsets, metadata))
-        sharded_state_dict.update(
-            self.lora_b.sharded_state_dict(f"{prefix}lora_b.", sharded_offsets, metadata)
-        )
-        return sharded_state_dict
-
 
 @dataclass
 class LoRA(PEFT):

--- a/nemo/collections/llm/peft/lora.py
+++ b/nemo/collections/llm/peft/lora.py
@@ -15,7 +15,7 @@
 import math
 import re
 from dataclasses import dataclass, field
-from typing import List, Literal, Optional
+from typing import List, Literal
 
 import torch
 from megatron.core import parallel_state

--- a/nemo/collections/llm/peft/lora.py
+++ b/nemo/collections/llm/peft/lora.py
@@ -15,7 +15,7 @@
 import math
 import re
 from dataclasses import dataclass, field
-from typing import List, Literal
+from typing import List, Literal, Optional
 
 import torch
 from megatron.core import parallel_state
@@ -112,6 +112,16 @@ class LinearAdapter(nn.Module):
         if self.dropout_position == 'post':
             lora_res = self.dropout(lora_res)
         return res + lora_res
+
+    def sharded_state_dict(
+        self, prefix: str = '', sharded_offsets: tuple = (), metadata: Optional[dict] = None
+    ) -> ShardedStateDict:
+        sharded_state_dict = {}
+        sharded_state_dict.update(self.lora_a.sharded_state_dict(f"{prefix}lora_a.", sharded_offsets, metadata))
+        sharded_state_dict.update(
+            self.lora_b.sharded_state_dict(f"{prefix}lora_b.", sharded_offsets, metadata)
+        )
+        return sharded_state_dict
 
 
 @dataclass

--- a/nemo/lightning/pytorch/callbacks/peft.py
+++ b/nemo/lightning/pytorch/callbacks/peft.py
@@ -302,8 +302,11 @@ class WrappedAdapterIO(_WrappingCheckpointIO, AsyncCompatibleCheckpointIO):
     def save_checkpoint(self, checkpoint: Dict[str, Any], path: _PATH, storage_options: Optional[Any] = None) -> None:
         assert self.checkpoint_io is not None
 
-        checkpoint['sharded_state_dict'] = dict(
-            filter(lambda item: self.peft.adapter_key_filter(item[0]), checkpoint['sharded_state_dict'].items())
+        state_key = 'sharded_state_dict'
+        if not state_key in checkpoint:
+            state_key = 'state_dict'
+        checkpoint[state_key] = dict(
+            filter(lambda item: self.peft.adapter_key_filter(item[0]), checkpoint[state_key].items())
         )
         request = self.checkpoint_io.save_checkpoint(checkpoint, path, storage_options=storage_options)
 
@@ -311,7 +314,9 @@ class WrappedAdapterIO(_WrappingCheckpointIO, AsyncCompatibleCheckpointIO):
 
         if is_global_rank_zero():
             metadata = {"model_ckpt_path": str(self.model_ckpt_path)}
-            adapter_meta_path = ckpt_to_dir(path) / ADAPTER_META_FILENAME
+            base_dir = ckpt_to_dir(path)
+            base_dir.mkdir(parents=True, exist_ok=True)
+            adapter_meta_path = base_dir / ADAPTER_META_FILENAME
             with open(adapter_meta_path, "w") as f:
                 json.dump(metadata, f)
         return request


### PR DESCRIPTION
# What does this PR do ?
Handle ckpt saving for `LinearAdapter` which does not have `sharded_state_dict`

Need to confirm both save & restore work correctly wrt to all saving options.

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
