### PR TITLE
Set zarr range to >=2.18.2 and <3.0.0

### DIFF
--- a/requirements/requirements_deploy.txt
+++ b/requirements/requirements_deploy.txt
@@ -3,4 +3,4 @@ nvidia-pytriton
 pydantic-settings
 tensorstore
 uvicorn
-zarr
+zarr>=2.18.2,<3.0.0

--- a/requirements/requirements_infer.txt
+++ b/requirements/requirements_infer.txt
@@ -5,4 +5,4 @@ nvidia-pytriton
 pydantic-settings
 tensorstore
 uvicorn
-zarr
+zarr>=2.18.2,<3.0.0

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -22,4 +22,4 @@ sacrebleu  # manually install sacrebleu[ja] for Japanese support; MeCab is unsup
 sentence_transformers
 tensorstore
 tiktoken==0.7.0
-zarr
+zarr>=2.18.2,<3.0.0


### PR DESCRIPTION
# What does this PR do ?

The repo currently does not work with the dependency zarr >= 3.0, so this defines the valid range to be >= 2.18.2 and <3.0.0.

**Collection**: [Note which collection this PR will affect]
deploy, export, infer, nlp

# Changelog 
- Set zarr range to >=2.18.2 and <3.0.0

# Usage
n/a

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
