### PR TITLE
Remove auto-import of lhotse when importing nemo.collections.common.data

### DIFF
--- a/nemo/collections/common/data/__init__.py
+++ b/nemo/collections/common/data/__init__.py
@@ -13,5 +13,4 @@
 # limitations under the License.
 
 from nemo.collections.common.data.dataset import CodeSwitchedDataset, ConcatDataset, ConcatMapDataset
-from nemo.collections.common.data.lhotse import *
 from nemo.collections.common.data.prompt_fn import apply_prompt_format_fn, get_prompt_format_fn

--- a/tests/collections/common/test_lhotse_prompt_format_data_types.py
+++ b/tests/collections/common/test_lhotse_prompt_format_data_types.py
@@ -17,10 +17,9 @@ from lhotse import CutSet, SupervisionSegment
 from lhotse.cut import Cut
 from lhotse.testing.dummies import dummy_cut
 
-from nemo.collections.common.data import (
+from nemo.collections.common.data.lhotse import (
     NeMoSFTExample,
     SourceTargetTextExample,
-    TextExample,
     get_lhotse_dataloader_from_config,
 )
 from nemo.collections.common.tokenizers import SentencePieceTokenizer


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
