### PR TITLE
Fix issue with Wandb update to settings parsing

### DIFF
--- a/nemo/lightning/nemo_logger.py
+++ b/nemo/lightning/nemo_logger.py
@@ -176,7 +176,7 @@ class NeMoLogger(IOMixin):
                 elif isinstance(logger, WandbLogger):
                     logger._id = version or ""
                     logger._save_dir = Path(dir) / logger.save_dir
-                    logger._wandb_init["dir"] = Path(dir) / logger.save_dir
+                    logger._wandb_init["dir"] = str(Path(dir) / logger.save_dir)
                     logging.warning(
                         f'"update_logger_directory" is True. Overwriting wandb logger "save_dir" to {logger._save_dir}'
                     )


### PR DESCRIPTION
In this PR: https://github.com/wandb/wandb/pull/8649 Wandb added a hard constraint that directories are passed as strings rather than `pathlib.Path`s. We've requested a change on their end to allow for both types. In the interim, either this change or pinning `wandb==0.16.0` resolves the issue. We should avoid using pathlib.Path with Wandb constructs for now.