### PR TITLE
chore(beep boop 🤖): Bump `MCORE_TAG=4dc8977...` (2025-01-08)

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -54,7 +54,7 @@ RUN pip install nemo_run@git+https://github.com/NVIDIA/NeMo-Run.git@${NEMO_RUN_T
 # Install NeMo requirements
 ARG TE_TAG=7d576ed25266a17a7b651f2c12e8498f67e0baea
 ARG MODELOPT_VERSION=0.21.0
-ARG MCORE_TAG=076972e37420b5325c5fe06e7131be7d96f05b53
+ARG MCORE_TAG=4dc8977167d71f86bdec47a60a98e85c4cfa0031
 
 ARG APEX_TAG=810ffae374a2b9cb4b5c5e28eaeca7d7998fca0c
 RUN \


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `Dockerfile.ci` to `MCORE_TAG=4dc8977167d71f86bdec47a60a98e85c4cfa0031`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.