### PR TITLE
Downgrading the 'datasets' package from 3.0.0 to 2.21.0 for Multilang_ASR.ipynb and ASR_CTC_Language_Finetuning.ipynb

### DIFF
--- a/tutorials/asr/ASR_CTC_Language_Finetuning.ipynb
+++ b/tutorials/asr/ASR_CTC_Language_Finetuning.ipynb
@@ -37,6 +37,7 @@
         "!apt-get install sox libsndfile1 ffmpeg libsox-fmt-mp3\n",
         "!pip install text-unidecode\n",
         "!pip install matplotlib>=3.3.2\n",
+        "!pip install datasets==2.21.0 # downgrading to 2.21.0 because latest version (3.0.0) has some issues\n",
         "\n",
         "## Install NeMo\n",
         "BRANCH = 'main'\n",

--- a/tutorials/asr/Multilang_ASR.ipynb
+++ b/tutorials/asr/Multilang_ASR.ipynb
@@ -98,6 +98,7 @@
     "!pip install matplotlib>=3.3.2\n",
     "# this is needed for RNNT loss\n",
     "!pip install --upgrade numba\n",
+    "!pip install datasets==2.21.0 # downgrading to 2.21.0 because latest version (3.0.0) has some issues\n",
     "\n",
     "# this is needed to pre-process MCV Spanish dataset, which contains mp3 files\n",
     "!apt-get install -y sox libsox-fmt-mp3\n",


### PR DESCRIPTION
# What does this PR do ?

'[datasets](https://pypi.org/project/datasets/#history)' recently released the latest version `3.0.0` on Sep 11th, but some HF datasets (e.g., [MCV 3.0](https://huggingface.co/datasets/mozilla-foundation/common_voice_3_0), [MCV 6.1](https://huggingface.co/datasets/mozilla-foundation/common_voice_6_1)) do not update their code for the latest version.  Attempting to download these MCV datasets using datasets `3.0.0` results in the following error:
`TypeError: DownloadConfig.__init__() got an unexpected keyword argument 'ignore_url_params'.`

As a workaround, we need to downgrade the datasets package to version `2.21.0` in some tutorial notebooks. Please check the first block of each notebook for this change.



**Collection**: [Note which collection this PR will affect]
NeMo/tutorial/asr 

# Changelog 
Adding `!pip install datasets==2.21.0` in the first block of each tutorial.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
Although unrelated to this PR, I wanted to highlight an issue encountered when calling Trainer.test() multiple times. In the `Multilang_ASR.ipynb` notebook, this sometimes results in a `RuntimeError: CUDA error: an illegal memory access was encountered` error in certain containers with specific PyTorch versions. This behavior has been verified in containers `24.06` and `24.12-rc0` (`nvcr.io/nvidia/nemo:24.12-rc0`), though it does not occur consistently and does not appear in other containers like `24.05` (`nvcr.io/nvidia/nemo:24.05`). A similar issue has been documented [here](https://github.com/pytorch/pytorch/issues/130615) with the `24.06` container (`nvcr.io/nvidia/pytorch:24.06-py3`). Testing is ongoing, but the root cause has not yet been identified. 
