### PR TITLE
Chore: Update requirements.txt

### DIFF
--- a/tools/speech_data_explorer/requirements.txt
+++ b/tools/speech_data_explorer/requirements.txt
@@ -8,3 +8,4 @@ numpy
 plotly
 SoundFile
 tqdm
+pandas

--- a/tools/speech_data_explorer/requirements.txt
+++ b/tools/speech_data_explorer/requirements.txt
@@ -5,7 +5,7 @@ editdistance
 jiwer
 librosa>=0.9.1
 numpy
+pandas
 plotly
 SoundFile
 tqdm
-pandas


### PR DESCRIPTION
When only using/installing the speech data explorer, pandas is not installed but needed to execute the tool. To stream line the process I edited the requirements.txt

# What does this PR do ?

It should help to streamline the process of installing the requirements, since pandas is used but not installed with the original file.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Added: "pandas" to line 11

# Usage
* When only using the Speech data explorer, in a new python enviroment.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
