### PR TITLE
Allow arguments passed to dataset class + Gemma recipe fix

### DIFF
--- a/examples/llm/sft/hf.py
+++ b/examples/llm/sft/hf.py
@@ -41,7 +41,7 @@ def squad(tokenizer) -> pl.LightningDataModule:
         micro_batch_size=2,
         global_batch_size=128,  # assert gbs == mbs * accumulate_grad_batches
         num_workers=0,
-        sanity_check_dist_workers=False,
+        dataset_kwargs={"sanity_check_dist_workers": False},
     )
 
 

--- a/nemo/collections/llm/gpt/data/dolly.py
+++ b/nemo/collections/llm/gpt/data/dolly.py
@@ -57,7 +57,7 @@ class DollyDataModule(FineTuningDataModule, IOMixin):
         pin_memory: bool = True,
         persistent_workers: bool = False,
         packed_sequence_specs: Optional["PackedSequenceSpecs"] = None,
-        dataset_kwargs: Dict[str, Any] = None,
+        dataset_kwargs: Optional[Dict[str, Any]] = None,
     ):
         self.force_redownload = force_redownload
         self.delete_raw = delete_raw

--- a/nemo/collections/llm/gpt/data/dolly.py
+++ b/nemo/collections/llm/gpt/data/dolly.py
@@ -14,7 +14,7 @@
 
 import json
 import shutil
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Dict, Any
 
 import numpy as np
 from datasets import load_dataset
@@ -56,8 +56,8 @@ class DollyDataModule(FineTuningDataModule, IOMixin):
         num_workers: int = 8,
         pin_memory: bool = True,
         persistent_workers: bool = False,
-        pad_to_max_length: bool = False,
         packed_sequence_specs: Optional["PackedSequenceSpecs"] = None,
+        dataset_kwargs: Dict[str, Any] = None,
     ):
         self.force_redownload = force_redownload
         self.delete_raw = delete_raw
@@ -74,8 +74,8 @@ class DollyDataModule(FineTuningDataModule, IOMixin):
             num_workers=num_workers,
             pin_memory=pin_memory,
             persistent_workers=persistent_workers,
-            pad_to_max_length=pad_to_max_length,
             packed_sequence_specs=packed_sequence_specs,
+            dataset_kwargs=dataset_kwargs,
         )
 
     def prepare_data(self) -> None:

--- a/nemo/collections/llm/gpt/data/fine_tuning.py
+++ b/nemo/collections/llm/gpt/data/fine_tuning.py
@@ -51,7 +51,7 @@ class FineTuningDataModule(pl.LightningDataModule):
         pin_memory (bool, optional): Whether to pin memory during data loading for faster GPU training. Defaults to True.
         persistent_workers (bool, optional): Whether to keep data loading workers persistent across epochs. Defaults to False.
         packed_sequence_specs (PackedSequenceSpecs, optional): See PackedSequenceSpecs for details
-        dataset_kwargs (Dict[str, Any], optional): Keyword arguments to pass into the GPTSFTDataset class
+        dataset_kwargs (Optional[Dict[str, Any]], optional): Keyword arguments to pass into the GPTSFTDataset class
     """
 
     def __init__(
@@ -68,7 +68,7 @@ class FineTuningDataModule(pl.LightningDataModule):
         pin_memory: bool = True,
         persistent_workers: bool = False,
         packed_sequence_specs: Optional["PackedSequenceSpecs"] = None,
-        dataset_kwargs: Dict[str, Any] = None,
+        dataset_kwargs: Optional[Dict[str, Any]] = None,
     ):
         super().__init__()
         self.seq_length = seq_length
@@ -87,7 +87,7 @@ class FineTuningDataModule(pl.LightningDataModule):
         self.packed_sequence_specs = packed_sequence_specs
         self.packed_sequence_size = -1 if not packed_sequence_specs else packed_sequence_specs.packed_sequence_size
         self.validate_batch_size_for_packed_sequence()
-        self.dataset_kwargs = dataset_kwargs
+        self.dataset_kwargs = dataset_kwargs or {}
 
     def validate_batch_size_for_packed_sequence(self):
         if self.packed_sequence_size > 0 and self.micro_batch_size > 1:

--- a/nemo/collections/llm/gpt/data/fine_tuning.py
+++ b/nemo/collections/llm/gpt/data/fine_tuning.py
@@ -15,7 +15,7 @@
 import math
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union, Dict, Any
 
 import pytorch_lightning as pl
 from torch.utils.data import DataLoader
@@ -50,9 +50,8 @@ class FineTuningDataModule(pl.LightningDataModule):
         num_workers (int, optional): The number of worker processes for data loading. Defaults to 8.
         pin_memory (bool, optional): Whether to pin memory during data loading for faster GPU training. Defaults to True.
         persistent_workers (bool, optional): Whether to keep data loading workers persistent across epochs. Defaults to False.
-        max_train_steps (int, optional): Maximum number of steps to train. Used to calculate samples mapping for the mmap dataset
-        pad_to_max_length (bool, optional): Whether to pad the input to the max sequence length. If False, will pad to the max length of the current batch.
         packed_sequence_specs (PackedSequenceSpecs, optional): See PackedSequenceSpecs for details
+        dataset_kwargs (Dict[str, Any], optional): Keyword arguments to pass into the GPTSFTDataset class
     """
 
     def __init__(
@@ -68,9 +67,8 @@ class FineTuningDataModule(pl.LightningDataModule):
         num_workers: int = 8,
         pin_memory: bool = True,
         persistent_workers: bool = False,
-        pad_to_max_length: bool = False,
         packed_sequence_specs: Optional["PackedSequenceSpecs"] = None,
-        sanity_check_dist_workers: bool = True,
+        dataset_kwargs: Dict[str, Any] = None,
     ):
         super().__init__()
         self.seq_length = seq_length
@@ -86,11 +84,10 @@ class FineTuningDataModule(pl.LightningDataModule):
         self.rampup_batch_size = rampup_batch_size
         self.data_sampler = None
         self.max_train_samples = None
-        self.pad_to_max_length = pad_to_max_length
         self.packed_sequence_specs = packed_sequence_specs
         self.packed_sequence_size = -1 if not packed_sequence_specs else packed_sequence_specs.packed_sequence_size
         self.validate_batch_size_for_packed_sequence()
-        self._sanity_check_dist_workers = sanity_check_dist_workers
+        self.dataset_kwargs = dataset_kwargs
 
     def validate_batch_size_for_packed_sequence(self):
         if self.packed_sequence_size > 0 and self.micro_batch_size > 1:
@@ -135,8 +132,7 @@ class FineTuningDataModule(pl.LightningDataModule):
             self._create_dataset(
                 self.train_path if self.packed_sequence_size <= 0 else self.train_path_packed,
                 max_num_samples=self.max_train_samples,
-                pad_to_max_length=self.pad_to_max_length,
-                sanity_check_dist_workers=self._sanity_check_dist_workers,
+                **self.dataset_kwargs,
             )
         )
 
@@ -145,8 +141,7 @@ class FineTuningDataModule(pl.LightningDataModule):
             self._create_dataset(
                 self.validation_path,
                 is_test=True,
-                pad_to_max_length=self.pad_to_max_length,
-                sanity_check_dist_workers=self._sanity_check_dist_workers,
+                **self.dataset_kwargs,
             ),
         )
 
@@ -156,8 +151,7 @@ class FineTuningDataModule(pl.LightningDataModule):
                 self.test_path,
                 tokens_to_generate=32,
                 is_test=True,
-                pad_to_max_length=self.pad_to_max_length,
-                sanity_check_dist_workers=self._sanity_check_dist_workers,
+                **self.dataset_kwargs,
             )
         )
 

--- a/nemo/collections/llm/gpt/data/squad.py
+++ b/nemo/collections/llm/gpt/data/squad.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 import json
 import shutil
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Optional, Dict, Any
 
 from datasets import DatasetDict, load_dataset
 
@@ -54,9 +54,8 @@ class SquadDataModule(FineTuningDataModule, IOMixin):
         num_workers: int = 8,
         pin_memory: bool = True,
         persistent_workers: bool = False,
-        pad_to_max_length: bool = False,
         packed_sequence_specs: Optional["PackedSequenceSpecs"] = None,
-        sanity_check_dist_workers: bool = True,
+        dataset_kwargs: Dict[str, Any] = None,
     ):
         self.force_redownload = force_redownload
         self.delete_raw = delete_raw
@@ -73,9 +72,8 @@ class SquadDataModule(FineTuningDataModule, IOMixin):
             num_workers=num_workers,
             pin_memory=pin_memory,
             persistent_workers=persistent_workers,
-            pad_to_max_length=pad_to_max_length,
             packed_sequence_specs=packed_sequence_specs,
-            sanity_check_dist_workers=sanity_check_dist_workers,
+            dataset_kwargs=dataset_kwargs,
         )
 
     def prepare_data(self) -> None:

--- a/nemo/collections/llm/gpt/data/squad.py
+++ b/nemo/collections/llm/gpt/data/squad.py
@@ -55,7 +55,7 @@ class SquadDataModule(FineTuningDataModule, IOMixin):
         pin_memory: bool = True,
         persistent_workers: bool = False,
         packed_sequence_specs: Optional["PackedSequenceSpecs"] = None,
-        dataset_kwargs: Dict[str, Any] = None,
+        dataset_kwargs: Optional[Dict[str, Any]] = None,
     ):
         self.force_redownload = force_redownload
         self.delete_raw = delete_raw

--- a/nemo/collections/llm/recipes/gemma2_27b.py
+++ b/nemo/collections/llm/recipes/gemma2_27b.py
@@ -213,6 +213,9 @@ def finetune_recipe(
     recipe = default_finetune_recipe(
         model(), "google/gemma-2-27b", dir, name, num_nodes, num_gpus_per_node, packed_sequence
     )
+    # Gemma requires BOS
+    recipe.data.dataset_kwargs = {'add_bos': True}
+
     if peft_scheme is None or peft_scheme.lower() == 'none':
         recipe.optim.config.lr = 5e-6
         recipe.trainer.strategy.tensor_model_parallel_size = 8

--- a/nemo/collections/llm/recipes/gemma2_2b.py
+++ b/nemo/collections/llm/recipes/gemma2_2b.py
@@ -213,6 +213,9 @@ def finetune_recipe(
     recipe = default_finetune_recipe(
         model(), "google/gemma-2-2b", dir, name, num_nodes, num_gpus_per_node, packed_sequence
     )
+    # Gemma requires BOS
+    recipe.data.dataset_kwargs = {'add_bos': True}
+
     if peft_scheme is None or peft_scheme.lower() == 'none':
         recipe.optim.config.lr = 5e-6
     elif peft_scheme.lower() == 'lora':

--- a/nemo/collections/llm/recipes/gemma2_9b.py
+++ b/nemo/collections/llm/recipes/gemma2_9b.py
@@ -213,6 +213,9 @@ def finetune_recipe(
     recipe = default_finetune_recipe(
         model(), "google/gemma-2-9b", dir, name, num_nodes, num_gpus_per_node, packed_sequence
     )
+    # Gemma requires BOS
+    recipe.data.dataset_kwargs = {'add_bos': True}
+
     if peft_scheme is None or peft_scheme.lower() == 'none':
         recipe.optim.config.lr = 5e-6
         recipe.trainer.strategy.tensor_model_parallel_size = 4

--- a/nemo/collections/llm/recipes/gemma_2b.py
+++ b/nemo/collections/llm/recipes/gemma_2b.py
@@ -278,6 +278,9 @@ def finetune_recipe(
     recipe = default_finetune_recipe(
         model(), "google/gemma-2b", dir, name, num_nodes, num_gpus_per_node, packed_sequence
     )
+    # Gemma requires BOS
+    recipe.data.dataset_kwargs = {'add_bos': True}
+
     if peft_scheme is None or peft_scheme.lower() == 'none':
         recipe.trainer.strategy.tensor_model_parallel_size = 2
         recipe.optim.config.lr = 5e-6

--- a/nemo/collections/llm/recipes/gemma_7b.py
+++ b/nemo/collections/llm/recipes/gemma_7b.py
@@ -278,6 +278,9 @@ def finetune_recipe(
     recipe = default_finetune_recipe(
         model(), "google/gemma-7b", dir, name, num_nodes, num_gpus_per_node, packed_sequence
     )
+    # Gemma requires BOS
+    recipe.data.dataset_kwargs = {'add_bos': True}
+
     if peft_scheme is None or peft_scheme.lower() == 'none':
         recipe.trainer.strategy.tensor_model_parallel_size = 2
         recipe.optim.config.lr = 5e-6

--- a/tests/collections/llm/gpt/model/megatron_ssm_finetuning.py
+++ b/tests/collections/llm/gpt/model/megatron_ssm_finetuning.py
@@ -109,7 +109,7 @@ if __name__ == "__main__":
         global_batch_size=4,
         tokenizer=model.tokenizer,
         num_workers=0,
-        pad_to_max_length=True,
+        dataset_kwargs={"pad_to_max_length": True},
     )
 
     app_state = _setup(


### PR DESCRIPTION
# What does this PR do ?

Expose all arguments in GPTSFTDataset through a kwargs input to the datamodule.
Fix gemma recipe which requires add_bos=True.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
