### PR TITLE
Separate pylint stage. Make pylint incremental

### DIFF
--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -1,4 +1,4 @@
-name: Isort and Black Formatting; PyLint Docs check
+name: Isort and Black Formatting
 # Incrementally reformat only changed files with black, all files with isort
 #
 # Replaces pre-commit.ci, since it reformats all the files.

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -13,14 +13,9 @@ on:
   pull_request_target:
     paths:
       - '**.py'
-    types: [ opened, synchronize, reopened, labeled, unlabeled ]
-
-defaults:
-  run:
-    shell: bash -x -e -u -o pipefail {0}
 
 jobs:
-  reformat_with_isort_and_black_and_pylint:
+  reformat_with_isort_and_black:
     runs-on: ubuntu-latest
     permissions:
       # write permissions required to commit changes
@@ -71,17 +66,3 @@ jobs:
         with:
             message: Apply isort and black reformatting
             commit: --signoff
-
-      - name: pylint
-        if: ${{ steps.changed-files.outputs.any_changed == 'true' && !contains( github.event.pull_request.labels.*.name, 'skip-docs') }}
-        env:
-          # only *.py files included
-          CHANGED_FILES: "${{ steps.changed-files.outputs.all_changed_files }}"
-        run: |
-          pip install pylint
-
-          ADDITIONAL_PYLINT_ARGS=()
-          echo ${{ github.event.pull_request.labels.*.name }}
-
-          pylint ${ADDITIONAL_PYLINT_ARGS[@]} $CHANGED_FILES || \
-            { echo "Pylint failed. In case of long strings, format docstrings and other strings manually."; exit 1; }

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -62,7 +62,7 @@ jobs:
           NEW_FILES_LOG="${NEW_FILES_LOG//$'\r'/'%0D'}"
 
           echo $NEW_FILES_LOG
-          echo "::set-output name=new_files::$NEW_FILES_LOG"
+          echo "new_files=${NEW_FILES_LOG}" >> $GITHUB_OUTPUT
 
           CHANGED_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $CHANGED_FILES)
           CHANGED_FILES_LOG="${CHANGED_FILES_LOG//'%'/'%25'}"

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -70,7 +70,7 @@ jobs:
           fi
 
       - name: add_message
-        if: ${{always() && github.event_name == 'pull_request'}}
+        if: always()
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ github.event.number }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -82,12 +82,12 @@ jobs:
         with:
           issue-number: ${{ github.event.number }}
           body: |
-            ## Pylint new files checks results: 
+            ## Pylint result for new files (required): 
             ```
             ${{ steps.pylint.outputs.new_files }}
             ```
             
-            ## Pylint existing files checks results:
+            ## Pylint result for changed files (suggestion):
             ```
             ${{ steps.pylint.outputs.changed_files }}
             ```

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -1,0 +1,86 @@
+name: PyLint Docs check
+# Incrementally reformat only changed files with black, all files with isort
+#
+# Replaces pre-commit.ci, since it reformats all the files.
+# See issue https://github.com/pre-commit-ci/issues/issues/90
+#
+# The action requires a custom token to trigger workflow after pushing reformatted files back to the branch.
+# `secrets.GITHUB_TOKEN` can be used instead, but this will result
+# in not running necessary checks after reformatting, which is undesirable.
+# For details see https://github.com/orgs/community/discussions/25702
+
+on:
+  pull_request_target:
+    paths:
+      - '**.py'
+    types: [ opened, synchronize, reopened, labeled, unlabeled ]
+
+jobs:
+  run_pylint_checks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout branch
+        uses: actions/checkout@v4
+        with:
+          # setup repository and ref for PRs, see
+          # https://github.com/EndBug/add-and-commit?tab=readme-ov-file#working-with-prs
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          # custom token is required to trigger actions after reformatting + pushing
+          token: ${{ secrets.NEMO_REFORMAT_TOKEN }}
+
+      # https://github.com/tj-actions/changed-files
+      - name: Get changed files
+        id: changed-files
+        uses: tj-actions/changed-files@v44
+        with:
+          files: |
+            **.py
+
+      - name: Setup Python env
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: pylint
+        id: pylint
+        if: ${{ steps.changed-files.outputs.any_changed == 'true' && !contains( github.event.pull_request.labels.*.name, 'skip-docs') }}
+        env:
+          # only *.py files included
+          NEW_FILES: "${{ steps.changed-files.outputs.added_files }}"
+          CHANGED_FILES: "${{ steps.changed-files.outputs.all_changed_files }}"
+        run: |
+          pip install pylint
+      
+          ADDITIONAL_PYLINT_ARGS=()
+          echo ${{ github.event.pull_request.labels.*.name }}
+      
+          # pylint is required for new (added) files
+          NEW_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $NEW_FILES)
+          NEW_FILES_CODE=$?
+          echo "new_files=$NEW_FILES_LOG" >> $GITHUB_OUTPUT
+          
+          # optional check for existing (modified) files
+          CHANGED_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $CHANGED_FILES) 
+          echo "changed_files=$CHANGED_FILES_LOG" >> $GITHUB_OUTPUT
+          
+          if [ ${NEW_FILES_CODE} -ne 0 ]; then
+            echo "Pylint failed for new files. In case of long strings, format docstrings and other strings manually."
+            exit $NEW_FILES_CODE
+          fi
+
+      - name: add_message
+        if: ${{always() && github.event_name == 'pull_request'}}
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.number }}
+          body: |
+            ## Pylint new files checks results: 
+            ```
+            ${{ steps.pylint.outputs.new_files }}
+            ```
+            
+            ## Pylint existing files checks results:
+            ```
+            ${{ steps.pylint.outputs.changed_files }}
+            ```

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -15,10 +15,6 @@ on:
       - '**.py'
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
 
-defaults:
-  run:
-    shell: bash --noprofile --norc +e +o pipefail
-
 jobs:
   run_pylint_checks:
     runs-on: ubuntu-latest
@@ -55,11 +51,11 @@ jobs:
           CHANGED_FILES: "${{ steps.changed-files.outputs.all_changed_files }}"
         run: |
           pip install pylint
-          echo "pylint installed"
       
           ADDITIONAL_PYLINT_ARGS=()
           echo ${{ github.event.pull_request.labels.*.name }}
 
+          set +e
           NEW_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $NEW_FILES)
           NEW_FILES_CODE=$?
           echo $NEW_FILES_LOG

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -54,14 +54,12 @@ jobs:
       
           ADDITIONAL_PYLINT_ARGS=()
           echo ${{ github.event.pull_request.labels.*.name }}
-      
-          # pylint is required for new (added) files
+
           NEW_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $NEW_FILES)
           NEW_FILES_CODE=$?
           echo $NEW_FILES_LOG
           echo "new_files=$NEW_FILES_LOG" >> $GITHUB_OUTPUT
-          
-          # optional check for existing (modified) files
+
           CHANGED_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $CHANGED_FILES)
           echo $CHANGED_FILES_LOG
           echo "changed_files=$CHANGED_FILES_LOG" >> $GITHUB_OUTPUT

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -72,10 +72,7 @@ jobs:
           CHANGED_FILES_LOG="${CHANGED_FILES_LOG//$'\r'/'%0D'}"
           echo $CHANGED_FILES_LOG
           echo "::set-output name=changed_files::$CHANGED_FILES_LOG"
-#          echo 'changed_files<<EOF' >> $GITHUB_OUTPUT
-#          echo $CHANGED_FILES_LOG >> $GITHUB_OUTPUT
-#          echo 'EOF' >> $GITHUB_OUTPUT
-          
+
           if [ ${NEW_FILES_CODE} -ne 0 ]; then
             echo "Pylint failed for new files. In case of long strings, format docstrings and other strings manually."
             exit $NEW_FILES_CODE

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -51,6 +51,7 @@ jobs:
           CHANGED_FILES: "${{ steps.changed-files.outputs.all_changed_files }}"
         run: |
           pip install pylint
+          echo "pylint installed"
       
           ADDITIONAL_PYLINT_ARGS=()
           echo ${{ github.event.pull_request.labels.*.name }}

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -57,12 +57,18 @@ jobs:
 
           set +e
           NEW_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $NEW_FILES); NEW_FILES_CODE=$?
+          NEW_FILES_LOG="${NEW_FILES_LOG//'%'/'%25'}"
+          NEW_FILES_LOG="${NEW_FILES_LOG//$'\n'/'%0A'}"
+          NEW_FILES_LOG="${NEW_FILES_LOG//$'\r'/'%0D'}"
           echo $NEW_FILES_LOG
           echo 'new_files<<EOF' >> $GITHUB_OUTPUT
           echo $NEW_FILES_LOG >> $GITHUB_OUTPUT
           echo 'EOF' >> $GITHUB_OUTPUT
 
           CHANGED_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $CHANGED_FILES)
+          CHANGED_FILES_LOG="${CHANGED_FILES_LOG//'%'/'%25'}"
+          CHANGED_FILES_LOG="${CHANGED_FILES_LOG//$'\n'/'%0A'}"
+          CHANGED_FILES_LOG="${CHANGED_FILES_LOG//$'\r'/'%0D'}"
           echo $CHANGED_FILES_LOG
           echo 'changed_files<<EOF' >> $GITHUB_OUTPUT
           echo $CHANGED_FILES_LOG >> $GITHUB_OUTPUT

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -15,6 +15,10 @@ on:
       - '**.py'
     types: [ opened, synchronize, reopened, labeled, unlabeled ]
 
+defaults:
+  run:
+    shell: bash --noprofile --norc +e +o pipefail
+
 jobs:
   run_pylint_checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -62,7 +62,7 @@ jobs:
           NEW_FILES_LOG="${NEW_FILES_LOG//$'\r'/'%0D'}"
 
           echo $NEW_FILES_LOG
-          echo "new_files=${NEW_FILES_LOG}" >> $GITHUB_OUTPUT
+          echo "::set-output name=new_files::$NEW_FILES_LOG"
 
           CHANGED_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $CHANGED_FILES)
           CHANGED_FILES_LOG="${CHANGED_FILES_LOG//'%'/'%25'}"

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -62,9 +62,7 @@ jobs:
           NEW_FILES_LOG="${NEW_FILES_LOG//$'\r'/'%0D'}"
 
           echo $NEW_FILES_LOG
-          echo 'new_files<<EOF' >> $GITHUB_OUTPUT
-          echo $NEW_FILES_LOG >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          echo "::set-output name=new_files::$NEW_FILES_LOG"
 
           CHANGED_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $CHANGED_FILES)
           CHANGED_FILES_LOG="${CHANGED_FILES_LOG//'%'/'%25'}"

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -58,10 +58,12 @@ jobs:
           # pylint is required for new (added) files
           NEW_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $NEW_FILES)
           NEW_FILES_CODE=$?
+          echo $NEW_FILES_LOG
           echo "new_files=$NEW_FILES_LOG" >> $GITHUB_OUTPUT
           
           # optional check for existing (modified) files
-          CHANGED_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $CHANGED_FILES) 
+          CHANGED_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $CHANGED_FILES)
+          echo $CHANGED_FILES_LOG
           echo "changed_files=$CHANGED_FILES_LOG" >> $GITHUB_OUTPUT
           
           if [ ${NEW_FILES_CODE} -ne 0 ]; then

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -60,6 +60,7 @@ jobs:
           NEW_FILES_LOG="${NEW_FILES_LOG//'%'/'%25'}"
           NEW_FILES_LOG="${NEW_FILES_LOG//$'\n'/'%0A'}"
           NEW_FILES_LOG="${NEW_FILES_LOG//$'\r'/'%0D'}"
+
           echo $NEW_FILES_LOG
           echo 'new_files<<EOF' >> $GITHUB_OUTPUT
           echo $NEW_FILES_LOG >> $GITHUB_OUTPUT
@@ -70,9 +71,10 @@ jobs:
           CHANGED_FILES_LOG="${CHANGED_FILES_LOG//$'\n'/'%0A'}"
           CHANGED_FILES_LOG="${CHANGED_FILES_LOG//$'\r'/'%0D'}"
           echo $CHANGED_FILES_LOG
-          echo 'changed_files<<EOF' >> $GITHUB_OUTPUT
-          echo $CHANGED_FILES_LOG >> $GITHUB_OUTPUT
-          echo 'EOF' >> $GITHUB_OUTPUT
+          echo "::set-output name=changed_files::$CHANGED_FILES_LOG"
+#          echo 'changed_files<<EOF' >> $GITHUB_OUTPUT
+#          echo $CHANGED_FILES_LOG >> $GITHUB_OUTPUT
+#          echo 'EOF' >> $GITHUB_OUTPUT
           
           if [ ${NEW_FILES_CODE} -ne 0 ]; then
             echo "Pylint failed for new files. In case of long strings, format docstrings and other strings manually."

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -56,14 +56,17 @@ jobs:
           echo ${{ github.event.pull_request.labels.*.name }}
 
           set +e
-          NEW_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $NEW_FILES)
-          NEW_FILES_CODE=$?
+          NEW_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $NEW_FILES); NEW_FILES_CODE=$?
           echo $NEW_FILES_LOG
-          echo "new_files=$NEW_FILES_LOG" >> $GITHUB_OUTPUT
+          echo 'new_files<<EOF' >> $GITHUB_OUTPUT
+          echo $NEW_FILES_LOG >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
 
           CHANGED_FILES_LOG=$(pylint ${ADDITIONAL_PYLINT_ARGS[@]} $CHANGED_FILES)
           echo $CHANGED_FILES_LOG
-          echo "changed_files=$CHANGED_FILES_LOG" >> $GITHUB_OUTPUT
+          echo 'changed_files<<EOF' >> $GITHUB_OUTPUT
+          echo $CHANGED_FILES_LOG >> $GITHUB_OUTPUT
+          echo 'EOF' >> $GITHUB_OUTPUT
           
           if [ ${NEW_FILES_CODE} -ne 0 ]; then
             echo "Pylint failed for new files. In case of long strings, format docstrings and other strings manually."


### PR DESCRIPTION
# What does this PR do ?

- separate `pylint` stage
- make `pylint` required for new files
- make `pylint` optional for changed files
- add `pylint` output as a comment to PR

Demo PR: https://github.com/NVIDIA/NeMo/pull/11215

**Collection**: [CI]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
