### PR TITLE
Update Llama3 Fine-Tuning Notebook

### DIFF
--- a/tutorials/llm/llama-3/biomedical-qa/llama3-lora-nemofw.ipynb
+++ b/tutorials/llm/llama-3/biomedical-qa/llama3-lora-nemofw.ipynb
@@ -36,8 +36,8 @@
    "metadata": {},
    "source": [
     "---\n",
-    "## Before you begin\n",
-    "Ensure that you have the `Meta Llama3 8B Instruct .nemo` model downloaded and the corresponding folder mounted to the container."
+    "## Downloading the model\n",
+    "The Meta Llama3 8B Instruct model can be downloaded as a `.nemo` file from NGC for use in fine-tuning."
    ]
   },
   {
@@ -49,6 +49,8 @@
    },
    "outputs": [],
    "source": [
+    "!mkdir -p /workspace/llama-3-8b-instruct-nemo_v1.0\n",
+    "!wget --content-disposition 'https://api.ngc.nvidia.com/v2/models/org/nvidia/team/nemo/llama-3-8b-instruct-nemo/1.0/files?redirect=true&path=8b_instruct_nemo_bf16.nemo' -O /workspace/llama-3-8b-instruct-nemo_v1.0/8b_instruct_nemo_bf16.nemo\n",
     "!ls /workspace/llama-3-8b-instruct-nemo_v1.0"
    ]
   },
@@ -260,6 +262,7 @@
     "    trainer.max_steps=500 \\\n",
     "    model.megatron_amp_O2=True \\\n",
     "    ++model.mcore_gpt=True \\\n",
+    "    ++model.dist_ckpt_load_strictness=log_all \\\n",
     "    model.tensor_model_parallel_size=${TP_SIZE} \\\n",
     "    model.pipeline_model_parallel_size=${PP_SIZE} \\\n",
     "    model.micro_batch_size=1 \\\n",


### PR DESCRIPTION
# What does this PR do ?

Update the Llama3-8B PubMeQA fine-tuning example notebook for a seamless experience.

**Collection**: NLP

# Changelog 
- Fix an issue where using a base model with an older Transformer Engine version would cause a crash indicating missing model weight files.
- Download the model directly from NGC in the notebook for a full end-to-end example.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
