### PR TITLE
fix the issue during batched inference of Sortformer diarizer

### DIFF
--- a/nemo/collections/asr/data/audio_to_diar_label_lhotse.py
+++ b/nemo/collections/asr/data/audio_to_diar_label_lhotse.py
@@ -76,7 +76,7 @@ class LhotseAudioToSpeechE2ESpkDiarDataset(torch.utils.data.Dataset):
             target_fr_len = get_hidden_length_from_sample_length(
                 audio_len, self.num_sample_per_mel_frame, self.num_mel_frame_per_target_frame
             )
-            target_lens_list.append([target_fr_len])
+            target_lens_list.append(target_fr_len)
         target_lens = torch.tensor(target_lens_list)
 
         return audio, audio_lens, targets, target_lens

--- a/nemo/collections/asr/models/sortformer_diar_models.py
+++ b/nemo/collections/asr/models/sortformer_diar_models.py
@@ -256,19 +256,21 @@ class SortformerEncLabelModel(ModelPT, ExportableEncDecModel, SpkDiarizationMixi
             emb_seq = self.sortformer_modules.encoder_proj(emb_seq)
         return emb_seq, emb_seq_length
 
-    def forward_infer(self, emb_seq):
+    def forward_infer(self, emb_seq, emb_seq_length):
         """
         The main forward pass for diarization for offline diarization inference.
 
         Args:
             emb_seq (torch.Tensor): tensor containing FastConformer encoder states (embedding vectors).
                 Dimension: (batch_size, diar_frame_count, emb_dim)
+            emb_seq_length (torch.Tensor): tensor containing lengths of FastConformer encoder states.
+                Dimension: (batch_size,)
 
         Returns:
             preds (torch.Tensor): Sorted tensor containing Sigmoid values for predicted speaker labels.
                 Dimension: (batch_size, diar_frame_count, num_speakers)
         """
-        encoder_mask = self.sortformer_modules.length_to_mask(emb_seq)
+        encoder_mask = self.sortformer_modules.length_to_mask(emb_seq_length, emb_seq.shape[1])
         trans_emb_seq = self.transformer_encoder(encoder_states=emb_seq, encoder_mask=encoder_mask)
         preds = self.sortformer_modules.forward_speaker_sigmoids(trans_emb_seq)
         return preds
@@ -407,6 +409,8 @@ class SortformerEncLabelModel(ModelPT, ExportableEncDecModel, SpkDiarizationMixi
         processed_signal, processed_signal_length = self.preprocessor(
             input_signal=audio_signal, length=audio_signal_length
         )
+        if not self.training:
+            torch.cuda.empty_cache()
         return processed_signal, processed_signal_length
 
     def forward(
@@ -434,10 +438,10 @@ class SortformerEncLabelModel(ModelPT, ExportableEncDecModel, SpkDiarizationMixi
         if self._cfg.get("streaming_mode", False):
             raise NotImplementedError("Streaming mode is not implemented yet.")
         else:
-            emb_seq, _ = self.frontend_encoder(
+            emb_seq, emb_seq_length = self.frontend_encoder(
                 processed_signal=processed_signal, processed_signal_length=processed_signal_length
             )
-            preds = self.forward_infer(emb_seq)
+            preds = self.forward_infer(emb_seq, emb_seq_length)
         return preds
 
     def _get_aux_train_evaluations(self, preds, targets, target_lens) -> dict:


### PR DESCRIPTION
# What does this PR do ?

This PR fixes the ghost timestamps issue occurs during batched inference of Sortformer model.

**Collection**: 

ASR

# Changelog 

        modified:   nemo/collections/asr/data/audio_to_diar_label_lhotse.py
        modified:   nemo/collections/asr/models/sortformer_diar_models.py
        modified:   nemo/collections/asr/modules/sortformer_modules.py

# Usage
* You can potentially add a usage example below


```python
python $BASEPATH/neural_diarizer/e2e_diarize_speech.py \
    model_path=/path/to/diar_sortformer_4spk_v1.nemo \
    batch_size=1 \
    dataset_manifest=/path/to/diarization_manifest.json
```

# GitHub Actions CI

Run CICD

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in NeMo ASR

# Additional Information
Sortformer Train/Inference