### PR TITLE
feat: Run PyLint

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -1,4 +1,4 @@
-name: Isort and Black Formatting
+name: Isort and Black Formatting; PyLint Docs check
 # Incrementally reformat only changed files with black, all files with isort
 #
 # Replaces pre-commit.ci, since it reformats all the files.
@@ -13,9 +13,14 @@ on:
   pull_request_target:
     paths:
       - '**.py'
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+
+defaults:
+  run:
+    shell: bash -x -e -u -o pipefail {0}
 
 jobs:
-  reformat_with_isort_and_black:
+  reformat_with_isort_and_black_and_pylint:
     runs-on: ubuntu-latest
     permissions:
       # write permissions required to commit changes
@@ -64,3 +69,15 @@ jobs:
         with:
             message: Apply isort and black reformatting
             commit: --signoff
+
+      - name: pylint
+        if: ${{ !contains( github.event.pull_request.labels.*.name, 'skip-docs') }}
+        run: |
+          pip install pylint
+          
+          CHANGED_FILES=$(git diff --name-only --diff-filter=d --merge-base origin/main nemo/ | grep '\.py$' || true)
+
+          ADDITIONAL_PYLINT_ARGS=()
+          echo ${{ github.event.pull_request.labels.*.name }}
+
+          pylint ${ADDITIONAL_PYLINT_ARGS[@]} $CHANGED_FILES

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,12 @@
+[MAIN]
+ignore-paths=tests
+max-line-length=119
+
+[MESSAGES CONTROL]
+disable=all
+
+enable=C0115,C0116,W0611,C0301
+# C0115: missing-class-docstring
+# C0116: missing-function-docstring
+# W0611: unused-import
+# C0301: line-too-long


### PR DESCRIPTION
# What does this PR do ?

Runs Pylint on changed files with the following rules:

* C0115: missing-class-docstring
* C0116: missing-function-docstring
* W0611: unused-import
* C0301: line-too-long
 
We can skip Pylint by attaching the label `skip-docs`. This will re-run the check automatically.

This label-mechanism is implemented by modifying the reformat workflow to run - additionally to its default triggers (`opened, synchronize, reopened`) - also on the events `labeled, unlabeled`. So every time a PR is labeled/unlabeled, the reformat workflow will run. 

!!! For testing purpose, I added the event trigger `pull_request`. We need to remove this before merge. This is here only for show-casing. !!!

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
