### PR TITLE
[Bugfix] Skip processing if extra_state loads as None

### DIFF
--- a/nemo/export/trt_llm/nemo_ckpt_loader/nemo_file.py
+++ b/nemo/export/trt_llm/nemo_ckpt_loader/nemo_file.py
@@ -93,6 +93,9 @@ def preprocess_scaling_factors_for_local_export(state_dict: Dict[str, Any]) -> D
     scales = {}
 
     for key, value in scales_dict.items():
+        if value is None:
+            continue
+
         value.seek(0)
         extra_state = torch.load(value)
         if extra_state is not None and 'scale_fwd' in extra_state:


### PR DESCRIPTION
# What does this PR do ?

Addressing bug on trying to parse scaling factors that load to `None` on exporting a model to TensorRT-LLM:
```
  File "/opt/NeMo/nemo/export/trt_llm/nemo_ckpt_loader/nemo_file.py", line 496, in load_nemo_model
    model = preprocess_scaling_factors_for_local_export(model)
  File "/opt/NeMo/nemo/export/trt_llm/nemo_ckpt_loader/nemo_file.py", line 96, in preprocess_scaling_factors_for_local_export
    value.seek(0)
AttributeError: 'NoneType' object has no attribute 'seek'
```

Applies only to `use_mcore_path=False` case as extra states in Megatron-LM is correctly filtered out [here](https://github.com/NVIDIA/Megatron-LM/blob/df28200e53056604cad1829ec55bb9ba7c555f23/megatron/core/export/trtllm/trtllm_helper.py#L211-L212).

**Collection**: NLP / LLM

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
