### PR TITLE
Enable ucc backend for pp

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -192,6 +192,7 @@ class MegatronBaseModel(NLPModel):
             tensor_model_parallel_size=cfg.get('tensor_model_parallel_size', 1),
             expert_model_parallel_size=cfg.get('expert_model_parallel_size', 1),
             pipeline_model_parallel_size=cfg.get('pipeline_model_parallel_size', 1),
+            pipeline_model_parallel_comm_backend=cfg.get('pipeline_model_parallel_comm_backend', 'nccl'),
             virtual_pipeline_model_parallel_size=vp_size,
             pipeline_model_parallel_split_rank=cfg.get('pipeline_model_parallel_split_rank', 0),
             use_tp_pp_dp_mapping=cfg.get('use_tp_pp_dp_mapping', False),

--- a/nemo/collections/nlp/modules/common/megatron/megatron_init.py
+++ b/nemo/collections/nlp/modules/common/megatron/megatron_init.py
@@ -94,6 +94,7 @@ def initialize_model_parallel_for_nemo(
     pipeline_model_parallel_size=1,
     virtual_pipeline_model_parallel_size=None,
     pipeline_model_parallel_split_rank=None,
+    pipeline_model_parallel_comm_backend='nccl',
     context_parallel_size=1,
     encoder_tensor_model_parallel_size=0,
     encoder_pipeline_model_parallel_size=0,
@@ -124,6 +125,7 @@ def initialize_model_parallel_for_nemo(
     app_state.context_parallel_size = context_parallel_size
     app_state.encoder_tensor_model_parallel_size = encoder_tensor_model_parallel_size
     app_state.encoder_pipeline_model_parallel_size = encoder_pipeline_model_parallel_size
+    app_state.pipeline_model_parallel_comm_backend = pipeline_model_parallel_comm_backend
     app_state.use_fp8 = use_fp8
     app_state.init_mpi_proc_group = init_mpi_proc_group
     (

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -157,6 +157,7 @@ def init_model_parallel(
                 pipeline_model_parallel_size=app_state.pipeline_model_parallel_size,
                 virtual_pipeline_model_parallel_size=app_state.virtual_pipeline_model_parallel_size,
                 pipeline_model_parallel_split_rank=app_state.pipeline_model_parallel_split_rank,
+                pipeline_model_parallel_comm_backend=app_state.pipeline_model_parallel_comm_backend,
                 context_parallel_size=app_state.context_parallel_size,
                 nccl_communicator_config_path=nccl_communicator_config_path,
                 use_sharp=sharp,

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -54,6 +54,7 @@ class AppState(metaclass=Singleton):
         self._encoder_pipeline_model_parallel_size = None
         self._pipeline_model_parallel_group = None
         self._pipeline_model_parallel_split_rank = None
+        self._pipeline_model_parallel_comm_backend = None
         self._is_megatron_initialized = False
         self._data_parallel_size = None
         self._data_parallel_group = None
@@ -201,6 +202,22 @@ class AppState(metaclass=Singleton):
             size (int):  Number of GPUs in each model parallel group.
         """
         self._pipeline_model_parallel_size = size
+    
+    @property
+    def pipeline_model_parallel_comm_backend(self):
+        """Property returns the backend communication library of pipeline communication.
+        Returns:
+            Backend communication library of pipeline communication.
+        """
+        return self._pipeline_model_parallel_comm_backend
+
+    @pipeline_model_parallel_comm_backend.setter
+    def pipeline_model_parallel_comm_backend(self, backend):
+        """Property sets the backend communication library of pipeline communication.
+        Args:
+            backend (str): Backend communication library of pipeline communication.
+        """
+        self._pipeline_model_parallel_comm_backend = backend
 
     @property
     def encoder_tensor_model_parallel_size(self):

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -202,7 +202,7 @@ class AppState(metaclass=Singleton):
             size (int):  Number of GPUs in each model parallel group.
         """
         self._pipeline_model_parallel_size = size
-    
+
     @property
     def pipeline_model_parallel_comm_backend(self):
         """Property returns the backend communication library of pipeline communication.


### PR DESCRIPTION
# What does this PR do ?

This MR provides an interface to enable the UCC backend for PP communication.
To enable the UCC backend, set the following argument:

`training.model.pipeline_model_parallel_comm_backend=ucc`

Requires a related MCore MR ([link](https://gitlab-master.nvidia.com/ADLR/megatron-lm/-/merge_requests/2116)).
