### PR TITLE
Nemo 2.0 canonical lora

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -4361,6 +4361,34 @@ jobs:
         --pp_size 1 \
         --mbs 1 --packed
 
+  L2_NeMo_2_GPT_CLoRA_TP1PP1_MBS1_PACKED:
+    needs: [cicd-test-container-setup]
+    uses: ./.github/workflows/_test_template.yml
+    if: contains(fromJSON(needs.cicd-test-container-setup.outputs.test_to_run), 'L2_NeMo_2_GPT_CLoRA_TP1PP1_MBS1_PACKED') || needs.cicd-test-container-setup.outputs.all == 'true'
+    with:
+      RUNNER: self-hosted-azure
+      SCRIPT: |
+  
+        python tests/collections/llm/gpt_finetuning.py \
+        --restore_path /home/TestData/nemo2_ckpt/llama_68M \
+        --devices 2 \
+        --max_steps 3 \
+        --experiment_dir /tmp/nemo2_gpt_finetune/${{ github.run_id }} \
+        --peft canonical_lora \
+        --tp_size 1 \
+        --pp_size 1 \
+        --mbs 1 --packed
+        
+        python tests/collections/llm/gpt_finetuning.py \
+        --restore_path /home/TestData/nemo2_ckpt/llama_68M \
+        --devices 2 \
+        --max_steps 6 \
+        --experiment_dir /tmp/nemo2_gpt_finetune/${{ github.run_id }} \
+        --peft canonical_lora \
+        --tp_size 1 \
+        --pp_size 1 \
+        --mbs 1 --packed
+
   L2_NeMo_2_Mixtral_LoRA_EP2PP1_MBS2:
     needs: [cicd-test-container-setup]
     uses: ./.github/workflows/_test_template.yml
@@ -4604,6 +4632,7 @@ jobs:
       - L2_NeMo_2_GPT_LoRA_TP2PP1_MBS2
       - L2_NeMo_2_GPT_LoRA_TP1PP1_MBS1_PACKED
       - L2_NeMo_2_GPT_DoRA_TP1PP1_MBS1_PACKED
+      - L2_NeMo_2_GPT_CLoRA_TP1PP1_MBS1_PACKED
       - L2_NeMo_2_Mixtral_LoRA_EP2PP1_MBS2
       - L2_NeMo_2_Mixtral_LoRA_TP1PP1_MBS1
       - L2_NeMo_2_Mixtral_LoRA_TP2PP1_MBS1

--- a/nemo/collections/llm/peft/__init__.py
+++ b/nemo/collections/llm/peft/__init__.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 from nemo.collections.llm.peft.api import gpt_lora, merge_lora
+from nemo.collections.llm.peft.canonical_lora import CanonicalLoRA
 from nemo.collections.llm.peft.dora import DoRA
 from nemo.collections.llm.peft.lora import LoRA
-from nemo.collections.llm.peft.canonical_lora import CanonicalLoRA
 
 PEFT_STR2CLS = {
     "LoRA": LoRA,

--- a/nemo/collections/llm/peft/__init__.py
+++ b/nemo/collections/llm/peft/__init__.py
@@ -15,12 +15,15 @@
 from nemo.collections.llm.peft.api import gpt_lora, merge_lora
 from nemo.collections.llm.peft.dora import DoRA
 from nemo.collections.llm.peft.lora import LoRA
+from nemo.collections.llm.peft.canonical_lora import CanonicalLoRA
 
 PEFT_STR2CLS = {
     "LoRA": LoRA,
     "lora": LoRA,
     "DoRA": DoRA,
     "dora": DoRA,
+    "CanonicalLoRA": CanonicalLoRA,
+    "canonical_lora": CanonicalLoRA,
 }
 
-__all__ = ["LoRA", "DoRA", "gpt_lora", "PEFT_STR2CLS", "merge_lora"]
+__all__ = ["LoRA", "DoRA", "CanonicalLoRA", "gpt_lora", "PEFT_STR2CLS", "merge_lora"]

--- a/nemo/collections/llm/peft/canonical_lora.py
+++ b/nemo/collections/llm/peft/canonical_lora.py
@@ -71,7 +71,8 @@ class ModuleDict(nn.ModuleDict):
 
 
 class LoRALinearSplitQKV(AdapterWrapper):
-    """ TODO An adapter wrapper that adds the output of the adapter to the output of the wrapped module.
+    """ An adapter wrapper for `linear_qkv` where q, k, v are three separate adapters.
+    This module that adds the output of the adapters to the output of the wrapped module while taking care of shape.
 
     This class is designed to be used with LoRA (Low-Rank Adaptation) and similar techniques
     where the adapter's output is added to the main module's output. It extends the AdapterWrapper
@@ -95,7 +96,8 @@ class LoRALinearSplitQKV(AdapterWrapper):
 
 
 class LoRALinearSplitFC1UpGate(AdapterWrapper):
-    """ TODO An adapter wrapper that adds the output of the adapter to the output of the wrapped module.
+    """ An adapter wrapper for `linear_fc1` where up_proj and gate_proj are two separate adapters.
+    This module that adds the output of the adapters to the output of the wrapped module while taking care of shape.
 
     This class is designed to be used with LoRA (Low-Rank Adaptation) and similar techniques
     where the adapter's output is added to the main module's output. It extends the AdapterWrapper

--- a/nemo/collections/llm/peft/canonical_lora.py
+++ b/nemo/collections/llm/peft/canonical_lora.py
@@ -20,8 +20,8 @@ import torch
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from torch import nn
 
-from nemo.collections.llm.peft.lora import LoRALinear, LinearAdapter
-from nemo.collections.llm.peft.utils import wildcard_match, get_adapter_attributes_from_linear, is_expert_linear
+from nemo.collections.llm.peft.lora import LinearAdapter, LoRALinear
+from nemo.collections.llm.peft.utils import get_adapter_attributes_from_linear, is_expert_linear, wildcard_match
 from nemo.lightning.pytorch.callbacks.peft import PEFT, AdapterWrapper
 from nemo.utils import logging
 

--- a/nemo/collections/llm/peft/canonical_lora.py
+++ b/nemo/collections/llm/peft/canonical_lora.py
@@ -20,13 +20,8 @@ import torch
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from torch import nn
 
-from nemo.collections.llm.peft.lora import (
-    LinearAdapter,
-    LoRALinear,
-    _get_adapter_attributes_from_linear,
-    is_expert_linear,
-)
-from nemo.collections.llm.peft.utils import wildcard_match
+from nemo.collections.llm.peft.lora import LoRALinear, LinearAdapter
+from nemo.collections.llm.peft.utils import wildcard_match, get_adapter_attributes_from_linear, is_expert_linear
 from nemo.lightning.pytorch.callbacks.peft import PEFT, AdapterWrapper
 from nemo.utils import logging
 
@@ -244,7 +239,7 @@ class CanonicalLoRA(PEFT):
                     m, dim=self.dim, alpha=self.alpha, dropout=self.dropout, lora_A_init_method=self.lora_A_init_method
                 )
 
-            input_is_parallel, in_features, out_features = _get_adapter_attributes_from_linear(m)
+            input_is_parallel, in_features, out_features = get_adapter_attributes_from_linear(m)
 
             adapter_kwargs = dict(
                 dim=self.dim,

--- a/nemo/collections/llm/peft/canonical_lora.py
+++ b/nemo/collections/llm/peft/canonical_lora.py
@@ -1,0 +1,256 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import List, Literal, Dict, Set
+
+from torch import nn
+
+from nemo.collections.llm.peft.lora import LoRALinear, _get_adapter_attributes_from_linear, is_expert_linear, \
+    LinearAdapter
+from nemo.lightning.pytorch.callbacks.peft import PEFT, AdapterWrapper
+from nemo.utils import logging
+from nemo.utils.import_utils import safe_import_from
+
+TEColumnParallelLinear, HAVE_TE_COL_LINEAR = safe_import_from(
+    "megatron.core.extensions.transformer_engine", "TEColumnParallelLinear"
+)
+TELayerNormColumnParallelLinear, HAVE_TE_LN_COL_LINEAR = safe_import_from(
+    "megatron.core.extensions.transformer_engine",
+    "TELayerNormColumnParallelLinear",
+)
+TERowParallelLinear, HAVE_TE_ROW_LINEAR = safe_import_from(
+    "megatron.core.extensions.transformer_engine", "TERowParallelLinear"
+)
+HAVE_TE = all((HAVE_TE_COL_LINEAR, HAVE_TE_LN_COL_LINEAR, HAVE_TE_ROW_LINEAR))
+
+
+class LoRALinearSplitQKV(AdapterWrapper):
+    """ TODO An adapter wrapper that adds the output of the adapter to the output of the wrapped module.
+
+    This class is designed to be used with LoRA (Low-Rank Adaptation) and similar techniques
+    where the adapter's output is added to the main module's output. It extends the AdapterWrapper
+    class to provide a specific implementation of the forward method.
+    """
+
+    def forward(self, x):
+        ...
+        # linear_output, bias, layernorm_output = self.base_linear_forward(x)
+        # adapter_output = self.adapter(layernorm_output.contiguous())
+        # return linear_output + adapter_output, bias
+
+class LoRALinearSplitFC1UpGate(AdapterWrapper):
+    """ TODO An adapter wrapper that adds the output of the adapter to the output of the wrapped module.
+
+    This class is designed to be used with LoRA (Low-Rank Adaptation) and similar techniques
+    where the adapter's output is added to the main module's output. It extends the AdapterWrapper
+    class to provide a specific implementation of the forward method.
+    """
+
+    def forward(self, x):
+        ...
+        # linear_output, bias, layernorm_output = self.base_linear_forward(x)
+        # adapter_output = self.adapter(layernorm_output.contiguous())
+        # return linear_output + adapter_output, bias
+
+
+
+@dataclass
+class CanonicalLoRA(PEFT):
+    """
+    Implements the LoRA (Low-Rank Adaptation) module for parameter-efficient fine-tuning.
+    Canonical LoRA applies LoRA on Q, K, V projection matrices separately, as well as Up and Gate projection
+    matrices separately. This follows more closely with Huggingface's implementation of LoRA.
+
+    Args:
+        target_modules (List[str], optional): A list of module names to apply LoRA to.
+            Defaults to all linear layers ['linear_q', 'linear_k', 'linear_v', 'linear_proj',
+                                           'linear_fc1_up', 'linear_fc1_gate', 'linear_fc2'].
+                - 'linear_q', 'linear_k', 'linear_v': Apply LoRA to the linear layer used for query, key, and value
+                        projections in self-attention. This is fused into one matrix in NeMo LoRA, but left as three
+                        separate matrices in Canonical LoRA.
+                - 'linear_proj': Apply LoRA to the linear layer used for projecting the output of self-attention.
+                - 'linear_fc1_up', 'linear_fc1_proj': Apply LoRA to the Up proj and Gate proj layers.
+                        These two together constitute the first fully-connected layer in MLP in NeMo LoRA.
+                - 'linear_fc2': Apply LoRA to the second fully-connected layer in MLP.
+            Target modules can also contain wildcards. For example, you can specify
+                target_modules=['*.layers.0.*.linear_q', '*.layers.1.*.linear_q'] to add LoRA to only linear_q
+                on the first two layers.
+        dim (int): Dimension of the low-rank projection space. Defaults to 32.
+        alpha (int): Weighting factor for the low-rank projection. Defaults to 32.
+        dropout (float): Dropout rate for the low-rank projection. Defaults to 0.0.
+        dropout_position (Literal['pre', 'post'], optional): Position for applying dropout.
+            Can be 'pre' (before the low-rank projection) or 'post' (after). Defaults to 'pre'.
+
+    Example:
+    --------
+        >>> from nemo.collections import llm
+        >>> lora = llm.peft.CanonicalLoRA(target_modules=['linear_q', 'linear_k', 'linear_v', 'linear_fc1_up'], dim=32)
+        >>> model = llm.Mistral7BModel(model_transform=lora)
+        >>> # (set up trainer and data)
+        >>> trainer.fit(model, data)
+
+    References:
+    -----------
+        Hu, E. J., Shen, Y., Wallis, P., Allen-Zhu, Z., Li, Y., Wang, S., Wang, L., & Chen, W. (2021).
+        LoRA: Low-Rank Adaptation of Large Language Models. arXiv preprint arXiv:2106.09685.
+        https://arxiv.org/abs/2106.09685
+
+    )
+    """
+
+    target_modules: List[str] = field(
+        default_factory=lambda: [
+            'linear_q', 'linear_k', 'linear_v', 'linear_proj', 'linear_fc1_up', 'linear_fc1_gate', 'linear_fc2'
+        ]
+    )
+    dim: int = 32
+    alpha: int = 32
+    dropout: float = 0.0
+    dropout_position: Literal['pre', 'post'] = 'pre'
+    lora_A_init_method: str = "xavier"
+    lora_B_init_method: str = "zero"
+
+    def __post_init__(self):
+        """
+        Construct a mapping from the target module as supported in LoRA() to the specific parts of the layer for which
+        adapter is applied.
+
+        For example, if user specifies target_module = ['linear_q', 'linear_k', 'linear_proj', 'linear_fc1_up'], then
+        canonical_lora_mapping = {
+            "linear_qkv": {'linear_q', 'linear_k'},
+            "linear_proj": {'linear_proj'},  # the value of this key does not matter
+            "linear_fc1": {'linear_fc1_up'},
+        }
+
+        If user specifies target_module = ['*.layers.0.*.linear_q', '*.layers.1.*.linear_q'], then
+        canonical_lora_mapping = {
+            "'*.layers.0.*.linear_qkv'": {'linear_q'},
+            "'*.layers.1.*.linear_qkv'": {'linear_q'},
+        }
+
+        """
+        self.canonical_mapping: Dict[str, Set] = defaultdict(set)
+        for target in self.target_modules:
+            assert "linear_qkv" not in target, \
+                ("Canonical LoRA does not support target 'linear_qkv'. Either use 'linear_qkv' with LoRA() or "
+                 "use ['linear_q', 'linear_k', 'linear_v'] with Canonical LoRA")
+            assert "linear_fc1" not in target, \
+                ("Canonical LoRA does not support target 'linear_fc1'. Either use 'linear_fc1' with LoRA() or "
+                 "use ['linear_fc1_up', 'linear_fc1_gate'] with Canonical LoRA")
+
+            if 'linear_q' in target:
+                self.canonical_mapping[target.replace('linear_q', 'linear_qkv')].add('linear_q')
+            elif 'linear_k' in target:
+                self.canonical_mapping[target.replace('linear_k', 'linear_qkv')].add('linear_k')
+            elif 'linear_v' in target:
+                self.canonical_mapping[target.replace('linear_v', 'linear_qkv')].add('linear_v')
+            elif 'linear_fc1_up' in target:
+                self.canonical_mapping[target.replace('linear_fc1_up', 'linear_fc1')].add('linear_fc1_up')
+            elif 'linear_fc1_gate' in target:
+                self.canonical_mapping[target.replace('linear_fc1_gate', 'linear_fc1')].add('linear_fc1_gate')
+            else:
+                self.canonical_mapping[target].add(target)
+
+    def transform(self, m: nn.Module, name=None, prefix=None):
+        """
+        Applies LoRA to a specific module within the model architecture.
+
+        Args:
+            m (nn.Module): The module to apply LoRA to.
+            name (str, optional): Name of the module (if applicable). Defaults to None.
+            prefix (str, optional): Prefix for the module name (if applicable). Defaults to None.
+
+        Returns:
+            nn.Module: The modified module with LoRA applied, or the original module if not a target.
+        """
+        from nemo.collections.nlp.modules.common.megatron.adapters.parallel_adapters import ParallelLinearAdapter
+
+        # todo reuse this wildcard match
+        def wildcard_match(pattern, key):
+            if key is None:
+                return None
+            regex_pattern = re.compile("^" + pattern.replace("*", "(.*)") + "$")
+            match = regex_pattern.match(key)
+            return match is not None
+
+        full_name = f"{prefix}.{name}" if prefix else name
+
+        """
+        Find the element in canonical_mapping which 
+        1) matches the current `name` exactly, OR
+        2) matches the current `full_name` with regex
+        match is None if current module name doesn't match the specified targets.
+        """
+        match = None
+        for pattern in self.canonical_mapping:
+            if name == pattern or wildcard_match(pattern, full_name):
+                match = pattern
+                break
+
+
+        if match is not None:
+            if isinstance(m, nn.Linear):
+                return LinearAdapter(
+                    m, dim=self.dim, alpha=self.alpha, dropout=self.dropout, lora_A_init_method=self.lora_A_init_method
+                )
+
+            input_is_parallel, in_features, out_features = _get_adapter_attributes_from_linear(m)
+
+            adapter_kwargs = dict(
+                dim=self.dim,
+                activation='identity',
+                norm_position=None,
+                norm_type=None,
+                column_init_method=self.lora_A_init_method,
+                row_init_method=self.lora_B_init_method,
+                gather_output=False,
+                input_is_parallel=input_is_parallel,
+                dropout=self.dropout,
+                dropout_position=self.dropout_position,
+                model_parallel_config=getattr(m, "config", None),
+                alpha=self.alpha,
+                is_expert=is_expert_linear(full_name),
+            )
+            if name in ['linear_proj', 'linear_fc2']:
+                adapter = ParallelLinearAdapter(in_features, out_features, **adapter_kwargs)
+                logging.info(f"Adding lora to: {full_name}")
+                return LoRALinear(m, adapter)
+
+            canonical_submodules = self.canonical_mapping[match]
+            logging.info(f"Adding lora to: {full_name} ({canonical_submodules})")
+            if name == 'linear_qkv':
+                adapter_q, adapter_k, adapter_v = None, None, None
+                if 'linear_q' in canonical_submodules:
+                    out_features = m.config.kv_channels * m.config.num_query_groups
+                    adapter_q = ParallelLinearAdapter(in_features, out_features, **adapter_kwargs)
+                if 'linear_k' in canonical_submodules:
+                    adapter_k = ParallelLinearAdapter(in_features, in_features, **adapter_kwargs)
+                if 'linear_v' in canonical_submodules:
+                    adapter_v = ParallelLinearAdapter(in_features, in_features, **adapter_kwargs)
+                adapters = nn.ModuleDict({'adapter_q': adapter_q, 'adapter_k': adapter_k, 'adapter_v': adapter_v})
+                return LoRALinearSplitQKV(m, adapters)
+
+            if name == 'linear_fc1':
+                adapter_up, adapter_gate = None, None
+                if 'linear_fc1_up' in canonical_submodules:
+                    adapter_up = ParallelLinearAdapter(in_features, out_features//2, **adapter_kwargs)
+                if 'linear_fc1_gate' in canonical_submodules:
+                    adapter_gate = ParallelLinearAdapter(in_features, out_features//2, **adapter_kwargs)
+                adapters = nn.ModuleDict({'adapter_up': adapter_up, 'adapter_gate': adapter_gate})
+                return LoRALinearSplitFC1UpGate(m, adapters)
+
+        return m

--- a/nemo/collections/llm/peft/canonical_lora.py
+++ b/nemo/collections/llm/peft/canonical_lora.py
@@ -68,6 +68,7 @@ class LoRALinearSplitQKV(AdapterWrapper):
     """
 
     def forward(self, x):
+        # pylint: disable=C0115,C0116
         linear_output, bias, layernorm_output = self.base_linear_forward(x)
         query = self.adapter.adapter_q(layernorm_output)
         key = self.adapter.adapter_k(layernorm_output)
@@ -93,6 +94,7 @@ class LoRALinearSplitFC1UpGate(AdapterWrapper):
     """
 
     def forward(self, x):
+        # pylint: disable=C0115,C0116
         linear_output, bias, layernorm_output = self.base_linear_forward(x)
         adapter_output_gate = self.adapter.adapter_gate(layernorm_output)
         adapter_output_up = self.adapter.adapter_up(layernorm_output)

--- a/nemo/collections/llm/peft/dora.py
+++ b/nemo/collections/llm/peft/dora.py
@@ -18,17 +18,14 @@ from dataclasses import dataclass, field
 from typing import List, Literal, Optional
 
 import torch
-from megatron.core import parallel_state
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
 from megatron.core.tensor_parallel import (
-    ColumnParallelLinear,
-    RowParallelLinear,
     gather_from_tensor_model_parallel_region,
 )
 from megatron.core.utils import make_sharded_tensor_for_checkpoint, make_tp_sharded_tensor_for_checkpoint
 from torch import nn
 
-from nemo.collections.llm.peft.lora import LinearAdapter
+from nemo.collections.llm.peft.lora import _get_adapter_attributes_from_linear
 from nemo.collections.nlp.modules.common.megatron.adapters.parallel_adapters import ParallelLinearAdapter
 from nemo.lightning.pytorch.callbacks.peft import PEFT, AdapterWrapper
 from nemo.utils import logging
@@ -208,38 +205,7 @@ class DoRA(PEFT):
 
         full_name = f"{prefix}.{name}" if prefix else name
         if name in self.target_modules or any(wildcard_match(pattern, full_name) for pattern in self.target_modules):
-            if HAVE_TE and isinstance(m, TEColumnParallelLinear) or isinstance(m, TELayerNormColumnParallelLinear):
-                input_is_parallel = False
-                # m.in_features and m.out_features are divided by tp_size already,
-                # but in_features and out_features passed to ParallelLinearAdapter are not.
-                tp_size = parallel_state.get_tensor_model_parallel_world_size()
-                in_features = m.in_features
-                out_features = m.out_features * tp_size
-                # DoRA is applied after layernorm, so layernorm output must be returned
-                m.return_layernorm_output = True
-                # perf optimization for DoRA + SP (to check!)
-                if m.config.sequence_parallel and not m.ub_overlap_ag:
-                    m.return_layernorm_output_gathered = True
-            elif HAVE_TE and isinstance(m, TERowParallelLinear):
-                input_is_parallel = True
-                tp_size = parallel_state.get_tensor_model_parallel_world_size()
-                in_features = m.in_features * tp_size
-                out_features = m.out_features
-            elif isinstance(m, ColumnParallelLinear):
-                input_is_parallel = False
-                in_features = m.input_size
-                out_features = m.output_size
-            elif isinstance(m, RowParallelLinear):
-                input_is_parallel = True
-                in_features = m.input_size
-                out_features = m.output_size
-            elif isinstance(m, nn.Linear):
-                return LinearAdapter(
-                    m, dim=self.dim, alpha=self.alpha, dropout=self.dropout, lora_A_init_method=self.lora_A_init_method
-                )
-            else:
-                raise NotImplementedError(f"Layer type is unrecognized for LoRA: {type(m)}")
-
+            input_is_parallel, in_features, out_features = _get_adapter_attributes_from_linear(m)
             logging.info(f"Adding DoRA to: {full_name}")
             adapter = ParallelLinearDoRAAdapter(
                 in_features,

--- a/nemo/collections/llm/peft/dora.py
+++ b/nemo/collections/llm/peft/dora.py
@@ -21,7 +21,7 @@ from megatron.core.tensor_parallel import gather_from_tensor_model_parallel_regi
 from megatron.core.utils import make_sharded_tensor_for_checkpoint, make_tp_sharded_tensor_for_checkpoint
 from torch import nn
 
-from nemo.collections.llm.peft.utils import _get_adapter_attributes_from_linear, wildcard_match
+from nemo.collections.llm.peft.utils import get_adapter_attributes_from_linear, wildcard_match
 from nemo.collections.nlp.modules.common.megatron.adapters.parallel_adapters import ParallelLinearAdapter
 from nemo.lightning.pytorch.callbacks.peft import PEFT, AdapterWrapper
 from nemo.utils import logging
@@ -180,7 +180,7 @@ class DoRA(PEFT):
         """
         full_name = f"{prefix}.{name}" if prefix else name
         if name in self.target_modules or any(wildcard_match(pattern, full_name) for pattern in self.target_modules):
-            input_is_parallel, in_features, out_features = _get_adapter_attributes_from_linear(m)
+            input_is_parallel, in_features, out_features = get_adapter_attributes_from_linear(m)
             logging.info(f"Adding DoRA to: {full_name}")
             adapter = ParallelLinearDoRAAdapter(
                 in_features,

--- a/nemo/collections/llm/peft/dora.py
+++ b/nemo/collections/llm/peft/dora.py
@@ -17,9 +17,7 @@ from typing import List, Literal, Optional
 
 import torch
 from megatron.core.dist_checkpointing.mapping import ShardedStateDict
-from megatron.core.tensor_parallel import (
-    gather_from_tensor_model_parallel_region,
-)
+from megatron.core.tensor_parallel import gather_from_tensor_model_parallel_region
 from megatron.core.utils import make_sharded_tensor_for_checkpoint, make_tp_sharded_tensor_for_checkpoint
 from torch import nn
 
@@ -27,6 +25,7 @@ from nemo.collections.llm.peft.utils import _get_adapter_attributes_from_linear,
 from nemo.collections.nlp.modules.common.megatron.adapters.parallel_adapters import ParallelLinearAdapter
 from nemo.lightning.pytorch.callbacks.peft import PEFT, AdapterWrapper
 from nemo.utils import logging
+
 
 class ParallelLinearDoRAAdapter(ParallelLinearAdapter):
     """

--- a/nemo/collections/llm/peft/lora.py
+++ b/nemo/collections/llm/peft/lora.py
@@ -19,7 +19,7 @@ from typing import List, Literal
 import torch
 from torch import nn
 
-from nemo.collections.llm.peft.utils import _get_adapter_attributes_from_linear, is_expert_linear, wildcard_match
+from nemo.collections.llm.peft.utils import is_expert_linear, wildcard_match, get_adapter_attributes_from_linear
 from nemo.lightning.pytorch.callbacks.peft import PEFT, AdapterWrapper
 from nemo.utils import logging
 
@@ -154,7 +154,7 @@ class LoRA(PEFT):
                     m, dim=self.dim, alpha=self.alpha, dropout=self.dropout, lora_A_init_method=self.lora_A_init_method
                 )
 
-            input_is_parallel, in_features, out_features = _get_adapter_attributes_from_linear(m)
+            input_is_parallel, in_features, out_features = get_adapter_attributes_from_linear(m)
             logging.info(f"Adding lora to: {full_name}")
             adapter = ParallelLinearAdapter(
                 in_features,

--- a/nemo/collections/llm/peft/lora.py
+++ b/nemo/collections/llm/peft/lora.py
@@ -33,12 +33,16 @@ class LoRALinear(AdapterWrapper):
     """
 
     def forward(self, x):
+        # pylint: disable=C0115,C0116
         linear_output, bias, layernorm_output = self.base_linear_forward(x)
         adapter_output = self.adapter(layernorm_output.contiguous())
         return linear_output + adapter_output, bias
 
 
 class LinearAdapter(nn.Module):
+    """
+    A simple LoRA linear module for non-megatron models.
+    """
     def __init__(
         self, orig_linear, dim=8, alpha=32, dropout=0.1, dropout_position='post', lora_A_init_method='xavier'
     ):
@@ -70,6 +74,7 @@ class LinearAdapter(nn.Module):
         self.dropout_position = dropout_position
 
     def forward(self, x):
+        # pylint: disable=C0115,C0116
         res = self.orig_linear(x)
         if self.dropout_position == 'pre':
             x = self.dropout(x)

--- a/nemo/collections/llm/peft/lora.py
+++ b/nemo/collections/llm/peft/lora.py
@@ -43,6 +43,7 @@ class LinearAdapter(nn.Module):
     """
     A simple LoRA linear module for non-megatron models.
     """
+
     def __init__(
         self, orig_linear, dim=8, alpha=32, dropout=0.1, dropout_position='post', lora_A_init_method='xavier'
     ):

--- a/nemo/collections/llm/peft/lora.py
+++ b/nemo/collections/llm/peft/lora.py
@@ -19,7 +19,7 @@ from typing import List, Literal
 import torch
 from torch import nn
 
-from nemo.collections.llm.peft.utils import is_expert_linear, wildcard_match, _get_adapter_attributes_from_linear
+from nemo.collections.llm.peft.utils import _get_adapter_attributes_from_linear, is_expert_linear, wildcard_match
 from nemo.lightning.pytorch.callbacks.peft import PEFT, AdapterWrapper
 from nemo.utils import logging
 

--- a/nemo/collections/llm/peft/lora.py
+++ b/nemo/collections/llm/peft/lora.py
@@ -19,7 +19,7 @@ from typing import List, Literal
 import torch
 from torch import nn
 
-from nemo.collections.llm.peft.utils import is_expert_linear, wildcard_match, get_adapter_attributes_from_linear
+from nemo.collections.llm.peft.utils import get_adapter_attributes_from_linear, is_expert_linear, wildcard_match
 from nemo.lightning.pytorch.callbacks.peft import PEFT, AdapterWrapper
 from nemo.utils import logging
 

--- a/nemo/collections/llm/peft/utils.py
+++ b/nemo/collections/llm/peft/utils.py
@@ -1,0 +1,92 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import re
+from megatron.core import parallel_state
+from megatron.core.tensor_parallel import ColumnParallelLinear, RowParallelLinear
+from torch import nn
+
+from nemo.utils.import_utils import safe_import_from
+
+TEColumnParallelLinear, HAVE_TE_COL_LINEAR = safe_import_from(
+    "megatron.core.extensions.transformer_engine", "TEColumnParallelLinear"
+)
+TELayerNormColumnParallelLinear, HAVE_TE_LN_COL_LINEAR = safe_import_from(
+    "megatron.core.extensions.transformer_engine",
+    "TELayerNormColumnParallelLinear",
+)
+TERowParallelLinear, HAVE_TE_ROW_LINEAR = safe_import_from(
+    "megatron.core.extensions.transformer_engine", "TERowParallelLinear"
+)
+HAVE_TE = all((HAVE_TE_COL_LINEAR, HAVE_TE_LN_COL_LINEAR, HAVE_TE_ROW_LINEAR))
+
+def _get_adapter_attributes_from_linear(m: nn.Module):
+    """
+
+    """
+    if HAVE_TE and isinstance(m, TEColumnParallelLinear) or isinstance(m, TELayerNormColumnParallelLinear):
+        input_is_parallel = False
+        # m.in_features and m.out_features are divided by tp_size already,
+        # but in_features and out_features passed to ParallelLinearAdapter are not.
+        tp_size = parallel_state.get_tensor_model_parallel_world_size()
+        in_features = m.in_features
+        out_features = m.out_features * tp_size
+        # LoRA is applied after layernorm, so layernorm output must be returned
+        m.return_layernorm_output = True
+        # perf optimization for LoRA + SP
+        if m.config.sequence_parallel and not m.ub_overlap_ag:
+            m.return_layernorm_output_gathered = True
+    elif HAVE_TE and isinstance(m, TERowParallelLinear):
+        input_is_parallel = True
+        tp_size = parallel_state.get_tensor_model_parallel_world_size()
+        in_features = m.in_features * tp_size
+        out_features = m.out_features
+    elif isinstance(m, ColumnParallelLinear):
+        input_is_parallel = False
+        in_features = m.input_size
+        out_features = m.output_size
+    elif isinstance(m, RowParallelLinear):
+        input_is_parallel = True
+        in_features = m.input_size
+        out_features = m.output_size
+    else:
+        raise NotImplementedError(f"Layer type is unrecognized for LoRA: {type(m)}")
+
+    return input_is_parallel, in_features, out_features
+
+
+def is_expert_linear(fqn):
+    """
+    Return whether the current base module is an expert linear module.
+    See ParallelLinearAdapter.is_expert for usage details.
+    """
+    return re.match('.*mlp\.experts\.local_experts.[0-9]+\.linear_fc[1-2]$', fqn) is not None
+
+
+def wildcard_match(pattern, key):
+    """
+    Return whether the pattern (target module to add LoRA) matches the key (model weight name).
+
+    Example:
+    --------
+        >>> wildcard_match("*.layers.0.*.linear_qkv", "decoder.layers.0.self_attention.linear_qkv")
+        True
+        >>> wildcard_match("*.layers.0.*.linear_qkv", "decoder.layers.1.self_attention.linear_qkv")
+        False
+    """
+    if key is None:
+        return None
+    regex_pattern = re.compile("^" + pattern.replace("*", "(.*)") + "$")
+    match = regex_pattern.match(key)
+    return match is not None

--- a/nemo/collections/llm/peft/utils.py
+++ b/nemo/collections/llm/peft/utils.py
@@ -31,9 +31,10 @@ TERowParallelLinear, HAVE_TE_ROW_LINEAR = safe_import_from(
 )
 HAVE_TE = all((HAVE_TE_COL_LINEAR, HAVE_TE_LN_COL_LINEAR, HAVE_TE_ROW_LINEAR))
 
-
-def _get_adapter_attributes_from_linear(m: nn.Module):
-    """ """
+def get_adapter_attributes_from_linear(m: nn.Module):
+    """
+    Return input_is_parallel, in_features, out_feature attributes based on implementation of the base layer.
+    """
     if HAVE_TE and isinstance(m, TEColumnParallelLinear) or isinstance(m, TELayerNormColumnParallelLinear):
         input_is_parallel = False
         # m.in_features and m.out_features are divided by tp_size already,

--- a/nemo/collections/llm/peft/utils.py
+++ b/nemo/collections/llm/peft/utils.py
@@ -31,10 +31,9 @@ TERowParallelLinear, HAVE_TE_ROW_LINEAR = safe_import_from(
 )
 HAVE_TE = all((HAVE_TE_COL_LINEAR, HAVE_TE_LN_COL_LINEAR, HAVE_TE_ROW_LINEAR))
 
-def _get_adapter_attributes_from_linear(m: nn.Module):
-    """
 
-    """
+def _get_adapter_attributes_from_linear(m: nn.Module):
+    """ """
     if HAVE_TE and isinstance(m, TEColumnParallelLinear) or isinstance(m, TELayerNormColumnParallelLinear):
         input_is_parallel = False
         # m.in_features and m.out_features are divided by tp_size already,

--- a/nemo/collections/llm/peft/utils.py
+++ b/nemo/collections/llm/peft/utils.py
@@ -31,6 +31,7 @@ TERowParallelLinear, HAVE_TE_ROW_LINEAR = safe_import_from(
 )
 HAVE_TE = all((HAVE_TE_COL_LINEAR, HAVE_TE_LN_COL_LINEAR, HAVE_TE_ROW_LINEAR))
 
+
 def get_adapter_attributes_from_linear(m: nn.Module):
     """
     Return input_is_parallel, in_features, out_feature attributes based on implementation of the base layer.

--- a/nemo/lightning/pytorch/callbacks/peft.py
+++ b/nemo/lightning/pytorch/callbacks/peft.py
@@ -239,7 +239,7 @@ class AdapterWrapper(nn.Module):
         implement the forward method.
 
     Example:
-        class AdapterParallelAdd(AdapterWrapper):
+        class LoRALinear(AdapterWrapper):
             def __init__(self, to_wrap, adapter):
                 super().__init__(to_wrap, adapter)
 
@@ -248,7 +248,7 @@ class AdapterWrapper(nn.Module):
 
         main_module = nn.Linear(100, 100)
         adapter = nn.Linear(100, 100)
-        parallel_adapter = AdapterParallelAdd(main_module, adapter)
+        parallel_adapter = LoRALinear(main_module, adapter)
     """
 
     def __init__(self, to_wrap: nn.Module, adapter: nn.Module):

--- a/tests/collections/llm/gpt_finetuning.py
+++ b/tests/collections/llm/gpt_finetuning.py
@@ -94,7 +94,7 @@ if __name__ == '__main__':
         ),
     )
 
-    if args.peft in ['lora', 'dora']:
+    if args.peft in llm.peft.PEFT_STR2CLS.keys():
         peft = llm.peft.PEFT_STR2CLS[args.peft]()
     else:
         peft = None
@@ -105,7 +105,7 @@ if __name__ == '__main__':
     dolly = llm.DollyDataModule(
         seq_length=2048,
         micro_batch_size=args.mbs,
-        global_batch_size=8,
+        global_batch_size=4,
         num_workers=0,
         packed_sequence_specs=packed_sequence_specs,
     )


### PR DESCRIPTION
# What does this PR do ?

Add canonical LoRA (aka unfused LoRA) to NeMo 2.0.

This variant follows the HF implementation more closely and adds three separate adapters for attention q_proj, k_proj, and v_proj, as well as two separate adapters for MLP up_proj and gate_proj. In NeMo/Mcore, these are fused into one adapter for performance reasons.

Convergence test:
![image](https://github.com/user-attachments/assets/f4cdb1c5-1153-4664-9c9f-98b440eccee6)


**Collection**: [Note which collection this PR will affect]

# Changelog 
- Renamed `AdapterParallelAdd` to `LoRALinear` to be more explicit. 

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
