### PR TITLE
Add performance-optimized example for llama2 70b LoRA

### DIFF
--- a/nemo/collections/llm/gpt/data/__init__.py
+++ b/nemo/collections/llm/gpt/data/__init__.py
@@ -17,6 +17,7 @@ from nemo.collections.llm.gpt.data.chat import ChatDataModule
 from nemo.collections.llm.gpt.data.dolly import DollyDataModule
 from nemo.collections.llm.gpt.data.fine_tuning import FineTuningDataModule
 from nemo.collections.llm.gpt.data.hf_dataset import HFDatasetDataModule
+from nemo.collections.llm.gpt.data.mlperf_govreport import MLPerfGovReportDataModule
 from nemo.collections.llm.gpt.data.mock import MockDataModule
 from nemo.collections.llm.gpt.data.pre_training import PreTrainingDataModule, build_pretraining_datamodule
 from nemo.collections.llm.gpt.data.retrieval import CustomRetrievalDataModule
@@ -28,6 +29,7 @@ __all__ = [
     "DollyDataModule",
     "FineTuningDataModule",
     "HFDatasetDataModule",
+    "MLPerfGovReportDataModule",
     "MockDataModule",
     "PreTrainingDataModule",
     "build_pretraining_datamodule",

--- a/nemo/collections/llm/gpt/data/mlperf_govreport.py
+++ b/nemo/collections/llm/gpt/data/mlperf_govreport.py
@@ -83,9 +83,9 @@ class MLPerfGovReportDataModule(FineTuningDataModule, IOMixin):
 
         if self.packed_sequence_size != self.seq_length:
             raise ValueError(
-                f"{self.__class__.__name__} requires `packed_sequence_specs.packed_sequence_size` to be nonzero
-                and equal to `seq_length`.  Instead got packed_sequence_size = {self.packed_sequence_size}
-                and seq_length = {self.seq_length}"
+                f"{self.__class__.__name__} requires `packed_sequence_specs.packed_sequence_size` to be nonzero "
+                f"and equal to `seq_length`.  Instead got packed_sequence_size = {self.packed_sequence_size} "
+                f"and seq_length = {self.seq_length}"
             )
 
     def prepare_data(self) -> None:

--- a/nemo/collections/llm/gpt/data/mlperf_govreport.py
+++ b/nemo/collections/llm/gpt/data/mlperf_govreport.py
@@ -1,0 +1,180 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import shutil
+from pathlib import Path
+from typing import TYPE_CHECKING, Annotated, Any, Callable, Dict, List, Optional
+
+from datasets import DatasetDict, load_dataset
+import numpy as np
+
+import torch
+from torch import nn
+
+from nemo.collections.llm.gpt.data.core import get_dataset_root
+from nemo.collections.llm.gpt.data.fine_tuning import FineTuningDataModule
+from nemo.collections.llm.utils import Config
+from nemo.lightning import OptimizerModule
+from nemo.lightning.io.mixin import IOMixin
+from nemo.utils import logging
+
+if TYPE_CHECKING:
+    from nemo.collections.common.tokenizers import TokenizerSpec
+    from nemo.collections.llm.gpt.data.packed_sequence import PackedSequenceSpecs
+
+class MLPerfGovReportDataModule(FineTuningDataModule, IOMixin):
+    """
+    A data module for fine-tuning on the govreport dataset as preprocessed for MLPerf; see https://huggingface.co/datasets/regisss/scrolls_gov_report_preprocessed_mlperf_2
+
+    Inherits from `FineTuningDataModule` and handles data download, splitting, and saving in a format ready for training.
+
+    Args:
+        force_redownload (bool, optional): Whether to force re-download the dataset even if it exists locally. Defaults to False.
+        delete_raw (bool, optional): Whether to delete the raw downloaded dataset after preprocessing. Defaults to True.
+        See FineTuningDataModule for the other args
+    """
+    def __init__(
+        self,
+        seq_length: int = 2048,
+        tokenizer: Optional["TokenizerSpec"] = None,
+        micro_batch_size: int = 4,
+        global_batch_size: int = 8,
+        rampup_batch_size: Optional[List[int]] = None,
+        force_redownload: bool = False,
+        delete_raw: bool = True,
+        seed: int = 1234,
+        memmap_workers: int = 1,
+        num_workers: int = 8,
+        pin_memory: bool = True,
+        persistent_workers: bool = False,
+        packed_sequence_specs: Optional["PackedSequenceSpecs"] = None,
+        dataset_kwargs: Optional[Dict[str, Any]] = None,
+    ):
+        self.force_redownload = force_redownload
+        self.delete_raw = delete_raw
+
+        super().__init__(
+            dataset_root=get_dataset_root("govreport"),
+            seq_length=seq_length,
+            tokenizer=tokenizer,
+            micro_batch_size=micro_batch_size,
+            global_batch_size=global_batch_size,
+            rampup_batch_size=rampup_batch_size,
+            seed=seed,
+            memmap_workers=memmap_workers,
+            num_workers=num_workers,
+            pin_memory=pin_memory,
+            persistent_workers=persistent_workers,
+            packed_sequence_specs=packed_sequence_specs,
+            dataset_kwargs=dataset_kwargs,
+        )
+
+        if self.packed_sequence_size != self.seq_length:
+            raise ValueError(f"{self.__class__.__name__} requires `packed_sequence_specs.packed_sequence_size` to be nonzero and equal to `seq_length`.  Instead got packed_sequence_size = {self.packed_sequence_size} and seq_length = {self.seq_length}")
+
+    def prepare_data(self) -> None:
+        # if train file is specified, no need to do anything
+        if not self.train_path.exists() or self.force_redownload:
+            dset = self._download_data()
+            self._preprocess_and_split_data(dset)
+        super().prepare_data()
+
+    def _download_data(self):
+        logging.info(f"Downloading {self.__class__.__name__}...")
+        return load_dataset(
+            "regisss/scrolls_gov_report_preprocessed_mlperf_2",
+            cache_dir=str(self.dataset_root),
+            download_mode="force_redownload" if self.force_redownload else None,
+        )
+
+    def _preprocess_and_split_data(
+        self, dset: DatasetDict, split_val_from_train: bool = True, val_proportion: float = 0.05
+    ):
+        """Preprocesses and splits the downloaded dataset into training, validation, and test sets.
+
+        Args:
+            dset (DatasetDict): The downloaded dataset object.
+            split_val_from_train (bool, optional): Whether to split the validation set from the training set.
+                If False, the validation set is split from the test set. Defaults to True.
+            val_proportion (float, optional): The proportion of the training or test set to be used for the validation split.
+                Defaults to 0.05.
+        """
+        logging.info(f"Preprocessing {self.__class__.__name__} to npy format and splitting...")
+        save_splits = {}
+        train_set = dset.get('train')
+        val_set = dset.get('validation')
+
+        if split_val_from_train:
+            split_dataset = train_set.train_test_split(test_size=val_proportion, seed=self.seed)
+            save_splits['training'] = split_dataset['train']
+            save_splits['validation'] = split_dataset['test']
+            save_splits['test'] = val_set
+        else:
+            split_dataset = val_set.train_test_split(test_size=val_proportion, seed=self.seed)
+            save_splits['training'] = train_set
+            save_splits['validation'] = split_dataset['test']
+            save_splits['test'] = split_dataset['train']
+
+        for split_name, dataset in save_splits.items():
+            output_file = self.dataset_root / f"{split_name}.npy"
+            processed_data = [{
+                "input_ids": example["input_ids"],
+                "loss_mask": [int(x != -100) for x in example["labels"]],
+                "seq_start_id": [0],
+                } for example in dataset]
+            np.save(output_file, processed_data)
+
+            logging.info(f"{split_name} split saved to {output_file}")
+
+        if self.delete_raw:
+            for p in self.dataset_root.iterdir():
+                if p.is_dir():
+                    shutil.rmtree(p)
+                elif '.npy' not in str(p.name):
+                    p.unlink()
+
+    @property
+    def train_path(self) -> Path:
+        """Path to training dataset file"""
+        return self.dataset_root / "training.npy"
+
+    @property
+    def validation_path(self) -> Path:
+        """Path to validation dataset file"""
+        return self.dataset_root / "validation.npy"
+
+    @property
+    def test_path(self) -> Path:
+        """Path to test dataset file"""
+        return self.dataset_root / "test.npy"
+
+    @property
+    def default_pack_path(self) -> Path:
+        return None
+
+    @property
+    def pack_metadata(self) -> Path:
+        return None
+
+    @property
+    def train_path_packed(self) -> Path:
+        """Path to training dataset file for packed sequence. The file path contains a reference to the
+        tokenizer/model name since packed sequence dataset consists of tokenized indices."""
+        return self.train_path
+
+    @property
+    def validation_path_packed(self) -> Path:
+        """Path to validation dataset file for packed sequence. The file path contains a reference to the
+        tokenizer/model name since packed sequence dataset consists of tokenized indices."""
+        return self.validation_path

--- a/nemo/collections/llm/gpt/data/mlperf_govreport.py
+++ b/nemo/collections/llm/gpt/data/mlperf_govreport.py
@@ -14,18 +14,13 @@
 
 import shutil
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from datasets import DatasetDict, load_dataset
 import numpy as np
 
-import torch
-from torch import nn
-
 from nemo.collections.llm.gpt.data.core import get_dataset_root
 from nemo.collections.llm.gpt.data.fine_tuning import FineTuningDataModule
-from nemo.collections.llm.utils import Config
-from nemo.lightning import OptimizerModule
 from nemo.lightning.io.mixin import IOMixin
 from nemo.utils import logging
 

--- a/nemo/collections/llm/gpt/data/mlperf_govreport.py
+++ b/nemo/collections/llm/gpt/data/mlperf_govreport.py
@@ -31,13 +31,17 @@ if TYPE_CHECKING:
 
 class MLPerfGovReportDataModule(FineTuningDataModule, IOMixin):
     """
-    A data module for fine-tuning on the govreport dataset as preprocessed for MLPerf; see https://huggingface.co/datasets/regisss/scrolls_gov_report_preprocessed_mlperf_2
+    A data module for fine-tuning on the govreport dataset as preprocessed for MLPerf;
+    see https://huggingface.co/datasets/regisss/scrolls_gov_report_preprocessed_mlperf_2
 
-    Inherits from `FineTuningDataModule` and handles data download, splitting, and saving in a format ready for training.
+    Inherits from `FineTuningDataModule` and handles data download, splitting, and
+    saving in a format ready for training.
 
     Args:
-        force_redownload (bool, optional): Whether to force re-download the dataset even if it exists locally. Defaults to False.
-        delete_raw (bool, optional): Whether to delete the raw downloaded dataset after preprocessing. Defaults to True.
+        force_redownload (bool, optional): Whether to force re-download the dataset even
+            if it exists locally. Defaults to False.
+        delete_raw (bool, optional): Whether to delete the raw downloaded dataset after
+            preprocessing. Defaults to True.
         See FineTuningDataModule for the other args
     """
 
@@ -79,7 +83,9 @@ class MLPerfGovReportDataModule(FineTuningDataModule, IOMixin):
 
         if self.packed_sequence_size != self.seq_length:
             raise ValueError(
-                f"{self.__class__.__name__} requires `packed_sequence_specs.packed_sequence_size` to be nonzero and equal to `seq_length`.  Instead got packed_sequence_size = {self.packed_sequence_size} and seq_length = {self.seq_length}"
+                f"{self.__class__.__name__} requires `packed_sequence_specs.packed_sequence_size` to be nonzero
+                and equal to `seq_length`.  Instead got packed_sequence_size = {self.packed_sequence_size}
+                and seq_length = {self.seq_length}"
             )
 
     def prepare_data(self) -> None:
@@ -106,7 +112,8 @@ class MLPerfGovReportDataModule(FineTuningDataModule, IOMixin):
             dset (DatasetDict): The downloaded dataset object.
             split_val_from_train (bool, optional): Whether to split the validation set from the training set.
                 If False, the validation set is split from the test set. Defaults to True.
-            val_proportion (float, optional): The proportion of the training or test set to be used for the validation split.
+            val_proportion (float, optional): The proportion of the training or test set to be used for
+                the validation split.
                 Defaults to 0.05.
         """
         logging.info(f"Preprocessing {self.__class__.__name__} to npy format and splitting...")

--- a/nemo/collections/llm/gpt/data/mlperf_govreport.py
+++ b/nemo/collections/llm/gpt/data/mlperf_govreport.py
@@ -16,8 +16,8 @@ import shutil
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-from datasets import DatasetDict, load_dataset
 import numpy as np
+from datasets import DatasetDict, load_dataset
 
 from nemo.collections.llm.gpt.data.core import get_dataset_root
 from nemo.collections.llm.gpt.data.fine_tuning import FineTuningDataModule
@@ -27,6 +27,7 @@ from nemo.utils import logging
 if TYPE_CHECKING:
     from nemo.collections.common.tokenizers import TokenizerSpec
     from nemo.collections.llm.gpt.data.packed_sequence import PackedSequenceSpecs
+
 
 class MLPerfGovReportDataModule(FineTuningDataModule, IOMixin):
     """
@@ -39,6 +40,7 @@ class MLPerfGovReportDataModule(FineTuningDataModule, IOMixin):
         delete_raw (bool, optional): Whether to delete the raw downloaded dataset after preprocessing. Defaults to True.
         See FineTuningDataModule for the other args
     """
+
     def __init__(
         self,
         seq_length: int = 2048,
@@ -76,7 +78,9 @@ class MLPerfGovReportDataModule(FineTuningDataModule, IOMixin):
         )
 
         if self.packed_sequence_size != self.seq_length:
-            raise ValueError(f"{self.__class__.__name__} requires `packed_sequence_specs.packed_sequence_size` to be nonzero and equal to `seq_length`.  Instead got packed_sequence_size = {self.packed_sequence_size} and seq_length = {self.seq_length}")
+            raise ValueError(
+                f"{self.__class__.__name__} requires `packed_sequence_specs.packed_sequence_size` to be nonzero and equal to `seq_length`.  Instead got packed_sequence_size = {self.packed_sequence_size} and seq_length = {self.seq_length}"
+            )
 
     def prepare_data(self) -> None:
         # if train file is specified, no need to do anything
@@ -123,11 +127,14 @@ class MLPerfGovReportDataModule(FineTuningDataModule, IOMixin):
 
         for split_name, dataset in save_splits.items():
             output_file = self.dataset_root / f"{split_name}.npy"
-            processed_data = [{
-                "input_ids": example["input_ids"],
-                "loss_mask": [int(x != -100) for x in example["labels"]],
-                "seq_start_id": [0],
-                } for example in dataset]
+            processed_data = [
+                {
+                    "input_ids": example["input_ids"],
+                    "loss_mask": [int(x != -100) for x in example["labels"]],
+                    "seq_start_id": [0],
+                }
+                for example in dataset
+            ]
             np.save(output_file, processed_data)
 
             logging.info(f"{split_name} split saved to {output_file}")

--- a/nemo/collections/llm/gpt/model/__init__.py
+++ b/nemo/collections/llm/gpt/model/__init__.py
@@ -15,6 +15,12 @@
 from nemo.collections.llm.gpt.model.baichuan import Baichuan2Config, Baichuan2Config7B, Baichuan2Model
 from nemo.collections.llm.gpt.model.base import (
     GPTConfig,
+    GPTConfig5B,
+    GPTConfig7B,
+    GPTConfig20B,
+    GPTConfig40B,
+    GPTConfig126M,
+    GPTConfig175B,
     GPTModel,
     MaskedTokenLossReduction,
     gpt_data_step,
@@ -60,7 +66,7 @@ from nemo.collections.llm.gpt.model.llama import (
     MLPerfLoRALlamaModel,
 )
 from nemo.collections.llm.gpt.model.llama_embedding import Llama32EmbeddingConfig1B, LlamaEmbeddingModel
-from nemo.collections.llm.gpt.model.mistral import MistralConfig7B, MistralModel
+from nemo.collections.llm.gpt.model.mistral import MistralConfig7B, MistralModel, MistralNeMoConfig12B
 from nemo.collections.llm.gpt.model.mixtral import (
     MixtralConfig,
     MixtralConfig8x3B,

--- a/nemo/collections/llm/gpt/model/__init__.py
+++ b/nemo/collections/llm/gpt/model/__init__.py
@@ -15,12 +15,6 @@
 from nemo.collections.llm.gpt.model.baichuan import Baichuan2Config, Baichuan2Config7B, Baichuan2Model
 from nemo.collections.llm.gpt.model.base import (
     GPTConfig,
-    GPTConfig5B,
-    GPTConfig7B,
-    GPTConfig20B,
-    GPTConfig40B,
-    GPTConfig126M,
-    GPTConfig175B,
     GPTModel,
     MaskedTokenLossReduction,
     gpt_data_step,
@@ -66,7 +60,7 @@ from nemo.collections.llm.gpt.model.llama import (
     MLPerfLoRALlamaModel,
 )
 from nemo.collections.llm.gpt.model.llama_embedding import Llama32EmbeddingConfig1B, LlamaEmbeddingModel
-from nemo.collections.llm.gpt.model.mistral import MistralConfig7B, MistralModel, MistralNeMoConfig12B
+from nemo.collections.llm.gpt.model.mistral import MistralConfig7B, MistralModel
 from nemo.collections.llm.gpt.model.mixtral import (
     MixtralConfig,
     MixtralConfig8x3B,

--- a/nemo/collections/llm/gpt/model/__init__.py
+++ b/nemo/collections/llm/gpt/model/__init__.py
@@ -113,9 +113,16 @@ from nemo.collections.llm.gpt.model.starcoder2 import (
 
 __all__ = [
     "GPTConfig",
+    "GPTConfig5B",
+    "GPTConfig7B",
+    "GPTConfig20B",
+    "GPTConfig40B",
+    "GPTConfig126M",
+    "GPTConfig175B",
     "GPTModel",
     "MistralConfig7B",
     "MistralModel",
+    "MistralNeMoConfig12B",
     "MixtralConfig8x3B",
     "MixtralConfig8x7B",
     "MixtralConfig8x22B",

--- a/nemo/collections/llm/gpt/model/__init__.py
+++ b/nemo/collections/llm/gpt/model/__init__.py
@@ -63,6 +63,7 @@ from nemo.collections.llm.gpt.model.llama import (
     Llama32Config3B,
     LlamaConfig,
     LlamaModel,
+    MLPerfLoRALlamaModel,
 )
 from nemo.collections.llm.gpt.model.llama_embedding import Llama32EmbeddingConfig1B, LlamaEmbeddingModel
 from nemo.collections.llm.gpt.model.mistral import MistralConfig7B, MistralModel, MistralNeMoConfig12B
@@ -167,6 +168,7 @@ __all__ = [
     "Gemma2Config9B",
     "Gemma2Model",
     "LlamaModel",
+    "MLPerfLoRALlamaModel",
     "Baichuan2Config",
     "Baichuan2Config7B",
     "Baichuan2Model",

--- a/nemo/collections/llm/gpt/model/llama.py
+++ b/nemo/collections/llm/gpt/model/llama.py
@@ -465,6 +465,7 @@ class HFLlamaPEFTExporter(HFLlamaExporter):
         pn = "decoder.layers."
         ph = "base_model.model.model.layers."
 
+        #pylint: disable = line-too-long
         mapping = {
             # linear_proj for both canonical and performant lora
             f"{pn}*.self_attention.linear_proj.adapter.linear_in.weight": f"{ph}*.self_attn.o_proj.lora_A.default.weight",
@@ -700,7 +701,8 @@ def apply_rope_scaling(
     old_context_len: int = 8192,
 ):
     logging.info(
-        f"Apply rope scaling with factor={factor}, low_freq_factor={low_freq_factor}, high_freq_factor={high_freq_factor}, old_context_len={old_context_len}."
+        f"Apply rope scaling with factor={factor}, low_freq_factor={low_freq_factor}, "
+        f"high_freq_factor={high_freq_factor}, old_context_len={old_context_len}."
     )
 
     low_freq_wavelen = old_context_len / low_freq_factor

--- a/nemo/collections/llm/gpt/model/llama.py
+++ b/nemo/collections/llm/gpt/model/llama.py
@@ -465,14 +465,21 @@ class HFLlamaPEFTExporter(HFLlamaExporter):
         pn = "decoder.layers."
         ph = "base_model.model.model.layers."
 
-        # pylint: disable = line-too-long
+        # linear_proj and linear_fc2 prefixes
+        p_proj = "self_attention.linear_proj.adapter"
+        p_fc2 = "mlp.linear_fc2.adapter"
+
+        # linear_qkv and linear_fc1 prefixes
+        p_qkv = "self_attention.linear_qkv.adapter"
+        p_fc1 = "mlp.linear_fc1.adapter"
+
         mapping = {
             # linear_proj for both canonical and performant lora
-            f"{pn}*.self_attention.linear_proj.adapter.linear_in.weight": f"{ph}*.self_attn.o_proj.lora_A.default.weight",
-            f"{pn}*.self_attention.linear_proj.adapter.linear_out.weight": f"{ph}*.self_attn.o_proj.lora_B.default.weight",
+            f"{pn}*.{p_proj}.linear_in.weight": f"{ph}*.self_attn.o_proj.lora_A.default.weight",
+            f"{pn}*.{p_proj}.linear_out.weight": f"{ph}*.self_attn.o_proj.lora_B.default.weight",
             # linear_fc2 for both canonical and performant lora
-            f"{pn}*.mlp.linear_fc2.adapter.linear_in.weight": f"{ph}*.mlp.down_proj.lora_A.default.weight",
-            f"{pn}*.mlp.linear_fc2.adapter.linear_out.weight": f"{ph}*.mlp.down_proj.lora_B.default.weight",
+            f"{pn}*.{p_fc2}.linear_in.weight": f"{ph}*.mlp.down_proj.lora_A.default.weight",
+            f"{pn}*.{p_fc2}.linear_out.weight": f"{ph}*.mlp.down_proj.lora_B.default.weight",
         }
         transforms = []
 
@@ -480,17 +487,17 @@ class HFLlamaPEFTExporter(HFLlamaExporter):
             mapping.update(
                 {
                     # linear_qkv for canonical lora
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_q.linear_in.weight": f"{ph}*.self_attn.q_proj.lora_A.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_q.linear_out.weight": f"{ph}*.self_attn.q_proj.lora_B.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_k.linear_in.weight": f"{ph}*.self_attn.k_proj.lora_A.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_k.linear_out.weight": f"{ph}*.self_attn.k_proj.lora_B.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_v.linear_in.weight": f"{ph}*.self_attn.v_proj.lora_A.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_v.linear_out.weight": f"{ph}*.self_attn.v_proj.lora_B.default.weight",
+                    f"{pn}*.{p_qkv}.adapter_q.linear_in.weight": f"{ph}*.self_attn.q_proj.lora_A.default.weight",
+                    f"{pn}*.{p_qkv}.adapter_q.linear_out.weight": f"{ph}*.self_attn.q_proj.lora_B.default.weight",
+                    f"{pn}*.{p_qkv}.adapter_k.linear_in.weight": f"{ph}*.self_attn.k_proj.lora_A.default.weight",
+                    f"{pn}*.{p_qkv}.adapter_k.linear_out.weight": f"{ph}*.self_attn.k_proj.lora_B.default.weight",
+                    f"{pn}*.{p_qkv}.adapter_v.linear_in.weight": f"{ph}*.self_attn.v_proj.lora_A.default.weight",
+                    f"{pn}*.{p_qkv}.adapter_v.linear_out.weight": f"{ph}*.self_attn.v_proj.lora_B.default.weight",
                     # linear_fc1 for canonical lora
-                    f"{pn}*.mlp.linear_fc1.adapter.adapter_up.linear_in.weight": f"{ph}*.mlp.up_proj.lora_A.default.weight",
-                    f"{pn}*.mlp.linear_fc1.adapter.adapter_up.linear_out.weight": f"{ph}*.mlp.up_proj.lora_B.default.weight",
-                    f"{pn}*.mlp.linear_fc1.adapter.adapter_gate.linear_in.weight": f"{ph}*.mlp.gate_proj.lora_A.default.weight",
-                    f"{pn}*.mlp.linear_fc1.adapter.adapter_gate.linear_out.weight": f"{ph}*.mlp.gate_proj.lora_B.default.weight",
+                    f"{pn}*.{p_fc1}.adapter_up.linear_in.weight": f"{ph}*.mlp.up_proj.lora_A.default.weight",
+                    f"{pn}*.{p_fc1}.adapter_up.linear_out.weight": f"{ph}*.mlp.up_proj.lora_B.default.weight",
+                    f"{pn}*.{p_fc1}.adapter_gate.linear_in.weight": f"{ph}*.mlp.gate_proj.lora_A.default.weight",
+                    f"{pn}*.{p_fc1}.adapter_gate.linear_out.weight": f"{ph}*.mlp.gate_proj.lora_B.default.weight",
                 }
             )
         else:

--- a/nemo/collections/llm/gpt/model/llama.py
+++ b/nemo/collections/llm/gpt/model/llama.py
@@ -465,7 +465,7 @@ class HFLlamaPEFTExporter(HFLlamaExporter):
         pn = "decoder.layers."
         ph = "base_model.model.model.layers."
 
-        #pylint: disable = line-too-long
+        # pylint: disable = line-too-long
         mapping = {
             # linear_proj for both canonical and performant lora
             f"{pn}*.self_attention.linear_proj.adapter.linear_in.weight": f"{ph}*.self_attn.o_proj.lora_A.default.weight",

--- a/nemo/collections/llm/gpt/model/llama.py
+++ b/nemo/collections/llm/gpt/model/llama.py
@@ -276,7 +276,8 @@ class MLPerfLoRALlamaModel(LlamaModel):
     def configure_model(self):
         # Apply context managers to reduce memory by (1) avoiding unnecessary gradients
         # and (2) requesting that TE initialize params as FP8.
-        # See https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html#transformer_engine.pytorch.fp8_model_init
+        # See https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html
+            #transformer_engine.pytorch.fp8_model_init
         import transformer_engine.pytorch as te
 
         with torch.no_grad(), te.fp8_model_init():
@@ -467,8 +468,10 @@ class HFLlamaPEFTExporter(HFLlamaExporter):
 
         mapping = {
             # linear_proj for both canonical and performant lora
-            f"{pn}*.self_attention.linear_proj.adapter.linear_in.weight": f"{ph}*.self_attn.o_proj.lora_A.default.weight",
-            f"{pn}*.self_attention.linear_proj.adapter.linear_out.weight": f"{ph}*.self_attn.o_proj.lora_B.default.weight",
+            f"{pn}*.self_attention.linear_proj.adapter.linear_in.weight":
+                f"{ph}*.self_attn.o_proj.lora_A.default.weight",
+            f"{pn}*.self_attention.linear_proj.adapter.linear_out.weight":
+                f"{ph}*.self_attn.o_proj.lora_B.default.weight",
             # linear_fc2 for both canonical and performant lora
             f"{pn}*.mlp.linear_fc2.adapter.linear_in.weight": f"{ph}*.mlp.down_proj.lora_A.default.weight",
             f"{pn}*.mlp.linear_fc2.adapter.linear_out.weight": f"{ph}*.mlp.down_proj.lora_B.default.weight",
@@ -479,17 +482,27 @@ class HFLlamaPEFTExporter(HFLlamaExporter):
             mapping.update(
                 {
                     # linear_qkv for canonical lora
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_q.linear_in.weight": f"{ph}*.self_attn.q_proj.lora_A.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_q.linear_out.weight": f"{ph}*.self_attn.q_proj.lora_B.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_k.linear_in.weight": f"{ph}*.self_attn.k_proj.lora_A.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_k.linear_out.weight": f"{ph}*.self_attn.k_proj.lora_B.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_v.linear_in.weight": f"{ph}*.self_attn.v_proj.lora_A.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_v.linear_out.weight": f"{ph}*.self_attn.v_proj.lora_B.default.weight",
+                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_q.linear_in.weight":
+                        f"{ph}*.self_attn.q_proj.lora_A.default.weight",
+                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_q.linear_out.weight":
+                        f"{ph}*.self_attn.q_proj.lora_B.default.weight",
+                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_k.linear_in.weight":
+                        f"{ph}*.self_attn.k_proj.lora_A.default.weight",
+                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_k.linear_out.weight":
+                        f"{ph}*.self_attn.k_proj.lora_B.default.weight",
+                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_v.linear_in.weight":
+                        f"{ph}*.self_attn.v_proj.lora_A.default.weight",
+                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_v.linear_out.weight":
+                        f"{ph}*.self_attn.v_proj.lora_B.default.weight",
                     # linear_fc1 for canonical lora
-                    f"{pn}*.mlp.linear_fc1.adapter.adapter_up.linear_in.weight": f"{ph}*.mlp.up_proj.lora_A.default.weight",
-                    f"{pn}*.mlp.linear_fc1.adapter.adapter_up.linear_out.weight": f"{ph}*.mlp.up_proj.lora_B.default.weight",
-                    f"{pn}*.mlp.linear_fc1.adapter.adapter_gate.linear_in.weight": f"{ph}*.mlp.gate_proj.lora_A.default.weight",
-                    f"{pn}*.mlp.linear_fc1.adapter.adapter_gate.linear_out.weight": f"{ph}*.mlp.gate_proj.lora_B.default.weight",
+                    f"{pn}*.mlp.linear_fc1.adapter.adapter_up.linear_in.weight":
+                        f"{ph}*.mlp.up_proj.lora_A.default.weight",
+                    f"{pn}*.mlp.linear_fc1.adapter.adapter_up.linear_out.weight":
+                        f"{ph}*.mlp.up_proj.lora_B.default.weight",
+                    f"{pn}*.mlp.linear_fc1.adapter.adapter_gate.linear_in.weight":
+                        f"{ph}*.mlp.gate_proj.lora_A.default.weight",
+                    f"{pn}*.mlp.linear_fc1.adapter.adapter_gate.linear_out.weight":
+                        f"{ph}*.mlp.gate_proj.lora_B.default.weight",
                 }
             )
         else:

--- a/nemo/collections/llm/gpt/model/llama.py
+++ b/nemo/collections/llm/gpt/model/llama.py
@@ -267,6 +267,10 @@ class MLPerfLoRALlamaModel(LlamaModel):
     ):
         super().__init__(config or LlamaConfig(), optim=optim, tokenizer=tokenizer, model_transform=model_transform)
 
+        from nemo.utils.import_utils import safe_import
+        _, HAVE_TE = safe_import("transformer_engine")
+        assert HAVE_TE, "TransformerEngine is required for MLPerfLoRALlamaModel."
+
     def configure_model(self):
         # Apply context managers to reduce memory by (1) avoiding unnecessary gradients
         # and (2) requesting that TE initialize params as FP8.

--- a/nemo/collections/llm/gpt/model/llama.py
+++ b/nemo/collections/llm/gpt/model/llama.py
@@ -277,7 +277,7 @@ class MLPerfLoRALlamaModel(LlamaModel):
         # Apply context managers to reduce memory by (1) avoiding unnecessary gradients
         # and (2) requesting that TE initialize params as FP8.
         # See https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html
-            #transformer_engine.pytorch.fp8_model_init
+        # transformer_engine.pytorch.fp8_model_init
         import transformer_engine.pytorch as te
 
         with torch.no_grad(), te.fp8_model_init():
@@ -468,10 +468,8 @@ class HFLlamaPEFTExporter(HFLlamaExporter):
 
         mapping = {
             # linear_proj for both canonical and performant lora
-            f"{pn}*.self_attention.linear_proj.adapter.linear_in.weight":
-                f"{ph}*.self_attn.o_proj.lora_A.default.weight",
-            f"{pn}*.self_attention.linear_proj.adapter.linear_out.weight":
-                f"{ph}*.self_attn.o_proj.lora_B.default.weight",
+            f"{pn}*.self_attention.linear_proj.adapter.linear_in.weight": f"{ph}*.self_attn.o_proj.lora_A.default.weight",
+            f"{pn}*.self_attention.linear_proj.adapter.linear_out.weight": f"{ph}*.self_attn.o_proj.lora_B.default.weight",
             # linear_fc2 for both canonical and performant lora
             f"{pn}*.mlp.linear_fc2.adapter.linear_in.weight": f"{ph}*.mlp.down_proj.lora_A.default.weight",
             f"{pn}*.mlp.linear_fc2.adapter.linear_out.weight": f"{ph}*.mlp.down_proj.lora_B.default.weight",
@@ -482,27 +480,17 @@ class HFLlamaPEFTExporter(HFLlamaExporter):
             mapping.update(
                 {
                     # linear_qkv for canonical lora
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_q.linear_in.weight":
-                        f"{ph}*.self_attn.q_proj.lora_A.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_q.linear_out.weight":
-                        f"{ph}*.self_attn.q_proj.lora_B.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_k.linear_in.weight":
-                        f"{ph}*.self_attn.k_proj.lora_A.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_k.linear_out.weight":
-                        f"{ph}*.self_attn.k_proj.lora_B.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_v.linear_in.weight":
-                        f"{ph}*.self_attn.v_proj.lora_A.default.weight",
-                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_v.linear_out.weight":
-                        f"{ph}*.self_attn.v_proj.lora_B.default.weight",
+                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_q.linear_in.weight": f"{ph}*.self_attn.q_proj.lora_A.default.weight",
+                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_q.linear_out.weight": f"{ph}*.self_attn.q_proj.lora_B.default.weight",
+                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_k.linear_in.weight": f"{ph}*.self_attn.k_proj.lora_A.default.weight",
+                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_k.linear_out.weight": f"{ph}*.self_attn.k_proj.lora_B.default.weight",
+                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_v.linear_in.weight": f"{ph}*.self_attn.v_proj.lora_A.default.weight",
+                    f"{pn}*.self_attention.linear_qkv.adapter.adapter_v.linear_out.weight": f"{ph}*.self_attn.v_proj.lora_B.default.weight",
                     # linear_fc1 for canonical lora
-                    f"{pn}*.mlp.linear_fc1.adapter.adapter_up.linear_in.weight":
-                        f"{ph}*.mlp.up_proj.lora_A.default.weight",
-                    f"{pn}*.mlp.linear_fc1.adapter.adapter_up.linear_out.weight":
-                        f"{ph}*.mlp.up_proj.lora_B.default.weight",
-                    f"{pn}*.mlp.linear_fc1.adapter.adapter_gate.linear_in.weight":
-                        f"{ph}*.mlp.gate_proj.lora_A.default.weight",
-                    f"{pn}*.mlp.linear_fc1.adapter.adapter_gate.linear_out.weight":
-                        f"{ph}*.mlp.gate_proj.lora_B.default.weight",
+                    f"{pn}*.mlp.linear_fc1.adapter.adapter_up.linear_in.weight": f"{ph}*.mlp.up_proj.lora_A.default.weight",
+                    f"{pn}*.mlp.linear_fc1.adapter.adapter_up.linear_out.weight": f"{ph}*.mlp.up_proj.lora_B.default.weight",
+                    f"{pn}*.mlp.linear_fc1.adapter.adapter_gate.linear_in.weight": f"{ph}*.mlp.gate_proj.lora_A.default.weight",
+                    f"{pn}*.mlp.linear_fc1.adapter.adapter_gate.linear_out.weight": f"{ph}*.mlp.gate_proj.lora_B.default.weight",
                 }
             )
         else:

--- a/nemo/collections/llm/gpt/model/llama.py
+++ b/nemo/collections/llm/gpt/model/llama.py
@@ -258,6 +258,7 @@ class MLPerfLoRALlamaModel(LlamaModel):
 
     Changes made here are experimental, proceed with caution.
     """
+
     def __init__(
         self,
         config: Annotated[Optional[LlamaConfig], Config[LlamaConfig]] = None,
@@ -268,6 +269,7 @@ class MLPerfLoRALlamaModel(LlamaModel):
         super().__init__(config or LlamaConfig(), optim=optim, tokenizer=tokenizer, model_transform=model_transform)
 
         from nemo.utils.import_utils import safe_import
+
         _, HAVE_TE = safe_import("transformer_engine")
         assert HAVE_TE, "TransformerEngine is required for MLPerfLoRALlamaModel."
 
@@ -276,6 +278,7 @@ class MLPerfLoRALlamaModel(LlamaModel):
         # and (2) requesting that TE initialize params as FP8.
         # See https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html#transformer_engine.pytorch.fp8_model_init
         import transformer_engine.pytorch as te
+
         with torch.no_grad(), te.fp8_model_init():
             super().configure_model()
 

--- a/nemo/collections/llm/gpt/model/llama.py
+++ b/nemo/collections/llm/gpt/model/llama.py
@@ -33,7 +33,7 @@ from nemo.utils import logging
 
 if TYPE_CHECKING:
     from megatron.core.models.gpt.gpt_model import GPTModel as MCoreGPTModel
-    from peft import PeftConfig
+    from peft import AutoPeftModelForCausalLM, PeftConfig
     from transformers import LlamaConfig as HFLlamaConfig
     from transformers import LlamaForCausalLM
 
@@ -275,9 +275,8 @@ class MLPerfLoRALlamaModel(LlamaModel):
 
     def configure_model(self):
         # Apply context managers to reduce memory by (1) avoiding unnecessary gradients
-        # and (2) requesting that TE initialize params as FP8.
-        # See https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html
-        # transformer_engine.pytorch.fp8_model_init
+        # and (2) requesting that TE initialize params as FP8. See:
+        # https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/api/pytorch.html#transformer_engine.pytorch.fp8_model_init
         import transformer_engine.pytorch as te
 
         with torch.no_grad(), te.fp8_model_init():

--- a/nemo/collections/llm/recipes/tp_overlap_configs/userbuffers.py
+++ b/nemo/collections/llm/recipes/tp_overlap_configs/userbuffers.py
@@ -31,6 +31,7 @@ class PipelineOverlapCfg(TPOverlapCfg):
     num_splits: int
     set_sm_margin: bool
     fp8_buf: bool = (False,)
+    atomic_gemm: bool = False
     method: str = 'pipeline'
 
 
@@ -41,7 +42,10 @@ class RingExchangeOverlapCfg(TPOverlapCfg):
     aggregate: bool = False
     method: str = 'ring_exchange'
     num_sm: int = 1
+    cga_size: int = 1
     set_sm_margin: bool = False
+    fp8_buf: bool = False
+    atomic_gemm: bool = False
 
 
 @dataclass

--- a/nemo/lightning/pytorch/callbacks/megatron_comm_overlap.py
+++ b/nemo/lightning/pytorch/callbacks/megatron_comm_overlap.py
@@ -296,7 +296,9 @@ class MegatronCommOverlapCallback(Callback):
         else:
             # ub_cfgs is a dataclass, however TE needs a dict, so convert here
             self.tp_comm_overlap_cfg = asdict(self.tp_comm_overlap_cfg)
-            self.tp_comm_overlap_cfg = {key: value for key, value in self.tp_comm_overlap_cfg.items() if value is not None}
+            self.tp_comm_overlap_cfg = {
+                key: value for key, value in self.tp_comm_overlap_cfg.items() if value is not None
+            }
 
         micro_batch_size = get_micro_batch_size()
         hidden_size = model_parallel_cfg.hidden_size

--- a/nemo/lightning/pytorch/callbacks/megatron_comm_overlap.py
+++ b/nemo/lightning/pytorch/callbacks/megatron_comm_overlap.py
@@ -296,6 +296,7 @@ class MegatronCommOverlapCallback(Callback):
         else:
             # ub_cfgs is a dataclass, however TE needs a dict, so convert here
             self.tp_comm_overlap_cfg = asdict(self.tp_comm_overlap_cfg)
+            self.tp_comm_overlap_cfg = {key: value for key, value in self.tp_comm_overlap_cfg.items() if value is not None}
 
         micro_batch_size = get_micro_batch_size()
         hidden_size = model_parallel_cfg.hidden_size

--- a/nemo/lightning/pytorch/callbacks/megatron_comm_overlap.py
+++ b/nemo/lightning/pytorch/callbacks/megatron_comm_overlap.py
@@ -296,6 +296,7 @@ class MegatronCommOverlapCallback(Callback):
         else:
             # ub_cfgs is a dataclass, however TE needs a dict, so convert here
             self.tp_comm_overlap_cfg = asdict(self.tp_comm_overlap_cfg)
+            # remove keys with None values from dictionary to match TE's expectations
             self.tp_comm_overlap_cfg = {
                 key: value for key, value in self.tp_comm_overlap_cfg.items() if value is not None
             }

--- a/scripts/llm/performance/mlperf_lora_llama2_70b.py
+++ b/scripts/llm/performance/mlperf_lora_llama2_70b.py
@@ -14,8 +14,8 @@
 
 import nemo_run as run
 import torch
-from megatron.core.optimizer import OptimizerConfig
 from argument_parser import parse_cli_args
+from megatron.core.optimizer import OptimizerConfig
 from utils import import_ckpt_experiment, slurm_executor
 
 from nemo import lightning as nl
@@ -262,7 +262,7 @@ if __name__ == "__main__":
         )
 
     num_gpus_per_node = NUM_GPUS_PER_NODE if args.gpus_per_node is None else args.gpus_per_node
-    num_gpus = NUM_NODES*num_gpus_per_node if args.num_gpus is None else args.num_gpus
+    num_gpus = NUM_NODES * num_gpus_per_node if args.num_gpus is None else args.num_gpus
     num_nodes = -(num_gpus // -num_gpus_per_node)
 
     mbs = MICRO_BATCH_SIZE if args.micro_batch_size is None else args.micro_batch_size

--- a/scripts/llm/performance/mlperf_lora_llama2_70b.py
+++ b/scripts/llm/performance/mlperf_lora_llama2_70b.py
@@ -268,17 +268,16 @@ if __name__ == "__main__":
     )
 
     env_vars = {
-        "LORA_A2A": "1",
-        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
-        "CUBLAS_FORCE_XMMA_KERNEL_INIT": "DEVICE",
-        "CUDNN_FRONTEND_ATTN_DP_WORKSPACE_LIMIT": "0",
-        "NVTE_FP8_DPA_BWD": "1",
-        "NVTE_RS_STRIDED_ATOMIC": "2",
-        "NCCL_MIN_CTAS": "32",
-        "NCCL_MIN_P2P_NCHANNELS": "32",
-        "NCCL_NCHANNELS_PER_NET_PEER": "32",
-        "NCCL_NVLS_ENABLE": "0",
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": "1",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1", # Limit GPUs to one compute stream so that kernels will be executed in consistent order, for best performance with communication overlap configs
+        "CUBLAS_FORCE_XMMA_KERNEL_INIT": "DEVICE", # Use a device kernel instead of memset for matrix multiply initialization, which can help reduce CPU-side overhead
+        "CUDNN_FRONTEND_ATTN_DP_WORKSPACE_LIMIT": "0", # Reduce memory used by cuDNN attention
+        "NVTE_FP8_DPA_BWD": "1", # Enable TransformerEngine FP8 attention for bprop
+        "NVTE_RS_STRIDED_ATOMIC": "2", # Reduce-scatter communication will be done as a single kernel (with userbuffer TP communication overlap)
+        "NCCL_MIN_CTAS": "32", # Increase CTA resources available to NCCL to improve communication perf
+        "NCCL_MIN_P2P_NCHANNELS": "32", # Likewise, increase P2P channels availabe to NCCL
+        "NCCL_NCHANNELS_PER_NET_PEER": "32", # Likewise, increase per-peer P2P channel limit
+        "NCCL_NVLS_ENABLE": "0", # Disable NVLink SHARP to save memory
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": "1", # Disable caching NCCL communication buffer memory
     }
 
     executor = slurm_executor(

--- a/scripts/llm/performance/mlperf_lora_llama2_70b.py
+++ b/scripts/llm/performance/mlperf_lora_llama2_70b.py
@@ -268,16 +268,16 @@ if __name__ == "__main__":
     )
 
     env_vars = {
-        "CUDA_DEVICE_MAX_CONNECTIONS": "1", # Limit GPUs to one compute stream so that kernels will be executed in consistent order, for best performance with communication overlap configs
-        "CUBLAS_FORCE_XMMA_KERNEL_INIT": "DEVICE", # Use a device kernel instead of memset for matrix multiply initialization, which can help reduce CPU-side overhead
-        "CUDNN_FRONTEND_ATTN_DP_WORKSPACE_LIMIT": "0", # Reduce memory used by cuDNN attention
-        "NVTE_FP8_DPA_BWD": "1", # Enable TransformerEngine FP8 attention for bprop
-        "NVTE_RS_STRIDED_ATOMIC": "2", # Reduce-scatter communication will be done as a single kernel (with userbuffer TP communication overlap)
-        "NCCL_MIN_CTAS": "32", # Increase CTA resources available to NCCL to improve communication perf
-        "NCCL_MIN_P2P_NCHANNELS": "32", # Likewise, increase P2P channels availabe to NCCL
-        "NCCL_NCHANNELS_PER_NET_PEER": "32", # Likewise, increase per-peer P2P channel limit
-        "NCCL_NVLS_ENABLE": "0", # Disable NVLink SHARP to save memory
-        "TORCH_NCCL_AVOID_RECORD_STREAMS": "1", # Disable caching NCCL communication buffer memory
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1",  # Limit GPUs to one compute stream so that kernels will be executed in consistent order, for best performance with communication overlap configs
+        "CUBLAS_FORCE_XMMA_KERNEL_INIT": "DEVICE",  # Use a device kernel instead of memset for matrix multiply initialization, which can help reduce CPU-side overhead
+        "CUDNN_FRONTEND_ATTN_DP_WORKSPACE_LIMIT": "0",  # Reduce memory used by cuDNN attention
+        "NVTE_FP8_DPA_BWD": "1",  # Enable TransformerEngine FP8 attention for bprop
+        "NVTE_RS_STRIDED_ATOMIC": "2",  # Reduce-scatter communication will be done as a single kernel (with userbuffer TP communication overlap)
+        "NCCL_MIN_CTAS": "32",  # Increase CTA resources available to NCCL to improve communication perf
+        "NCCL_MIN_P2P_NCHANNELS": "32",  # Likewise, increase P2P channels availabe to NCCL
+        "NCCL_NCHANNELS_PER_NET_PEER": "32",  # Likewise, increase per-peer P2P channel limit
+        "NCCL_NVLS_ENABLE": "0",  # Disable NVLink SHARP to save memory
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": "1",  # Disable caching NCCL communication buffer memory
     }
 
     executor = slurm_executor(

--- a/scripts/llm/performance/mlperf_lora_llama2_70b.py
+++ b/scripts/llm/performance/mlperf_lora_llama2_70b.py
@@ -26,7 +26,7 @@ from nemo.collections.llm.gpt.data import MLPerfGovReportDataModule
 
 from nemo import lightning as nl
 from nemo.lightning.pytorch.callbacks.megatron_comm_overlap import MegatronCommOverlapCallback
-from nemo.lightning.pytorch.optim import CosineAnnealingScheduler, MegatronOptimizerModule
+from nemo.lightning.pytorch.optim import CosineAnnealingScheduler
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from utils import (

--- a/scripts/llm/performance/mlperf_lora_llama2_70b.py
+++ b/scripts/llm/performance/mlperf_lora_llama2_70b.py
@@ -1,0 +1,325 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nemo_run as run
+
+import torch
+
+from megatron.core.optimizer import OptimizerConfig
+
+from nemo.collections import llm
+from nemo.collections.llm.gpt.model.llama import *
+from nemo.collections.common.tokenizers.huggingface import AutoTokenizer
+from nemo.collections.llm.gpt.data.packed_sequence import PackedSequenceSpecs
+from nemo.collections.llm.gpt.data import MLPerfGovReportDataModule
+
+from nemo import lightning as nl
+from nemo.lightning.pytorch.callbacks.megatron_comm_overlap import MegatronCommOverlapCallback
+from nemo.lightning.pytorch.optim import CosineAnnealingScheduler, MegatronOptimizerModule
+from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
+
+from utils import (
+    import_ckpt_experiment,
+    parse_cli_args,
+    slurm_executor,
+)
+
+NUM_NODES = 1
+NUM_GPUS_PER_NODE = 8
+MICRO_BATCH_SIZE = 1
+GLOBAL_BATCH_SIZE = 8
+TP_SIZE = 4 # tp_comm_overlap_cfg may need to be re-tuned if altering
+PP_SIZE = 1
+CP_SIZE = 1
+MAX_STEPS = 100
+
+SEQ_LENGTH = 8192
+HF_MODEL_URI = "meta-llama/Llama-2-70b-hf"
+SKIP_IMPORT = False
+
+
+def mlperf_lora_llama2_70b_recipe(
+    num_nodes: int,
+    num_gpus_per_node: int,
+    mbs: int,
+    gbs: int,
+    tp_size: int,
+    pp_size: int,
+    cp_size: int,
+    max_steps: int,
+):
+    """
+    A recipe for llama2 70B LoRA training based on performance optimizations used in NVIDIA's MLPerf submissions.
+    Some optimizations are experimental; use caution.
+    Last updated for the 4.1 submission.
+    """
+    tokenizer = run.Config(
+        AutoTokenizer,
+        pretrained_model_name=HF_MODEL_URI,
+    )
+
+    packed_sequence_specs = run.Config(
+        PackedSequenceSpecs,
+        packed_sequence_size=SEQ_LENGTH,
+    )
+
+    datamodule = run.Config(
+        MLPerfGovReportDataModule,
+        seq_length=SEQ_LENGTH,
+        tokenizer=tokenizer,
+        micro_batch_size=mbs,
+        global_batch_size=gbs,
+        persistent_workers=True,
+        packed_sequence_specs=packed_sequence_specs,
+        dataset_kwargs={
+            "return_cu_seqlen": False,
+        }
+    )
+
+    optimizer_config = run.Config(
+        OptimizerConfig,
+        lr=2e-4,
+        clip_grad=0.3,
+        weight_decay=0.0001,
+        bf16=True,
+        params_dtype=torch.bfloat16,
+        use_distributed_optimizer=True,
+    )
+
+    scheduler = run.Config(
+        CosineAnnealingScheduler,
+        max_steps=max_steps,
+        warmup_steps=500,
+        constant_steps=0,
+        min_lr=0,
+    )
+    optimizer = run.Config(
+        nl.MegatronOptimizerModule,
+        config=optimizer_config,
+        lr_scheduler=scheduler,
+    )
+    peft = run.Config(
+        llm.peft.lora.LoRA,
+        dim=16,
+        alpha=32,
+        dropout=0.1,
+        a2a_experimental=True,
+        dropout_position="pre",
+        lora_A_init_method="kaiming",
+        target_modules=['linear_proj', 'linear_qkv'],
+    )
+    llama2_config = run.Config(
+        llm.Llama2Config70B,
+        seq_length=SEQ_LENGTH,
+        tp_comm_overlap_disable_qkv=True,
+        fp8_dot_product_attention=1,
+        cross_entropy_loss_fusion=False,
+        disable_parameter_transpose_cache=True,
+        external_cuda_graph=False,
+        enable_cuda_graph=False,
+    )
+    llama2_config.microbatch_group_size_per_vp_stage = 1
+    model = run.Config(
+        MLPerfLoRALlamaModel,
+        llama2_config,
+    )
+
+    resume = llm.recipes.finetune_default.nemo_resume(HF_MODEL_URI)
+
+    from megatron.core.distributed import DistributedDataParallelConfig
+    strategy = run.Config(
+        nl.MegatronStrategy,
+        tensor_model_parallel_size=tp_size,
+        pipeline_model_parallel_size=pp_size,
+        context_parallel_size=cp_size,
+        sequence_parallel=1 if (tp_size > 1) else 0,
+        pipeline_dtype=torch.bfloat16,
+        ckpt_load_directly_on_device=False,
+        ckpt_parallel_load=False,
+        ckpt_load_strictness="log_all",
+        gradient_as_bucket_view=True,
+        use_te_rng_tracker=True,
+        ddp=run.Config(
+            DistributedDataParallelConfig,
+            use_distributed_optimizer=True,
+        ),
+    )
+
+    precision = run.Config(
+        nl.MegatronMixedPrecision,
+        precision="bf16-mixed",
+        params_dtype=torch.bfloat16,
+        pipeline_dtype=torch.bfloat16,
+        autocast_enabled=True,
+        grad_reduce_in_fp32=False,
+        fp8="hybrid",
+        fp8_amax_history_len=32,
+        fp8_amax_compute_algo='max',
+        fp8_params=True,
+        fp8_dot_product_attention=1,
+    )
+
+    # Communication overlap settings
+    tp_comm_overlap_cfg = None
+    ub_tp_comm_overlap = (tp_size > 1)
+    if ub_tp_comm_overlap:
+        from nemo.collections.llm.recipes.tp_overlap_configs.userbuffers import PipelineOverlapCfg, RingExchangeOverlapCfg, BulkOverlapCfg, TransformerLayerTPOverlapCfg
+        tp_comm_overlap_cfg = TransformerLayerTPOverlapCfg(
+            qkv_fprop=RingExchangeOverlapCfg(),
+            fc1_fprop=RingExchangeOverlapCfg(),
+            proj_dgrad=RingExchangeOverlapCfg(),
+            fc2_dgrad=RingExchangeOverlapCfg(),
+            proj_fprop=PipelineOverlapCfg(num_sm=32, cga_size=2, num_splits=4, set_sm_margin=True, atomic_gemm=True, fp8_buf=True),
+            fc2_fprop=PipelineOverlapCfg(num_sm=16, cga_size=2, num_splits=4, set_sm_margin=True, atomic_gemm=True, fp8_buf=False),
+            qkv_dgrad=BulkOverlapCfg(num_sm=4, cga_size=2, set_sm_margin=False),
+            fc1_dgrad=RingExchangeOverlapCfg(cga_size=2, set_sm_margin=True),
+            qkv_wgrad=None,
+            fc1_wgrad=None,
+        )
+    overlap_callback = run.Config(
+        MegatronCommOverlapCallback,
+        tp_comm_overlap=ub_tp_comm_overlap,
+        tp_comm_overlap_cfg=tp_comm_overlap_cfg,
+        overlap_grad_reduce=False,
+        overlap_param_gather=False,
+        overlap_param_gather_with_optimizer_step=False,
+    )
+
+    # Disable garbage collection
+    from nemo.lightning.pytorch.callbacks.garbage_collection import GarbageCollectionCallback
+    gc_callback = run.Config(
+        GarbageCollectionCallback,
+        max_steps + 1,
+        max_steps + 1,
+    )
+
+    # Log step times
+    from nemo.utils.exp_manager import TimingCallback
+    timing_callback = run.Config(TimingCallback)
+
+    trainer = run.Config(
+        nl.Trainer,
+        max_steps=max_steps,
+        val_check_interval=(max_steps - 1),
+        limit_val_batches=0,
+        devices=num_gpus_per_node,
+        num_nodes=num_nodes,
+        accelerator="gpu",
+        strategy=strategy,
+        plugins=precision,
+        num_sanity_val_steps=0,
+        accumulate_grad_batches=1,
+        enable_checkpointing=False,
+        enable_model_summary=False,
+        enable_progress_bar=True,
+        use_distributed_sampler=False,
+        log_every_n_steps=10,
+        callbacks=[overlap_callback, gc_callback, timing_callback],
+    )
+
+    from nemo.collections.llm.recipes.log.default import tensorboard_logger
+    recipe = run.Partial(
+        llm.finetune,
+        model=model,
+        trainer=trainer,
+        data=datamodule,
+        optim=optimizer,
+        resume=resume,
+        peft=peft,
+    )
+    recipe.model.tokenizer = tokenizer
+    return recipe
+
+
+if __name__ == "__main__":
+    args = parse_cli_args().parse_args()
+
+    if args.finetuning.lower() != "lora" or args.compute_dtype != "fp8":
+        raise ValueError(f"This example assumes LoRA and fp8; instead got --finetuning={args.finetuning} --compute_dtype={args.compute_dtype}")
+
+    exp_name = "_".join(
+        [
+            args.finetuning.lower(),
+            "llama2_70b",
+            args.compute_dtype,
+            f"{NUM_NODES}nodes",
+            f"tp{TP_SIZE}_pp{PP_SIZE}_cp{CP_SIZE}",
+            f"{MICRO_BATCH_SIZE}mbs_{GLOBAL_BATCH_SIZE}gbs",
+        ]
+    )
+
+    env_vars = {
+        "LORA_A2A": "1",
+        "CUDA_DEVICE_MAX_CONNECTIONS": "1",
+        "CUBLAS_FORCE_XMMA_KERNEL_INIT": "DEVICE",
+        "CUDNN_FRONTEND_ATTN_DP_WORKSPACE_LIMIT": "0",
+        "NVTE_FP8_DPA_BWD": "1",
+        "NVTE_RS_STRIDED_ATOMIC": "2",
+        "NCCL_MIN_CTAS": "32",
+        "NCCL_MIN_P2P_NCHANNELS": "32",
+        "NCCL_NCHANNELS_PER_NET_PEER": "32",
+        "NCCL_NVLS_ENABLE": "0",
+        "TORCH_NCCL_AVOID_RECORD_STREAMS": "1",
+    }
+
+    executor = slurm_executor(
+        args.account,
+        args.partition,
+        args.log_dir,
+        NUM_NODES,
+        NUM_GPUS_PER_NODE,
+        args.time_limit,
+        args.container_image,
+        custom_mounts=[],
+        custom_env_vars=env_vars,
+        hf_token=args.hf_token,
+        nemo_home=args.nemo_home,
+    )
+
+    recipe = mlperf_lora_llama2_70b_recipe(
+        NUM_NODES,
+        NUM_GPUS_PER_NODE,
+        MICRO_BATCH_SIZE,
+        GLOBAL_BATCH_SIZE,
+        TP_SIZE,
+        PP_SIZE,
+        CP_SIZE,
+        MAX_STEPS,
+    )
+
+    if not args.tensorboard:
+        recipe.log.tensorboard = None
+        recipe.trainer.logger = False
+    else:
+        recipe.log.log_dir = "/nemo_run/lightning_logs"
+
+    plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if PP_SIZE > 1 else None)]
+    if args.enable_profiling:
+        plugins.append(NsysPlugin(start_step=5, end_step=6))
+
+    with run.Experiment(exp_name) as exp:
+        if not SKIP_IMPORT:
+            exp.add(*import_ckpt_experiment(executor, run.Config(LlamaModel, config=run.Config(Llama2Config70B)), source=f"hf://{HF_MODEL_URI}"))
+        exp.add(
+            recipe,
+            executor=executor,
+            name=exp_name,
+            plugins=plugins,
+        )
+
+        if not args.dryrun:
+            exp.run(sequential=True, detach=True)
+        else:
+            exp.dryrun()
+


### PR DESCRIPTION
# What does this PR do ?

This PR adds an example script for llama2 70b LoRA tuning (tp4pp1cp1 on H100) including optimized configs used in MLPerf 4.1 submission, plus supporting changes.

Requires #11961.

**Collection**: llm

# Changelog 
- Added example script `scripts/llm/performance/mlperf_lora_llama2_70b.py`
- Enabled use of atomic GEMM settings for TP overlap
- Added a custom datamodule for downloading MLPerf-processed govreport data from HF
- Added a wrapper around LlamaModel which wraps configure_model to reduce memory consumption

# Usage
* You can potentially add a usage example below

```
python scripts/llm/performance/mlperf_lora_llama2_70b.py --help
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
