### PR TITLE
Make HFDatasetDataModule a datasets.load_dataset wrapper

### DIFF
--- a/nemo/collections/llm/gpt/data/api.py
+++ b/nemo/collections/llm/gpt/data/api.py
@@ -41,8 +41,8 @@ def dolly() -> pl.LightningDataModule:
 
 @run.cli.factory
 @run.autoconvert
-def hf_dataset(dataset: str) -> pl.LightningDataModule:
-    return HFDatasetDataModule(dataset=dataset, global_batch_size=16, micro_batch_size=2)
+def hf_dataset(path: str) -> pl.LightningDataModule:
+    return HFDatasetDataModule(path=path, global_batch_size=16, micro_batch_size=2)
 
 
 __all__ = ["mock", "squad", "dolly", "hf_dataset"]

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from datasets import load_dataset
-from nemo.lightning.pytorch.plugins import MegatronDataSampler
-from nemo.utils import logging
-from torch.utils.data import DataLoader
-
 import datasets.dataset_dict
 import lightning.pytorch as pl
 import torch
+from datasets import load_dataset
+from torch.utils.data import DataLoader
+
+from nemo.lightning.pytorch.plugins import MegatronDataSampler
+from nemo.utils import logging
+
 
 def make_dataset_splits(path, split, split_aliases, kwargs):
     """
@@ -60,7 +61,6 @@ def make_dataset_splits(path, split, split_aliases, kwargs):
         for alias in _split_aliases:
             alias_to_split[alias] = split_name
 
-
     if isinstance(dataset, datasets.dataset_dict.DatasetDict):
         dataset_split_names = dataset.keys()
         logging.info(f"HF dataset has the following splits: {dataset_split_names}")
@@ -89,9 +89,11 @@ def make_dataset_splits(path, split, split_aliases, kwargs):
     else:
         raise ValueError("Expected split name to be None, str or a list")
 
-    assert sum(map(lambda x: x is not None, dataset_splits.values())) > 0, \
-        "Expected at least one dataset to have been initialized"
+    assert (
+        sum(map(lambda x: x is not None, dataset_splits.values())) > 0
+    ), "Expected at least one dataset to have been initialized"
     return dataset_splits
+
 
 class HFDatasetDataModule(pl.LightningDataModule):
     def __init__(
@@ -120,11 +122,7 @@ class HFDatasetDataModule(pl.LightningDataModule):
         # A dataset usually will have several splits (e.g. train, val, test, etc).
         # We map synonym names to canonical names (train, test, val).
         # A synonym can be a prefix/suffixed word e.g. train <> training.
-        split_aliases = {
-            'train': train_aliases,
-            'test': test_aliases,
-            'val': val_aliases
-        }
+        split_aliases = {'train': train_aliases, 'test': test_aliases, 'val': val_aliases}
 
         # self.dataset_splits will hold the actual dataset for each split.
         self.dataset_splits = make_dataset_splits(path, split, split_aliases, kwargs)

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -117,12 +117,16 @@ class HFDatasetDataModule(pl.LightningDataModule):
 
         logging.info(f"Loading HF dataset from {path}")
 
-        # self.dataset_splits will hold the actual dataset for each split.
+        # A dataset usually will have several splits (e.g. train, val, test, etc).
+        # We canonicalize synonym names to canonical names (train, test, val).
+        # A synonym can be a prefix/suffixed word e.g. train <> training.
         split_aliases = {
             'train': train_aliases,
             'test': test_aliases,
             'val': val_aliases
         }
+
+        # self.dataset_splits will hold the actual dataset for each split.
         self.dataset_splits = make_dataset_splits(path, split, split_aliases, kwargs)
 
         self.num_workers = num_workers

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -21,7 +21,7 @@ import datasets.dataset_dict.DatasetDict
 import lightning.pytorch as pl
 import torch
 
-def make_dataset_splits(path, split=None, **kwargs):
+def make_dataset_splits(path, split, kwargs):
     """
     Loads a dataset with datasets.load_dataset and returns a dict containing dataset splits,
     For example:
@@ -108,7 +108,7 @@ class HFDatasetDataModule(pl.LightningDataModule):
         logging.info(f"Loading HF dataset from {path}")
 
         # self.dataset_splits will hold the actual dataset for each split.
-        self.dataset_splits = make_dataset_splits(path, split, **kwargs)
+        self.dataset_splits = make_dataset_splits(path, split, kwargs)
 
         self.num_workers = num_workers
         self.pin_memory = pin_memory

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -203,7 +203,7 @@ class HFDatasetDataModule(pl.LightningDataModule):
 
     def map(self, function=None, split_names=None, **kwargs):
         if isinstance(split_names, str):
-            dataset_splits = {'split_names': self.dataset_splits[split_names]}
+            dataset_splits = {split_names: self.dataset_splits[split_names]}
         elif isinstance(split_names, list):
             dataset_splits = {k: self.dataset_splits[k] for k in split_names}
         else:

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -109,7 +109,7 @@ class HFDatasetDataModule(pl.LightningDataModule):
         mcore_dataloader_type='cyclic',
         train_aliases=["train", "training"],
         test_aliases=["test", "testing"],
-        val_aliases=["val", "validation", "eval"],
+        val_aliases=["val", "validation", "valid", "eval"],
         **kwargs,
     ) -> None:
         super().__init__()

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -12,12 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datasets import load_dataset
+from nemo.lightning.pytorch.plugins import MegatronDataSampler
+from nemo.utils import logging
+from torch.utils.data import DataLoader
+
+import datasets.dataset_dict.DatasetDict
 import lightning.pytorch as pl
 import torch
-from torch.utils.data import DataLoader
-from nemo.lightning.pytorch.plugins import MegatronDataSampler
-from datasets import load_dataset
-import datasets.dataset_dict.DatasetDict
 
 def listify(x):
     if isinstance(x, list):
@@ -54,7 +56,15 @@ class HFDatasetDataModule(pl.LightningDataModule):
         super().__init__()
         assert pad_token_id is not None
 
+        logging.info(f"Loading HF dataset from {path}")
+
         self.dataset = load_dataset(path, **kwargs)
+        if isinstance(self.dataset, datasets.dataset_dict.DatasetDict):
+            split_names = self.dataset.keys()
+            logging.info(f"HF dataset has the following splits: {split_names}")
+        else:
+            logging.info(f"Loaded HF dataset has a single split.")
+
 
         self.num_workers = num_workers
         self.pin_memory = pin_memory

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -141,14 +141,14 @@ class HFDatasetDataModule(pl.LightningDataModule):
 
     def map(self, function=None, split_names=None, **kwargs):
         if split_names is not None:
-            dataset = extract_split(self.dataset, split_names)
+            datasets = extract_split(self.dataset, split_names)
         else:
-            dataset = self.dataset
+            datasets = self.dataset
 
         if isinstance(dataset, datasets.dataset_dict.DatasetDict):
-            dataset_iter = dataset.values()
+            dataset_iter = datasets.values()
         else:
-            dataset_iter = [dataset]
+            dataset_iter = [datasets]
 
         for subset in dataset_iter:
             subset.map(function, **kwargs)

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -118,7 +118,7 @@ class HFDatasetDataModule(pl.LightningDataModule):
         logging.info(f"Loading HF dataset from {path}")
 
         # A dataset usually will have several splits (e.g. train, val, test, etc).
-        # We canonicalize synonym names to canonical names (train, test, val).
+        # We map synonym names to canonical names (train, test, val).
         # A synonym can be a prefix/suffixed word e.g. train <> training.
         split_aliases = {
             'train': train_aliases,

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -17,7 +17,7 @@ from nemo.lightning.pytorch.plugins import MegatronDataSampler
 from nemo.utils import logging
 from torch.utils.data import DataLoader
 
-import datasets.dataset_dict.DatasetDict
+import datasets.dataset_dict
 import lightning.pytorch as pl
 import torch
 

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -21,24 +21,6 @@ import datasets.dataset_dict.DatasetDict
 import lightning.pytorch as pl
 import torch
 
-def listify(x):
-    if isinstance(x, list):
-        return x
-    return [x]
-
-def is_dataset_dict(dataset):
-    return isinstance(dataset, datasets.dataset_dict.DatasetDict)
-
-def extract_matching_split(dataset, split_names):
-    assert is_dataset_dict(dataset)
-    for split_name in split_names:
-        if split_name in dataset:
-            return dataset[split_name]
-    raise ValueError(("Dataset does not contain any of " + str(split_names) + \
-        "; available splits= " + str(dataset.keys()))
-    )
-
-
 def make_dataset_splits(path, split=None, **kwargs):
     """
     Loads a dataset with datasets.load_dataset and returns a dict containing dataset splits,
@@ -188,14 +170,6 @@ class HFDatasetDataModule(pl.LightningDataModule):
             collate_fn=collate_fn,
             batch_size=self.micro_batch_size,
         )
-
-    def _extract_split_from_dict(self, split_names):
-        if is_dataset_dict(self.dataset):
-            return extract_matching_split(self.dataset, split_names)
-        else:
-            if self.split is not None:
-                assert any(map(lambda x: x in split_names, self.split))
-            return self.dataset
 
     def train_dataloader(self, collate_fn=None):
         return self._make_dataloader(self.dataset_splits['train'], collate_fn)

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -200,12 +200,12 @@ class HFDatasetDataModule(pl.LightningDataModule):
         return self._make_dataloader(self.dataset_splits['test'], collate_fn)
 
     def map(self, function=None, split_names=None, **kwargs):
-        if isintance(split_names, str):
-            dataset_splits = [self.dataset[split_names]]
-        elif isintance(split_names, list):
-            dataset_splits = [self.dataset[k] for k in split_names]
+        if isinstance(split_names, str):
+            dataset_splits = [self.dataset_splits[split_names]]
+        elif isinstance(split_names, list):
+            dataset_splits = [self.dataset_splits[k] for k in split_names]
         else:
-            dataset_splits = self.dataset.values()
+            dataset_splits = self.dataset_splits.values()
 
         for subset in dataset_splits:
             subset.map(function, **kwargs)

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -208,4 +208,6 @@ class HFDatasetDataModule(pl.LightningDataModule):
             dataset_splits = self.dataset_splits.values()
 
         for subset in dataset_splits:
+            if subset is None:
+                continue
             subset.map(function, **kwargs)

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -181,15 +181,12 @@ class HFDatasetDataModule(pl.LightningDataModule):
         return self._make_dataloader(self.dataset_splits['test'], collate_fn)
 
     def map(self, function=None, split_names=None, **kwargs):
-        if split_names is not None:
-            datasets = extract_split(self.dataset, split_names)
+        if isintance(split_names, str):
+            dataset_splits = [self.dataset[split_names]]
+        elif isintance(split_names, list):
+            dataset_splits = [self.dataset[k] for k in split_names]
         else:
-            datasets = self.dataset
+            dataset_splits = self.dataset.values()
 
-        if isinstance(dataset, datasets.dataset_dict.DatasetDict):
-            dataset_iter = datasets.values()
-        else:
-            dataset_iter = [datasets]
-
-        for subset in dataset_iter:
+        for subset in dataset_splits:
             subset.map(function, **kwargs)

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -23,7 +23,9 @@ import torch
 
 def make_dataset_splits(path, split, kwargs):
     """
-    Loads a dataset with datasets.load_dataset and returns a dict containing dataset splits,
+    Loads a dataset with datasets.load_dataset and
+    returns a dictionary containing all dataset splits.
+
     For example:
 
     ans = make_dataset_splits("dataset-id")
@@ -85,7 +87,8 @@ def make_dataset_splits(path, split, kwargs):
     else:
         raise ValueError("Expected split name to be None, str or a list")
 
-    assert sum(map(lambda x: x is not None, dataset_splits.values())) > 0, "Expected at least one dataset to have been initialized"
+    assert sum(map(lambda x: x is not None, dataset_splits.values())) > 0, \
+        "Expected at least one dataset to have been initialized"
     return dataset_splits
 
 class HFDatasetDataModule(pl.LightningDataModule):

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -74,6 +74,11 @@ def make_dataset_splits(path, split, kwargs):
     elif isinstance(split, str):
         logging.info(f"Loaded HF dataset has a single split.")
         assert not isinstance(dataset, list)
+        alias_split_name = split
+        if '+' in alias_split_name:
+            raise ValueError("Split concatenation not supported")
+        elif '[' in alias_split_name:
+            alias_split_name = alias_split_name.split('[')[0]
         split_name = alias_to_split[alias_split_name]
         assert dataset_splits[split_name] is None
         dataset_splits[split_name] = dataset

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -118,9 +118,12 @@ class HFDatasetDataModule(pl.LightningDataModule):
         logging.info(f"Loading HF dataset from {path}")
 
         # self.dataset_splits will hold the actual dataset for each split.
-        self.dataset_splits = make_dataset_splits(path, split, {
-            'train':train_aliases, 'test': test_aliases, 'val': val_aliases},
-            kwargs)
+        split_aliases = {
+            'train': train_aliases,
+            'test': test_aliases,
+            'val': val_aliases
+        }
+        self.dataset_splits = make_dataset_splits(path, split, split_aliases, kwargs)
 
         self.num_workers = num_workers
         self.pin_memory = pin_memory

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -178,6 +178,8 @@ class HFDatasetDataModule(pl.LightningDataModule):
         )
 
     def _make_dataloader(self, dataset, collate_fn=None):
+        assert dataset is not None
+
         if collate_fn is None:
             collate_fn = lambda x: HFDatasetDataModule.collate_fn(x, pad_token_id=self.pad_token_id)
 
@@ -201,13 +203,13 @@ class HFDatasetDataModule(pl.LightningDataModule):
 
     def map(self, function=None, split_names=None, **kwargs):
         if isinstance(split_names, str):
-            dataset_splits = [self.dataset_splits[split_names]]
+            dataset_splits = {'split_names': self.dataset_splits[split_names]}
         elif isinstance(split_names, list):
-            dataset_splits = [self.dataset_splits[k] for k in split_names]
+            dataset_splits = {k: self.dataset_splits[k] for k in split_names}
         else:
-            dataset_splits = self.dataset_splits.values()
+            dataset_splits = self.dataset_splits
 
-        for subset in dataset_splits:
+        for split_name, subset in dataset_splits.items():
             if subset is None:
                 continue
-            subset.map(function, **kwargs)
+            dataset_splits[split_name] = subset.map(function, **kwargs)

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -108,6 +108,7 @@ class HFDatasetDataModule(pl.LightningDataModule):
     - loading multiple splits (train, validation) from a dataset
     llm.HFDatasetDataModule("rajpurkar/squad", split=["train", "validation"])
     """
+
     def __init__(
         self,
         path,

--- a/nemo/collections/llm/gpt/data/hf_dataset.py
+++ b/nemo/collections/llm/gpt/data/hf_dataset.py
@@ -190,14 +190,26 @@ class HFDatasetDataModule(pl.LightningDataModule):
             batch_size=self.micro_batch_size,
         )
 
+    @property
+    def train(self):
+        return self.dataset_splits['train']
+
+    @property
+    def val(self):
+        return self.dataset_splits['val']
+
+    @property
+    def test(self):
+        return self.dataset_splits['test']
+
     def train_dataloader(self, collate_fn=None):
-        return self._make_dataloader(self.dataset_splits['train'], collate_fn)
+        return self._make_dataloader(self.train, collate_fn)
 
     def val_dataloader(self, collate_fn=None):
-        return self._make_dataloader(self.dataset_splits['val'], collate_fn)
+        return self._make_dataloader(self.val, collate_fn)
 
     def test_dataloader(self, collate_fn=None):
-        return self._make_dataloader(self.dataset_splits['test'], collate_fn)
+        return self._make_dataloader(self.test, collate_fn)
 
     def map(self, function=None, split_names=None, **kwargs):
         if isinstance(split_names, str):

--- a/nemo/collections/llm/inference/base.py
+++ b/nemo/collections/llm/inference/base.py
@@ -25,9 +25,6 @@ from megatron.core.inference.engines.mcore_engine import MCoreEngine
 from megatron.core.inference.model_inference_wrappers.abstract_model_inference_wrapper import (
     AbstractModelInferenceWrapper,
 )
-from megatron.core.inference.text_generation_controllers.encoder_decoder_text_generation_controller import (
-    EncoderDecoderTextGenerationController,
-)
 from megatron.core.inference.text_generation_controllers.simple_text_generation_controller import (
     SimpleTextGenerationController,
 )
@@ -232,6 +229,9 @@ def generate(
     Returns:
         dict: A dictionary containing the generated results.
     """
+    from megatron.core.inference.text_generation_controllers.encoder_decoder_text_generation_controller import (
+        EncoderDecoderTextGenerationController,
+    )
     if encoder_prompts is not None:
         text_generation_controller = EncoderDecoderTextGenerationController(
             inference_wrapped_model=model, tokenizer=tokenizer

--- a/nemo/collections/llm/inference/base.py
+++ b/nemo/collections/llm/inference/base.py
@@ -232,6 +232,7 @@ def generate(
     from megatron.core.inference.text_generation_controllers.encoder_decoder_text_generation_controller import (
         EncoderDecoderTextGenerationController,
     )
+
     if encoder_prompts is not None:
         text_generation_controller = EncoderDecoderTextGenerationController(
             inference_wrapped_model=model, tokenizer=tokenizer

--- a/nemo/collections/llm/t5/model/t5.py
+++ b/nemo/collections/llm/t5/model/t5.py
@@ -320,6 +320,7 @@ class T5Model(L.LightningModule, io.IOMixin, io.ConnectorMixin, fn.FNMixin):
             padded_vocab_size=self.tokenizer.vocab_size,
         )
         from megatron.core.inference.model_inference_wrappers.t5.t5_inference_wrapper import T5InferenceWrapper
+
         model_inference_wrapper = T5InferenceWrapper(mcore_model, inference_wrapper_config)
         return model_inference_wrapper
 

--- a/nemo/collections/llm/t5/model/t5.py
+++ b/nemo/collections/llm/t5/model/t5.py
@@ -20,7 +20,7 @@ import lightning.pytorch as L
 import torch
 import torch.distributed
 from megatron.core.inference.model_inference_wrappers.inference_wrapper_config import InferenceWrapperConfig
-from megatron.core.inference.model_inference_wrappers.t5.t5_inference_wrapper import T5InferenceWrapper
+
 from megatron.core.models.T5.t5_model import T5Model as MCoreT5Model
 from megatron.core.optimizer import OptimizerConfig
 from megatron.core.transformer.spec_utils import ModuleSpec
@@ -319,7 +319,7 @@ class T5Model(L.LightningModule, io.IOMixin, io.ConnectorMixin, fn.FNMixin):
             inference_batch_times_seqlen_threshold=inference_batch_times_seqlen_threshold,
             padded_vocab_size=self.tokenizer.vocab_size,
         )
-
+        from megatron.core.inference.model_inference_wrappers.t5.t5_inference_wrapper import T5InferenceWrapper
         model_inference_wrapper = T5InferenceWrapper(mcore_model, inference_wrapper_config)
         return model_inference_wrapper
 

--- a/tests/collections/llm/gpt/data/test_hf_datamodule.py
+++ b/tests/collections/llm/gpt/data/test_hf_datamodule.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+import nemo.lightning as nl
+from nemo.collections.llm.gpt.data.pre_training import PreTrainingDataModule
+from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenizer
+from nemo.collections import llm
+
+
+DATA_PATH = "/home/TestData/lite/hf_cache/squad/"
+
+def test_load_single_split():
+    ds = llm.HFDatasetDataModule(
+        path=DATA_PATH,
+        split='train',
+        seq_length=512,
+        micro_batch_size=2,
+        global_batch_size=2,
+    )
+    from datasets.arrow_dataset import Dataset
+    assert isinstance(ds.dataset_splits, dict)
+    assert len(ds.dataset_splits) == 3
+    assert 'train' in ds.dataset_splits
+    assert ds.dataset_splits['train'] is not None
+    assert ds.train is not None
+    assert isinstance(ds.dataset_splits['train'], Dataset)
+    assert 'val' in ds.dataset_splits
+    assert ds.dataset_splits['val'] is None
+    assert ds.val is None
+    assert 'test' in ds.dataset_splits
+    assert ds.dataset_splits['test'] is None
+    assert ds.test is None
+
+def test_load_nonexistent_split():
+    exception_msg = ''
+    expected_msg = '''Unknown split "this_split_name_should_not_exist". Should be one of ['train', 'validation'].'''
+    try:
+        llm.HFDatasetDataModule(
+            path=DATA_PATH,
+            split='this_split_name_should_not_exist',
+            seq_length=512,
+            micro_batch_size=2,
+            global_batch_size=2,
+        )
+    except ValueError as e:
+        exception_msg = str(e)
+    assert exception_msg == expected_msg, exception_msg
+
+def test_load_multiple_split():
+    ds = llm.HFDatasetDataModule(
+        path=DATA_PATH,
+        split=['train', 'validation'],
+        seq_length=512,
+        micro_batch_size=2,
+        global_batch_size=2,
+    )
+    from datasets.arrow_dataset import Dataset
+    assert isinstance(ds.dataset_splits, dict)
+    assert len(ds.dataset_splits) == 3
+    assert 'train' in ds.dataset_splits
+    assert ds.dataset_splits['train'] is not None
+    assert ds.train is not None
+    assert isinstance(ds.dataset_splits['train'], Dataset)
+    assert isinstance(ds.train, Dataset)
+    assert 'val' in ds.dataset_splits
+    assert ds.dataset_splits['val'] is not None
+    assert ds.val is not None
+    assert isinstance(ds.dataset_splits['val'], Dataset)
+    assert isinstance(ds.val, Dataset)
+    assert 'test' in ds.dataset_splits
+    assert ds.dataset_splits['test'] is None
+    assert ds.test is None
+
+
+
+def test_validate_dataset_asset_accessibility_file_does_not_exist():
+    raised_exception = False
+    try:
+        data = llm.HFDatasetDataModule(
+            path="/this/path/should/not/exist/",
+            seq_length=512,
+            micro_batch_size=2,
+            global_batch_size=2,
+        )
+    except FileNotFoundError:
+        raised_exception = True
+
+    assert raised_exception == True, "Expected to raise a FileNotFoundError"
+
+
+def test_validate_dataset_asset_accessibility_file_is_none(): #tokenizer, trainer):
+    raised_exception = False
+    try:
+        data = llm.HFDatasetDataModule(
+            path=None,
+            seq_length=512,
+            micro_batch_size=2,
+            global_batch_size=2,
+        )
+    except TypeError:
+        raised_exception = True
+
+    assert raised_exception == True, "Expected to raise a ValueError"

--- a/tests/collections/llm/gpt/data/test_hf_datamodule.py
+++ b/tests/collections/llm/gpt/data/test_hf_datamodule.py
@@ -15,8 +15,6 @@
 import pytest
 
 import nemo.lightning as nl
-from nemo.collections.llm.gpt.data.pre_training import PreTrainingDataModule
-from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenizer
 from nemo.collections import llm
 
 
@@ -89,7 +87,7 @@ def test_load_multiple_split():
 def test_validate_dataset_asset_accessibility_file_does_not_exist():
     raised_exception = False
     try:
-        data = llm.HFDatasetDataModule(
+        llm.HFDatasetDataModule(
             path="/this/path/should/not/exist/",
             seq_length=512,
             micro_batch_size=2,
@@ -104,7 +102,7 @@ def test_validate_dataset_asset_accessibility_file_does_not_exist():
 def test_validate_dataset_asset_accessibility_file_is_none(): #tokenizer, trainer):
     raised_exception = False
     try:
-        data = llm.HFDatasetDataModule(
+        llm.HFDatasetDataModule(
             path=None,
             seq_length=512,
             micro_batch_size=2,

--- a/tests/collections/llm/gpt/data/test_hf_datamodule.py
+++ b/tests/collections/llm/gpt/data/test_hf_datamodule.py
@@ -20,6 +20,7 @@ from nemo.collections import llm
 
 DATA_PATH = "/home/TestData/lite/hf_cache/squad/"
 
+
 def test_load_single_split():
     ds = llm.HFDatasetDataModule(
         path=DATA_PATH,
@@ -29,6 +30,7 @@ def test_load_single_split():
         global_batch_size=2,
     )
     from datasets.arrow_dataset import Dataset
+
     assert isinstance(ds.dataset_splits, dict)
     assert len(ds.dataset_splits) == 3
     assert 'train' in ds.dataset_splits
@@ -41,6 +43,7 @@ def test_load_single_split():
     assert 'test' in ds.dataset_splits
     assert ds.dataset_splits['test'] is None
     assert ds.test is None
+
 
 def test_load_nonexistent_split():
     exception_msg = ''
@@ -57,6 +60,7 @@ def test_load_nonexistent_split():
         exception_msg = str(e)
     assert exception_msg == expected_msg, exception_msg
 
+
 def test_load_multiple_split():
     ds = llm.HFDatasetDataModule(
         path=DATA_PATH,
@@ -66,6 +70,7 @@ def test_load_multiple_split():
         global_batch_size=2,
     )
     from datasets.arrow_dataset import Dataset
+
     assert isinstance(ds.dataset_splits, dict)
     assert len(ds.dataset_splits) == 3
     assert 'train' in ds.dataset_splits
@@ -83,7 +88,6 @@ def test_load_multiple_split():
     assert ds.test is None
 
 
-
 def test_validate_dataset_asset_accessibility_file_does_not_exist():
     raised_exception = False
     try:
@@ -99,7 +103,7 @@ def test_validate_dataset_asset_accessibility_file_does_not_exist():
     assert raised_exception == True, "Expected to raise a FileNotFoundError"
 
 
-def test_validate_dataset_asset_accessibility_file_is_none(): #tokenizer, trainer):
+def test_validate_dataset_asset_accessibility_file_is_none():  # tokenizer, trainer):
     raised_exception = False
     try:
         llm.HFDatasetDataModule(

--- a/tests/collections/llm/gpt/data/test_hf_datamodule.py
+++ b/tests/collections/llm/gpt/data/test_hf_datamodule.py
@@ -12,11 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pytest
-
-import nemo.lightning as nl
 from nemo.collections import llm
-
 
 DATA_PATH = "/home/TestData/lite/hf_cache/squad/"
 


### PR DESCRIPTION
# What does this PR do ?

Before:
```
dataset = load_dataset("rajpurkar/squad", split="train")
datamodule = llm.HFDatasetDataModule(dataset, pad_token_id=tokenizer.eos_token_id)
```

After:
```
datamodule = llm.HFDatasetDataModule("rajpurkar/squad", split="train", pad_token_id=tokenizer.eos_token_id)
```

Some additional use-cases:

- Load multiple partitions:
```
datamodule = llm.HFDatasetDataModule("rajpurkar/squad", split=["train", "validation"], pad_token_id=tokenizer.eos_token_id)
```

- Custom collate-fn:
```
def my_collate_fn(examples):
    ....
datamodule = llm.HFDatasetDataModule("rajpurkar/squad", split=["train", "validation"], collate_fn=my_collate_fn)
```

- Custom map function:
```
datamodule = llm.HFDatasetDataModule("rajpurkar/squad", split="train", pad_token_id=tokenizer.eos_token_id)
datamodule.map(formatting_prompts_func, batched=False, batch_size=2)
```
Instead of calling `.map` on the dataset we call it on the datamodule (which forwards it to the dataset).

**Note:** We expect the user to take appropriate care so that the keys in the returned batch (dict of tensors) matches the arguments of the downstream model.

**Collection**: LLM

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
