### PR TITLE
Fix finetuning datamodule resume

### DIFF
--- a/examples/llm/sft/hf.py
+++ b/examples/llm/sft/hf.py
@@ -22,7 +22,7 @@ from nemo.collections import llm
 
 
 class SquadDataModuleWithPthDataloader(llm.SquadDataModule):
-    def _create_dataloader(self, dataset, **kwargs) -> DataLoader:
+    def _create_dataloader(self, dataset, mode, **kwargs) -> DataLoader:
         return DataLoader(
             dataset,
             num_workers=self.num_workers,

--- a/nemo/collections/llm/gpt/data/fine_tuning.py
+++ b/nemo/collections/llm/gpt/data/fine_tuning.py
@@ -35,26 +35,29 @@ class FineTuningDataModule(pl.LightningDataModule):
     """Base class for fine-tuning an LLM.
 
     This class provides a foundation for building custom data modules for fine-tuning Nemo NLP models. It inherits from
-    `pl.LightningDataModule` from the PyTorch Lightning library and handles data loading, preprocessing, and batch creation
-    for training, validation, and testing.
+    `pl.LightningDataModule` from the PyTorch Lightning library and handles data loading, preprocessing, and batch
+    creation for training, validation, and testing.
 
     Args:
         dataset_root (Union[str, Path]): The root directory containing the training, validation, and test data.
         seq_length (int, optional): The maximum sequence length for the input and output text. Defaults to 2048.
-        tokenizer (Optional[TokenizerSpec], optional): The tokenizer to use for preprocessing the text. Defaults to None.
+        tokenizer (Optional[TokenizerSpec], optional): The tokenizer to use for preprocessing the text.
             If not provided, a Megatron GPT2 BPE tokenizer will be used.
         micro_batch_size (int, optional): The micro batch size for training. Defaults to 4.
         global_batch_size (int, optional): The global batch size for training. Defaults to 8.
-        rampup_batch_size (Optional[List[int]], optional): A list of batch sizes for ramping up during training. Defaults to None.
+        rampup_batch_size (Optional[List[int]], optional): A list of batch sizes for ramping up during training.
+            Defaults to None.
         seed (int, optional): The random seed for data shuffling. Defaults to 1234.
-        memmap_workers (int, optional): The number of worker processes for loading data using TextMemMapDataset. Defaults to 1.
+        memmap_workers (int, optional): The number of worker processes for loading data using TextMemMapDataset.
+            Defaults to 1.
         num_workers (int, optional): The number of worker processes for data loading. Defaults to 8.
-        pin_memory (bool, optional): Whether to pin memory during data loading for faster GPU training. Defaults to True.
-        persistent_workers (bool, optional): Whether to keep data loading workers persistent across epochs. Defaults to False.
+        pin_memory (bool, optional): Whether to pin memory during data loading for faster GPU training.
+            Defaults to True.
+        persistent_workers (bool, optional): Whether to keep data loading workers persistent across epochs.
+            Defaults to False.
         packed_sequence_specs (PackedSequenceSpecs, optional): See PackedSequenceSpecs for details
         dataset_kwargs (Optional[Dict[str, Any]], optional): Keyword arguments to pass into the GPTSFTDataset class
     """
-
     def __init__(
         self,
         dataset_root: Union[str, Path],
@@ -91,18 +94,28 @@ class FineTuningDataModule(pl.LightningDataModule):
         self.dataset_kwargs = dataset_kwargs or {}
 
     def validate_batch_size_for_packed_sequence(self):
+        """
+        Validate that micro batch size must be 1 when using packed sequence.
+        """
         if self.packed_sequence_size > 0 and self.micro_batch_size > 1:
             raise ValueError(
                 "Micro batch size should be 1 when training with packed sequence, but your micro batch size "
                 f"is {self.micro_batch_size}. \nThe following config is equivalent to your current setting for "
                 f"a packed dataset. Please update your config to the following: \n"
                 f"Set micro batch size to 1 (currently {self.micro_batch_size})\n"
-                f"Set global batch size to {self.global_batch_size // self.micro_batch_size} (currently {self.global_batch_size}) \n"
-                f"Set packed sequence length to {self.packed_sequence_size*self.micro_batch_size} (currently {self.packed_sequence_size}) \n"
-                f"For details please visit https://docs.nvidia.com/nemo-framework/user-guide/latest/nemotoolkit/features/optimizations/sequence_packing.html"
+                f"Set global batch size to {self.global_batch_size // self.micro_batch_size} "
+                f"(currently {self.global_batch_size}) \n"
+                f"Set packed sequence length to {self.packed_sequence_size*self.micro_batch_size} "
+                f"(currently {self.packed_sequence_size}) \n"
+                f"For details please visit "
+                f"https://docs.nvidia.com/nemo-framework/user-guide/latest/nemotoolkit/features/optimizations/"
+                f"sequence_packing.html"
             )
 
     def prepare_data(self) -> None:
+        """
+        Prepare packed sequence data
+        """
         if self.packed_sequence_size > 0 and not self.train_path_packed.is_file():
             from nemo.collections.llm.gpt.data.packed_sequence import prepare_packed_sequence_data
 
@@ -116,6 +129,8 @@ class FineTuningDataModule(pl.LightningDataModule):
             )
 
     def setup(self, stage: str):
+        """ Called by pytorch lightning in datamodule setup """
+
         # data_sampler is used in `setup_data_sampler` in MegatronStrategy.setup
         self.data_sampler = MegatronDataSampler(
             seq_len=self.seq_length,
@@ -165,6 +180,7 @@ class FineTuningDataModule(pl.LightningDataModule):
         self.data_sampler.if_first_step = 1
 
     def train_dataloader(self) -> DataLoader:
+        # pylint: disable=C0115,C0116
         return self._create_dataloader(
             self._create_dataset(
                 self.train_path if self.packed_sequence_size <= 0 else self.train_path_packed,
@@ -175,6 +191,7 @@ class FineTuningDataModule(pl.LightningDataModule):
         )
 
     def val_dataloader(self) -> DataLoader:
+        # pylint: disable=C0115,C0116
         return self._create_dataloader(
             self._create_dataset(
                 self.validation_path,
@@ -185,6 +202,7 @@ class FineTuningDataModule(pl.LightningDataModule):
         )
 
     def test_dataloader(self) -> DataLoader:
+        # pylint: disable=C0115,C0116
         return self._create_dataloader(
             self._create_dataset(
                 self.test_path,
@@ -197,6 +215,7 @@ class FineTuningDataModule(pl.LightningDataModule):
 
     @lru_cache
     def _create_dataset(self, path, is_test=False, **kwargs):
+        # pylint: disable=C0115,C0116
         return create_sft_dataset(
             path,
             tokenizer=self.tokenizer,
@@ -208,6 +227,7 @@ class FineTuningDataModule(pl.LightningDataModule):
         )
 
     def _create_dataloader(self, dataset, mode, **kwargs) -> DataLoader:
+        # pylint: disable=C0115,C0116
         return WrappedDataLoader(
             mode=mode,
             dataset=dataset,
@@ -220,10 +240,13 @@ class FineTuningDataModule(pl.LightningDataModule):
 
     @property
     def train_path(self) -> Path:
+        """ Path to training dataset file """
         return self.dataset_root / "training.jsonl"
 
     @property
     def train_path_packed(self) -> Path:
+        """ Path to training dataset file for packed sequence. The file path contains a reference to the
+        tokenizer/model name since packed sequence dataset consists of tokenized indices. """
         if self.packed_sequence_size > 0:
             if self.packed_sequence_specs.packed_data_path is not None:
                 return self.packed_sequence_specs.packed_data_path
@@ -236,13 +259,16 @@ class FineTuningDataModule(pl.LightningDataModule):
 
     @property
     def validation_path(self) -> Path:
+        """ Path to validation dataset file """
         return self.dataset_root / "validation.jsonl"
 
     @property
     def test_path(self) -> Path:
+        """ Path to test dataset file """
         return self.dataset_root / "test.jsonl"
 
     def _extract_tokenizer_model_name(self) -> str:
+        """ Automatically get the model name from model path. """
         if self.packed_sequence_specs.tokenizer_model_name is not None:
             tokenizer_model_name = self.packed_sequence_specs.tokenizer_model_name
         elif isinstance(self.tokenizer, AutoTokenizer):

--- a/nemo/collections/llm/gpt/data/fine_tuning.py
+++ b/nemo/collections/llm/gpt/data/fine_tuning.py
@@ -58,6 +58,7 @@ class FineTuningDataModule(pl.LightningDataModule):
         packed_sequence_specs (PackedSequenceSpecs, optional): See PackedSequenceSpecs for details
         dataset_kwargs (Optional[Dict[str, Any]], optional): Keyword arguments to pass into the GPTSFTDataset class
     """
+
     def __init__(
         self,
         dataset_root: Union[str, Path],
@@ -129,7 +130,7 @@ class FineTuningDataModule(pl.LightningDataModule):
             )
 
     def setup(self, stage: str):
-        """ Called by pytorch lightning in datamodule setup """
+        """Called by pytorch lightning in datamodule setup"""
 
         # data_sampler is used in `setup_data_sampler` in MegatronStrategy.setup
         self.data_sampler = MegatronDataSampler(
@@ -240,13 +241,13 @@ class FineTuningDataModule(pl.LightningDataModule):
 
     @property
     def train_path(self) -> Path:
-        """ Path to training dataset file """
+        """Path to training dataset file"""
         return self.dataset_root / "training.jsonl"
 
     @property
     def train_path_packed(self) -> Path:
-        """ Path to training dataset file for packed sequence. The file path contains a reference to the
-        tokenizer/model name since packed sequence dataset consists of tokenized indices. """
+        """Path to training dataset file for packed sequence. The file path contains a reference to the
+        tokenizer/model name since packed sequence dataset consists of tokenized indices."""
         if self.packed_sequence_size > 0:
             if self.packed_sequence_specs.packed_data_path is not None:
                 return self.packed_sequence_specs.packed_data_path
@@ -259,16 +260,16 @@ class FineTuningDataModule(pl.LightningDataModule):
 
     @property
     def validation_path(self) -> Path:
-        """ Path to validation dataset file """
+        """Path to validation dataset file"""
         return self.dataset_root / "validation.jsonl"
 
     @property
     def test_path(self) -> Path:
-        """ Path to test dataset file """
+        """Path to test dataset file"""
         return self.dataset_root / "test.jsonl"
 
     def _extract_tokenizer_model_name(self) -> str:
-        """ Automatically get the model name from model path. """
+        """Automatically get the model name from model path."""
         if self.packed_sequence_specs.tokenizer_model_name is not None:
             tokenizer_model_name = self.packed_sequence_specs.tokenizer_model_name
         elif isinstance(self.tokenizer, AutoTokenizer):

--- a/nemo/collections/llm/gpt/data/fine_tuning.py
+++ b/nemo/collections/llm/gpt/data/fine_tuning.py
@@ -136,7 +136,9 @@ class FineTuningDataModule(pl.LightningDataModule):
             A dictionary containing datamodule state.
 
         """
-        consumed_samples = self.data_sampler.compute_consumed_samples(self.trainer.global_step - self.data_sampler.init_global_step)
+        consumed_samples = self.data_sampler.compute_consumed_samples(
+            self.trainer.global_step - self.data_sampler.init_global_step
+        )
         return {"consumed_samples": consumed_samples}
 
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:


### PR DESCRIPTION
# What does this PR do ?

Save and load `consumed_samples` for proper resume of finetuning data module

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
