### PR TITLE
Hyena wrapper: Weight decay override function

### DIFF
--- a/nemo/collections/llm/gpt/model/hyena.py
+++ b/nemo/collections/llm/gpt/model/hyena.py
@@ -40,6 +40,7 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from nemo.collections.llm.gpt.model.base import GPTModel, gpt_data_step
 from nemo.lightning import get_vocab_size, io, teardown
 
+
 def hyena_forward_step(model, batch) -> torch.Tensor:
 
     forward_args = {

--- a/nemo/collections/llm/gpt/model/hyena.py
+++ b/nemo/collections/llm/gpt/model/hyena.py
@@ -24,6 +24,7 @@ try:
     from megatron.core import parallel_state
     from megatron.core.models.hyena import HyenaModel as MCoreHyenaModel
     from megatron.core.models.hyena.hyena_layer_specs import hyena_stack_spec
+    from megatron.core.ssm.hyena_utils import hyena_no_weight_decay_cond
 
     HAVE_MEGATRON_CORE_OR_TE = True
 
@@ -93,6 +94,11 @@ class HyenaConfig(TransformerConfig, io.IOMixin):
     tokenizer_model_path: str = None
     hyena_init_method: str = None
     hyena_output_layer_init_method: str = None
+    hyena_filter_no_wd: bool = True
+
+    def __post_init__(self):
+        super().__post_init__()
+        self.hyena_no_weight_decay_cond_fn = hyena_no_weight_decay_cond if self.hyena_filter_no_wd else None
 
     def configure_model(self, tokenizer) -> "MCoreHyenaModel":
         model = MCoreHyenaModel(
@@ -498,6 +504,7 @@ class HyenaTestConfig(HyenaConfig):
     recompute_num_layers: int = 2
     hyena_init_method: str = 'small_init'
     hyena_output_layer_init_method: str = 'wang_init'
+    hyena_filter_no_wd: bool = True
 
 
 @dataclass
@@ -531,6 +538,7 @@ class Hyena7bConfig(HyenaConfig):
     recompute_num_layers: int = 4
     hyena_init_method: str = 'small_init'
     hyena_output_layer_init_method: str = 'wang_init'
+    hyena_filter_no_wd: bool = True
 
 
 __all__ = [

--- a/tests/collections/llm/gpt/model/test_hyena.py
+++ b/tests/collections/llm/gpt/model/test_hyena.py
@@ -126,7 +126,7 @@ if __name__ == '__main__':
         use_distributed_optimizer=True,
         bf16=True,
     )
-    opt = MegatronOptimizerModule(config=opt_config)
+    opt = MegatronOptimizerModule(config=opt_config, no_weight_decay_cond=hyena_config.hyena_no_weight_decay_cond_fn)
 
     trainer = nl.Trainer(
         devices=args.devices,


### PR DESCRIPTION
# What does this PR do ?

Hyena wrapper: Weight decay override function
Still TODO: Apply it in non-test scenario

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
