### PR TITLE
Replace reference of requirements_infer.txt with requirements_deploy.txt

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -58,7 +58,7 @@ if [[ "$HEAVY_DEPS" == "TRUE" ]]; then
     virtualenv /opt/venv &&
     /opt/venv/bin/pip install --no-cache-dir --no-build-isolation \
       -r /workspace/requirements/requirements_vllm.txt \
-      -r /workspace/requirements/requirements_infer.txt
+      -r /workspace/requirements/requirements_deploy.txt
 
   DEPS+=(
     "llama-index==0.10.43"

--- a/requirements/requirements_infer.txt
+++ b/requirements/requirements_infer.txt
@@ -1,8 +1,0 @@
-# This is a copy of requirements_deploy.txt for a seamless rename 'infer' -> 'deploy'.
-# TODO: Remove this file once it is not used in container build anywhere.
-fastapi
-nvidia-pytriton
-pydantic-settings
-tensorstore
-uvicorn
-zarr>=2.18.2,<3.0.0


### PR DESCRIPTION
# What does this PR do ?

Replace reference of requirements_infer.txt with requirements_deploy.txt.
Related PR: 
https://github.com/NVIDIA/NeMo/pull/11749#discussion_r1910654006

Per @janekl , requirements_deploy.txt is the same as requirements_infer.txt but we want to move towards using requirements_deploy.txt.

**Collection**: [Note which collection this PR will affect]

# Changelog 
- Replace reference of requirements_infer.txt with requirements_deploy.txt.

# Usage
n/a

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
