### PR TITLE
PTQ & TRT-LLM updates related to upcoming PyTorch 25.01 bump

### DIFF
--- a/nemo/collections/llm/quantization/utils.py
+++ b/nemo/collections/llm/quantization/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from pathlib import Path
+from typing import Optional
 
 import torch
 
@@ -73,6 +74,7 @@ def load_with_modelopt_layer_spec(
     tensor_model_parallel_size: int = 1,
     pipeline_model_parallel_size: int = 1,
     inference_only: bool = True,
+    ckpt_load_strictness: Optional[str] = None,
 ):
     """Loads a model from a NeMo 2.0 checkpoint using modelopt layer spec."""
     # TODO: setting ddp="pytorch" and deleting model.optim is a hackish way to disable DDP initialization.
@@ -84,6 +86,7 @@ def load_with_modelopt_layer_spec(
             pipeline_dtype=torch.bfloat16,
             ckpt_load_optimizer=False,
             ckpt_parallel_save_optim=False,
+            ckpt_load_strictness=ckpt_load_strictness,
             setup_optimizers=False,
             lazy_init=True,
             ddp="pytorch",
@@ -93,6 +96,7 @@ def load_with_modelopt_layer_spec(
             tensor_model_parallel_size=tensor_model_parallel_size,
             pipeline_model_parallel_size=pipeline_model_parallel_size,
             pipeline_dtype=torch.bfloat16,
+            ckpt_load_strictness=ckpt_load_strictness,
         )
 
     trainer = nl.Trainer(

--- a/nemo/collections/llm/quantization/utils.py
+++ b/nemo/collections/llm/quantization/utils.py
@@ -75,8 +75,20 @@ def load_with_modelopt_layer_spec(
     pipeline_model_parallel_size: int = 1,
     inference_only: bool = True,
     ckpt_load_strictness: Optional[str] = None,
-):
-    """Loads a model from a NeMo 2.0 checkpoint using modelopt layer spec."""
+) -> llm.GPTModel:
+    """
+    Loads a model from a NeMo 2.0 checkpoint using modelopt layer spec.
+
+    Args:
+        nemo_checkpoint_path (str): Path to the NeMo checkpoint.
+        tensor_model_parallel_size (int): Size of the tensor model parallelism.
+        pipeline_model_parallel_size (int): Size of the pipeline model parallelism.
+        inference_only (bool): If True, loads the model for inference only w/o initializing the optimizer.
+        ckpt_load_strictness (Optional[str]): Handling of checkpoint loading mismatch for tensor keys.
+
+    Returns:
+        llm.GPTModel: The loaded model with the specified configuration.
+    """
     # TODO: setting ddp="pytorch" and deleting model.optim is a hackish way to disable DDP initialization.
     # Needs a systematic solution.
     if inference_only:

--- a/nemo/export/tensorrt_llm.py
+++ b/nemo/export/tensorrt_llm.py
@@ -472,6 +472,10 @@ class TensorRTLLM(ITritonDeployable):
                     )
 
                     for weight_dict, model_config in zip(weights_dicts, model_configs):
+
+                        for k, v in weight_dict.items():
+                            print(f"key: {k: <60} | {str(v.dtype): <16} | {type(v)}")
+                        breakpoint()
                         build_and_save_engine(
                             max_input_len=max_input_len,
                             max_output_len=max_output_len,

--- a/nemo/export/tensorrt_llm.py
+++ b/nemo/export/tensorrt_llm.py
@@ -472,10 +472,6 @@ class TensorRTLLM(ITritonDeployable):
                     )
 
                     for weight_dict, model_config in zip(weights_dicts, model_configs):
-
-                        for k, v in weight_dict.items():
-                            print(f"key: {k: <60} | {str(v.dtype): <16} | {type(v)}")
-                        breakpoint()
                         build_and_save_engine(
                             max_input_len=max_input_len,
                             max_output_len=max_output_len,

--- a/nemo/export/trt_llm/converter/utils.py
+++ b/nemo/export/trt_llm/converter/utils.py
@@ -280,8 +280,8 @@ def save_scaling_factor(scaling_factors: dict, key: str, val: torch.Tensor, conf
     if not is_scaling_factor(key):
         return scaling_factors
 
-    activation_factor = torch_to_numpy(1 / val[0].view(1))
-    weights_factor = torch_to_numpy(1 / val[1].view(1))
+    activation_factor = 1 / val[0].view(1)
+    weights_factor = 1 / val[1].view(1)
 
     (weights_key, activation_key), gate_keys = get_scaling_factor_keys(key)
     scaling_factors[activation_key] = activation_factor
@@ -523,7 +523,7 @@ def split_and_save_weight(
 
         if use_fp8_kv_cache:
             base_key = trt_llm_key.replace('.qkv.weight', '')
-            scaling_factor = np.array([1.0], dtype=np.float32)
+            scaling_factor = torch.FloatTensor([1.0])
             save_val(scaling_factor, dir, base_key + '.kv_cache_scaling_factor')
 
     elif any_word_in_key(key, attention_not_mapped_keys):

--- a/nemo/export/trt_llm/converter/utils.py
+++ b/nemo/export/trt_llm/converter/utils.py
@@ -280,8 +280,8 @@ def save_scaling_factor(scaling_factors: dict, key: str, val: torch.Tensor, conf
     if not is_scaling_factor(key):
         return scaling_factors
 
-    activation_factor = 1 / val[0].view(1)
-    weights_factor = 1 / val[1].view(1)
+    activation_factor = torch_to_numpy(1 / val[0].view(1))
+    weights_factor = torch_to_numpy(1 / val[1].view(1))
 
     (weights_key, activation_key), gate_keys = get_scaling_factor_keys(key)
     scaling_factors[activation_key] = activation_factor

--- a/nemo/export/trt_llm/converter/utils.py
+++ b/nemo/export/trt_llm/converter/utils.py
@@ -280,8 +280,8 @@ def save_scaling_factor(scaling_factors: dict, key: str, val: torch.Tensor, conf
     if not is_scaling_factor(key):
         return scaling_factors
 
-    activation_factor = torch_to_numpy(1 / val[0].view(1))
-    weights_factor = torch_to_numpy(1 / val[1].view(1))
+    activation_factor = 1 / val[0].view(1)
+    weights_factor = 1 / val[1].view(1)
 
     (weights_key, activation_key), gate_keys = get_scaling_factor_keys(key)
     scaling_factors[activation_key] = activation_factor

--- a/scripts/llm/ptq.py
+++ b/scripts/llm/ptq.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import argparse
+
 from nemo.collections.llm import quantization
 
 
@@ -63,6 +64,7 @@ def get_args():
     parser.add_argument(
         '--generate_sample', help='Generate sample model output after performing PTQ', action='store_true'
     )
+    parser.add_argument('--ckpt_load_strictness', type=str, help='Defines handling of checkpoint load mismatch')
     parser.set_defaults(generate_sample=False)
 
     args = parser.parse_args()
@@ -97,7 +99,12 @@ def main():
     )
 
     quantizer = quantization.Quantizer(quantization_config, export_config)
-    model = quantization.load_with_modelopt_layer_spec(args.nemo_checkpoint, args.calibration_tp, args.calibration_pp)
+    model = quantization.load_with_modelopt_layer_spec(
+        args.nemo_checkpoint,
+        args.calibration_tp,
+        args.calibration_pp,
+        ckpt_load_strictness=args.ckpt_load_strictness,
+    )
     model = quantizer.quantize(model)
     quantizer.export(model, args.nemo_checkpoint)
 


### PR DESCRIPTION
# What does this PR do ?

Addressing issues on PyTorch 25.01 update:

**1. Legacy Zarr checkpoint loading failures**
```
  File "/opt/NeMo/nemo/export/trt_llm/nemo_ckpt_loader/nemo_file.py", line 202, in load_sharded_pickle_extra_state_scale
    extra_states[dir.name + '/' + shard_name] = torch.load(opened_file)
                                                ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/serialization.py", line 1455, in load
    raise pickle.UnpicklingError(_get_wo_message(str(e))) from None
_pickle.UnpicklingError: Weights only load failed. This file can still be loaded, to do so you have two options, do those steps only if you trust the source of the checkpoint. (...)
```

**2. Loading NeMo 2.0 checkpoints (using older TE versions) in PTQ workflow**
```
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/checkpoint/default_planner.py", line 233, in create_local_plan
    return create_default_local_load_plan(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/distributed/checkpoint/default_planner.py", line 354, in create_default_local_load_plan
    raise RuntimeError(f"Missing key in checkpoint state_dict: {fqn}.")
RuntimeError: Missing key in checkpoint state_dict: module.decoder.layers.self_attention.linear_qkv.layer_norm__extra_state/shard_0_32.
```

**3. Passing torch Tensors instead of NumPy arrays for direct FP8 engine build**
```
  File "/usr/local/lib/python3.12/dist-packages/tensorrt_llm/models/modeling_utils.py", line 1711, in preprocess_weights
    add_kv_cache_rcp_scaling_factor(weights)
  File "/usr/local/lib/python3.12/dist-packages/tensorrt_llm/models/modeling_utils.py", line 1708, in add_kv_cache_rcp_scaling_factor
    new_entries.append((rcp_name, torch.reciprocal(param)))
                                  ^^^^^^^^^^^^^^^^^^^^^^^
TypeError: reciprocal(): argument 'input' (position 1) must be Tensor, not numpy.ndarray
```

**Collection**: NLP / LLM

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
