### PR TITLE
fix: mcore_ckpt_to_nemo.py broken from load_mlm arg

### DIFF
--- a/nemo/collections/nlp/models/nlp_model.py
+++ b/nemo/collections/nlp/models/nlp_model.py
@@ -367,9 +367,7 @@ class NLPModel(ModelPT, Exportable):
             # override the hparams with values that were passed in
             cfg = checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY].get('cfg', checkpoint[cls.CHECKPOINT_HYPER_PARAMS_KEY])
             # TODO: can we do this without overriding?
-            config_kwargs = kwargs.copy()
-            if 'trainer' in config_kwargs:
-                config_kwargs.pop('trainer')
+            config_kwargs = {k: v for k, v in kwargs.copy().items() if k in cfg}
             cfg.update(config_kwargs)
 
             if cfg.get('megatron_amp_O2', False) and checkpoint_dir is None:


### PR DESCRIPTION
In examples/nlp/language_modeling/megatron_ckpt_to_nemo.py, the introduction of load_mlm in this invocation

https://github.com/NVIDIA/NeMo/blob/5ed118f24c31ba1e4729ff3fae33dc8482bd1b64/examples/nlp/language_modeling/megatron_ckpt_to_nemo.py#L203

causes an error because load_mlm is not excluded from the model config during the update in nlp_model.py. This change just excludes all keys not in the model config to avoid this kind of error for other kwargs that aren't model config args.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
