### PR TITLE
[BUG] wandb init path

### DIFF
--- a/nemo/lightning/nemo_logger.py
+++ b/nemo/lightning/nemo_logger.py
@@ -176,7 +176,7 @@ class NeMoLogger(IOMixin):
                 elif isinstance(logger, WandbLogger):
                     logger._id = version or ""
                     logger._save_dir = Path(dir) / logger.save_dir
-                    logger._wandb_init["dir"] = Path(dir) / logger.save_dir
+                    logger._wandb_init["dir"] = str(Path(dir) / logger.save_dir)
                     logging.warning(
                         f'"update_logger_directory" is True. Overwriting wandb logger "save_dir" to {logger._save_dir}'
                     )


### PR DESCRIPTION
Wandb recently changed the init directory to be validated as a string, pathlib.Path fails. We have requested them to change this, in the interim we should either pin Wandb `wandb==0.16.0` or avoid using pathlib.Path with Wandb constructs.

