### PR TITLE
Fixing Multi_Task_Adapters.ipynb by replacing canary2 with canary_custom

### DIFF
--- a/tutorials/asr/asr_adapters/Multi_Task_Adapters.ipynb
+++ b/tutorials/asr/asr_adapters/Multi_Task_Adapters.ipynb
@@ -433,7 +433,7 @@
    "outputs": [],
    "source": [
     "@registered_prompt_format_fn\n",
-    "def canary2(cuts, tokenizer, inference: bool):\n",
+    "def canary_custom(cuts, tokenizer, inference: bool):\n",
     "    \"\"\" Users can implement this as needed \"\"\"\n",
     "    raise NotImplementedError()\n",
     "\n",
@@ -449,7 +449,7 @@
    },
    "outputs": [],
    "source": [
-    "temp = get_prompt_format_fn('canary2')\n",
+    "temp = get_prompt_format_fn('canary_custom')\n",
     "temp.__name__"
    ]
   },
@@ -549,7 +549,7 @@
     "class CanaryPromptFormatterV2(model.prompt.__class__):\n",
     "\n",
     "    # make sure to provide a new name\n",
-    "    NAME: str = \"canary2\"\n",
+    "    NAME: str = \"canary_custom\"\n",
     "\n",
     "    # Make any changes as necessary.\n",
     "    # For this demonstration, we will not change anything other than the name"
@@ -565,7 +565,7 @@
    "outputs": [],
    "source": [
     "# Next, lets update the model's prompt formatter\n",
-    "model.change_prompt(\"canary2\")"
+    "model.change_prompt(\"canary_custom\")"
    ]
   },
   {
@@ -577,9 +577,9 @@
    "source": [
     "---\n",
     "\n",
-    "We have now successfully changed the prompt format to `canary2`.\n",
+    "We have now successfully changed the prompt format to `canary_custom`.\n",
     "\n",
-    "**Note**: It is important to know that when changing the prompt format, the name of the new prompt format class (`canary2` in this case) **has to match** the name of the prompt function registered with `@registered_prompt_format_fn`!"
+    "**Note**: It is important to know that when changing the prompt format, the name of the new prompt format class (`canary_custom` in this case) **has to match** the name of the prompt function registered with `@registered_prompt_format_fn`!"
    ]
   },
   {


### PR DESCRIPTION
# What does this PR do ?

There is already a `canary2.py` file under the `nemo/collections/common/prompts` folder. In this tutorial, we register a new custom prompt formatter with the name `canary2`, which creates a conflict with the existing `canary2.py`. This PR resolves the conflict by changing the variable name from `canary2` to `canary_custom`.

**Collection**: [Note which collection this PR will affect]
NeMo/tutorial/asr 

# Changelog 
- Add specific line by line info of high level changes in this PR.
Updated requirements file 

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
