### PR TITLE
chore(beep boop 🤖): Bump `MCORE_TAG=bafab5a...` (2025-01-09)

### DIFF
--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -67,7 +67,7 @@ pip install --no-cache-dir --no-build-isolation --extra-index-url https://pypi.n
 ".[all]"
 EOF
 
-ARG MCORE_TAG=4dc8977167d71f86bdec47a60a98e85c4cfa0031
+ARG MCORE_TAG=bafab5a54b55f2f7309e6625cd0887756548a44b
 RUN <<"EOF" bash -ex
 # Megatron-LM installation
 git clone https://github.com/NVIDIA/Megatron-LM.git


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `Dockerfile.ci` to `MCORE_TAG=bafab5a54b55f2f7309e6625cd0887756548a44b`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.