### PR TITLE
TP+MoE peft fix

### DIFF
--- a/nemo/collections/llm/peft/lora.py
+++ b/nemo/collections/llm/peft/lora.py
@@ -116,6 +116,7 @@ class LinearAdapter(nn.Module):
 def is_expert_linear(fqn):
     return re.match('.*mlp\.experts\.local_experts.[0-9]+\.linear_fc[1-2]$', fqn) is not None
 
+
 @dataclass
 class LoRA(PEFT):
     """

--- a/nemo/collections/llm/peft/lora.py
+++ b/nemo/collections/llm/peft/lora.py
@@ -66,7 +66,6 @@ class AdapterParallelAdd(AdapterWrapper):
         elif len(linear_output) == 3:
             linear_output, bias, layernorm_output = linear_output
             x = layernorm_output
-
         adapter_output = self.adapter(x.contiguous())
         return linear_output + adapter_output, bias
 
@@ -113,6 +112,9 @@ class LinearAdapter(nn.Module):
             lora_res = self.dropout(lora_res)
         return res + lora_res
 
+
+def is_expert_linear(fqn):
+    return re.match('.*mlp\.experts\.local_experts.[0-9]+\.linear_fc[1-2]$', fqn) is not None
 
 @dataclass
 class LoRA(PEFT):
@@ -237,6 +239,7 @@ class LoRA(PEFT):
                 dropout_position=self.dropout_position,
                 model_parallel_config=getattr(m, "config", None),
                 alpha=self.alpha,
+                is_expert=is_expert_linear(full_name),
             )
             return AdapterParallelAdd(m, adapter)
         return m

--- a/nemo/collections/nlp/modules/common/megatron/adapters/parallel_adapters.py
+++ b/nemo/collections/nlp/modules/common/megatron/adapters/parallel_adapters.py
@@ -135,8 +135,10 @@ class InfusedAdapterConfig(AdapterConfig):
 class MLPInfusedAdapterConfig(InfusedAdapterConfig):
     _target_: str = "{0}.{1}".format(MLPInfusedAdapter.__module__, MLPInfusedAdapter.__name__)
 
+
 def pad_seq_to_mult(x, mult):
     import torch.nn.functional as F
+
     if x.shape[0] % mult == 0:
         return x, 0
     pad_len = mult - (x.shape[0] % mult)
@@ -145,12 +147,14 @@ def pad_seq_to_mult(x, mult):
         x = torch.nn.functional.pad(x, (0, 0, 0, pad_len))
     return x, pad_len
 
+
 def unpad_seq_to_mult(x, pad_len):
     if pad_len <= 0:
         return x
     with torch.no_grad():
         # prune tail padding
         return x[:-pad_len, :]
+
 
 class ParallelLinearAdapter(nn.Module, AdapterModuleUtil):
     def __init__(

--- a/nemo/collections/nlp/modules/common/megatron/adapters/parallel_adapters.py
+++ b/nemo/collections/nlp/modules/common/megatron/adapters/parallel_adapters.py
@@ -135,6 +135,22 @@ class InfusedAdapterConfig(AdapterConfig):
 class MLPInfusedAdapterConfig(InfusedAdapterConfig):
     _target_: str = "{0}.{1}".format(MLPInfusedAdapter.__module__, MLPInfusedAdapter.__name__)
 
+def pad_seq_to_mult(x, mult):
+    import torch.nn.functional as F
+    if x.shape[0] % mult == 0:
+        return x, 0
+    pad_len = mult - (x.shape[0] % mult)
+    with torch.no_grad():
+        # pad at the tail
+        x = torch.nn.functional.pad(x, (0, 0, 0, pad_len))
+    return x, pad_len
+
+def unpad_seq_to_mult(x, pad_len):
+    if pad_len <= 0:
+        return x
+    with torch.no_grad():
+        # prune tail padding
+        return x[:-pad_len, :]
 
 class ParallelLinearAdapter(nn.Module, AdapterModuleUtil):
     def __init__(
@@ -154,6 +170,7 @@ class ParallelLinearAdapter(nn.Module, AdapterModuleUtil):
         alpha: float | None = None,
         dropout_position: str = 'post',
         a2a_experimental: bool = False,  # TODO: should rename this or make it a default feature
+        is_expert: bool = False,
         **kwargs,
     ):
         super().__init__()
@@ -167,6 +184,7 @@ class ParallelLinearAdapter(nn.Module, AdapterModuleUtil):
         self.input_is_parallel = input_is_parallel
         self.dropout_position = dropout_position
         self.use_a2a = a2a_experimental
+        self.is_expert = is_expert
 
         # megatron_gpt_peft_models will provide this arg, but deprecated ones do not.
         # in case this arg is not provided, use the dummy default config.
@@ -292,6 +310,10 @@ class ParallelLinearAdapter(nn.Module, AdapterModuleUtil):
         if self.dropout is not None and self.dropout_position == 'pre':
             x = self.dropout(x)
 
+        pad_len = 0
+        if self.is_expert:
+            x, pad_len = pad_seq_to_mult(x, self.config.tensor_model_parallel_size)
+
         if self.norm_position == 'pre':
             x = self.layer_norm(x)
         if self._sequence_parallel and not self.input_is_parallel:
@@ -311,7 +333,7 @@ class ParallelLinearAdapter(nn.Module, AdapterModuleUtil):
             x.activation_offloading = True
         x, _ = self.linear_out(x)
 
-        if self._sequence_parallel and self.input_is_parallel:
+        if self._sequence_parallel and self.input_is_parallel and not self.is_expert:
             # for attention_dense and linear_fc2
             # layernorm after lora is impacted by sequence parallel,
             # hence seq dim need to be scattered right after lora linear layers
@@ -330,6 +352,10 @@ class ParallelLinearAdapter(nn.Module, AdapterModuleUtil):
             x = self.dropout(x)
 
         x = x * (self.alpha / self.dim)
+
+        if pad_len > 0:
+            # Remove MoE padding.
+            x = unpad_seq_to_mult(x, pad_len)
 
         return x
 


### PR DESCRIPTION
# What does this PR do ?

Model= MoE-based
ParallelismConfig= TP> 1 and SP=True

During token routing it is possible that experts might be routed a sequence with length non-dividable by TP, as a result when applying the adapter's output on the linear's output there's shape mismatch. This PR adds appropriate padding to the sequence of expert linear layers to avoid this issue. Please do note that routed tokens are not sequence parallel.


# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
