### PR TITLE
Github Actions tests for Llava Next and modify pretrain recipe to have language model path

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -4613,7 +4613,7 @@ jobs:
     uses: ./.github/workflows/_test_template.yml
     if: contains(fromJSON(needs.cicd-test-container-setup.outputs.test_to_run), 'L2_NeMo_2_LLAVA_NEXT_MOCK_TRAINING') || needs.cicd-test-container-setup.outputs.all == 'true'
     with:
-      RUNNER: azure-gpu-vm-runner1-cpu
+      RUNNER: self-hosted-azure-gpus-1
       SCRIPT: |
         python tests/collections/vlm/test_llava_next_train.py \
         --devices=1 \

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -4608,7 +4608,7 @@ jobs:
         rm -rf /tmp/nemo2_ckpt
         rm -rf /tmp/nemo2_ptq_engine
   
-   L2_NeMo_2_LLAVA_NEXT_MOCK_TRAINING:
+  L2_NeMo_2_LLAVA_NEXT_MOCK_TRAINING:
     needs: [cicd-test-container-setup]
     uses: ./.github/workflows/_test_template.yml
     if: contains(fromJSON(needs.cicd-test-container-setup.outputs.test_to_run), 'L2_NeMo_2_LLAVA_NEXT_MOCK_TRAINING') || needs.cicd-test-container-setup.outputs.all == 'true'

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -4613,7 +4613,7 @@ jobs:
     uses: ./.github/workflows/_test_template.yml
     if: contains(fromJSON(needs.cicd-test-container-setup.outputs.test_to_run), 'L2_NeMo_2_LLAVA_NEXT_MOCK_TRAINING') || needs.cicd-test-container-setup.outputs.all == 'true'
     with:
-      RUNNER: self-hosted-azure
+      RUNNER: azure-gpu-vm-runner1-cpu
       SCRIPT: |
         python tests/collections/vlm/test_llava_next_train.py \
         --devices=1 \

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -4607,6 +4607,21 @@ jobs:
       AFTER_SCRIPT: |
         rm -rf /tmp/nemo2_ckpt
         rm -rf /tmp/nemo2_ptq_engine
+  
+   L2_NeMo_2_LLAVA_NEXT_MOCK_TRAINING:
+    needs: [cicd-test-container-setup]
+    uses: ./.github/workflows/_test_template.yml
+    if: contains(fromJSON(needs.cicd-test-container-setup.outputs.test_to_run), 'L2_NeMo_2_LLAVA_NEXT_MOCK_TRAINING') || needs.cicd-test-container-setup.outputs.all == 'true'
+    with:
+      RUNNER: self-hosted-azure
+      SCRIPT: |
+        python tests/collections/vlm/test_llava_next_train.py \
+        --devices=1 \
+        --max-steps=5 \
+        --experiment-dir=/tmp/nemo2_llava_next_results/${{ github.run_id }}
+
+      AFTER_SCRIPT: |
+        rm -rf /tmp/nemo2_llava_next_results
 
   Nemo_CICD_Test:
     needs:
@@ -4771,6 +4786,7 @@ jobs:
       - L2_Megatron_GPT_Reranker
       - L2_NeMo_2_NeMo_Mcore_Mixtral_bitexact
       - L2_NeMo_2_PTQ_Llama2_FP8
+      - L2_NeMo_2_LLAVA_NEXT_MOCK_TRAINING
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/nemo/collections/vlm/llava_next/data/mock.py
+++ b/nemo/collections/vlm/llava_next/data/mock.py
@@ -20,12 +20,12 @@ import torch
 from lightning.pytorch.utilities.types import EVAL_DATALOADERS, TRAIN_DATALOADERS
 from torch.utils import data
 from torch.utils.data import DataLoader, Dataset
+from transformers import AutoProcessor
 
+from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
 from nemo.collections.vlm.neva.data.multimodal_tokens import IMAGE_TOKEN_INDEX
 from nemo.lightning.pytorch.plugins import MegatronDataSampler
 from nemo.utils import logging
-from transformers import AutoProcessor
-from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
 
 
 class MockDataModule(pl.LightningDataModule):

--- a/nemo/collections/vlm/llava_next/data/mock.py
+++ b/nemo/collections/vlm/llava_next/data/mock.py
@@ -24,6 +24,8 @@ from torch.utils.data import DataLoader, Dataset
 from nemo.collections.vlm.neva.data.multimodal_tokens import IMAGE_TOKEN_INDEX
 from nemo.lightning.pytorch.plugins import MegatronDataSampler
 from nemo.utils import logging
+from transformers import AutoProcessor
+from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
 
 
 class MockDataModule(pl.LightningDataModule):
@@ -79,14 +81,12 @@ class MockDataModule(pl.LightningDataModule):
         self.persistent_workers = persistent_workers
         self.micro_batch_size = micro_batch_size
         self.global_batch_size = global_batch_size
-
+        model_name = ''
+        processor = None
         if tokenizer is None or image_processor is None:
             logging.warning(
                 f"Processor or tokenizer are not provided! Fall back to `llava-hf/llava-v1.6-vicuna-7b-hf`."
             )
-            from transformers import AutoProcessor
-
-            from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
 
             model_name = "llava-hf/llava-v1.6-vicuna-7b-hf"
 

--- a/nemo/collections/vlm/llava_next/data/mock.py
+++ b/nemo/collections/vlm/llava_next/data/mock.py
@@ -91,8 +91,8 @@ class MockDataModule(pl.LightningDataModule):
             model_name = "llava-hf/llava-v1.6-vicuna-7b-hf"
 
             processor = AutoProcessor.from_pretrained(model_name)
-            self.tokenizer = tokenizer or AutoTokenizer(model_name)
-            self.image_processor = image_processor or processor.image_processor
+        self.tokenizer = tokenizer or AutoTokenizer(model_name)
+        self.image_processor = image_processor or processor.image_processor
         self.data_sampler = MegatronDataSampler(
             seq_len=self.seq_length,
             decoder_seq_len=self.decoder_seq_len,

--- a/nemo/collections/vlm/recipes/llava_next_7b.py
+++ b/nemo/collections/vlm/recipes/llava_next_7b.py
@@ -163,7 +163,7 @@ def pretrain_recipe(
     name: str = "default",
     num_nodes: int = 1,
     num_gpus_per_node: int = 8,
-    peft_scheme: Optional[str] = 'none',
+    language_model_from_pretrained: Optional[str] = None,
 ) -> run.Partial:
     """
     Create a Pre-training recipe for Llava1.6 7B model.
@@ -223,6 +223,7 @@ def pretrain_recipe(
                 freeze_language_model=True,
                 freeze_vision_model=True,
                 freeze_vision_projection=False,
+                language_model_from_pretrained=language_model_from_pretrained,
             )
         ),
         trainer=trainer,

--- a/tests/collections/vlm/test_llava_next_train.py
+++ b/tests/collections/vlm/test_llava_next_train.py
@@ -49,7 +49,6 @@ if __name__ == '__main__':
 
     gbs = 2
     mbs = 2
-    seq_length = 576
     decoder_seq_length = 1024
     processor = AutoProcessor.from_pretrained("llava-hf/llava-v1.6-vicuna-7b-hf")
     tokenizer = AutoTokenizer("llava-hf/llava-v1.6-vicuna-7b-hf")

--- a/tests/collections/vlm/test_llava_next_train.py
+++ b/tests/collections/vlm/test_llava_next_train.py
@@ -1,0 +1,158 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## NOTE: This script is present for github-actions testing only.
+## There are no guarantees that this script is up-to-date with latest NeMo.
+
+import argparse
+
+import torch
+from megatron.core.optimizer import OptimizerConfig
+from pytorch_lightning.loggers import TensorBoardLogger
+from transformers import AutoProcessor
+
+from nemo import lightning as nl
+from nemo.collections import llm, vlm
+from nemo.collections.common.tokenizers.huggingface.auto_tokenizer import AutoTokenizer
+from nemo.collections.llm.api import train
+from nemo.lightning import AutoResume, NeMoLogger
+from nemo.lightning.pytorch.callbacks import ModelCheckpoint, ParameterDebugger
+from nemo.lightning.pytorch.optim.megatron import MegatronOptimizerModule
+
+
+def get_args():
+    # pylint: disable=C0115,C0116
+    parser = argparse.ArgumentParser(description='Train a small Llava Next model using NeMo 2.0')
+    parser.add_argument('--devices', type=int, default=1, help="Number of devices to use for training")
+    parser.add_argument('--max-steps', type=int, default=5, help="Number of steps to train for")
+    parser.add_argument(
+        '--experiment-dir', type=str, default=None, help="directory to write results and checkpoints to"
+    )
+
+    return parser.parse_args()
+
+
+if __name__ == '__main__':
+
+    args = get_args()
+
+    gbs = 2
+    mbs = 2
+    seq_length = 576
+    decoder_seq_length = 1024
+    processor = AutoProcessor.from_pretrained("llava-hf/llava-v1.6-vicuna-7b-hf")
+    tokenizer = AutoTokenizer("llava-hf/llava-v1.6-vicuna-7b-hf")
+
+    data = vlm.LlavaNextMockDataModule(
+        seq_length=decoder_seq_length,
+        tokenizer=tokenizer,
+        image_processor=processor.image_processor,
+        global_batch_size=gbs,
+        micro_batch_size=mbs,
+        num_workers=0,
+    )
+
+    # Transformer configurations
+    language_transformer_config = llm.Llama2Config7B(seq_length=decoder_seq_length, num_layers=2)
+
+    vision_transformer_config = vlm.HFCLIPVisionConfig(
+        pretrained_model_name_or_path="openai/clip-vit-large-patch14-336"
+    )
+    vision_projection_config = vlm.MultimodalProjectorConfig(
+        projector_type="mlp2x_gelu",
+        input_size=1024,
+        hidden_size=4096,
+        ffn_hidden_size=4096,
+    )
+
+    # Llava Next model configuration
+    neva_config = vlm.LlavaNextConfig(
+        language_transformer_config=language_transformer_config,
+        vision_transformer_config=vision_transformer_config,
+        vision_projection_config=vision_projection_config,
+        freeze_language_model=True,
+        freeze_vision_model=True,
+    )
+
+    model = vlm.LlavaNextModel(neva_config, tokenizer=data.tokenizer)
+
+    strategy = nl.MegatronStrategy(
+        tensor_model_parallel_size=1,
+        pipeline_model_parallel_size=1,
+        encoder_pipeline_model_parallel_size=0,
+        pipeline_dtype=torch.bfloat16,
+    )
+    checkpoint_callback = ModelCheckpoint(
+        every_n_train_steps=5000,
+        save_optim_on_train_end=True,
+    )
+
+    def create_verify_precision(precision: torch.dtype):
+        def verify_precision(tensor: torch.Tensor) -> None:
+            assert tensor.dtype == precision
+
+        return verify_precision
+
+    debugger = ParameterDebugger(
+        param_fn=create_verify_precision(torch.bfloat16),
+        grad_fn=create_verify_precision(torch.float32),
+        log_on_hooks=["on_train_start", "on_train_end"],
+    )
+    callbacks = [checkpoint_callback, debugger]
+
+    loggers = []
+    tensorboard_logger = TensorBoardLogger(
+        save_dir='dummy',  ## NOTE: this gets overwritten by default
+    )
+    loggers.append(tensorboard_logger)
+
+    opt_config = OptimizerConfig(
+        optimizer='adam',
+        lr=6e-4,
+        min_lr=6e-5,
+        use_distributed_optimizer=False,
+        bf16=True,
+    )
+    opt = MegatronOptimizerModule(config=opt_config)
+
+    trainer = nl.Trainer(
+        devices=args.devices,
+        max_steps=args.max_steps,
+        accelerator="gpu",
+        strategy=strategy,
+        logger=loggers,
+        callbacks=callbacks,
+        log_every_n_steps=1,
+        limit_val_batches=2,
+        plugins=nl.MegatronMixedPrecision(precision="bf16-mixed"),
+    )
+
+    nemo_logger = NeMoLogger(
+        log_dir=args.experiment_dir,
+    )
+
+    resume = AutoResume(
+        resume_if_exists=True,
+        resume_ignore_no_checkpoint=True,
+    )
+
+    train(
+        model=model,
+        data=data,
+        trainer=trainer,
+        log=nemo_logger,
+        resume=resume,
+        tokenizer='data',
+        optim=opt,
+    )


### PR DESCRIPTION
# What does this PR do ?

Adding Github Actions tests for Llava Next

**Collection**: VLM

# Changelog 
- github actions CI test for llava next training.
- modify pretrain recipe to have pretrained language model path

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
