### PR TITLE
Utilities to detect and drop deprecated arguments from NeMo 2.0 checkpoint context io.json

### DIFF
--- a/nemo/lightning/io/__init__.py
+++ b/nemo/lightning/io/__init__.py
@@ -2,7 +2,7 @@ from nemo.lightning.io import registry  # noqa: F401
 from nemo.lightning.io.api import export_ckpt, import_ckpt, load, load_context, model_exporter, model_importer
 from nemo.lightning.io.capture import reinit
 from nemo.lightning.io.connector import Connector, ModelConnector
-from nemo.lightning.io.mixin import ConnectorMixin, IOMixin, track_io
+from nemo.lightning.io.mixin import ConnectorMixin, drop_unexpected_params, IOMixin, track_io
 from nemo.lightning.io.pl import TrainerContext, is_distributed_ckpt
 from nemo.lightning.io.state import TransformCTX, apply_transforms, state_transform
 
@@ -10,6 +10,7 @@ __all__ = [
     "apply_transforms",
     "Connector",
     "ConnectorMixin",
+    "drop_unexpected_params",
     "IOMixin",
     "track_io",
     "import_ckpt",

--- a/nemo/lightning/io/__init__.py
+++ b/nemo/lightning/io/__init__.py
@@ -2,7 +2,7 @@ from nemo.lightning.io import registry  # noqa: F401
 from nemo.lightning.io.api import export_ckpt, import_ckpt, load, load_context, model_exporter, model_importer
 from nemo.lightning.io.capture import reinit
 from nemo.lightning.io.connector import Connector, ModelConnector
-from nemo.lightning.io.mixin import ConnectorMixin, drop_unexpected_params, IOMixin, track_io
+from nemo.lightning.io.mixin import ConnectorMixin, IOMixin, drop_unexpected_params, track_io
 from nemo.lightning.io.pl import TrainerContext, is_distributed_ckpt
 from nemo.lightning.io.state import TransformCTX, apply_transforms, state_transform
 

--- a/nemo/lightning/io/mixin.py
+++ b/nemo/lightning/io/mixin.py
@@ -687,6 +687,45 @@ def _artifact_transform_load(cfg: fdl.Config, path: Path):
             pass
 
 
+def drop_unexpected_params(config: fdl.Config) -> bool:
+    """
+    Analyzes config to detect unexpected keyword arguments -- for example, deprecated parameters -- and
+    updates the config by dropping them. Returns True if the config gets updated and False otherwise.
+
+    Args:
+        config (fdl.Config): The configuration object to analyze.
+    """
+
+    updated = False
+
+    def analyze(config: fdl.Config, prefix: str):
+
+        if isinstance(config, fdl.Config):
+            signature = inspect.signature(config.__fn_or_cls__)
+
+            accept_kwargs = any(param.kind is inspect.Parameter.VAR_KEYWORD for param in signature.parameters.values())
+
+            if not accept_kwargs:
+                to_drop = [param for param in config.__arguments__ if param not in signature.parameters]
+
+                if to_drop:
+                    nonlocal updated
+                    updated = True
+                    logging.warning(f"Deprecated parameters to drop from {prefix}: {to_drop}")
+                    for param in to_drop:
+                        del config.__arguments__[param]
+            else:
+                logging.info(f"Skip analyzing {prefix} as it accepts arbitrary keyword arguments.")
+
+            # Proceed recursively for all arguments
+            for key, value in config.__arguments__.items():
+                analyze(value, prefix + "." + key)
+
+    analyze(config, "<root>")
+
+    return updated
+
+
 def load(path: Path, output_type: Type[CkptType] = Any, subpath: Optional[str] = None, build: bool = True) -> CkptType:
     """
     Loads a configuration from a pickle file and constructs an object of the specified type.

--- a/scripts/llm/update_io_context.py
+++ b/scripts/llm/update_io_context.py
@@ -7,7 +7,7 @@ import fiddle as fdl
 from fiddle._src.experimental import serialization
 
 from nemo.lightning.ckpt_utils import ckpt_to_context_subdir
-from nemo.lightning.io import load, drop_unexpected_params
+from nemo.lightning.io import drop_unexpected_params, load
 from nemo.utils import logging
 
 IO_FILE = "io.json"

--- a/scripts/llm/update_io_context.py
+++ b/scripts/llm/update_io_context.py
@@ -1,0 +1,80 @@
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import fiddle as fdl
+from fiddle._src.experimental import serialization
+
+from nemo.lightning.ckpt_utils import ckpt_to_context_subdir
+from nemo.lightning.io import load, drop_unexpected_params
+from nemo.utils import logging
+
+IO_FILE = "io.json"
+
+"""
+Script to update NeMo 2.0 model context (stored in io.json) for unexpected
+keword arguments for compatibility with the currently running environment.
+
+It accepts path to a NeMo 2.0 checkpoint and optional flag for building
+the updated configuration. It performs the following steps:
+
+1. Loads config from the model context directory.
+2. Checks the config for unexpected (e.g. deprecated) arguments and drops them.
+3. Attempts to build the updated configuration if --build flag is on.
+4. Backs up the existing context file and saves the updated configuration.
+"""
+
+
+def get_args():
+    """Parses command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Script to drop unexpected arguments from NeMo 2.0 io.json model context."
+    )
+    parser.add_argument("--model_path", type=str, required=True, help="Path to a NeMo 2.0 checkpoint.")
+    parser.add_argument("--build", action="store_true", help="Whether to test building the updated config.")
+    return parser.parse_args()
+
+
+def save_io(config: fdl.Config, path: str):
+    """
+    Saves the given configuration object to a specified file path in JSON format.
+
+    Args:
+        config (fdl.Config): The configuration object to be saved.
+        path (str): The file path where the configuration will be saved.
+    """
+    config_json = serialization.dump_json(config)
+    with open(path, "w") as f:
+        f.write(config_json)
+
+
+if __name__ == "__main__":
+    args = get_args()
+
+    model_path = Path(args.model_path)
+    context_path = ckpt_to_context_subdir(model_path)
+    logging.info(f"Path to model context: {context_path}.")
+
+    config = load(context_path, build=False)
+    updated = drop_unexpected_params(config)
+
+    if not updated:
+        logging.info("Config does not need any updates.")
+        sys.exit(0)
+
+    if args.build:
+        try:
+            fdl.build(config)
+        except Exception as e:
+            logging.error("Build for the updated config failed.")
+            raise
+        else:
+            logging.info("Build for the updated config successful.")
+
+    # Backup the existing context file and save the updated config
+    io_path = context_path / IO_FILE
+    io_path_backup = context_path / f"BACKUP_{datetime.now().strftime('%Y_%m_%d_%H_%M_%S')}_{IO_FILE}"
+    io_path.rename(io_path_backup)
+    save_io(config, io_path)
+    logging.info(f"Config saved to {io_path}.")

--- a/scripts/llm/update_io_context.py
+++ b/scripts/llm/update_io_context.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import argparse
 import sys
 from datetime import datetime

--- a/tests/collections/llm/io/test_drop_unexpected_params.py
+++ b/tests/collections/llm/io/test_drop_unexpected_params.py
@@ -71,11 +71,7 @@ class TestDropUnexpectedParams:
         """
         Test that a nested config with unexpected parameters gets updated.
         """
-        config = fdl.Config(
-            self.OuterClass,
-            z=4,
-            t=fdl.Config(self.MockClassOld, x=1, y=2, deprecated=3)
-        )
+        config = fdl.Config(self.OuterClass, z=4, t=fdl.Config(self.MockClassOld, x=1, y=2, deprecated=3))
 
         # Simulate deprecation issue by overriding target class
         config.t.__dict__["__fn_or_cls__"] = self.MockClassNew

--- a/tests/collections/llm/io/test_drop_unexpected_params.py
+++ b/tests/collections/llm/io/test_drop_unexpected_params.py
@@ -1,0 +1,88 @@
+# Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import fiddle as fdl
+
+from nemo.lightning.io import drop_unexpected_params
+
+
+class TestDropUnexpectedParams:
+
+    def setup_method(self):
+        """
+        Setup common test resources.
+        """
+
+        class MockClassOld:
+            def __init__(self, x, y, deprecated):
+                pass
+
+        class MockClassNew:
+            def __init__(self, x, y):
+                pass
+
+        class OuterClass:
+            def __init__(self, z, t):
+                pass
+
+        self.MockClassOld = MockClassOld
+        self.MockClassNew = MockClassNew
+        self.OuterClass = OuterClass
+
+    def test_valid_config_stays_same(self):
+        """
+        Test that a valid config remains unchanged.
+        """
+
+        config = fdl.Config(self.MockClassNew, x=1, y=2)
+        updated = drop_unexpected_params(config)
+
+        assert not updated, "Expected the config to remain unchanged."
+        assert config.x == 1
+        assert config.y == 2
+
+    def test_config_updates(self):
+        """
+        Test that a config with unexpected parameters gets updated.
+        """
+        config = fdl.Config(self.MockClassOld, x=1, y=2, deprecated=3)
+
+        # Simulate deprecation issue by overriding target class
+        config.__dict__['__fn_or_cls__'] = self.MockClassNew
+
+        updated = drop_unexpected_params(config)
+        assert updated, "Expected the config to be updated."
+        assert config.x == 1
+        assert config.y == 2
+        assert not hasattr(config, "deprecated"), "Expected 'deprecated' to be removed from the config."
+
+    def test_nested_config_updates(self):
+        """
+        Test that a nested config with unexpected parameters gets updated.
+        """
+        config = fdl.Config(
+            self.OuterClass,
+            z=4,
+            t=fdl.Config(self.MockClassOld, x=1, y=2, deprecated=3)
+        )
+
+        # Simulate deprecation issue by overriding target class
+        config.t.__dict__["__fn_or_cls__"] = self.MockClassNew
+
+        updated = drop_unexpected_params(config)
+        assert updated, "Expected the nested config to be updated."
+        assert config.z == 4
+        assert config.t.x == 1
+        assert config.t.y == 2
+        assert not hasattr(config.t, "deprecated"), "Expected 'deprecated' to be removed from the inner config."


### PR DESCRIPTION
# What does this PR do ?

Detecting and dropping unknown (deprecated) arguments from NeMo 2.0 io.json context.

**Collection**: LLM

# Usage

Loading the context for a NeMo 2.0 checkpoint produced using [24.09 container](https://catalog.ngc.nvidia.com/orgs/nvidia/containers/nemo/tags) and used with a more recent version results in the following error:
```
  File "/usr/local/lib/python3.10/dist-packages/fiddle/_src/daglish.py", line 786, in apply
    result = self.traversal_fn(value, state)
  File "/usr/local/lib/python3.10/dist-packages/fiddle/_src/building.py", line 180, in _build
    return call_buildable(value, arguments, current_path=state.current_path)
  File "/usr/local/lib/python3.10/dist-packages/fiddle/_src/building.py", line 120, in call_buildable
    return buildable.__build__(*args, **kwargs)
  File "/usr/local/lib/python3.10/dist-packages/fiddle/_src/config.py", line 783, in __build__
    return self.__fn_or_cls__(*args, **kwargs)
TypeError: OptimizerConfig.__init__() got an unexpected keyword argument 'overlap_grad_reduce'
```

This is a consequence of a recent Megatron-Core  refactor that removed `overlap_grad_reduce` and `overlap_param_gather` from `OptimizerConfig`, see https://github.com/NVIDIA/Megatron-LM/commit/6ac4db023bf7eb0e825e09aa8532af4a2c55f359.

The context may be cleared from deprecated parameters and updated using the provided script to load model successfully for subsequent processing:
```
python scripts/llm/update_io_context.py \
    --model_path /opt/checkpoints/LLAMA3-8B-nemo2-24-09 \
    --build
```

Alternatively, `drop_unexpected_params(config)` can be directly called in `load` function from **nemo/lightning/io/mixin.py** in  [L754](https://github.com/NVIDIA/NeMo/blob/0133deb268812109eab5211f902d7c4b99b6ee95/nemo/lightning/io/mixin.py#L754).

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
