### PR TITLE
Don't use nvidia_torch_version until after None check

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -388,11 +388,10 @@ class MegatronBaseModel(NLPModel):
         def is_official_release_version(nvidia_torch_version):
             return re.fullmatch("[0-9][0-9]\.[0-9][0-9].*", nvidia_torch_version)  # "YY.MM.*"
 
-        # Support DLFW dev container
-        if not is_official_release_version(nvidia_torch_version):
-            nvidia_torch_version = datetime.now().strftime('%y.%m')
-
         if nvidia_torch_version is not None:
+            # Support DLFW dev container
+            if not is_official_release_version(nvidia_torch_version):
+                nvidia_torch_version = datetime.now().strftime('%y.%m')
             try:
                 NVIDIA_TORCH_MAJOR = int(nvidia_torch_version.split('.')[0])
             except Exception:


### PR DESCRIPTION
# What does this PR do ?

There was a crash when nvidia_torch_version came back as None because it was still being used before the None check.

**Collection**: [NLP]

# Changelog 
Fixed crash when NVIDIA_PYTORCH_VERSION is not set

# Usage
* You can potentially add a usage example below
Run a anything that exercises this code without NVIDIA_PYTORCH_VERSION set

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [X ] Did you write any new necessary tests?
- [ X] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [X ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

 @MaximumEntropy  @thomasdhc  (Not sure if I'm supposed to ping the whole NLP reviewer list)

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
This is a minor fix. No associated tests or documentation. I tried to keep it simple. Devs may prefer different logic (e.g. an extra none check before the official release check, move the is_official_release_version def inside the None check block, etc)