### PR TITLE
Removing qk layernorms for DiT diffusion attention modules as qk layernorm is not supported for CrossAttention

### DIFF
--- a/nemo/collections/diffusion/models/dit/dit_layer_spec.py
+++ b/nemo/collections/diffusion/models/dit/dit_layer_spec.py
@@ -718,8 +718,6 @@ def get_stdit_adaln_block_with_transformer_engine_spec() -> ModuleSpec:
                     linear_kv=TEColumnParallelLinear,
                     core_attention=TEDotProductAttention,
                     linear_proj=TERowParallelLinear,
-                    q_layernorm=TENorm,
-                    k_layernorm=TENorm,
                 ),
             ),
             mlp=ModuleSpec(
@@ -757,8 +755,6 @@ def get_dit_adaln_block_with_transformer_engine_spec(attn_mask_type=AttnMaskType
                     linear_kv=TEColumnParallelLinear,
                     core_attention=TEDotProductAttention,
                     linear_proj=TERowParallelLinear,
-                    q_layernorm=RMSNorm,
-                    k_layernorm=RMSNorm,
                 ),
             ),
             mlp=ModuleSpec(


### PR DESCRIPTION
* Docker Image: `nvcr.io/nvidia/nemo:24.12`

* Command: `torchrun --nproc-per-node 8 nemo/collections/diffusion/train.py --yes --factory pretrain_xl`

* Error: `CrossAttentionSubmodules.__init__() got an unexpected keyword argument q_layernorm`

* Reason: `megatron.core.transformer.attention.CrossAttentionSubmodules` does not have argument `q_layernorm` and `k_layernorm`.

