### PR TITLE
Fix per-rank log file creation

### DIFF
--- a/nemo/lightning/nemo_logger.py
+++ b/nemo/lightning/nemo_logger.py
@@ -244,21 +244,12 @@ class NeMoLogger(IOMixin):
         nemo_testing = get_envbool(NEMO_ENV_VARNAME_TESTING, False)
         log_file = log_dir / f"nemo_log_globalrank-{self.global_rank}_localrank-{self.local_rank}.txt"
 
-        def add_handler_after_wait_for_rank0():
-            # Need rank 0 to finish _setup_files_to_move() before creating new log files
-            rank0_log_file = log_dir / f"nemo_log_globalrank-0_localrank-0.txt"
-            if not self.global_rank == 0:
-                while not os.path.exists(rank0_log_file):
-                    pass
-
-            logging.add_file_handler(log_file)
-
         if self.log_local_rank_0_only and not nemo_testing and self.local_rank == 0:
-            add_handler_after_wait_for_rank0()
+            logging.add_file_handler(log_file)
         elif self.log_global_rank_0_only and not nemo_testing and self.global_rank == 0:
-            add_handler_after_wait_for_rank0()
+            logging.add_file_handler(log_file)
         elif not (self.log_local_rank_0_only or self.log_global_rank_0_only):
-            add_handler_after_wait_for_rank0()
+            logging.add_file_handler(log_file)
 
         add_handlers_to_mcore_logger()
 

--- a/nemo/lightning/nemo_logger.py
+++ b/nemo/lightning/nemo_logger.py
@@ -244,12 +244,21 @@ class NeMoLogger(IOMixin):
         nemo_testing = get_envbool(NEMO_ENV_VARNAME_TESTING, False)
         log_file = log_dir / f"nemo_log_globalrank-{self.global_rank}_localrank-{self.local_rank}.txt"
 
+        def add_handler_after_wait_for_rank0():
+            # Need rank 0 to finish _setup_files_to_move() before creating new log files
+            rank0_log_file = log_dir / f"nemo_log_globalrank-0_localrank-0.txt"
+            if not self.global_rank == 0:
+                while not os.path.exists(rank0_log_file):
+                    pass
+
+            logging.add_file_handler(log_file)
+
         if self.log_local_rank_0_only and not nemo_testing and self.local_rank == 0:
-            logging.add_file_handler(log_file)
+            add_handler_after_wait_for_rank0()
         elif self.log_global_rank_0_only and not nemo_testing and self.global_rank == 0:
-            logging.add_file_handler(log_file)
+            add_handler_after_wait_for_rank0()
         elif not (self.log_local_rank_0_only or self.log_global_rank_0_only):
-            logging.add_file_handler(log_file)
+            add_handler_after_wait_for_rank0()
 
         add_handlers_to_mcore_logger()
 

--- a/nemo/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/nemo/lightning/pytorch/callbacks/model_checkpoint.py
@@ -143,7 +143,9 @@ class ModelCheckpoint(PTLModelCheckpoint):
 
         app_state = AppState()
 
-        torch.distributed.broadcast_object_list([app_state.log_dir, app_state.version], src=0)
+        bcast_list = [app_state.log_dir, app_state.version]
+        torch.distributed.broadcast_object_list(bcast_list, src=0)
+        app_state.log_dir, app_state.version = bcast_list
         self._setup_file_logging(app_state.log_dir, app_state)
 
         if self.save_top_k != -1 and app_state.restore:

--- a/nemo/utils/app_state.py
+++ b/nemo/utils/app_state.py
@@ -76,6 +76,8 @@ class AppState(metaclass=Singleton):
         self._version = None
         self._create_checkpoint_callback = None
         self._checkpoint_callback_params = None
+        self._log_global_rank_0_only = None
+        self._log_local_rank_0_only = None
 
         # Save and Restore (.nemo)
         self._tmpdir_name = None
@@ -775,3 +777,19 @@ class AppState(metaclass=Singleton):
     @restore.setter
     def restore(self, restore: bool):
         self._restore = restore
+
+    @property
+    def log_local_rank_0_only(self) -> bool:
+        return self._log_local_rank_0_only
+
+    @log_local_rank_0_only.setter
+    def log_local_rank_0_only(self, log_local_rank_0_only: bool):
+        self._log_local_rank_0_only = log_local_rank_0_only
+
+    @property
+    def log_global_rank_0_only(self) -> bool:
+        return self._log_global_rank_0_only
+
+    @log_global_rank_0_only.setter
+    def log_global_rank_0_only(self, log_global_rank_0_only: bool):
+        self._log_global_rank_0_only = log_global_rank_0_only


### PR DESCRIPTION
# What does this PR do ?

Fix per-rank log file creation timing.

**Collection**: [lightning, NeMo 2.0]

# Changelog 

# Usage
* You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"
**Pre checks**:
- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:
- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.


## Who can review?

Anyone in the community is free to review the PR once the checks have passed. 
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information
* Related to # (issue)
