### PR TITLE
remove tensorstore pin in requirements*.txt

### DIFF
--- a/requirements/requirements_infer.txt
+++ b/requirements/requirements_infer.txt
@@ -1,6 +1,6 @@
 fastapi
 nvidia-pytriton
 pydantic-settings
-tensorstore==0.1.45
+tensorstore
 uvicorn
 zarr

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -21,6 +21,6 @@ rapidfuzz
 rouge_score
 sacrebleu  # manually install sacrebleu[ja] for Japanese support; MeCab is unsupported in Python 3.11+
 sentence_transformers
-tensorstore<0.1.46
+tensorstore
 tiktoken==0.7.0
 zarr


### PR DESCRIPTION
# What does this PR do ?

Removes an outdated pin to tensorstore 0.1.45

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Removes version pins in requirements_infer.txt and requirements_nlp.txt

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
