### PR TITLE
LLava next data module changes for energon and mock

### DIFF
--- a/nemo/collections/vlm/neva/data/llava_next_energon.py
+++ b/nemo/collections/vlm/neva/data/llava_next_energon.py
@@ -27,6 +27,18 @@ from nemo.utils import logging
 
 @dataclass
 class LlavaNextTextSample(ImageTextSample):
+    '''Sample type for LLaVA-Next, extending ImageTextSample to support tiled image data.
+
+    This class adds additional attributes for handling high-resolution images processed as tiles,
+    along with metadata about the tiled images.
+
+    Attributes:
+        num_media_tiles (int): The number of tiles used to represent the high-resolution image.
+        image_sizes (torch.Tensor): A tensor representing the sizes of the tiled images. Defaults to an empty tensor.
+        attention_mask (Optional[torch.Tensor]): An optional attention mask for the sample, used to determine
+            which tokens or tiles are attended to during processing. Defaults to None.
+    '''
+
     num_media_tiles: int = 0
     image_sizes: torch.tensor = field(default_factory=lambda: torch.tensor([]))
     attention_mask: Optional[torch.tensor] = None
@@ -34,6 +46,17 @@ class LlavaNextTextSample(ImageTextSample):
 
 @dataclass
 class LlavaNextTextRawBatch(ImageTextRawBatch):
+    '''Batch type for raw LLaVA-Next samples, supporting tiled image data.
+
+    This class aggregates multiple `LlavaNextTextSample` instances into a batch for processing.
+    It includes attributes for managing tiled images and associated metadata for each sample in the batch.
+
+    Attributes:
+        num_media_tiles (List[int]): A list containing the number of tiles for each image in the batch.
+        image_sizes (torch.Tensor): A tensor containing the sizes of all tiled images in the batch. Defaults to an empty tensor.
+        attention_mask (Optional[torch.Tensor]): An optional batch-level attention mask for tiled image samples. Defaults to None.
+    '''
+
     num_media_tiles: List[int] = field(default_factory=list)
     image_sizes: torch.tensor = field(default_factory=lambda: torch.tensor([]))
     attention_mask: Optional[torch.tensor] = None

--- a/nemo/collections/vlm/neva/data/llava_next_energon.py
+++ b/nemo/collections/vlm/neva/data/llava_next_energon.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from dataclasses import dataclass, field
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 import torch
 from megatron.energon import VQASample, batch_list, batch_pad_stack
@@ -25,13 +25,18 @@ from nemo.collections.multimodal.data.energon.task_encoder import MultiModalTask
 from nemo.utils import logging
 
 
+@dataclass
 class LlavaNextTextSample(ImageTextSample):
     num_media_tiles: int = 0
+    image_sizes: torch.tensor = field(default_factory=lambda: torch.tensor([]))
+    attention_mask: Optional[torch.tensor] = None
 
 
 @dataclass
 class LlavaNextTextRawBatch(ImageTextRawBatch):
     num_media_tiles: List[int] = field(default_factory=list)
+    image_sizes: torch.tensor = field(default_factory=lambda: torch.tensor([]))
+    attention_mask: Optional[torch.tensor] = None
 
 
 class LlavaNextSampleEncoder(VQASampleEncoder):
@@ -81,15 +86,14 @@ class LlavaNextSampleEncoder(VQASampleEncoder):
             images, loss masks, and metadata.
         """
         conversation_prompt = self.apply_prompt_template(input_sample)
-        logging.debug(f"task encoder encode_sample conversation_prompt {conversation_prompt}")
+        logging.debug(f"[Energon] task encoder encode_sample conversation_prompt {conversation_prompt}")
         # tokenize prompt
         tokens = self.tokenize(conversation_prompt)
         labels = self.compute_labels(tokens, input_sample)
-
         tokens = tokens[:-1].contiguous()
         labels = labels[1:].contiguous()
-        logging.debug(f"task encoder encode_sample after tokenize prompt tokens {tokens}")
-        logging.debug(f"task encoder encode_sample lables {labels}")
+        logging.debug(f"[Energon] task encoder encode_sample after tokenize prompt tokens {tokens}")
+        logging.debug(f"[Energon] task encoder encode_sample lables {labels}")
         loss_mask = self.compute_loss_mask(labels)
         processed_image = self.process_image(input_sample.image)
         output_sample.__key__ = input_sample.__key__
@@ -98,6 +102,10 @@ class LlavaNextSampleEncoder(VQASampleEncoder):
         output_sample.labels = labels
         output_sample.loss_mask = loss_mask
         output_sample.num_media_tiles = processed_image.shape[0]
+        output_sample.attention_mask = torch.ones(len(tokens), dtype=torch.long)
+        height = input_sample.image.shape[1]
+        width = input_sample.image.shape[2]
+        output_sample.image_sizes = torch.tensor([[height, width]], dtype=torch.long)
         return output_sample
 
 
@@ -133,7 +141,16 @@ class LlavaNextTaskEncoder(MultiModalTaskEncoder):
         LlavaNextTextRawBatch: A batch containing all input samples' images, tokens, labels,
             loss masks, and other metadata prepared for model processing.
         """
-        keys, images, tokens, labels, loss_mask, num_media_tiles = [], [], [], [], [], []
+        keys, images, tokens, labels, loss_mask, num_media_tiles, image_sizes, attention_mask = (
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+            [],
+        )
         for sample in samples:
             keys.append(sample.__key__)
             images.append(sample.images)
@@ -141,6 +158,8 @@ class LlavaNextTaskEncoder(MultiModalTaskEncoder):
             labels.append(sample.labels)
             loss_mask.append(sample.loss_mask)
             num_media_tiles.append(sample.num_media_tiles)
+            image_sizes.append(sample.image_sizes)
+            attention_mask.append(sample.attention_mask)
 
         batch_keys = batch_list(keys)
 
@@ -148,8 +167,9 @@ class LlavaNextTaskEncoder(MultiModalTaskEncoder):
 
         batch_tokens = pad_sequence(tokens, batch_first=True)
         batch_labels = pad_sequence(labels, batch_first=True)
-
+        image_sizes = torch.cat(image_sizes, dim=0)
         batch_loss_mask = batch_pad_stack(loss_mask)
+        batch_attention_mask = batch_pad_stack(attention_mask)
         batch_num_media_tiles = torch.tensor(batch_list(num_media_tiles), dtype=torch.int)
         return LlavaNextTextRawBatch(
             __keys__=batch_keys,
@@ -158,4 +178,6 @@ class LlavaNextTaskEncoder(MultiModalTaskEncoder):
             labels=batch_labels,
             loss_mask=batch_loss_mask,
             num_media_tiles=batch_num_media_tiles,
+            image_sizes=image_sizes,
+            attention_mask=batch_attention_mask,
         )

--- a/nemo/collections/vlm/neva/data/mock.py
+++ b/nemo/collections/vlm/neva/data/mock.py
@@ -42,6 +42,7 @@ class MockDataModule(pl.LightningDataModule):
         num_workers: int = 8,
         pin_memory: bool = True,
         persistent_workers: bool = False,
+        is_llava_next=False,
     ):
         super().__init__()
         self.seq_length = seq_length
@@ -52,14 +53,20 @@ class MockDataModule(pl.LightningDataModule):
         self.num_workers = num_workers
         self.pin_memory = pin_memory
         self.persistent_workers = persistent_workers
+        self.is_llava_next = is_llava_next
 
         if tokenizer is None or image_processor is None:
             logging.warning(f"Processor or tokenizer are not provided! Fall back to `llava-hf/llava-1.5-7b-hf`.")
             from transformers import AutoProcessor
             from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
 
-            processor = AutoProcessor.from_pretrained("llava-hf/llava-1.5-7b-hf")
-            self.tokenizer = tokenizer or AutoTokenizer("llava-hf/llava-1.5-7b-hf")
+            if is_llava_next:
+                model_name = "llava-hf/llava-v1.6-vicuna-7b-hf"
+            else:
+                model_name = "llava-hf/llava-1.5-7b-hf"
+
+            processor = AutoProcessor.from_pretrained(model_name)
+            self.tokenizer = tokenizer or AutoTokenizer(model_name)
             self.image_processor = image_processor or processor.image_processor
         self.data_sampler = MegatronDataSampler(
             seq_len=self.seq_length,
@@ -71,13 +78,13 @@ class MockDataModule(pl.LightningDataModule):
 
     def setup(self, stage: str = "") -> None:
         self._train_ds = _MockNevaDataset(
-            self.tokenizer, self.image_processor, "train", self.num_train_samples, self.seq_length
+            self.tokenizer, self.image_processor, self.is_llava_next, "train", self.num_train_samples, self.seq_length
         )
         self._validation_ds = _MockNevaDataset(
-            self.tokenizer, self.image_processor, "valid", self.num_val_samples, self.seq_length
+            self.tokenizer, self.image_processor, self.is_llava_next, "valid", self.num_val_samples, self.seq_length
         )
         self._test_ds = _MockNevaDataset(
-            self.tokenizer, self.image_processor, "test", self.num_test_samples, self.seq_length
+            self.tokenizer, self.image_processor, self.is_llava_next, "test", self.num_test_samples, self.seq_length
         )
 
     def train_dataloader(self) -> TRAIN_DATALOADERS:
@@ -111,6 +118,7 @@ class _MockNevaDataset(Dataset):
         self,
         tokenizer,
         image_processor,
+        is_llava_next,
         name: str,
         num_samples: int,
         seq_length: int,
@@ -130,6 +138,9 @@ class _MockNevaDataset(Dataset):
 
         self.loss_mask = torch.ones(self.seq_length, dtype=torch.float)
         self.position_ids = torch.arange(self.seq_length, dtype=torch.int64)
+        self.tokenizer = tokenizer
+        self.image_processor = image_processor
+        self.is_llava_next = is_llava_next
 
     def __len__(self) -> int:
         return self.length
@@ -147,13 +158,32 @@ class _MockNevaDataset(Dataset):
         images = torch.from_numpy(np_gen.random(size=[3, self.image_height, self.image_width], dtype=np.float32))
         tokens = tokens[:-1]
         labels = labels[1:]
-        return {
-            "media": images,
-            "tokens": tokens,
-            "labels": labels,
-            "loss_mask": self.loss_mask,
-            "position_ids": self.position_ids,
-        }
+        if not self.is_llava_next:
+            return {
+                "media": images,
+                "tokens": tokens,
+                "labels": labels,
+                "loss_mask": self.loss_mask,
+                "position_ids": self.position_ids,
+            }
+        else:
+            #  attention_mask, image_sizes, num_media_tiles required for llava-next. Neva model will ignore these
+            attention_mask = torch.ones(len(tokens), dtype=torch.long)
+            image_sizes = torch.tensor([[self.image_height, self.image_width]], dtype=torch.long)
+            image_array = self.image_processor.preprocess(images, return_tensors='pt', do_rescale=False)[
+                'pixel_values'
+            ][0]
+            num_media_tiles = image_array.shape[0]
+            return {
+                "media": image_array,
+                "tokens": tokens,
+                "labels": labels,
+                "loss_mask": self.loss_mask,
+                "position_ids": self.position_ids,
+                "image_sizes": image_sizes,
+                "num_media_tiles": num_media_tiles,
+                "attention_mask": attention_mask,
+            }
 
     def _collate_fn(self, batch):
         """
@@ -161,7 +191,13 @@ class _MockNevaDataset(Dataset):
         Users should override this method to define custom data loaders.
         """
         collated_batch = data.dataloader.default_collate(batch)
-        collated_batch["attention_mask"] = None
+        if not self.is_llava_next:
+            collated_batch["attention_mask"] = None
+        else:
+            collated_batch['media'] = collated_batch['media'].contiguous().view(-1, *collated_batch['media'].shape[2:])
+            collated_batch['image_sizes'] = (
+                collated_batch['image_sizes'].contiguous().view(-1, *collated_batch['image_sizes'].shape[2:])
+            )
         return collated_batch
 
     def collate_fn(self, batch):


### PR DESCRIPTION
# What does this PR do ?

LLava next data module changes for energon and mock

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Modified NeVA Mock data module to support llava-next
- Modified llava next sample/task encoder to include attention mask and image sizes

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
