### PR TITLE
PTQ CLI and param updates

### DIFF
--- a/nemo/collections/llm/api.py
+++ b/nemo/collections/llm/api.py
@@ -266,8 +266,8 @@ def validate(
 def ptq(
     nemo_checkpoint: str,
     export_config: ExportConfig,
-    calib_tp: int = 1,
-    calib_pp: int = 1,
+    calibration_tp: int = 1,
+    calibration_pp: int = 1,
     quantization_config: Annotated[Optional[QuantizationConfig], run.Config[QuantizationConfig]] = None,
 ) -> Path:
     """
@@ -280,8 +280,8 @@ def ptq(
     # Run calibration using tensor parallel set to 8 and export quantized checkpoint with tensor parallel equal 2
     nemo llm ptq nemo_checkpoint=/models/Llama-3-70B \
         export_config.path=/models/Llama-3-70B-FP8 \
-        calib_tp=8 \
-        export_config.inference_tensor_parallel=2
+        calibration_tp=8 \
+        export_config.inference_tp=2
     # Choose different quantization method, for example, INT8 SmoothQuant
     nemo llm ptq nemo_checkpoint=/models/Llama-3-8B \
         export_config.path=/models/Llama-3-8B-INT8_SQ \
@@ -289,8 +289,8 @@ def ptq(
     ```
     Args:
         nemo_checkpoint (str): The path to model to be quantized.
-        calib_tp (int): Calibration tensor parallelism.
-        calib_pp (int): Calibration pipeline parallelism.
+        calibration_tp (int): Calibration tensor parallelism.
+        calibration_pp (int): Calibration pipeline parallelism.
         quantization_config (QuantizationConfig): Configuration for quantization algorithm.
         export_config (ExportConfig): Export configuration for TensorRT-LLM checkpoint.
     Returns:
@@ -306,7 +306,7 @@ def ptq(
 
     quantizer = quantization.Quantizer(quantization_config, export_config)
 
-    model = quantization.load_with_modelopt_layer_spec(nemo_checkpoint, calib_tp, calib_pp)
+    model = quantization.load_with_modelopt_layer_spec(nemo_checkpoint, calibration_tp, calibration_pp)
 
     model = quantizer.quantize(model)
 

--- a/nemo/collections/llm/quantization/quantizer.py
+++ b/nemo/collections/llm/quantization/quantizer.py
@@ -80,7 +80,7 @@ class QuantizationConfig:
 class ExportConfig:
     """Inference configuration for the quantized TensorRT-LLM checkpoint."""
 
-    path: Union[Path, str]
+    path: str  # TODO: In fact `Union[Path, str]` but NeMo-Run CLI fails on type hint: unserializable PosixPath value
     dtype: Union[str, int] = "bf16"
     decoder_type: Optional[str] = None
     inference_tensor_parallel: int = 1

--- a/nemo/collections/llm/quantization/quantizer.py
+++ b/nemo/collections/llm/quantization/quantizer.py
@@ -83,8 +83,8 @@ class ExportConfig:
     path: str  # TODO: In fact `Union[Path, str]` but NeMo-Run CLI fails on type hint: unserializable PosixPath value
     dtype: Union[str, int] = "bf16"
     decoder_type: Optional[str] = None
-    inference_tensor_parallel: int = 1
-    inference_pipeline_parallel: int = 1
+    inference_tp: int = 1
+    inference_pp: int = 1
     generate_sample: bool = False
 
     def __post_init__(self):
@@ -287,8 +287,8 @@ class Quantizer:
     def export(self, model: MegatronParallel, model_dir: str) -> None:
         """Export model to a TensorRT-LLM checkpoint."""
         export_dir = self.export_config.path
-        inference_tp = self.export_config.inference_tensor_parallel
-        inference_pp = self.export_config.inference_pipeline_parallel
+        inference_tp = self.export_config.inference_tp
+        inference_pp = self.export_config.inference_pp
 
         use_nfs_workspace = model.config.pipeline_model_parallel_size > 1
         export_tensorrt_llm_checkpoint(

--- a/nemo/collections/llm/quantization/utils.py
+++ b/nemo/collections/llm/quantization/utils.py
@@ -69,15 +69,18 @@ def quantizable_model_config(model_cfg: llm.GPTConfig) -> llm.GPTConfig:
 
 
 def load_with_modelopt_layer_spec(
-    nemo_checkpoint_path: str, calib_tp: int = 1, calib_pp: int = 1, inference_only: bool = True
+    nemo_checkpoint_path: str,
+    tensor_model_parallel_size: int = 1,
+    pipeline_model_parallel_size: int = 1,
+    inference_only: bool = True,
 ):
     """Loads a model from a NeMo 2.0 checkpoint using modelopt layer spec."""
     # TODO: setting ddp="pytorch" and deleting model.optim is a hackish way to disable DDP initialization.
     # Needs a systematic solution.
     if inference_only:
         strategy = nl.MegatronStrategy(
-            tensor_model_parallel_size=calib_tp,
-            pipeline_model_parallel_size=calib_pp,
+            tensor_model_parallel_size=tensor_model_parallel_size,
+            pipeline_model_parallel_size=pipeline_model_parallel_size,
             pipeline_dtype=torch.bfloat16,
             ckpt_load_optimizer=False,
             ckpt_parallel_save_optim=False,
@@ -87,12 +90,14 @@ def load_with_modelopt_layer_spec(
         )
     else:
         strategy = nl.MegatronStrategy(
-            tensor_model_parallel_size=calib_tp, pipeline_model_parallel_size=calib_pp, pipeline_dtype=torch.bfloat16
+            tensor_model_parallel_size=tensor_model_parallel_size,
+            pipeline_model_parallel_size=pipeline_model_parallel_size,
+            pipeline_dtype=torch.bfloat16,
         )
 
     trainer = nl.Trainer(
-        devices=calib_tp,
-        num_nodes=calib_pp,
+        devices=tensor_model_parallel_size,
+        num_nodes=pipeline_model_parallel_size,
         strategy=strategy,
         plugins=nl.MegatronMixedPrecision(precision='bf16', params_dtype=torch.bfloat16, autocast_enabled=True),
     )

--- a/scripts/llm/ptq.py
+++ b/scripts/llm/ptq.py
@@ -17,7 +17,7 @@ from nemo.collections.llm import quantization
 
 
 def get_args():
-    """Parses PTQ arguments"""
+    """Parses PTQ arguments."""
 
     parser = argparse.ArgumentParser(
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -25,11 +25,11 @@ def get_args():
     )
     parser.add_argument("-nc", "--nemo_checkpoint", type=str, help="Source NeMo 2.0 checkpoint")
     parser.add_argument("--decoder_type", type=str, help="Decoder type for TensorRT-Model-Optimizer")
-    parser.add_argument("-ctp", "--calib_tp", type=int, default=1)
-    parser.add_argument("-cpp", "--calib_pp", type=int, default=1)
-    parser.add_argument("-tps", "--tensor_parallelism_size", type=int, default=1)
-    parser.add_argument("-pps", "--pipeline_parallelism_size", type=int, default=1)
-    parser.add_argument('-out', '--output_path', type=str, help='Path for the exported engine')
+    parser.add_argument("-ctp", "--calibration_tp", "--calib_tp", type=int, default=1)
+    parser.add_argument("-cpp", "--calibration_pp", "--calib_pp", type=int, default=1)
+    parser.add_argument("-itp", "--inference_tp", "--tensor_parallelism_size", type=int, default=1)
+    parser.add_argument("-ipp", "--inference_pp", "--pipeline_parallelism_size", type=int, default=1)
+    parser.add_argument('-out', '--export_path', '--output_path', type=str, help='Path for the exported engine')
     parser.add_argument(
         '-algo',
         '--algorithm',
@@ -66,9 +66,9 @@ def get_args():
     parser.set_defaults(generate_sample=False)
 
     args = parser.parse_args()
-    if args.output_path is None:
-        args.output_path = (
-            f"./qnemo_{args.algorithm}_tp{args.tensor_parallelism_size}_pp{args.pipeline_parallelism_size}"
+    if args.export_path is None:
+        args.export_path = (
+            f"./qnemo_{args.algorithm}_tp{args.inference_tp}_pp{args.inference_pp}"
         )
     return args
 
@@ -90,16 +90,16 @@ def main():
     )
 
     export_config = quantization.ExportConfig(
-        path=args.output_path,
+        path=args.export_path,
         decoder_type=args.decoder_type,
-        inference_tensor_parallel=args.tensor_parallelism_size,
-        inference_pipeline_parallel=args.pipeline_parallelism_size,
+        inference_tp=args.inference_tp,
+        inference_pp=args.inference_pp,
         dtype=args.dtype,
         generate_sample=args.generate_sample,
     )
 
     quantizer = quantization.Quantizer(quantization_config, export_config)
-    model = quantization.load_with_modelopt_layer_spec(args.nemo_checkpoint, args.calib_tp, args.calib_pp)
+    model = quantization.load_with_modelopt_layer_spec(args.nemo_checkpoint, args.calibration_tp, args.calibration_pp)
     model = quantizer.quantize(model)
     quantizer.export(model, args.nemo_checkpoint)
 

--- a/scripts/llm/ptq.py
+++ b/scripts/llm/ptq.py
@@ -67,9 +67,7 @@ def get_args():
 
     args = parser.parse_args()
     if args.export_path is None:
-        args.export_path = (
-            f"./qnemo_{args.algorithm}_tp{args.inference_tp}_pp{args.inference_pp}"
-        )
+        args.export_path = f"./qnemo_{args.algorithm}_tp{args.inference_tp}_pp{args.inference_pp}"
     return args
 
 


### PR DESCRIPTION
# What does this PR do ?

* Addressing CLI type hint issue `Unexpected error: Unserializable value /models/LLAMA31-8B-base-fp8 of type <class 'pathlib.PosixPath'>. Error occurred at path '<root>.export_config.path'.")` in [https://github.com/NVIDIA/NeMo/blob/a635607eea98b95a41f0f7a336ae083f38633630/nemo/collections/llm/quantization/quantizer.py#L83](https://github.com/NVIDIA/NeMo/blob/a635607eea98b95a41f0f7a336ae083f38633630/nemo/collections/llm/quantization/quantizer.py#L83)
* Some renaming

**Collection**: NLP / LLM

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [x] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to https://github.com/NVIDIA/NeMo-Run/pull/118 (prerequisite)
