### PR TITLE
fix convert_llama_hf_to_nemo.py llama31 argument

### DIFF
--- a/scripts/checkpoint_converters/convert_llama_hf_to_nemo.py
+++ b/scripts/checkpoint_converters/convert_llama_hf_to_nemo.py
@@ -64,9 +64,7 @@ def get_args():
     )
     parser.add_argument(
         "--llama31",
-        type=bool,
-        default=True,
-        required=False,
+        action="store_true",
         help="Whether the model is from LLaMa 3.1 family. LLaMa 3.1 enables scaling for RoPE frequencies.",
     )
     parser.add_argument("--precision", type=str, default="16", help="Model precision")


### PR DESCRIPTION
# What does this PR do ?

Fix conversion script arguments. The original script using type=bool convert empty strings to False and non-empty strings to True. Might not be an ideal way of using it.

**Collection**: NLP

# Changelog 
- Fix convert_llama_hf_to_nemo script --llama31 arguments.

# Usage

```shell
$ scripts/checkpoint_converters/convert_llama_hf_to_nemo.py --llama31  # when it is llama31
$ scripts/checkpoint_converters/convert_llama_hf_to_nemo.py                  # when it is not llama31
```

