### PR TITLE
Sync validation metrics for ASRModel

### DIFF
--- a/nemo/collections/asr/models/asr_model.py
+++ b/nemo/collections/asr/models/asr_model.py
@@ -201,7 +201,7 @@ class ASRModel(ModelPT, ABC):
         EncDecRNNTModel.decoding.decoding is the inference class with CUDA graphs.
         """
         WithOptionalCudaGraphs.disable_cuda_graphs_recursive(self, attribute_path="decoding.decoding")
-        return super().on_validation_epoch_end()
+        return super().on_validation_epoch_end(sync_metrics=True)
 
     def on_test_epoch_start(self) -> None:
         """

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -971,7 +971,7 @@ class ModelPT(LightningModule, Model):
             output_dict = self.multi_validation_epoch_end(self.validation_step_outputs, dataloader_idx=0)
 
             if output_dict is not None and 'log' in output_dict:
-                self.log_dict(output_dict.pop('log'), on_epoch=True)
+                self.log_dict(output_dict.pop('log'), on_epoch=True, sync_dist=sync_metrics)
 
             self.validation_step_outputs.clear()  # free memory
             return output_dict

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -941,7 +941,7 @@ class ModelPT(LightningModule, Model):
 
         return self._test_dl
 
-    def on_validation_epoch_end(self) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
+    def on_validation_epoch_end(self, sync_metrics: bool = False) -> Optional[Dict[str, Dict[str, torch.Tensor]]]:
         """
         Default DataLoader for Validation set which automatically supports multiple data loaders
         via `multi_validation_epoch_end`.
@@ -1032,7 +1032,7 @@ class ModelPT(LightningModule, Model):
                 self.validation_step_outputs[dataloader_idx].clear()  # free memory
 
             if 'log' in output_dict:
-                self.log_dict(output_dict.pop('log'), on_epoch=True)
+                self.log_dict(output_dict.pop('log'), on_epoch=True, sync_dist=sync_metrics)
 
             # return everything else
             return output_dict


### PR DESCRIPTION
# What does this PR do ?

Synchronizes validation metrics across DDP ranks at the end of validation epoch. Fixes critical issue with corrupted checkpoints for multi-GPU Canary runs. Follows up on https://github.com/NVIDIA/NeMo/pull/10257

**Collection**: ASR

# Changelog 
- Multi-GPU validation metric sync for ASR models

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
