### PR TITLE
Fix nemo 1 packed sequence TE version error

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -102,6 +102,7 @@ try:
         drain_embedding_wgrad_compute,
         get_model_config,
         init_method_normal,
+        is_te_min_version,
         scaled_init_method_normal,
     )
 
@@ -1366,7 +1367,9 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                             'attention_mask': None if self.get_attention_mask_from_fusion else batch['attention_mask'],
                             'labels': batch['labels'] if 'labels' in batch else None,
                         }
-
+                    if not is_te_min_version("1.13", check_equality=False):
+                        # cu_seqlens_unpadded != cu_seqlens is not supported in 1.13 or earlier
+                        cu_seqlens_unpadded = cu_seqlens
                     forward_args['packed_seq_params'] = PackedSeqParams(
                         cu_seqlens_q=cu_seqlens_unpadded,
                         cu_seqlens_kv=cu_seqlens_unpadded,

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1367,9 +1367,16 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                             'attention_mask': None if self.get_attention_mask_from_fusion else batch['attention_mask'],
                             'labels': batch['labels'] if 'labels' in batch else None,
                         }
-                    elif not is_te_min_version("1.13", check_equality=False):
-                        # cu_seqlens_unpadded != cu_seqlens is not supported in 1.13 or earlier when CP=1
-                        cu_seqlens_unpadded = cu_seqlens
+                    else:
+                        from packaging.version import Version as PkgVersion
+                        if (
+                            self.transformer_config.num_query_groups != self.transformer_config.num_attention_heads and
+                            not is_te_min_version("1.13", check_equality=False) and
+                            PkgVersion(os.getenv("CUDNN_VERSION", "9.5")) < PkgVersion("9.6")
+                        ):
+                            # cu_seqlens_unpadded != cu_seqlens when CP=1 is not supported in TE 1.13 or earlier
+                            # and im CUDNN 9.5 or earlier when using GQA.
+                            cu_seqlens_unpadded = cu_seqlens
                     forward_args['packed_seq_params'] = PackedSeqParams(
                         cu_seqlens_q=cu_seqlens_unpadded,
                         cu_seqlens_kv=cu_seqlens_unpadded,

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1367,8 +1367,8 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                             'attention_mask': None if self.get_attention_mask_from_fusion else batch['attention_mask'],
                             'labels': batch['labels'] if 'labels' in batch else None,
                         }
-                    if not is_te_min_version("1.13", check_equality=False):
-                        # cu_seqlens_unpadded != cu_seqlens is not supported in 1.13 or earlier
+                    elif not is_te_min_version("1.13", check_equality=False):
+                        # cu_seqlens_unpadded != cu_seqlens is not supported in 1.13 or earlier when CP=1
                         cu_seqlens_unpadded = cu_seqlens
                     forward_args['packed_seq_params'] = PackedSeqParams(
                         cu_seqlens_q=cu_seqlens_unpadded,

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -1369,10 +1369,11 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
                         }
                     else:
                         from packaging.version import Version as PkgVersion
+
                         if (
-                            self.transformer_config.num_query_groups != self.transformer_config.num_attention_heads and
-                            not is_te_min_version("1.13", check_equality=False) and
-                            PkgVersion(os.getenv("CUDNN_VERSION", "9.5")) < PkgVersion("9.6")
+                            self.transformer_config.num_query_groups != self.transformer_config.num_attention_heads
+                            and not is_te_min_version("1.13", check_equality=False)
+                            and PkgVersion(os.getenv("CUDNN_VERSION", "9.5")) < PkgVersion("9.6")
                         ):
                             # cu_seqlens_unpadded != cu_seqlens when CP=1 is not supported in TE 1.13 or earlier
                             # and im CUDNN 9.5 or earlier when using GQA.


### PR DESCRIPTION
# What does this PR do ?

Adds a te version guard for packed sequence in NeMo 1 (NeMo 2 is unaffected)
Changes in #10688 should be paired with TE version >1.3
https://github.com/NVIDIA/TransformerEngine/blob/3d63cbb469ace2d1ad7798a956e16dee42bd655b/transformer_engine/pytorch/attention.py#L8179-L8185

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
