### PR TITLE
Use Mcore ModelParallelConfig in strategy parallelism property

### DIFF
--- a/nemo/lightning/fabric/strategies.py
+++ b/nemo/lightning/fabric/strategies.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from contextlib import ExitStack, contextmanager
+from dataclasses import fields
 from datetime import timedelta
 from typing import (
     TYPE_CHECKING,
@@ -405,20 +406,17 @@ class FabricMegatronStrategy(DDPStrategy):
         return self._checkpoint_io
 
     @property
-    def parallelism(self):
-        from nemo.lightning.pytorch.strategies.megatron_strategy import ParallelismConfig
+    def parallelism(self) -> ModelParallelConfig:
+        # Get fields from ModelParallelConfig dataclass
+        config_fields = {}
+        for field in fields(ModelParallelConfig):
+            # Only include field if it exists in self
+            if hasattr(self, field.name):
+                config_fields[field.name] = getattr(self, field.name)
 
-        return ParallelismConfig(
-            tensor_model_parallel_size=self.tensor_model_parallel_size,
-            pipeline_model_parallel_size=self.pipeline_model_parallel_size,
-            virtual_pipeline_model_parallel_size=self.virtual_pipeline_model_parallel_size,
-            microbatch_group_size_per_vp_stage=self.microbatch_group_size_per_vp_stage,
-            context_parallel_size=self.context_parallel_size,
-            sequence_parallel=self.sequence_parallel,
-            expert_model_parallel_size=self.expert_model_parallel_size,
-            moe_extended_tp=self.moe_extended_tp,
-            pipeline_dtype=self.pipeline_dtype,
-        )
+        # Initialize ModelParallelConfig with only available fields
+        model_parallel_config = ModelParallelConfig(**config_fields)
+        return model_parallel_config
 
 
 # TODO: Fix this

--- a/nemo/lightning/fabric/strategies.py
+++ b/nemo/lightning/fabric/strategies.py
@@ -40,6 +40,7 @@ from lightning_fabric.strategies import DDPStrategy
 from lightning_fabric.strategies.strategy import _validate_keys_for_strict_loading
 from lightning_fabric.utilities.types import _PATH, _Stateful
 from megatron.core.distributed import DistributedDataParallelConfig
+from megatron.core.model_parallel_config import ModelParallelConfig
 from megatron.core.optimizer import OptimizerConfig
 from pytorch_lightning import LightningDataModule
 from pytorch_lightning.loops.fetchers import _DataFetcher
@@ -59,8 +60,6 @@ from nemo.lightning.megatron_parallel import CallbackConnector, MegatronParallel
 from nemo.lightning.pytorch.strategies import MegatronStrategy
 
 if TYPE_CHECKING:
-    from megatron.core.model_parallel_config import ModelParallelConfig
-
     from nemo.lightning.pytorch.plugins.data_sampler import DataSampler
 
 

--- a/nemo/lightning/pytorch/callbacks/megatron_comm_overlap.py
+++ b/nemo/lightning/pytorch/callbacks/megatron_comm_overlap.py
@@ -13,15 +13,15 @@
 # limitations under the License.
 
 from dataclasses import asdict, dataclass, fields
-import pytorch_lightning as pl
 
+import pytorch_lightning as pl
 from megatron.core import ModelParallelConfig
 from megatron.core.distributed import DistributedDataParallelConfig
 from megatron.core.optimizer import OptimizerConfig
 from pytorch_lightning.callbacks.callback import Callback
 
 from nemo.collections.llm.recipes.tp_overlap_configs.userbuffers import TransformerLayerTPOverlapCfg
-from nemo.lightning.pytorch.strategies.megatron_strategy import MegatronStrategy, ParallelismConfig
+from nemo.lightning.pytorch.strategies.megatron_strategy import MegatronStrategy
 from nemo.utils import logging
 
 try:
@@ -118,7 +118,7 @@ class MegatronCommOverlapCallback(Callback):
 
     def _get_model_comm_overlap_cfgs(
         self,
-        parallelism_cfg: ParallelismConfig,
+        parallelism_cfg: ModelParallelConfig,
     ) -> _CommOverlapConfig:
         comm_overlap_cfg = _CommOverlapConfig()
 
@@ -159,7 +159,7 @@ class MegatronCommOverlapCallback(Callback):
         comm_overlap_cfg = self._override_user_cfgs(comm_overlap_cfg)
         return comm_overlap_cfg
 
-    def _get_optimizer_overlap_cfgs(self, parallelism_cfg: ParallelismConfig) -> _CommOverlapConfig:
+    def _get_optimizer_overlap_cfgs(self, parallelism_cfg: ModelParallelConfig) -> _CommOverlapConfig:
         from nemo.utils import AppState
 
         app_state = AppState()

--- a/nemo/lightning/pytorch/strategies/megatron_strategy.py
+++ b/nemo/lightning/pytorch/strategies/megatron_strategy.py
@@ -18,7 +18,7 @@ import os
 import shutil
 from collections import OrderedDict
 from contextlib import ExitStack, contextmanager
-from dataclasses import dataclass, fields
+from dataclasses import fields
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,


### PR DESCRIPTION
This uses Mcore's ModelParallelConfig directly in `strategy.parallelism`. This should also enable backwards compatibility with different Mcore versions as it relies on the Mcore class now.