### PR TITLE
Revert "fix(export): GPT models w/ bias=False convert properly"

### DIFF
--- a/nemo/export/trt_llm/tensorrt_llm_build.py
+++ b/nemo/export/trt_llm/tensorrt_llm_build.py
@@ -118,14 +118,6 @@ def build_and_save_engine(
         build_config.lora_config = lora_config
 
     model = model_cls.from_config(model_config)
-    if not model_config.bias and model_config.architecture == 'GPTForCausalLM':
-        # NOTE: GPT models in megatron-core that set bias=False sets the bias false globally
-        #  whereas bias=False in TRTLLM GPT models sets it false everywhere except
-        #  LayerNorm. This change makes TRTLLM's implementation match megatron-core.
-        for name, module in model.named_modules():
-            if isinstance(module, tensorrt_llm.layers.normalization.LayerNorm):
-                module.bias = None
-                module.register_parameter('bias', None)
     model = optimize_model(
         model,
         use_parallel_embedding=model_config.use_parallel_embedding,


### PR DESCRIPTION
Reverts NVIDIA/NeMo#11255

This PR broke other models and was unnecessarily fixing gptnext when I should have just used llama