### PR TITLE
Configure FSDP to keep module params

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -1324,6 +1324,10 @@ class MegatronBaseModel(NLPModel):
             for submodule in frozen_submodule_names:
                 logging.debug(f"Ignoring state {submodule} in FSDP.")
             self.trainer.strategy.kwargs['ignored_states'] = frozen_submodules
+
+            # Transformer Engine expects that module parameters are available, so FSDP should not replace them
+            self.trainer.strategy.kwargs['use_orig_params'] = True
+
             # FSDP requires uniform status of require_grads
             # Diffusion models like SD has frozen parts and needs to be added to 'ignored_states'
             # from sharding for FSDP to work


### PR DESCRIPTION
# What does this PR do ?

This PR aims to fix a bug introduced in Transformer Engine 1.14 when running with FSDP.

Transformer Engine 1.14 changed its LayerNorm and RMSNorm implementation to use a prototype operation-based API (see https://github.com/NVIDIA/TransformerEngine/pull/1033). This is a generic API intended for kernel fusion and its forward pass requires calling [`torch.nn.Module.parameters`](https://pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.parameters) to interface with PyTorch's autograd infrastructure. However, the default behavior of [PyTorch FSDP](https://pytorch.org/docs/stable/fsdp.html) is to remove all module parameters and manage them via `FlatParameter`s. Since TE modules couldn't access their parameters, we got the following error:
```
  File "/opt/NeMo/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py", line 757, in fwd_bwd_step
    losses_reduced_per_micro_batch = fwd_bwd_function(
                                     ^^^^^^^^^^^^^^^^^
  File "/opt/megatron-lm/megatron/core/pipeline_parallel/schedules.py", line 467, in forward_backward_no_pipelining
    backward_step(input_tensor, output_tensor, output_tensor_grad, model_type, config)
  File "/opt/megatron-lm/megatron/core/pipeline_parallel/schedules.py", line 366, in backward_step
    custom_backward(output_tensor[0], output_tensor_grad[0])
  File "/opt/megatron-lm/megatron/core/pipeline_parallel/schedules.py", line 150, in custom_backward
    Variable._execution_engine.run_backward(
  File "/usr/local/lib/python3.12/dist-packages/torch/autograd/function.py", line 307, in apply
    return user_fn(self, *args)
           ^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/torch/autograd/function.py", line 600, in wrapper
    outputs = fn(ctx, *args)
              ^^^^^^^^^^^^^^
  File "/src/transformerengine/transformer_engine/pytorch/ops/fuser.py", line 267, in backward
    raise RuntimeError(
RuntimeError: Expected op 0 to generate 0 param grads, but got 2
```

This PR changes the FSDP configuration with `use_orig_params=True` so that TE modules can still access their parameters.

**Collection**: NLP

# Changelog

- Configure FSDP to keep module params

# Usage

Run GPT, e.g. with the config at https://github.com/NVIDIA/NeMo/blob/main/examples/nlp/language_modeling/conf/megatron_gpt_config.yaml.

Some relevant options:
- Transformer Engine: `model.transformer_engine=True`
- FSDP: `model.fsdp=True`, `fsdp_sharding_strategy=full`

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- https://github.com/NVIDIA/TransformerEngine/pull/1403 unsuccessfully attempted to fix this error
