### PR TITLE
Adding s3 requirements

### DIFF
--- a/docs/source/common/s3_checkpointing.rst
+++ b/docs/source/common/s3_checkpointing.rst
@@ -69,6 +69,8 @@ It has dependencies on
 
 If any of these are missing, this class can't be used. 
 
+You can install these dependencies with the `s3` extra requirements.
+
 
 
 s3_dirpath_utils

--- a/requirements/requirements_s3.txt
+++ b/requirements/requirements_s3.txt
@@ -1,0 +1,3 @@
+boto3[crt]
+s3fs==0.4.2
+tenacity

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ extras_require = {
     'multimodal': req_file("requirements_multimodal.txt"),
     'audio': req_file("requirements_audio.txt"),
     'deploy': req_file("requirements_deploy.txt"),
+    's3': req_file("requirements_s3.txt"),
 }
 
 


### PR DESCRIPTION
# What does this PR do ?

Adds extra group `s3` to install requirements for using `S3CheckpointIO`

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add `requirements/requirements_s3.txt` with reqs from docs
- Add relevant line to `setup.py` to include this

# Usage
* You can potentially add a usage example below

```python
from nemo.utils.callbacks.s3_checkpoint_io import S3CheckpointIO
s3_checkpoint_io = S3CheckpointIO(dirpath='s3://example-bucket/dir', chunk_size_MB=100, max_read_concurrency=10, max_write_concurrency=10, async_checkpointing=True)
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to #11926
