### PR TITLE
Enable precision-aware optimizer with TE.optim

### DIFF
--- a/nemo/collections/llm/recipes/optim/adam.py
+++ b/nemo/collections/llm/recipes/optim/adam.py
@@ -30,6 +30,7 @@ def distributed_fused_adam_with_cosine_annealing(
     max_lr: float = 1e-4,
     min_lr: Optional[float] = None,
     clip_grad: float = 1.0,
+    use_precision_aware_optimizer: bool = False,
 ) -> run.Config[PytorchOptimizerModule]:
 
     opt_cfg = run.Config(
@@ -45,6 +46,8 @@ def distributed_fused_adam_with_cosine_annealing(
         use_distributed_optimizer=True,
         clip_grad=clip_grad,
     )
+    if hasattr(opt_cfg, "use_precision_aware_optimizer"):
+        opt_cfg.use_precision_aware_optimizer = use_precision_aware_optimizer
 
     min_lr = min_lr if min_lr is not None else (0.1 * max_lr)
     sched = run.Config(

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -625,6 +625,10 @@ class ModelPT(LightningModule, Model):
                 'overlap_param_gather_with_optimizer_step', False
             ),
         )
+        if hasattr(megatron_optim_config, 'use_precision_aware_optimizer'):
+            megatron_optim_config.use_precision_aware_optimizer = self.cfg.optim.get(
+                'use_precision_aware_optimizer', False
+            )
         return megatron_optim_config
 
     def setup_optimization(


### PR DESCRIPTION
# What does this PR do ?

Interface for precision-aware optimizer that uses Transformer Engin optimizer.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add the interface to enable precision-aware optimizer at both nemo 1.0 and 2.0

# Usage
- Set `recipe.optim.config.use_precision_aware_optimizer` for nemo 2.0
- Set `model.optim.use_precision_aware_optimizer` for nemo 1.0

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
