### PR TITLE
Fix the tokenizer after llama-3

### DIFF
--- a/scripts/checkpoint_converters/convert_llama_nemo_to_hf.py
+++ b/scripts/checkpoint_converters/convert_llama_nemo_to_hf.py
@@ -18,7 +18,7 @@ from collections import OrderedDict
 
 import torch
 from lightning.pytorch import Trainer
-from omegaconf import open_dict
+
 from transformers import AutoModelForCausalLM, AutoTokenizer
 
 from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel


### PR DESCRIPTION
# What does this PR do ?

update 'LlamaTokenizer' → 'AutoTokenizer'

Starting from llama-3, the tokenizer has been switched to use `PreTrainedTokenizerFast` instead of `LlamaTokenizer`.
This PR fixes the tokenizer loading method, enabling it to function correctly with models released after llama-3

# Changelog 
- L21: remove unused import `open_dict`
- L22: `import LlamaTokenizer` → `import AutoTokenizer`
- L258: load tokenizer by `LlamaTokenizer` → load by `AutoTokenizer`
- L261: remove `LlamaTokenizer` parameter
- L263~265: the tokenizer load by `AutoTokenizer` is already a "Fast" tokenizer, we don't need to convert it
- L276: remove the unused variable

# Usage
```python
>>> from transformers import LlamaTokenizer
>>> try:
...     tokenizer = LlamaTokenizer.from_pretrained("meta-llama/Meta-Llama-3-8B")
... except Exception as e:
...     print(e)
The tokenizer class you load from this checkpoint is not the same type as the class this function is called from. It may result in unexpected tokenization. 
The tokenizer class you load from this checkpoint is 'PreTrainedTokenizerFast'. 
The class this function is called from is 'LlamaTokenizer'.
```

```python
from transformers import AutoTokenizer
tokenizer = AutoTokenizer.from_pretrained("meta-llama/Meta-Llama-3-8B")
```

# Before your PR is "Ready for review"

**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  

**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
