### PR TITLE
Fix freeze_model call in peft

### DIFF
--- a/tests/lightning/pytorch/callbacks/test_peft.py
+++ b/tests/lightning/pytorch/callbacks/test_peft.py
@@ -43,8 +43,9 @@ class TestPEFT:
 
         transformed_model = peft(model)
 
-        assert hasattr(peft, "is_called") and peft.is_called == True, \
-            "peft methods may subclass `freeze_model()`, so it must be called"
+        assert (
+            hasattr(peft, "is_called") and peft.is_called == True
+        ), "peft methods may subclass `freeze_model()`, so it must be called"
         assert transformed_model.linear.weight.requires_grad == False
         assert transformed_model.conv.weight.requires_grad == False
 

--- a/tests/lightning/pytorch/callbacks/test_peft.py
+++ b/tests/lightning/pytorch/callbacks/test_peft.py
@@ -26,6 +26,11 @@ class TestPEFT:
         def transform(self, module, name=None, prefix=None):
             return module  # No-op transform for testing
 
+        def freeze_model(self, module):
+            super().freeze_model(module)
+            self.is_called = True
+            return module
+
     class DummyModel(nn.Module, fn.FNMixin):
         def __init__(self):
             super().__init__()
@@ -38,6 +43,8 @@ class TestPEFT:
 
         transformed_model = peft(model)
 
+        assert hasattr(peft, "is_called") and peft.is_called == True, \
+            "peft methods may subclass `freeze_model()`, so it must be called"
         assert transformed_model.linear.weight.requires_grad == False
         assert transformed_model.conv.weight.requires_grad == False
 


### PR DESCRIPTION
# What does this PR do ?

freeze_model() must be called because some peft methods may have custom freeze strategies

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
