### PR TITLE
[Scripts] Remove fixed seed for adding noise

### DIFF
--- a/scripts/dataset_processing/add_noise.py
+++ b/scripts/dataset_processing/add_noise.py
@@ -131,7 +131,10 @@ def add_noise(infile, snrs, noise_manifest, out_dir, num_workers=1):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
-        "--input_manifest", type=str, required=True, help="clean test set",
+        "--input_manifest",
+        type=str,
+        required=True,
+        help="clean test set",
     )
     parser.add_argument("--noise_manifest", type=str, required=True, help="path to noise manifest file")
     parser.add_argument("--out_dir", type=str, required=True, help="destination directory for audio and manifests")


### PR DESCRIPTION
# What does this PR do ?

This PR removes a fixed value of seed when adding noise examples.
With a fixed seed, each worker will select the same noise file.
If required, fixed seed can be set from CLI.

**Collection**: Scripts

# Changelog 
- Changed default seed from `42` to `None`

# Usage
If necessary, the original behavior can be reproduced using

```python
python add_noisy.py ... --seed 42
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
