### PR TITLE
chore(ci): Disable VMs cron job on forks

### DIFF
--- a/.github/workflows/monitor-vms.yml
+++ b/.github/workflows/monitor-vms.yml
@@ -4,10 +4,11 @@ on:
   schedule:
     - cron: 0/15 * * * *
   workflow_dispatch:
-  
+
 jobs:
   pre-flight:
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'NVIDIA'
     outputs:
       list-of-vms: ${{ steps.main.outputs.main }}
     environment: main
@@ -25,13 +26,13 @@ jobs:
 
           MATRIX=$(echo $RUNNERS \
             | jq -c '[
-                .runners[] 
+                .runners[]
                 | select(.status == "online")
                 | select(.name | contains("cpu") | not)
                 | {
-                  "vm": .name, 
+                  "vm": .name,
                   "n_gpus": [
-                    .labels[] 
+                    .labels[]
                     | select(.name | endswith("gpu")) | .name
                   ][0][:1]
                 }


### PR DESCRIPTION
# What does this PR do ?

Disable the Reboots VMs job on forks.  I'm getting an email about a failed job every 15 minutes.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Add specific line by line info of high level changes in this PR.

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
