### PR TITLE
Handle _io_unflatten_object when _thread_local.output_dir is not available

### DIFF
--- a/nemo/lightning/io/mixin.py
+++ b/nemo/lightning/io/mixin.py
@@ -608,7 +608,9 @@ def _io_flatten_object(instance):
 
 
 def _io_unflatten_object(values, metadata):
-    assert hasattr(_thread_local, "output_dir")
+    if not hasattr(_thread_local, "output_dir"):
+        return fdl.Config.__unflatten__(values, metadata)
+
     output_dir = _thread_local.output_dir
 
     if len(values) == 1:


### PR DESCRIPTION
This prevents errors of the form
```
penwebtext/0 [default0]:  File "/opt/NeMo/nemo/lightning/io/mixin.py", line 564, in _io_unflatten_object
penwebtext/0 [default0]:    assert hasattr(_thread_local, "output_dir")
penwebtext/0 [default0]:AssertionError
```