### PR TITLE
Deprecate old preemption callback

### DIFF
--- a/nemo/lightning/pytorch/callbacks/preemption.py
+++ b/nemo/lightning/pytorch/callbacks/preemption.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import contextlib
+import importlib.util
 import signal
 import sys
 from typing import Optional
@@ -69,7 +70,8 @@ class PreemptionCallback(Callback, IOMixin):
             if trainer.checkpoint_callback:
                 monitor_candidates = trainer.checkpoint_callback._monitor_candidates(trainer)
                 trainer.checkpoint_callback._save_last_checkpoint(trainer, monitor_candidates)
-                if isinstance(trainer.strategy.checkpoint_io, AsyncFinalizableCheckpointIO):
+                mcore_available = importlib.util.find_spec("megatron.core")
+                if mcore_available and isinstance(trainer.strategy.checkpoint_io, AsyncFinalizableCheckpointIO):
                     logging.info("Async checkpointing detected, waiting for it to complete")
                     trainer.strategy.checkpoint_io.maybe_finalize_save_checkpoint(blocking=True)
                 sys.exit(0)

--- a/nemo/utils/callbacks/preemption.py
+++ b/nemo/utils/callbacks/preemption.py
@@ -22,7 +22,9 @@ from nemo.utils import logging
 from nemo.utils.decorators import deprecated
 
 
-@deprecated(explanation="nemo.utils.callbacks.preemption.PreemptionCallback is deprecated in favor of nemo.lightning.pytorch.callbacks.preemption.PreemptionCallback")
+@deprecated(
+    explanation="nemo.utils.callbacks.preemption.PreemptionCallback is deprecated in favor of nemo.lightning.pytorch.callbacks.preemption.PreemptionCallback"
+)
 class PreemptionCallback(Callback):
     """
     PreemptionCallback class creates a callback that checks for preemption during training at the end of every step.

--- a/nemo/utils/callbacks/preemption.py
+++ b/nemo/utils/callbacks/preemption.py
@@ -19,8 +19,10 @@ import torch
 from lightning.pytorch.callbacks import Callback
 
 from nemo.utils import logging
+from nemo.utils.decorators import deprecated
 
 
+@deprecated(explanation="nemo.utils.callbacks.preemption.PreemptionCallback is deprecated in favor of nemo.lightning.pytorch.callbacks.preemption.PreemptionCallback")
 class PreemptionCallback(Callback):
     """
     PreemptionCallback class creates a callback that checks for preemption during training at the end of every step.

--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -41,10 +41,10 @@ from omegaconf import DictConfig, OmegaConf, open_dict
 
 from nemo.collections.common.callbacks import EMA
 from nemo.constants import NEMO_ENV_VARNAME_TESTING, NEMO_ENV_VARNAME_VERSION
+from nemo.lightning.pytorch.callbacks import PreemptionCallback
 from nemo.utils import logging, timers
 from nemo.utils.app_state import AppState
 from nemo.utils.callbacks import NeMoModelCheckpoint
-from nemo.lightning.pytorch.callbacks import PreemptionCallback
 from nemo.utils.env_var_parsing import get_envbool
 from nemo.utils.exceptions import NeMoBaseException
 from nemo.utils.get_rank import is_global_rank_zero

--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -43,7 +43,8 @@ from nemo.collections.common.callbacks import EMA
 from nemo.constants import NEMO_ENV_VARNAME_TESTING, NEMO_ENV_VARNAME_VERSION
 from nemo.utils import logging, timers
 from nemo.utils.app_state import AppState
-from nemo.utils.callbacks import NeMoModelCheckpoint, PreemptionCallback
+from nemo.utils.callbacks import NeMoModelCheckpoint
+from nemo.lightning.pytorch.callbacks import PreemptionCallback
 from nemo.utils.env_var_parsing import get_envbool
 from nemo.utils.exceptions import NeMoBaseException
 from nemo.utils.get_rank import is_global_rank_zero
@@ -1217,8 +1218,8 @@ def configure_checkpointing(
         # Check if cuda is avialable as preemption is supported only on GPUs
         if torch.cuda.is_available():
             ## By default PreemptionCallback handles SIGTERM. To handle other signals pass the signal in the call as below:
-            ## PreemptionCallback(checkpoint_callback, signal.SIGCHLD)
-            preemption_callback = PreemptionCallback(checkpoint_callback)
+            ## PreemptionCallback(signal.SIGCHLD)
+            preemption_callback = PreemptionCallback()
             trainer.callbacks.append(preemption_callback)
         else:
             logging.info("Preemption is supported only on GPUs, disabling preemption")


### PR DESCRIPTION
# What does this PR do ?

There are 2 nearly equivalent classes for handling preemption. This PR adds a deprecation warning for the older version
Old: https://github.com/NVIDIA/NeMo/blob/main/nemo/utils/callbacks/preemption.py
New: https://github.com/NVIDIA/NeMo/blob/main/nemo/lightning/pytorch/callbacks/preemption.py

**Collection**: N/A

# Changelog 
Deprecate old preemption callback

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
