### PR TITLE
add use_fast option

### DIFF
--- a/nemo/collections/llm/gpt/model/hf_auto_model_for_causal_lm.py
+++ b/nemo/collections/llm/gpt/model/hf_auto_model_for_causal_lm.py
@@ -90,8 +90,7 @@ class HFAutoModelForCausalLM(pl.LightningModule, io.IOMixin, fn.FNMixin):
         try:
             return AutoTokenizer(model_name, use_fast=use_fast, trust_remote_code=trust_remote_code)
         except:
-            if use_fast:
-                return AutoTokenizer(model_name, use_fast=False, trust_remote_code=trust_remote_code)
+            return AutoTokenizer(model_name, use_fast=not use_fast, trust_remote_code=trust_remote_code)
 
     def configure_model(self):
         # create all your layers here

--- a/nemo/collections/llm/gpt/model/hf_auto_model_for_causal_lm.py
+++ b/nemo/collections/llm/gpt/model/hf_auto_model_for_causal_lm.py
@@ -86,8 +86,12 @@ class HFAutoModelForCausalLM(pl.LightningModule, io.IOMixin, fn.FNMixin):
         self._tokenizer = value
 
     @staticmethod
-    def configure_tokenizer(model_name, trust_remote_code=False):
-        return AutoTokenizer(model_name, trust_remote_code=trust_remote_code)
+    def configure_tokenizer(model_name, use_fast=True, trust_remote_code=False):
+        try:
+            return AutoTokenizer(model_name, use_fast=use_fast, trust_remote_code=trust_remote_code)
+        except:
+            if use_fast:
+                return AutoTokenizer(model_name, use_fast=False, trust_remote_code=trust_remote_code)
 
     def configure_model(self):
         # create all your layers here


### PR DESCRIPTION
# What does this PR do ?

`transfomer`'s `AutoTokenizer` has the `use_fast` argument set by default to `True`. NeMo's wrapper of the `AutoTokenizer` class has the default argument set to `False`. I considered changing the default argument to `True`, but I wanted to avoid breaking other things.

Instead, I've opted to change the default value only on AutoModel-created tokenizers and add a fallback to use the the opposite `use_fast` value if there's an exception thrown.


**Collection**: [LLM]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
