### PR TITLE
Fix Qwen2 importer

### DIFF
--- a/nemo/collections/llm/gpt/model/qwen2.py
+++ b/nemo/collections/llm/gpt/model/qwen2.py
@@ -152,6 +152,7 @@ class HFQwen2Importer(io.ModelConnector["AutoModelForCausalLM", Qwen2Model]):
         source = HFAutoConfig.from_pretrained(str(self), trust_remote_code=True)
 
         output = Qwen2Config(
+            vocab_size=source.vocab_size,
             num_layers=source.num_hidden_layers,
             hidden_size=source.hidden_size,
             ffn_hidden_size=source.intermediate_size,


### PR DESCRIPTION
# What does this PR do ?

A simple fix for the Qwen2 importer:

Qwen2 7B and larger require `vocab_size=152064` instead of default `vocab_size=151936`. The `HFQwen2Importer.config` missed this setting.

**Collection**: `llm`

# Usage
* You can potentially add a usage example below

```python
# This usage will fail without this PR
nemo llm import model=qwen2_7b source="hf://Qwen/Qwen2-7B"
python3 ./scripts/llm/generate.py --model_path /root/.cache/nemo/models/Qwen/Qwen2-7B --num_tokens_to_generate 64
```

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?
@suiyoubi , since you added Qwen2 to NeMo2