### PR TITLE
Update 00_NeMo_Primer.ipynb

### DIFF
--- a/tutorials/00_NeMo_Primer.ipynb
+++ b/tutorials/00_NeMo_Primer.ipynb
@@ -40,6 +40,8 @@
         "!pip install wget\n",
         "!apt-get install sox libsndfile1 ffmpeg\n",
         "!pip install text-unidecode\n",
+        "!pip install torch==2.2.0+cu118, torchvision==0.17.0+cu118 torchaudio==2.2.0+cu118 --index-url https://download.pytorch.org/whl/cu118\n",
+        "!pip install causal-conv1d==1.4.0\n",
         "\n",
         "# ## Install NeMo\n",
         "BRANCH = 'main'\n",


### PR DESCRIPTION
# What does this PR do ?

Fixed bug in google colab where message would appear stating "Failed to build causal-conv1d"

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Added in 2 commands that need to be run:

!pip install torch==2.2.0+cu118, torchvision==0.17.0+cu118 torchaudio==2.2.0+cu118 --index-url https://download.pytorch.org/whl/cu118
!pip install causal-conv1d==1.4.0

# Usage
N/A

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- Bugfix

## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
