### PR TITLE
Update restore from config for gpt type continual training in NeMo1

### DIFF
--- a/examples/nlp/language_modeling/conf/megatron_baichuan2_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_baichuan2_config.yaml
@@ -1,6 +1,4 @@
 name: megatron_baichuan2
-restore_from_path: null # used when starting from a .nemo file
-
 trainer:
   devices: 1
   num_nodes: 1
@@ -41,6 +39,10 @@ exp_manager:
     model_parallel_size: ${multiply:${model.tensor_model_parallel_size}, ${model.pipeline_model_parallel_size}}
 
 model:
+  # The following two settings are used for continual training:
+  restore_from_path: null # Set this to a .nemo file path to restore only the model weights
+  restore_from_ckpt: null # Set this to a training ckpt path to restore both model weights and optimizer states
+
   mcore_gpt: True
   # specify micro_batch_size, global_batch_size, and model parallelism
   # gradient accumulation will be done automatically based on data_parallel_size

--- a/examples/nlp/language_modeling/conf/megatron_chatglm_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_chatglm_config.yaml
@@ -1,6 +1,4 @@
 name: megatron_chatglm2
-restore_from_path: null # used when starting from a .nemo file
-
 trainer:
   devices: 1
   num_nodes: 1
@@ -41,6 +39,10 @@ exp_manager:
     model_parallel_size: ${multiply:${model.tensor_model_parallel_size}, ${model.pipeline_model_parallel_size}}
 
 model:
+  # The following two settings are used for continual training:
+  restore_from_path: null # Set this to a .nemo file path to restore only the model weights
+  restore_from_ckpt: null # Set this to a training ckpt path to restore both model weights and optimizer states
+
   mcore_gpt: True
   # specify micro_batch_size, global_batch_size, and model parallelism
   # gradient accumulation will be done automatically based on data_parallel_size

--- a/examples/nlp/language_modeling/conf/megatron_falcon_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_falcon_config.yaml
@@ -1,6 +1,4 @@
 name: megatron_falcon_gpt
-restore_from_path: null # used when starting from a .nemo file
-
 trainer:
   devices: 1
   num_nodes: 1
@@ -41,6 +39,10 @@ exp_manager:
     model_parallel_size: ${multiply:${model.tensor_model_parallel_size}, ${model.pipeline_model_parallel_size}}
 
 model:
+  # The following two settings are used for continual training:
+  restore_from_path: null # Set this to a .nemo file path to restore only the model weights
+  restore_from_ckpt: null # Set this to a training ckpt path to restore both model weights and optimizer states
+
   mcore_gpt: True
   # specify micro_batch_size, global_batch_size, and model parallelism
   # gradient accumulation will be done automatically based on data_parallel_size

--- a/examples/nlp/language_modeling/conf/megatron_gemma2_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_gemma2_config.yaml
@@ -1,5 +1,4 @@
 name: megatron_gemma2
-restore_from_path: null # used when starting from a .nemo file
 
 trainer:
   devices: 1
@@ -41,6 +40,10 @@ exp_manager:
     model_parallel_size: ${multiply:${model.tensor_model_parallel_size}, ${model.pipeline_model_parallel_size}}
 
 model:
+  # The following two settings are used for continual training:
+  restore_from_path: null # Set this to a .nemo file path to restore only the model weights
+  restore_from_ckpt: null # Set this to a training ckpt path to restore both model weights and optimizer states
+
   mcore_gpt: True
   # specify micro_batch_size, global_batch_size, and model parallelism
   # gradient accumulation will be done automatically based on data_parallel_size

--- a/examples/nlp/language_modeling/conf/megatron_gemma_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_gemma_config.yaml
@@ -1,6 +1,4 @@
 name: megatron_llama
-restore_from_path: null # used when starting from a .nemo file
-
 trainer:
   devices: 1
   num_nodes: 1
@@ -41,6 +39,10 @@ exp_manager:
     model_parallel_size: ${multiply:${model.tensor_model_parallel_size}, ${model.pipeline_model_parallel_size}}
 
 model:
+  # The following two settings are used for continual training:
+  restore_from_path: null # Set this to a .nemo file path to restore only the model weights
+  restore_from_ckpt: null # Set this to a training ckpt path to restore both model weights and optimizer states
+
   mcore_gpt: True
   # specify micro_batch_size, global_batch_size, and model parallelism
   # gradient accumulation will be done automatically based on data_parallel_size

--- a/examples/nlp/language_modeling/conf/megatron_llama_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_llama_config.yaml
@@ -1,6 +1,4 @@
 name: megatron_llama
-restore_from_path: null # used when starting from a .nemo file
-
 trainer:
   devices: 1
   num_nodes: 1
@@ -41,6 +39,10 @@ exp_manager:
     model_parallel_size: ${multiply:${model.tensor_model_parallel_size}, ${model.pipeline_model_parallel_size}}
 
 model:
+  # The following two settings are used for continual training:
+  restore_from_path: null # Set this to a .nemo file path to restore only the model weights
+  restore_from_ckpt: null # Set this to a training ckpt path to restore both model weights and optimizer states
+
   mcore_gpt: True
   # specify micro_batch_size, global_batch_size, and model parallelism
   # gradient accumulation will be done automatically based on data_parallel_size

--- a/examples/nlp/language_modeling/conf/megatron_qwen2_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_qwen2_config.yaml
@@ -1,6 +1,4 @@
 name: megatron_qwen2
-restore_from_path: null # used when starting from a .nemo file
-
 trainer:
   devices: 1
   num_nodes: 1
@@ -41,6 +39,10 @@ exp_manager:
     model_parallel_size: ${multiply:${model.tensor_model_parallel_size}, ${model.pipeline_model_parallel_size}}
 
 model:
+  # The following two settings are used for continual training:
+  restore_from_path: null # Set this to a .nemo file path to restore only the model weights
+  restore_from_ckpt: null # Set this to a training ckpt path to restore both model weights and optimizer states
+
   mcore_gpt: True
   # specify micro_batch_size, global_batch_size, and model parallelism
   # gradient accumulation will be done automatically based on data_parallel_size

--- a/examples/nlp/language_modeling/conf/megatron_starcoder2_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_starcoder2_config.yaml
@@ -1,6 +1,4 @@
 name: megatron_starcoder2
-restore_from_path: null # used when starting from a .nemo file
-
 trainer:
   num_nodes: 1
   devices: 1
@@ -39,7 +37,11 @@ exp_manager:
     model_parallel_size: 2
 
 model:
-  mcore_gpt: true
+  # The following two settings are used for continual training:
+  restore_from_path: null # Set this to a .nemo file path to restore only the model weights
+  restore_from_ckpt: null # Set this to a training ckpt path to restore both model weights and optimizer states
+
+  mcore_gpt: True
   # specify micro_batch_size, global_batch_size, and model parallelism
   # gradient accumulation will be done automatically based on data_parallel_size
   micro_batch_size: 1 # limited by GPU memory

--- a/examples/nlp/language_modeling/conf/megatron_starcoder_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_starcoder_config.yaml
@@ -1,6 +1,4 @@
 name: megatron_starcoder
-restore_from_path: null # used when starting from a .nemo file
-
 trainer:
   devices: 1
   num_nodes: 1

--- a/examples/nlp/language_modeling/conf/megatron_starcoder_config.yaml
+++ b/examples/nlp/language_modeling/conf/megatron_starcoder_config.yaml
@@ -39,6 +39,10 @@ exp_manager:
     model_parallel_size: ${multiply:${model.tensor_model_parallel_size}, ${model.pipeline_model_parallel_size}}
 
 model:
+  # The following two settings are used for continual training:
+  restore_from_path: null # Set this to a .nemo file path to restore only the model weights
+  restore_from_ckpt: null # Set this to a training ckpt path to restore both model weights and optimizer states
+
   # use GPTModel from megatron.core
   mcore_gpt: True
 


### PR DESCRIPTION
# What does this PR do ?

Some model's config is not properly updated for merging continual training + pre-training. Mainly moving restore_from config from root to under model config.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
