### PR TITLE
Workload Inspector (WiT) performance anomaly detection Tool across GPUs 

### DIFF
--- a/nemo/collections/multimodal/models/vision_language_foundation/clip/megatron_clip_models.py
+++ b/nemo/collections/multimodal/models/vision_language_foundation/clip/megatron_clip_models.py
@@ -734,7 +734,11 @@ class MegatronCLIPModel(MegatronBaseModel):
         )
 
         # Convert the global-batch-based profile index to micro-batch index
-        if hasattr(self, '_nsys_profile_enabled') or hasattr(self, '_memory_profile_enabled') or hasattr(self, '_wit_profile_enabled'):
+        if (
+            hasattr(self, '_nsys_profile_enabled')
+            or hasattr(self, '_memory_profile_enabled')
+            or hasattr(self, '_wit_profile_enabled')
+        ):
             mp_size = cfg.get('tensor_model_parallel_size', 1) * cfg.get('pipeline_model_parallel_size', 1)
             cp_size = cfg.get('context_parallel_size', 1)
             data_parallel_world_size = trainer.world_size // (mp_size * cp_size)

--- a/nemo/collections/multimodal/models/vision_language_foundation/clip/megatron_clip_models.py
+++ b/nemo/collections/multimodal/models/vision_language_foundation/clip/megatron_clip_models.py
@@ -734,7 +734,7 @@ class MegatronCLIPModel(MegatronBaseModel):
         )
 
         # Convert the global-batch-based profile index to micro-batch index
-        if hasattr(self, '_nsys_profile_enabled') or hasattr(self, '_memory_profile_enabled'):
+        if hasattr(self, '_nsys_profile_enabled') or hasattr(self, '_memory_profile_enabled') or hasattr(self, '_wit_profile_enabled'):
             mp_size = cfg.get('tensor_model_parallel_size', 1) * cfg.get('pipeline_model_parallel_size', 1)
             cp_size = cfg.get('context_parallel_size', 1)
             data_parallel_world_size = trainer.world_size // (mp_size * cp_size)
@@ -745,6 +745,9 @@ class MegatronCLIPModel(MegatronBaseModel):
             if hasattr(self, '_memory_profile_enabled'):
                 self._memory_profile_start_step *= grad_accum_steps
                 self._memory_profile_end_step *= grad_accum_steps
+            if hasattr(self, '_wit_profile_enabled'):
+                self._wit_profile_start_step *= grad_accum_steps
+                self._wit_profile_end_step *= grad_accum_steps
 
         self.initialize_ub = self.cfg.get('ub_tp_comm_overlap', False)
         self.log_train_loss = bool(int(os.getenv("NEMO_LOG_TRAIN_LOSS", 1)))

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -134,7 +134,11 @@ class MegatronBertModel(MegatronBaseModel):
             # Model wrapper to convert both model and inputs to half precision
             self._wrap_model_for_O2()
 
-        if hasattr(self, '_nsys_profile_enabled') or hasattr(self, '_memory_profile_enabled') or hasattr(self, '_wit_profile_enabled'):
+        if (
+            hasattr(self, '_nsys_profile_enabled')
+            or hasattr(self, '_memory_profile_enabled')
+            or hasattr(self, '_wit_profile_enabled')
+        ):
             mp_size = cfg.get('tensor_model_parallel_size', 1) * cfg.get('pipeline_model_parallel_size', 1)
             data_parallel_world_size = trainer.world_size // mp_size
             grad_accum_steps = cfg.get('global_batch_size') // (cfg.get('micro_batch_size') * data_parallel_world_size)

--- a/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_bert_model.py
@@ -134,7 +134,7 @@ class MegatronBertModel(MegatronBaseModel):
             # Model wrapper to convert both model and inputs to half precision
             self._wrap_model_for_O2()
 
-        if hasattr(self, '_nsys_profile_enabled') or hasattr(self, '_memory_profile_enabled'):
+        if hasattr(self, '_nsys_profile_enabled') or hasattr(self, '_memory_profile_enabled') or hasattr(self, '_wit_profile_enabled'):
             mp_size = cfg.get('tensor_model_parallel_size', 1) * cfg.get('pipeline_model_parallel_size', 1)
             data_parallel_world_size = trainer.world_size // mp_size
             grad_accum_steps = cfg.get('global_batch_size') // (cfg.get('micro_batch_size') * data_parallel_world_size)
@@ -144,6 +144,9 @@ class MegatronBertModel(MegatronBaseModel):
             if hasattr(self, '_memory_profile_enabled'):
                 self._memory_profile_start_step *= grad_accum_steps
                 self._memory_profile_end_step *= grad_accum_steps
+            if hasattr(self, '_wit_profile_enabled'):
+                self._wit_profile_start_step *= grad_accum_steps
+                self._wit_profile_end_step *= grad_accum_steps
 
     def model_provider_func(self, pre_process, post_process):
         cfg = self.cfg

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py
@@ -101,6 +101,9 @@ class MegatronGPTSFTModel(NLPAdapterModelMixin, MegatronGPTModel):
         if hasattr(self, '_memory_profile_enabled'):
             self._memory_profile_start_step = self.cfg.memory_profile.get('start_step', 0)
             self._memory_profile_end_step = self.cfg.memory_profile.get('end_step', 0)
+        if hasattr(self, '_wit_profile_enabled'):
+            self._wit_profile_start_step = self.cfg.wit_profile.get('start_step', 0)
+            self._wit_profile_end_step = self.cfg.wit_profile.get('end_step', 0)
 
         self.virtual_tokens = 0
         self.init_global_step = 0

--- a/nemo/collections/vision/models/megatron_vit_classification_models.py
+++ b/nemo/collections/vision/models/megatron_vit_classification_models.py
@@ -175,7 +175,11 @@ class MegatronVitClassificationModel(MegatronBaseModel):
         self.transformer_engine = cfg.get('transformer_engine', False)
 
         # Convert the global-batch-based profile index to micro-batch index
-        if hasattr(self, '_nsys_profile_enabled') or hasattr(self, '_memory_profile_enabled') or hasattr(self, '_wit_profile_enabled'):
+        if (
+            hasattr(self, '_nsys_profile_enabled')
+            or hasattr(self, '_memory_profile_enabled')
+            or hasattr(self, '_wit_profile_enabled')
+        ):
             mp_size = cfg.get('tensor_model_parallel_size', 1) * cfg.get('pipeline_model_parallel_size', 1)
             data_parallel_world_size = trainer.world_size // mp_size
             grad_accum_steps = cfg.get('global_batch_size') // (cfg.get('micro_batch_size') * data_parallel_world_size)

--- a/nemo/collections/vision/models/megatron_vit_classification_models.py
+++ b/nemo/collections/vision/models/megatron_vit_classification_models.py
@@ -175,7 +175,7 @@ class MegatronVitClassificationModel(MegatronBaseModel):
         self.transformer_engine = cfg.get('transformer_engine', False)
 
         # Convert the global-batch-based profile index to micro-batch index
-        if hasattr(self, '_nsys_profile_enabled') or hasattr(self, '_memory_profile_enabled'):
+        if hasattr(self, '_nsys_profile_enabled') or hasattr(self, '_memory_profile_enabled') or hasattr(self, '_wit_profile_enabled'):
             mp_size = cfg.get('tensor_model_parallel_size', 1) * cfg.get('pipeline_model_parallel_size', 1)
             data_parallel_world_size = trainer.world_size // mp_size
             grad_accum_steps = cfg.get('global_batch_size') // (cfg.get('micro_batch_size') * data_parallel_world_size)
@@ -185,6 +185,9 @@ class MegatronVitClassificationModel(MegatronBaseModel):
             if hasattr(self, '_memory_profile_enabled'):
                 self._memory_profile_start_step *= grad_accum_steps
                 self._memory_profile_end_step *= grad_accum_steps
+            if hasattr(self, '_wit_profile_enabled'):
+                self._wit_profile_start_step *= grad_accum_steps
+                self._wit_profile_end_step *= grad_accum_steps
         self.get_attention_mask_from_fusion = self.cfg.get('get_attention_mask_from_fusion', True)
         self.initialize_ub = self.cfg.get('ub_tp_comm_overlap', False)
 

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -213,9 +213,12 @@ class ModelPT(LightningModule, Model):
 
         from workload_inspector.bkg_runner import BackgroundRunner
         from workload_inspector.torch.nsys_downstream import NsysDownstream
+
         self._wit_profile_started = False
         self._wit_profile_complete = False
-        nsys_bg_thread = NsysDownstream(os.getenv('NSYS_LOG_DIR', None), os.getenv('GPU_KERN_STATS_OUTPUT_DIR', None), "stdev")
+        nsys_bg_thread = NsysDownstream(
+            os.getenv('NSYS_LOG_DIR', None), os.getenv('GPU_KERN_STATS_OUTPUT_DIR', None), "stdev"
+        )
         self.wit_bg_runner = BackgroundRunner(nsys_bg_thread)
 
     def __init_subclass__(cls) -> None:
@@ -1823,28 +1826,28 @@ class ModelPT(LightningModule, Model):
                     raise ValueError(
                         f'Memory profile output path ({self._memory_profile_output_path}) is not set or does not exist.'
                     )
-        
+
         if self.cfg.get('wit_profile', None) is not None:
             if self.cfg.wit_profile.get('enabled', False):
                 # WIT profiling options
-                self._wit_profile_enabled = True 
+                self._wit_profile_enabled = True
                 self._wit_profile_start_step = self.cfg.wit_profile.get('start_step', 0)
                 self._wit_profile_end_step = self.cfg.wit_profile.get('end_step', 0)
-     
-                if type(self._wit_profile_start_step) == int: 
+
+                if type(self._wit_profile_start_step) == int:
                     logging.info(f'Nsys profiling setup with start_step: {self._wit_profile_start_step}')
                 else:
                     raise ValueError(
                         f'Nsys start_step must be of type int. Found: {type(self._wit_profile_start_step)}'
-                    )    
+                    )
 
-                if type(self._wit_profile_end_step) == int: 
+                if type(self._wit_profile_end_step) == int:
                     logging.info(f'Nsys profiling setup with end_step: {self._wit_profile_end_step}')
                 else:
                     raise ValueError(f'Nsys end_step must be of type int. Found: {type(self._wit_profile_end_step)}')
 
                 if self._wit_profile_end_step >= self._wit_profile_start_step:
-                    pass 
+                    pass
                 else:
                     raise ValueError(f'Nsys end_step must be greater than or equal to nsys start_step')
 
@@ -1890,7 +1893,7 @@ class ModelPT(LightningModule, Model):
                         logging.info("====== Start CUDA memory profiling ======")
                         torch.cuda.memory._record_memory_history(max_entries=100000)
                         self._memory_profile_started = True
-            
+
             if hasattr(self, '_wit_profile_enabled'):
                 if self._wit_profile_enabled and not self._wit_profile_started:
                     if batch_idx >= self._wit_profile_start_step:
@@ -1943,7 +1946,7 @@ class ModelPT(LightningModule, Model):
                         )
                         torch.cuda.memory._record_memory_history(enabled=None)
                         self._memory_profile_complete = True
-            
+
             if hasattr(self, '_wit_profile_enabled'):
                 if self._wit_profile_enabled and not self._wit_profile_complete:
                     if batch_idx >= self._wit_profile_end_step:

--- a/nemo/lightning/pytorch/callbacks/__init__.py
+++ b/nemo/lightning/pytorch/callbacks/__init__.py
@@ -19,6 +19,7 @@ from nemo.lightning.pytorch.callbacks.memory_profiler import MemoryProfileCallba
 from nemo.lightning.pytorch.callbacks.model_checkpoint import ModelCheckpoint
 from nemo.lightning.pytorch.callbacks.model_transform import ModelTransform
 from nemo.lightning.pytorch.callbacks.nsys import NsysCallback
+from nemo.lightning.pytorch.callbacks.workload_inspector import WorkloadInspectorCallback
 from nemo.lightning.pytorch.callbacks.peft import PEFT
 from nemo.lightning.pytorch.callbacks.preemption import PreemptionCallback
 from nemo.lightning.pytorch.callbacks.progress_bar import MegatronProgressBar
@@ -30,6 +31,7 @@ __all__ = [
     "ModelTransform",
     "PEFT",
     "NsysCallback",
+    "WorkloadInspectorCallback",
     "MegatronProgressBar",
     "ProgressPrinter",
     "PreemptionCallback",

--- a/nemo/lightning/pytorch/callbacks/__init__.py
+++ b/nemo/lightning/pytorch/callbacks/__init__.py
@@ -19,11 +19,11 @@ from nemo.lightning.pytorch.callbacks.memory_profiler import MemoryProfileCallba
 from nemo.lightning.pytorch.callbacks.model_checkpoint import ModelCheckpoint
 from nemo.lightning.pytorch.callbacks.model_transform import ModelTransform
 from nemo.lightning.pytorch.callbacks.nsys import NsysCallback
-from nemo.lightning.pytorch.callbacks.workload_inspector import WorkloadInspectorCallback
 from nemo.lightning.pytorch.callbacks.peft import PEFT
 from nemo.lightning.pytorch.callbacks.preemption import PreemptionCallback
 from nemo.lightning.pytorch.callbacks.progress_bar import MegatronProgressBar
 from nemo.lightning.pytorch.callbacks.progress_printer import ProgressPrinter
+from nemo.lightning.pytorch.callbacks.workload_inspector import WorkloadInspectorCallback
 
 __all__ = [
     "MemoryProfileCallback",

--- a/nemo/lightning/pytorch/callbacks/workload_inspector.py
+++ b/nemo/lightning/pytorch/callbacks/workload_inspector.py
@@ -19,10 +19,11 @@ from pytorch_lightning.callbacks.callback import Callback
 
 from nemo.utils import logging
 
+
 class WorkloadInspectorCallback(Callback):
     """
     A Workload Inspector Lightening callback that leverages NVIDIA Nsight Systems (Nsys) profiling.
-   
+
 
     This callback enables profiling of specific steps during training using NVIDIA Nsys.
     It allows for precise control over when profiling starts and ends, and provides GPU-wise kernel and exposed comm summaries.
@@ -32,7 +33,7 @@ class WorkloadInspectorCallback(Callback):
     Args:
         start_step (int): Global batch to start profiling
         end_step (int): Global batch to end profiling
-    
+
     Example:
         >>> callback = WorkloadInspectorCallback(start_step=100, end_step=200)
         >>> trainer = Trainer(callbacks=[callback])
@@ -60,7 +61,10 @@ class WorkloadInspectorCallback(Callback):
         import os
         from workload_inspector.bkg_runner import BackgroundRunner
         from workload_inspector.torch.nsys_downstream import NsysDownstream
-        nsys_bg_thread = NsysDownstream(os.getenv('NSYS_LOG_DIR', None), os.getenv('GPU_KERN_STATS_OUTPUT_DIR', None), "stdev")
+
+        nsys_bg_thread = NsysDownstream(
+            os.getenv('NSYS_LOG_DIR', None), os.getenv('GPU_KERN_STATS_OUTPUT_DIR', None), "stdev"
+        )
         self.bg_runner = BackgroundRunner(nsys_bg_thread)
 
     def on_train_batch_start(self, trainer, pl_module, batch, batch_idx: int) -> Optional[int]:
@@ -75,7 +79,6 @@ class WorkloadInspectorCallback(Callback):
             if current_step == self._wit_profile_start_step:
                 logging.info("====== Start nsys profiling ======")
                 torch.cuda.cudart().cudaProfilerStart()
-                
 
     def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx: int) -> None:
         """PyTorch Lightning hook:
@@ -91,4 +94,3 @@ class WorkloadInspectorCallback(Callback):
                 torch.cuda.cudart().cudaProfilerStop()
                 self.bg_runner.start_background_task(args=None)
                 self.bg_runner.join_background_task()
-                

--- a/nemo/lightning/pytorch/callbacks/workload_inspector.py
+++ b/nemo/lightning/pytorch/callbacks/workload_inspector.py
@@ -1,0 +1,94 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List, Optional
+
+import torch
+from pytorch_lightning.callbacks.callback import Callback
+
+from nemo.utils import logging
+
+class WorkloadInspectorCallback(Callback):
+    """
+    A Workload Inspector Lightening callback that leverages NVIDIA Nsight Systems (Nsys) profiling.
+   
+
+    This callback enables profiling of specific steps during training using NVIDIA Nsys.
+    It allows for precise control over when profiling starts and ends, and provides GPU-wise kernel and exposed comm summaries.
+
+    More info about nsys can be found [here](https://developer.nvidia.com/nsight-systems).
+
+    Args:
+        start_step (int): Global batch to start profiling
+        end_step (int): Global batch to end profiling
+    
+    Example:
+        >>> callback = WorkloadInspectorCallback(start_step=100, end_step=200)
+        >>> trainer = Trainer(callbacks=[callback])
+    """
+
+    def __init__(
+        self,
+        start_step: int,
+        end_step: int,
+    ):
+        assert type(start_step) is int, f'trace capture start_step must be of type int. Found: {type(start_step)}'
+        self._wit_profile_start_step = start_step
+
+        assert type(end_step) is int, f'trace capture end_step must be of type int. Found: {type(start_step)}'
+        self._wit_profile_end_step = end_step
+
+        assert (
+            self._wit_profile_end_step >= self._wit_profile_start_step
+        ), 'Tracing end_step must be greater than or equal to start_step'
+
+        logging.info(
+            f'profiling setup with start_step: {self._wit_profile_start_step},'
+            f'and end_step: {self._wit_profile_end_step}'
+        )
+        import os
+        from workload_inspector.bkg_runner import BackgroundRunner
+        from workload_inspector.torch.nsys_downstream import NsysDownstream
+        nsys_bg_thread = NsysDownstream(os.getenv('NSYS_LOG_DIR', None), os.getenv('GPU_KERN_STATS_OUTPUT_DIR', None), "stdev")
+        self.bg_runner = BackgroundRunner(nsys_bg_thread)
+
+    def on_train_batch_start(self, trainer, pl_module, batch, batch_idx: int) -> Optional[int]:
+        """PyTorch Lightning hook:
+        https://pytorch-lightning.readthedocs.io/en/stable/common/lightning_module.html#on-train-batch-start
+        We use it here to enable nsys profiling via WIT tool on all ranks.
+        """
+
+        device = trainer.strategy.root_device
+        current_step = trainer.strategy.current_epoch_step
+        if device.type == 'cuda':
+            if current_step == self._wit_profile_start_step:
+                logging.info("====== Start nsys profiling ======")
+                torch.cuda.cudart().cudaProfilerStart()
+                
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx: int) -> None:
+        """PyTorch Lightning hook:
+        https://pytorch-lightning.readthedocs.io/en/stable/common/lightning_module.html#on-train-batch-end
+        We use it here to enable nsys profiling.
+        """
+
+        device = trainer.strategy.root_device
+        current_step = trainer.strategy.current_epoch_step
+        if device.type == 'cuda':
+            if current_step == self._wit_profile_end_step:
+                logging.info("====== End nsys profiling ======")
+                torch.cuda.cudart().cudaProfilerStop()
+                self.bg_runner.start_background_task(args=None)
+                self.bg_runner.join_background_task()
+                

--- a/nemo/lightning/run/plugins.py
+++ b/nemo/lightning/run/plugins.py
@@ -117,6 +117,7 @@ class NsysPlugin(run.Plugin):
         launcher.nsys_profile = True
         launcher.nsys_trace = self.nsys_trace or ["nvtx", "cuda"]
 
+
 @dataclass(kw_only=True)
 class WorkloadInspectorPlugin(run.Plugin):
     """
@@ -149,6 +150,7 @@ class WorkloadInspectorPlugin(run.Plugin):
         launcher = executor.get_launcher()
         launcher.wit_profile = True
         launcher.wit_trace = self.wit_trace or ["nvtx", "cuda"]
+
 
 @dataclass(kw_only=True)
 class WandbPlugin(run.Plugin):

--- a/tests/collections/nlp/test_falcon_model.py
+++ b/tests/collections/nlp/test_falcon_model.py
@@ -113,6 +113,7 @@ def model_cfg(test_data_dir):
         'ub_tp_comm_overlap_cfg': None,
         'use_flash_attention': False,
         'nsys_profile': {'enabled': False, 'start_step': 10, 'end_step': 10, 'ranks': [0], 'gen_shape': False},
+        'wit_profile': {'enabled': False, 'start_step': 10, 'end_step': 10},
         'optim': {
             'name': 'distributed_fused_adam',
             'lr': '2e-4',

--- a/tests/lightning/pytorch/callbacks/test_workload_inspector.py
+++ b/tests/lightning/pytorch/callbacks/test_workload_inspector.py
@@ -81,7 +81,7 @@ class TestWorkloadInspectorCallback:
     def test_on_train_batch_start_no_profiling(self, mock_cudart, mock_get_rank, mock_trainer, mock_pl_module):
         """Test on_train_batch_start when profiling should not start."""
         mock_get_rank.return_value = 0
-        callback = WorkloadInspectorCallback(start_step=10, end_step=20, ranks=[0])
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20)
 
         mock_trainer.strategy.current_epoch_step = 9
         callback.on_train_batch_start(mock_trainer, mock_pl_module, None, 9)
@@ -94,7 +94,7 @@ class TestWorkloadInspectorCallback:
     ):
         """Test on_train_batch_end when profiling should end."""
         mock_get_rank.return_value = 0
-        callback = WorkloadInspectorCallback(start_step=10, end_step=20, ranks=[0])
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20)
 
         mock_trainer.strategy.current_epoch_step = 20
         callback.on_train_batch_end(mock_trainer, mock_pl_module, None, None, 20)
@@ -107,7 +107,7 @@ class TestWorkloadInspectorCallback:
     ):
         """Test on_train_batch_end when profiling should not end."""
         mock_get_rank.return_value = 0
-        callback = WorkloadInspectorCallback(start_step=10, end_step=20, ranks=[0])
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20)
 
         callback.on_train_batch_end(mock_trainer, mock_pl_module, None, None, 19)
 
@@ -116,7 +116,7 @@ class TestWorkloadInspectorCallback:
     def test_non_cuda_device(self, mock_trainer, mock_pl_module):
         """Test behavior when the device is not CUDA."""
         mock_trainer.strategy.root_device.type = 'cpu'
-        callback = WorkloadInspectorCallback(start_step=10, end_step=20, ranks=[0])
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20)
 
         callback.on_train_batch_start(mock_trainer, mock_pl_module, None, 10)
         callback.on_train_batch_end(mock_trainer, mock_pl_module, None, None, 20)
@@ -126,9 +126,8 @@ class TestWorkloadInspectorCallback:
     def test_rank_not_in_profile_ranks(self, mock_get_rank, mock_trainer, mock_pl_module):
         """Test behavior when the current rank is not in the profile ranks."""
         mock_get_rank.return_value = 1
-        callback = WorkloadInspectorCallback(start_step=10, end_step=20, ranks=[0])
-        callback = WorkloadInspectorCallback(start_step=10, end_step=20, ranks=[0])
-
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20)
+        
         callback.on_train_batch_start(mock_trainer, mock_pl_module, None, 10)
         callback.on_train_batch_end(mock_trainer, mock_pl_module, None, None, 20)
 
@@ -159,7 +158,7 @@ class TestWorkloadInspectorCallback:
     ):
         """Test profiling behavior across different batch indices."""
         mock_get_rank.return_value = 0
-        callback = WorkloadInspectorCallback(start_step=start_step, end_step=end_step, ranks=[0])
+        callback = WorkloadInspectorCallback(start_step=start_step, end_step=end_step)
 
         mock_trainer.strategy.current_epoch_step = batch_idx
         callback.on_train_batch_start(mock_trainer, mock_pl_module, None, batch_idx)
@@ -173,7 +172,7 @@ class TestWorkloadInspectorCallback:
     def test_single_profile_range(self, mock_cudart, mock_get_rank, mock_trainer, mock_pl_module):
         """Test behavior with a single profile range."""
         mock_get_rank.return_value = 0
-        callback = WorkloadInspectorCallback(start_step=10, end_step=40, ranks=[0])
+        callback = WorkloadInspectorCallback(start_step=10, end_step=40)
 
         # Ensure the device type is 'cuda'
         mock_trainer.strategy.root_device.type = 'cuda'

--- a/tests/lightning/pytorch/callbacks/test_workload_inspector.py
+++ b/tests/lightning/pytorch/callbacks/test_workload_inspector.py
@@ -127,7 +127,7 @@ class TestWorkloadInspectorCallback:
         """Test behavior when the current rank is not in the profile ranks."""
         mock_get_rank.return_value = 1
         callback = WorkloadInspectorCallback(start_step=10, end_step=20)
-        
+
         callback.on_train_batch_start(mock_trainer, mock_pl_module, None, 10)
         callback.on_train_batch_end(mock_trainer, mock_pl_module, None, None, 20)
 

--- a/tests/lightning/pytorch/callbacks/test_workload_inspector.py
+++ b/tests/lightning/pytorch/callbacks/test_workload_inspector.py
@@ -1,0 +1,194 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from nemo.lightning.pytorch.callbacks.workload_inspector import WorkloadInspectorCallback
+
+
+class TestWorkloadInspectorCallback:
+    @pytest.fixture(autouse=True)
+    def setup_mocks(self):
+        self.cuda_mock = patch('torch.cuda')
+        self.cudart_mock = patch('torch.cuda.cudart')
+
+        self.cuda_mock.start()
+        self.cudart_mock.start()
+
+        # Mock CUDA availability
+        torch.cuda.is_available = MagicMock(return_value=True)
+        torch.cuda.current_device = MagicMock(return_value=0)
+
+        yield
+
+        self.cuda_mock.stop()
+        self.cudart_mock.stop()
+
+    @pytest.fixture
+    def mock_trainer(self):
+        trainer = MagicMock()
+        trainer.strategy.root_device.type = 'cuda'
+        return trainer
+
+    @pytest.fixture
+    def mock_pl_module(self):
+        return MagicMock()
+
+    def test_init_valid_params(self):
+        """Test initialization with valid parameters."""
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20)
+        assert callback._wit_profile_start_step == 10
+        assert callback._wit_profile_end_step == 20
+
+    def test_init_invalid_params(self):
+        """Test initialization with invalid parameters."""
+        with pytest.raises(AssertionError):
+            WorkloadInspectorCallback(start_step='10', end_step=20)
+
+        with pytest.raises(AssertionError):
+            WorkloadInspectorCallback(start_step=10, end_step='20')
+
+        with pytest.raises(AssertionError):
+            WorkloadInspectorCallback(start_step=20, end_step=10)
+
+    @patch('torch.cuda.cudart')
+    def test_on_train_batch_start_profiling(
+        self, mock_emit_nvtx, mock_cudart, mock_get_rank, mock_trainer, mock_pl_module
+    ):
+        """Test on_train_batch_start when profiling should start."""
+        mock_get_rank.return_value = 0
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20)
+
+        mock_trainer.strategy.current_epoch_step = 10
+        callback.on_train_batch_start(mock_trainer, mock_pl_module, None, 10)
+
+        mock_cudart().cudaProfilerStart.assert_called_once()
+
+    @patch('torch.cuda.cudart')
+    def test_on_train_batch_start_no_profiling(self, mock_cudart, mock_get_rank, mock_trainer, mock_pl_module):
+        """Test on_train_batch_start when profiling should not start."""
+        mock_get_rank.return_value = 0
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20, ranks=[0])
+
+        mock_trainer.strategy.current_epoch_step = 9
+        callback.on_train_batch_start(mock_trainer, mock_pl_module, None, 9)
+
+        mock_cudart().cudaProfilerStart.assert_not_called()
+
+    @patch('torch.cuda.cudart')
+    def test_on_train_batch_end_profiling(
+        self, mock_emit_nvtx, mock_cudart, mock_get_rank, mock_trainer, mock_pl_module
+    ):
+        """Test on_train_batch_end when profiling should end."""
+        mock_get_rank.return_value = 0
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20, ranks=[0])
+
+        mock_trainer.strategy.current_epoch_step = 20
+        callback.on_train_batch_end(mock_trainer, mock_pl_module, None, None, 20)
+
+        mock_cudart().cudaProfilerStop.assert_called_once()
+
+    @patch('torch.cuda.cudart')
+    def test_on_train_batch_end_no_profiling(
+        self, mock_emit_nvtx, mock_cudart, mock_get_rank, mock_trainer, mock_pl_module
+    ):
+        """Test on_train_batch_end when profiling should not end."""
+        mock_get_rank.return_value = 0
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20, ranks=[0])
+
+        callback.on_train_batch_end(mock_trainer, mock_pl_module, None, None, 19)
+
+        mock_cudart().cudaProfilerStop.assert_not_called()
+
+    def test_non_cuda_device(self, mock_trainer, mock_pl_module):
+        """Test behavior when the device is not CUDA."""
+        mock_trainer.strategy.root_device.type = 'cpu'
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20, ranks=[0])
+
+        callback.on_train_batch_start(mock_trainer, mock_pl_module, None, 10)
+        callback.on_train_batch_end(mock_trainer, mock_pl_module, None, None, 20)
+
+        # No exceptions should be raised, and no profiling calls should be made
+
+    def test_rank_not_in_profile_ranks(self, mock_get_rank, mock_trainer, mock_pl_module):
+        """Test behavior when the current rank is not in the profile ranks."""
+        mock_get_rank.return_value = 1
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20, ranks=[0])
+        callback = WorkloadInspectorCallback(start_step=10, end_step=20, ranks=[0])
+
+        callback.on_train_batch_start(mock_trainer, mock_pl_module, None, 10)
+        callback.on_train_batch_end(mock_trainer, mock_pl_module, None, None, 20)
+
+        # No profiling calls should be made
+
+    @pytest.mark.parametrize(
+        "start_step,end_step,batch_idx,expected_call",
+        [
+            (10, 20, 9, False),
+            (10, 20, 10, True),
+            (10, 20, 15, False),
+            (10, 20, 20, False),
+            (10, 20, 21, False),
+        ],
+    )
+    @patch('torch.cuda.cudart')
+    def test_profiling_range(
+        self,
+        mock_emit_nvtx,
+        mock_cudart,
+        mock_get_rank,
+        start_step,
+        end_step,
+        batch_idx,
+        expected_call,
+        mock_trainer,
+        mock_pl_module,
+    ):
+        """Test profiling behavior across different batch indices."""
+        mock_get_rank.return_value = 0
+        callback = WorkloadInspectorCallback(start_step=start_step, end_step=end_step, ranks=[0])
+
+        mock_trainer.strategy.current_epoch_step = batch_idx
+        callback.on_train_batch_start(mock_trainer, mock_pl_module, None, batch_idx)
+
+        if expected_call:
+            mock_cudart().cudaProfilerStart.assert_called_once()
+        else:
+            mock_cudart().cudaProfilerStart.assert_not_called()
+
+    @patch('torch.cuda.cudart')
+    def test_single_profile_range(self, mock_cudart, mock_get_rank, mock_trainer, mock_pl_module):
+        """Test behavior with a single profile range."""
+        mock_get_rank.return_value = 0
+        callback = WorkloadInspectorCallback(start_step=10, end_step=40, ranks=[0])
+
+        # Ensure the device type is 'cuda'
+        mock_trainer.strategy.root_device.type = 'cuda'
+
+        # Start of range
+        mock_trainer.strategy.current_epoch_step = 10
+        callback.on_train_batch_start(mock_trainer, mock_pl_module, None, 10)
+        assert mock_cudart().cudaProfilerStart.call_count == 1, "cudaProfilerStart was not called"
+
+        # Middle of range
+        mock_trainer.strategy.current_epoch_step = 25
+        callback.on_train_batch_start(mock_trainer, mock_pl_module, None, 25)
+        assert mock_cudart().cudaProfilerStart.call_count == 1, "cudaProfilerStart was called again"
+
+        # End of range
+        mock_trainer.strategy.current_epoch_step = 40
+        callback.on_train_batch_end(mock_trainer, mock_pl_module, None, None, 40)
+        assert mock_cudart().cudaProfilerStop.call_count == 1, "cudaProfilerStop was not called"

--- a/tests/lightning/pytorch/callbacks/test_workload_inspector.py
+++ b/tests/lightning/pytorch/callbacks/test_workload_inspector.py
@@ -127,7 +127,6 @@ class TestWorkloadInspectorCallback:
         """Test behavior when the current rank is not in the profile ranks."""
         mock_get_rank.return_value = 1
         callback = WorkloadInspectorCallback(start_step=10, end_step=20)
-
         callback.on_train_batch_start(mock_trainer, mock_pl_module, None, 10)
         callback.on_train_batch_end(mock_trainer, mock_pl_module, None, None, 20)
 

--- a/tests/lightning/test_nemo_run.py
+++ b/tests/lightning/test_nemo_run.py
@@ -132,3 +132,18 @@ def test_recipes_with_nemo_run(module, recipe, name, tmpdir, monkeypatch):
             plugins=run_plugins,
         )
         exp.dryrun()
+
+    run_plugins = [plugins.WorkloadInspectorPlugin(start_step=3, end_step=4)] + run_plugins
+    with run.Experiment(f"{name}-wit-unit-test") as exp:
+        exp.add(
+            recipe_config,
+            executor=run.SlurmExecutor(
+                account="dummy",
+                partition="dummy",
+                nodes=recipe_config.trainer.num_nodes,
+                ntasks_per_node=recipe_config.trainer.devices,
+            ),
+            name=name,
+            plugins=run_plugins,
+        )
+        exp.dryrun()


### PR DESCRIPTION
# What does this PR do ?

Workload analysis tool for anomaly detection and perf analysis. Tool uses Nsys trace captures. 
PR takes Nsys profiling changes as a reference.
 
Provides diagnostic information at per GPU level by analysis of Nsys traces.
  - Compute vs. exposed communication. 
  - Communication overlap at each collective and stream level. 
  - Slow kernels causing training bottlenecks. 

```
Kernel time per iteration: 401.182 (ms)
Kernel instances per iteration: 1006
 Kernel Statistic:
 Class            TimePerIter(ms)  InstancePerIter  TimePerIter(%)   TotalTime(ms)    TotalInstance  TotalTime(%)
 others                    25.68             5513            2.90         256.79            55254          2.90
 bf16_gemm                231.65             21236           53.99        2316.48           212400         53.99
 layernorm                  4.81             2808            0.80          48.12            28080          0.80
 reduce                     2.95             1112            0.62          29.53            11148          0.62
 userbuffer                 39.42            31332           23.96         394.18           313344         23.96
 elementwise_kernel         88.76            29088            6.66         887.55           291128          6.66
 attention                 7.83             1841             10.92          78.32            18432         10.92

NCCL time per iteration: 285.951 (ms)
NCCL overlapped comm time per iteration: 175.113 (ms)
NCCL Overlap Statistics:
Class                  TimePerIter(ms)    OverlapPerIter(ms) Overlap(ms)        OverlapPerIter(%)
AllGather                 109.85              71.50             714.98            65.09
ReduceScatter             134.08             103.61            1036.15            77.28

Per NCCL stream Overlap Statistics:
Class                               Stream ID        Grid Size        TimePerIter(ms)    OverlapPerIter(ms) Overlap(ms)        OverlapPerIter(%)    TotalTime(%)
ReduceScatter                       16               6                          20.37              0.00              0.00                0.00          3.53
ReduceScatter                       16               3                          10.48              0.00              0.00                0.00          0.02
AllGather                                10               4                          81.74             32.62            50.48            8.24           19.74
AllGather                                46               2                        35.45             26.84            67.37            14.97           25.95
AllGather                               22               1                           0.05              0.00              0.00                 0.00          0.00

GPU bubbles per iteration: 0.04%
Multiple NCCL streams overlap per iteration: 0.00%

```

# Changelog 

- Added a Workload Inspector Lightening callback [nemo/lightning/pytorch/callbacks/workload_inspector.py](https://github.com/NVIDIA/NeMo/commit/df4887aead1210b94c2edb254e4c05c996f6749e#diff-dd4d5723656416f43d36613d894dcb66a1547cd6de072137d39f118b038838b2)

- WorkloadInspectorPlugin added to enable the tool [nemo/lightning/run/plugins.py](https://github.com/NVIDIA/NeMo/commit/76586ffd541c605facf7d146dcd58bad42fbf87a#diff-2b4c9a34429f8078889e60cccd2e2b6759100659c2afaa4ebbb493eb97704615)

- Added WiT callback to [nemo/lightning/pytorch/callbacks/__init__.py](https://github.com/NVIDIA/NeMo/commit/76586ffd541c605facf7d146dcd58bad42fbf87a#diff-c9e02dfa089e3aacf2f24c451f7af596b1573f22d0e4f218511aca881f6dd5e4)

- WiT enabling changes in Interface for Pytorch-lightning based NeMo models [‎nemo/core/classes/modelPT.py](https://github.com/NVIDIA/NeMo/commit/76586ffd541c605facf7d146dcd58bad42fbf87a#diff-4b936f7283de92c1563db15e6e966eea3994139ff3ff18823b498592e060a75c) 

- Invoke WiT plugin in [tests/lightning/test_nemo_run.py](https://github.com/NVIDIA/NeMo/commit/76586ffd541c605facf7d146dcd58bad42fbf87a#diff-65cf660991d9d1586bea1caa565d4f8abdf348a4e59432e66d064d79858b38b9)

- WiT enabling steps in various Megatron based models:
[‎nemo/collections/multimodal/models/vision_language_foundation/clip/megatron_clip_models.py](https://github.com/NVIDIA/NeMo/commit/76586ffd541c605facf7d146dcd58bad42fbf87a#diff-db5f2e6c1e3156d33d2e5afa097b7d425e20c07e021f79e43d9916b993027c48)

[‎nemo/collections/nlp/models/language_modeling/megatron_bert_model.py](https://github.com/NVIDIA/NeMo/commit/76586ffd541c605facf7d146dcd58bad42fbf87a#diff-d496e911eb06fca3128061957d326a83ba0a603ca8482ad292aee3851f49bf61)

[nemo/collections/nlp/models/language_modeling/megatron_gpt_sft_model.py]
(https://github.com/NVIDIA/NeMo/commit/76586ffd541c605facf7d146dcd58bad42fbf87a#diff-d84a79499285d34da7d19099472502cb4e7c1b1672832488268066c9c7df852d)

[nemo/collections/vision/models/megatron_vit_classification_models.py](https://github.com/NVIDIA/NeMo/commit/76586ffd541c605facf7d146dcd58bad42fbf87a#diff-791dbc321fe2f4f37e07d17dd694d7a31b2b849510841958226c6d045b529035)

- Test cases for WiT 
[‎tests/lightning/pytorch/callbacks/test_workload_inspector.py](https://github.com/NVIDIA/NeMo/commit/76586ffd541c605facf7d146dcd58bad42fbf87a#diff-4b1ecd4d173033a01acb4e7389e7a6f043bb95916f063720ce9dc9ec3fe34319)

[‎tests/collections/nlp/test_falcon_model.py](https://github.com/NVIDIA/NeMo/commit/76586ffd541c605facf7d146dcd58bad42fbf87a#diff-ca09720d0bccee0bd8699c8342d3ba78b427c2b70f8a9387dbf5e8b21d435901)

# Usage

Workload Inspector (WiT) uses NVIDIA Nsight profiling and CUDA Profiler Start/Stop APIs to detect anomalies in training applications. 

```
 # Workload Inspector profiling options in yaml file
  wit_profile:
    enabled: False
    start_step: 10  # Global batch to start profiling
    end_step: 10 # Global batch to end profiling
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
