### PR TITLE
Fix RNN-T loss memory usage

### DIFF
--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
@@ -179,7 +179,7 @@ class _TDTNumba(Function):
     def backward(ctx, grad_output):
         label_grads, duration_grads = ctx.saved_tensors
         if grad_output is not None and label_grads is not None:
-            grad_output = grad_output.view(-1, 1, 1, 1).to(ctx.label_grads)
+            grad_output = grad_output.view(-1, 1, 1, 1).to(label_grads)
             return (
                 label_grads.mul_(grad_output),
                 duration_grads.mul_(grad_output),

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
@@ -80,15 +80,16 @@ class _RNNTNumba(Function):
                 if grads is not None:
                     grads /= minibatch_size
 
-        ctx.grads = grads
+        ctx.save_for_backward(grads)
 
         return costs
 
     @staticmethod
     def backward(ctx, grad_output):
-        if grad_output is not None and ctx.grads is not None:
-            grad_output = grad_output.view(-1, 1, 1, 1).to(ctx.grads)
-            return ctx.grads.mul_(grad_output), None, None, None, None, None, None, None
+        grads, = ctx.saved_tensors
+        if grad_output is not None and grads is not None:
+            grad_output = grad_output.view(-1, 1, 1, 1).to(grads)
+            return grads.mul_(grad_output), None, None, None, None, None, None, None
 
 
 class _TDTNumba(Function):
@@ -170,18 +171,18 @@ class _TDTNumba(Function):
                     label_grads /= minibatch_size
                     duration_grads /= minibatch_size
 
-        ctx.label_grads = label_grads
-        ctx.duration_grads = duration_grads
+        ctx.save_for_backward(label_grads, duration_grads)
 
         return costs
 
     @staticmethod
     def backward(ctx, grad_output):
-        if grad_output is not None and ctx.label_grads is not None:
+        label_grads, duration_grads = ctx.saved_tensors
+        if grad_output is not None and label_grads is not None:
             grad_output = grad_output.view(-1, 1, 1, 1).to(ctx.label_grads)
             return (
-                ctx.label_grads.mul_(grad_output),
-                ctx.duration_grads.mul_(grad_output),
+                label_grads.mul_(grad_output),
+                duration_grads.mul_(grad_output),
                 None,
                 None,
                 None,
@@ -251,15 +252,16 @@ class _MultiblankRNNTNumba(Function):
                 if grads is not None:
                     grads /= minibatch_size
 
-        ctx.grads = grads
+        ctx.save_for_backward(grads)
 
         return costs
 
     @staticmethod
     def backward(ctx, grad_output):
-        if grad_output is not None and ctx.grads is not None:
-            grad_output = grad_output.view(-1, 1, 1, 1).to(ctx.grads)
-            return ctx.grads.mul_(grad_output), None, None, None, None, None, None, None, None, None, None
+        grads, = ctx.saved_tensors
+        if grad_output is not None and grads is not None:
+            grad_output = grad_output.view(-1, 1, 1, 1).to(grads)
+            return grads.mul_(grad_output), None, None, None, None, None, None, None, None, None, None
 
 
 def rnnt_loss(

--- a/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
+++ b/nemo/collections/asr/parts/numba/rnnt_loss/rnnt_pytorch.py
@@ -86,7 +86,7 @@ class _RNNTNumba(Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        grads, = ctx.saved_tensors
+        (grads,) = ctx.saved_tensors
         if grad_output is not None and grads is not None:
             grad_output = grad_output.view(-1, 1, 1, 1).to(grads)
             return grads.mul_(grad_output), None, None, None, None, None, None, None
@@ -258,7 +258,7 @@ class _MultiblankRNNTNumba(Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        grads, = ctx.saved_tensors
+        (grads,) = ctx.saved_tensors
         if grad_output is not None and grads is not None:
             grad_output = grad_output.view(-1, 1, 1, 1).to(grads)
             return grads.mul_(grad_output), None, None, None, None, None, None, None, None, None, None


### PR DESCRIPTION
# What does this PR do ?

Fixes memory usage for Numba-based implementation of RNN-T and Multi-blank Transducer losses.
The current implementation requires 3x memory compared to the size of logits (logits, gradient, extra memory = size of logits). This PR fixes memory usage to the minimal possible 2x (logits, gradient). 

It looks like assigning tensors directly to `ctx` instead of saving them through `save_for_backward` breaks PyTorch logic, and it copies the gradient tensor (which results in extra memory usage).

TDT loss was not affected by this issue (I'm unsure why, but it requires contiguous tensor for labels-related logits).

**Before (main):**
- Peak memory before loss: 2.09 GB
- Peak memory after loss: **6.27 GB**

**After (this PR):**
- Peak memory before loss: 2.09 GB
- Peak memory after loss: **4.18 GB**

Code to check memory usage (size of tensors besides logits is negligible compared to logits):
```python
import torch
from nemo.collections.asr.parts.numba.rnnt_loss import RNNTLossNumba
device = torch.device("cuda")

loss = RNNTLossNumba(blank=1023, reduction='none')
batch_size = 32
logits = torch.rand([batch_size, 188, 90 + 1, 1024], device=device, dtype=torch.float32, requires_grad=True)
encoder_lengths = torch.full([batch_size], fill_value=188, device=device, dtype=torch.long)
label_lengths = torch.full([batch_size], fill_value=90, device=device, dtype=torch.long)
labels = torch.randint(0, 1022, size=[batch_size, 90], dtype=torch.long, device=device)
print(f"Peak memory before loss: {torch.cuda.max_memory_allocated() / (2 ** 30):.2f} GB")

loss_value = loss(acts=logits, act_lens=encoder_lengths, labels=labels, label_lens=label_lengths)
loss_value.sum().backward()
print(f"Peak memory after loss: {torch.cuda.max_memory_allocated() / (2 ** 30):.2f} GB")
```

**Collection**: [ASR]

# Changelog 
- In transducer-related functions that extend autograd, save tensors using `ctx.save_for_backward(...)` instead of directly assigning tensors [according to PyTorch documentation](https://pytorch.org/docs/stable/notes/extending.html#extending-autograd).

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
