### PR TITLE
Run nsys callback on GBS not on MBS

### DIFF
--- a/tests/lightning/pytorch/callbacks/test_nsys.py
+++ b/tests/lightning/pytorch/callbacks/test_nsys.py
@@ -111,6 +111,8 @@ class TestNsysCallback:
         callback = NsysCallback(start_step=10, end_step=20, ranks=[0])
 
         mock_trainer.strategy.current_epoch_step = 20
+        assert callback._has_nsys_enabled == False
+        callback._has_nsys_enabled = True
         callback.on_train_batch_end(mock_trainer, mock_pl_module, None, None, 20)
 
         mock_cudart().cudaProfilerStop.assert_called_once()


### PR DESCRIPTION
# What does this PR do ?

`get_current_epoch_step` tracks optimizer's current step (since the callback's start/end-step are in GBS). 
However, `on_train_batch_start` is called on every batch, therefore it is possible that it enters `if current_step == self._nsys_profile_start_step` and calls `emit_nvtx` multiple times.

This PR adds a boolean variable to prevent it from entering on each MBS.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
