### PR TITLE
AttributeError: module 'signal' has no attribute 'SIGKILL'

### DIFF
--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -167,7 +167,7 @@ class FaultToleranceParams:
     rank_heartbeat_timeout: Optional[float] = 45.0 * 60.0
     calculate_timeouts: bool = True
     safety_factor: float = 5.0
-    rank_termination_signal: signal.Signals = signal.SIGKILL
+    rank_termination_signal: signal.Signals = signal.SIGILL
     log_level: str = 'INFO'
     max_rank_restarts: int = 0
     max_subsequent_job_failures: int = 0


### PR DESCRIPTION
# What does this PR do ?

Resolve Issue.

**AttributeError**: module 'signal' has no attribute 'SIGKILL'

**PR Type**:
- [x] Bugfix

# Additional Information
* Related to # (issue)
