### PR TITLE
Update LLM model deployment scripts

### DIFF
--- a/nemo/deploy/service/rest_model_api.py
+++ b/nemo/deploy/service/rest_model_api.py
@@ -28,7 +28,7 @@ class TritonSettings(BaseSettings):
     def __init__(self):
         super(TritonSettings, self).__init__()
         try:
-            self._triton_service_port = int(os.environ.get('TRITON_PORT', 8080))
+            self._triton_service_port = int(os.environ.get('TRITON_PORT', 8000))
             self._triton_service_ip = os.environ.get('TRITON_HTTP_ADDRESS', '0.0.0.0')
             self._triton_request_timeout = int(os.environ.get('TRITON_REQUEST_TIMEOUT', 60))
             self._openai_format_response = os.environ.get('OPENAI_FORMAT_RESPONSE', 'False').lower() == 'true'
@@ -105,7 +105,7 @@ async def check_triton_health():
         raise HTTPException(status_code=503, detail=f"Cannot reach Triton server: {str(e)}")
 
 
-@app.post("/v1/completions/")
+@app.post("/v1/completions")
 def completions_v1(request: CompletionRequest):
     try:
         url = triton_settings.triton_service_ip + ":" + str(triton_settings.triton_service_port)

--- a/scripts/deploy/nlp/deploy_triton.py
+++ b/scripts/deploy/nlp/deploy_triton.py
@@ -407,6 +407,11 @@ def nemo_deploy(argv):
         raise ValueError("Backend: {0} is not supported.".format(backend))
 
     try:
+        os.environ['TRITON_PORT'] = args.triton_port
+        os.environ['TRITON_HTTP_ADDRESS'] = args.triton_http_address
+        os.environ['TRITON_REQUEST_TIMEOUT'] = args.triton_request_timeout
+        os.environ['OPENAI_FORMAT_RESPONSE'] = args.openai_format_response
+
         nm = DeployPyTriton(
             model=triton_deployable,
             triton_model_name=args.triton_model_name,


### PR DESCRIPTION
# What does this PR do ?

Updated the LLM model conversion and deployment scripts to be in-line with OpenAI standards and for a more streamlined execution process.

**Collection**: NLP

# Changelog 
* Change /v1/completions/ endpoint to /v1/completions to be aligned with OpenAI API specs.
* Update default Triton port to be consistent between deployment and API scripts.
* Set the requested environment variables used by the API in the deployment script.

# Usage
* Deploy an existing `.nemo` model with the following:

```
python3 scripts/deploy/nlp/deploy_triton.py --nemo_checkpoint /path/to/pretrained-model.nemo --tensor_parallelism_size 4 --start_rest_service True --triton_model_name triton-model --model_type mixtral --max_input_len 4096 --max_output_len 8192
```

Then, you can send a query to the service one deployed with:

```
curl -X POST http://0.0.0.0:8080/v1/completions/ -H "Content-Type: application/json" -H "accept: application/json" -d '{"prompt": "User: Write me a story about a baby dragon learning how to fly\nAssistant:", "model": "triton-model"}'
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
