### PR TITLE
Support both Path and str for APIs

### DIFF
--- a/nemo/collections/llm/api.py
+++ b/nemo/collections/llm/api.py
@@ -443,9 +443,9 @@ def evaluate(
     Args:
         nemo_checkpoint_path (Path): Path for nemo 2.0 checkpoint. This is used to get the tokenizer from the ckpt
         which is required to tokenize the evaluation input and output prompts.
-        url (str): grpc service url that were used in the deploy method above in the format: grpc://{grpc_service_ip}:{grpc_port}.
-        triton_http_port (int): HTTP port that was used for the PyTriton server in the
-            deploy method. Default: 8000.
+        url (str): grpc service url that were used in the deploy method above
+            in the format: grpc://{grpc_service_ip}:{grpc_port}.
+        triton_http_port (int): HTTP port that was used for the PyTriton server in the deploy method. Default: 8000.
         Please pass the triton_http_port if using a custom port in the deploy method.
         model_name (str): Name of the model that is deployed on PyTriton server. It should be the same as
         triton_model_name passed to the deploy method above to be able to launch evaluation. Deafult: "triton_model".

--- a/nemo/collections/llm/api.py
+++ b/nemo/collections/llm/api.py
@@ -565,7 +565,7 @@ def import_ckpt(
         ValueError: If the model does not implement ConnectorMixin, indicating a lack of
             necessary importer functionality.
     """
-    if not isinstance(output_path, Path):
+    if output_path and not isinstance(output_path, Path):
         output_path = Path(output_path)
 
     output = io.import_ckpt(model=model, source=source, output_path=output_path, overwrite=overwrite)
@@ -643,7 +643,7 @@ def export_ckpt(
     """
     if not isinstance(path, Path):
         path = Path(path)
-    if not isinstance(output_path, Path):
+    if output_path and not isinstance(output_path, Path):
         output_path = Path(output_path)
 
     output = io.export_ckpt(path, target, output_path, overwrite, load_connector)

--- a/nemo/collections/llm/api.py
+++ b/nemo/collections/llm/api.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
-import os
 import warnings
 from copy import deepcopy
 from pathlib import Path
@@ -445,7 +444,8 @@ def evaluate(
         nemo_checkpoint_path (Path): Path for nemo 2.0 checkpoint. This is used to get the tokenizer from the ckpt
         which is required to tokenize the evaluation input and output prompts.
         url (str): grpc service url that were used in the deploy method above in the format: grpc://{grpc_service_ip}:{grpc_port}.
-        triton_http_port (int): HTTP port that was used for the PyTriton server in the deploy method. Default: 8000.
+        triton_http_port (int): HTTP port that was used for the PyTriton server in the
+            deploy method. Default: 8000.
         Please pass the triton_http_port if using a custom port in the deploy method.
         model_name (str): Name of the model that is deployed on PyTriton server. It should be the same as
         triton_model_name passed to the deploy method above to be able to launch evaluation. Deafult: "triton_model".


### PR DESCRIPTION
# What does this PR do ?

APIs may need to be wrapped in `run.Partial`. `pathlib.Path` cannot be wrapped in `run.Config`, so our APIs should support taking either `pathlib.Path` or `str`.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
