### PR TITLE
fix: regular torch optims (e.g., sgd) no longer error with closure spec

### DIFF
--- a/nemo/core/optim/optimizer_with_main_params.py
+++ b/nemo/core/optim/optimizer_with_main_params.py
@@ -455,6 +455,7 @@ class MainParamsOptimizerWrapper(torch.optim.Optimizer):
             torch.cuda.synchronize()
 
         # Step the optimizer.
+        assert kwargs.pop('closure', None) is None, f"Specifying closures is not supported"
         self.optimizer.step(closure=None, **kwargs)
 
         # Update params from main params.

--- a/nemo/core/optim/optimizer_with_main_params.py
+++ b/nemo/core/optim/optimizer_with_main_params.py
@@ -459,7 +459,6 @@ class MainParamsOptimizerWrapper(torch.optim.Optimizer):
         assert closure is None, f"closre should be None but was passed {closure}"
 
         # Step the optimizer.
-        assert kwargs.pop('closure', None) is None, f"Specifying closures is not supported"
         self.optimizer.step(closure=None, **kwargs)
 
         # Update params from main params.

--- a/nemo/core/optim/optimizer_with_main_params.py
+++ b/nemo/core/optim/optimizer_with_main_params.py
@@ -454,6 +454,10 @@ class MainParamsOptimizerWrapper(torch.optim.Optimizer):
         if self._async_grad_allreduce:
             torch.cuda.synchronize()
 
+        closure = kwargs.pop('closure', None)
+        # Allows applications to specify closure kwarg without erroring due to duplicate specification
+        assert closure is None, f"closre should be None but was passed {closure}"
+
         # Step the optimizer.
         assert kwargs.pop('closure', None) is None, f"Specifying closures is not supported"
         self.optimizer.step(closure=None, **kwargs)

--- a/nemo/core/optim/optimizer_with_main_params.py
+++ b/nemo/core/optim/optimizer_with_main_params.py
@@ -456,7 +456,7 @@ class MainParamsOptimizerWrapper(torch.optim.Optimizer):
 
         closure = kwargs.pop('closure', None)
         # Allows applications to specify closure kwarg without erroring due to duplicate specification
-        assert closure is None, f"closre should be None but was passed {closure}"
+        assert closure is None, f"closure should be None but was passed {closure}"
 
         # Step the optimizer.
         self.optimizer.step(closure=None, **kwargs)

--- a/nemo/core/optim/optimizer_with_main_params.py
+++ b/nemo/core/optim/optimizer_with_main_params.py
@@ -455,7 +455,7 @@ class MainParamsOptimizerWrapper(torch.optim.Optimizer):
             torch.cuda.synchronize()
 
         closure = kwargs.pop('closure', None)
-        # Allows applications to specify closure kwarg without erroring due to duplicate specification
+        # Allows applications to specify closure as None without erroring due to duplicate specification
         assert closure is None, f"closure should be None but was passed {closure}"
 
         # Step the optimizer.


### PR DESCRIPTION
# What does this PR do ?

Mcore distributed optimizers now require us to specify the `closure` kwarg. Example:
https://github.com/NVIDIA/NeMo-Aligner/blob/ac97fe334eff9ad3177edf274c011e74d14a4d60/nemo_aligner/algorithms/dpo.py#L202

This means that if the application also specifies `None` for `closure`, we'll error b/c closure is passed twice. This change pops off closure and ensures it is `None` to be compliant.


**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
