### PR TITLE
Adding TFLOPs callback for Multimodal models and NeVA calculator

### DIFF
--- a/nemo/utils/flops_formulas.py
+++ b/nemo/utils/flops_formulas.py
@@ -14,20 +14,29 @@
 
 from dataclasses import dataclass
 from nemo.collections.common.parts.perf_metrics_utils import LLM_VOCAB_SIZE_MAP
+from typing import Optional
 
 
 @dataclass
 class FLOPSConfig:
     """Contains the model hparams needed for FLOPS computations"""
 
-    gbs: int
-    enc_seq_len: int
-    hs: int
-    layers: int
-    ffn_hs: int
-    attention_heads: int
-    moe_router_topk: int
-    query_groups: int
+    gbs: Optional[int] = None
+    enc_seq_len: Optional[int] = None
+    hs: Optional[int] = None
+    layers: Optional[int] = None
+    ffn_hs: Optional[int] = None
+    attention_heads: Optional[int] = None
+    moe_router_topk: Optional[int] = None
+    query_groups: Optional[int] = None
+    img_seq_len: Optional[int] = None
+    img_h: Optional[int] = None
+    img_w: Optional[int] = None
+    in_channels: Optional[int] = None
+    patch_dim: Optional[int] = None
+    class_token_len: Optional[int] = None
+    projector_type: Optional[str] = None
+    inp_s: Optional[int] = None
 
 
 def gpt3(config: FLOPSConfig):
@@ -134,3 +143,53 @@ def bert(config: FLOPSConfig):
         * config.hs
         * (1 + (config.enc_seq_len / (6 * config.hs)) + (vocab_size / (12 * config.hs * config.layers)))
     )
+
+def clip_vit_l(config: FLOPSConfig):
+    """Model FLOPs for CLIP ViT"""
+
+    if config.img_seq_len is None:
+        config.img_seq_len = (config.img_h * config.img_w) / (config.patch_dim * config.patch_dim) + config.class_token_len
+    return (
+        config.gbs
+        * config.layers
+        * config.hs
+        * config.hs
+        * config.img_seq_len
+        * (
+            24
+            + (4 * config.img_seq_len / config.hs)
+        )
+        + (
+            2 
+            * config.gbs 
+            * config.hs 
+            * config.in_channels 
+            * config.img_h 
+            * config.img_w
+        )
+    )
+
+def neva_projection(config: FLOPSConfig):
+    """Model FLOPs for NeVA Projection"""
+
+    if "mlp" in config.projector_type:
+        return (
+            6
+            * config.gbs
+            * config.img_seq_len
+            * config.ffn_hs
+            * (config.inp_s + config.hs)
+        ) 
+    elif config.projector_type == "affine":
+        return (
+            6
+            * config.gbs
+            * config.img_seq_len
+            * config.inp_s
+            * config.hs
+        )
+    else:
+        raise ValueError(
+            f"NeVA Projections FLOPs calculator only supports 'mlp', 'mcore_mlp'"
+            f" or 'affine' projector_type but found {config.projector_type}"
+        )


### PR DESCRIPTION
# What does this PR do ?

Adds TFLOPs callback for multimodal models. Works for any model architecture which has more than one model config in the architecture.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Adds new class for FLOPs calculation for Multimodal models which takes in a dictionary of model configs.
- Dictionary defines model name with model config.
- Also adds a few non-text modality specific config args for FLOPs calculation.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
