### PR TITLE
nemo-ux: deprecate app state

### DIFF
--- a/nemo/lightning/_strategy_lib.py
+++ b/nemo/lightning/_strategy_lib.py
@@ -96,6 +96,7 @@ def init_parallel_ranks(
         # apex_transformer_log_level=self.cfg.get('apex_transformer_log_level', 30),
     )
 
+
 def _set_random_seed(seed_):
     """Set random seed for reproducability."""
     if seed_ is None or not isinstance(seed_, int) or seed_ <= 0:
@@ -144,10 +145,12 @@ def setup_microbatch_calculator(global_batch_size, micro_batch_size):
 
     # TODO: add rampup_batch_size here when we have it implemented
     import os
+
     global_rank = int(os.environ['SLURM_PROCID'])
     rampup_batch_size = None
     if MCORE_MB_CALCULATOR:
         from megatron.core.num_microbatches_calculator import _GLOBAL_NUM_MICROBATCHES_CALCULATOR
+
         if _GLOBAL_NUM_MICROBATCHES_CALCULATOR is None:
             init_num_microbatches_calculator(
                 rank=global_rank,
@@ -185,7 +188,6 @@ def setup_microbatch_calculator(global_batch_size, micro_batch_size):
                 )
             else:
                 raise Exception("Microbatch calculator already initialized.")
-
 
 
 def init_model_parallel(parallel_config, use_te_rng_tracker=False, seed=1234) -> None:

--- a/nemo/lightning/_strategy_lib.py
+++ b/nemo/lightning/_strategy_lib.py
@@ -114,7 +114,7 @@ def _set_random_seed(seed_):
         tensor_parallel.model_parallel_cuda_manual_seed(seed)
 
 
-def setup_microbatch_calculator(global_batch_size, micro_batch_size):
+def setup_microbatch_calculator(global_batch_size, micro_batch_size, global_rank):
     if global_batch_size is None or micro_batch_size is None:
         return
 
@@ -144,9 +144,6 @@ def setup_microbatch_calculator(global_batch_size, micro_batch_size):
         MCORE_MB_CALCULATOR = False
 
     # TODO: add rampup_batch_size here when we have it implemented
-    import os
-
-    global_rank = int(os.environ['SLURM_PROCID'])
     rampup_batch_size = None
     if MCORE_MB_CALCULATOR:
         from megatron.core.num_microbatches_calculator import _GLOBAL_NUM_MICROBATCHES_CALCULATOR
@@ -164,7 +161,7 @@ def setup_microbatch_calculator(global_batch_size, micro_batch_size):
                 assert get_current_global_batch_size() == global_batch_size
                 assert get_micro_batch_size() == micro_batch_size
                 assert get_num_microbatches() == global_batch_size // (
-                    micro_batch_size * parallel_state.get_data_parallel_world_size(),
+                    micro_batch_size * parallel_state.get_data_parallel_world_size()
                 )
             else:
                 raise Exception("Microbatch calculator already initialized.")

--- a/nemo/lightning/data.py
+++ b/nemo/lightning/data.py
@@ -59,6 +59,7 @@ def setup_microbatch_calculator(
         Exception: If the microbatch calculator has already been initialized with different settings.
 
     """
+    return
     from nemo.lightning._strategy_lib import NEMO_MEGATRON_MODEL_PARALLEL_APPSTATE_OVERRIDE
     from nemo.utils import AppState
 

--- a/nemo/lightning/pytorch/plugins/data_sampler.py
+++ b/nemo/lightning/pytorch/plugins/data_sampler.py
@@ -86,20 +86,18 @@ class MegatronDataSampler(DataSampler):
             world_size=data_parallel_size,
         )
 
-    def compute_consumed_samples(self, steps_since_resume=0) -> int:
+    def compute_consumed_samples(self, data_parallel_size, steps_since_resume=0) -> int:
         from nemo.lightning.pytorch.strategies import MegatronStrategy
-        from nemo.utils import AppState
 
         if not hasattr(self, "trainer") or not isinstance(self.trainer.strategy, MegatronStrategy):
             return 0
 
-        app_state = AppState()
         if self.rampup_batch_size is not None:
             consumed_samples = self.prev_consumed_samples + self.if_first_step * self.current_global_batch_size
         else:
             consumed_samples = (
                 self.init_consumed_samples
-                + steps_since_resume * app_state.data_parallel_size * self.micro_batch_size * self.num_microbatches
+                + steps_since_resume * data_parallel_size * self.micro_batch_size * self.num_microbatches
             )
 
         return int(consumed_samples)
@@ -141,7 +139,9 @@ class MegatronDataSampler(DataSampler):
         self.prev_global_batch_size = self.current_global_batch_size
 
         if step.step_i:
-            consumed_samples = self.compute_consumed_samples(step.step_i + 1 - self.init_global_step)
+            from megatron.core import parallel_state
+            data_paralell_size = parallel_state.get_data_parallel_world_size()
+            consumed_samples = self.compute_consumed_samples(data_parallel_size, step.step_i + 1 - self.init_global_step)
             if self.output_log and trainer and getattr(trainer, "training", False):
                 # You may need to turn off logging, for example when doing trainer.predict(model, data)
                 pl_module.log(

--- a/nemo/lightning/pytorch/plugins/data_sampler.py
+++ b/nemo/lightning/pytorch/plugins/data_sampler.py
@@ -140,7 +140,7 @@ class MegatronDataSampler(DataSampler):
 
         if step.step_i:
             from megatron.core import parallel_state
-            data_paralell_size = parallel_state.get_data_parallel_world_size()
+            data_parallel_size = parallel_state.get_data_parallel_world_size()
             consumed_samples = self.compute_consumed_samples(data_parallel_size, step.step_i + 1 - self.init_global_step)
             if self.output_log and trainer and getattr(trainer, "training", False):
                 # You may need to turn off logging, for example when doing trainer.predict(model, data)

--- a/nemo/lightning/pytorch/plugins/data_sampler.py
+++ b/nemo/lightning/pytorch/plugins/data_sampler.py
@@ -140,8 +140,11 @@ class MegatronDataSampler(DataSampler):
 
         if step.step_i:
             from megatron.core import parallel_state
+
             data_parallel_size = parallel_state.get_data_parallel_world_size()
-            consumed_samples = self.compute_consumed_samples(data_parallel_size, step.step_i + 1 - self.init_global_step)
+            consumed_samples = self.compute_consumed_samples(
+                data_parallel_size, step.step_i + 1 - self.init_global_step
+            )
             if self.output_log and trainer and getattr(trainer, "training", False):
                 # You may need to turn off logging, for example when doing trainer.predict(model, data)
                 pl_module.log(

--- a/nemo/lightning/pytorch/strategies/megatron_strategy.py
+++ b/nemo/lightning/pytorch/strategies/megatron_strategy.py
@@ -435,7 +435,7 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         """Setups dist env"""
         super().setup_distributed()
         _strategy_lib.init_model_parallel(self.parallelism)
-        _strategy_lib.setup_microbatch_calculator(global_batch_size=256, micro_batch_size=1)
+        _strategy_lib.setup_microbatch_calculator(global_batch_size=256, micro_batch_size=1, global_rank=self.cluster_environment.global_rank())
 
         if self.data_sampler:
             assert isinstance(self.cluster_environment, ClusterEnvironment), "Cluster environment not initialized"

--- a/nemo/lightning/pytorch/strategies/megatron_strategy.py
+++ b/nemo/lightning/pytorch/strategies/megatron_strategy.py
@@ -882,13 +882,14 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         """Returns dist-sampler's kwargs"""
 
         from megatron.core import parallel_state
+
         if parallel_state.is_initialized():
             # When using model parallel, data parallel groups are non-trivial and they
             # correspond to the logical GPUs. This means that the GPUs that form a
             # single logical GPU all need to get the same batch of data.
             distributed_sampler_kwargs = dict(
                 num_replicas=parallel_state.get_data_parallel_world_size(),
-                rank=parallel_state.get_data_parallel_rank()
+                rank=parallel_state.get_data_parallel_rank(),
             )
             return distributed_sampler_kwargs
 

--- a/nemo/lightning/pytorch/strategies/megatron_strategy.py
+++ b/nemo/lightning/pytorch/strategies/megatron_strategy.py
@@ -435,7 +435,9 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         """Setups dist env"""
         super().setup_distributed()
         _strategy_lib.init_model_parallel(self.parallelism)
-        _strategy_lib.setup_microbatch_calculator(global_batch_size=256, micro_batch_size=1, global_rank=self.cluster_environment.global_rank())
+        _strategy_lib.setup_microbatch_calculator(
+            global_batch_size=256, micro_batch_size=1, global_rank=self.cluster_environment.global_rank()
+        )
 
         if self.data_sampler:
             assert isinstance(self.cluster_environment, ClusterEnvironment), "Cluster environment not initialized"


### PR DESCRIPTION
# What does this PR do ?

Initial work to deprecate `fake_initialize_model_parallel` and use mcore's `parallel_state` directly. By doing so we avoid duplicating code and therefore reduce maintenance overhead.


**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
