### PR TITLE
Remove default mutable arguments from AbstractEmbModel constructor

### DIFF
--- a/nemo/collections/diffusion/encoders/conditioner.py
+++ b/nemo/collections/diffusion/encoders/conditioner.py
@@ -20,7 +20,12 @@ from transformers import CLIPTextModel, CLIPTokenizer, T5EncoderModel, T5Tokeniz
 
 
 class AbstractEmbModel(nn.Module):
-    def __init__(self, enable_lora_finetune: bool = False, target_block: Optional[List[str]] = None, target_module: Optional[List[str]] = None) -> None:
+    def __init__(
+        self,
+        enable_lora_finetune: bool = False,
+        target_block: Optional[List[str]] = None,
+        target_module: Optional[List[str]] = None,
+    ) -> None:
         super().__init__()
         self._is_trainable = None
         self._ucg_rate = None

--- a/nemo/collections/diffusion/encoders/conditioner.py
+++ b/nemo/collections/diffusion/encoders/conditioner.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Union
+from typing import List, Union
 
 import torch
 import torch.nn as nn
@@ -20,14 +20,14 @@ from transformers import CLIPTextModel, CLIPTokenizer, T5EncoderModel, T5Tokeniz
 
 
 class AbstractEmbModel(nn.Module):
-    def __init__(self, enable_lora_finetune=False, target_block=[], target_module=[]):
+    def __init__(self, enable_lora_finetune: bool = False, target_block: Optional[List[str]] = None, target_module: Optional[List[str]] = None) -> None:
         super().__init__()
         self._is_trainable = None
         self._ucg_rate = None
         self._input_key = None
 
-        self.TARGET_BLOCK = target_block
-        self.TARGET_MODULE = target_module
+        self.TARGET_BLOCK = target_block or []
+        self.TARGET_MODULE = target_module or []
         if enable_lora_finetune:
             self.lora_layers = []
 

--- a/nemo/collections/diffusion/encoders/conditioner.py
+++ b/nemo/collections/diffusion/encoders/conditioner.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import List, Union
+from typing import List, Optional, Union
 
 import torch
 import torch.nn as nn


### PR DESCRIPTION
# What does this PR do ?

This changes the constructor signature. This change is backwards compatible with existing callers. 

**Collection**: [Note which collection this PR will affect]
Diffusion for NeMo2

# Changelog 
- Remove default mutable arguments from `AbstractEmbModel` constructor

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
