### PR TITLE
minor fix in model's summary identation during logging

### DIFF
--- a/nemo/lightning/pytorch/callbacks/model_transform.py
+++ b/nemo/lightning/pytorch/callbacks/model_transform.py
@@ -63,6 +63,7 @@ class ModelTransform(pl.Callback):
         self.model_transform: Optional[Callable[[nn.Module], nn.Module]] = None
 
     def setup(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", stage: str) -> None:
+        """ Setups model transform """
         logging.info(f"Setting up ModelTransform for stage: {stage}")
 
         if hasattr(pl_module, 'model_transform'):
@@ -74,16 +75,20 @@ class ModelTransform(pl.Callback):
             logging.info("No model_transform attribute found on pl_module")
 
     def on_train_epoch_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
+        """ event hook """
         self._maybe_apply_transform(trainer)
 
     def on_validation_epoch_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
+        """ event hook """
         self._maybe_apply_transform(trainer)
 
     def _maybe_apply_transform(self, trainer):
+        """ Applies transform if haven't already """
         if self._needs_to_call:
             self.apply_transform(trainer)
 
     def apply_transform(self, trainer):
+        """ Applies a model transform e.g., PeFT """
         self.model_transform(trainer.model)
         from lightning.pytorch.utilities import model_summary
 
@@ -95,6 +100,7 @@ class ModelTransform(pl.Callback):
 
     @property
     def _needs_to_call(self) -> bool:
+        """ boolean var to indicate whether need to run transform based on call counter """
         return self.model_transform and self.model_transform.__num_calls__ == 0
 
 

--- a/nemo/lightning/pytorch/callbacks/model_transform.py
+++ b/nemo/lightning/pytorch/callbacks/model_transform.py
@@ -87,8 +87,10 @@ class ModelTransform(pl.Callback):
         self.model_transform(trainer.model)
         from lightning.pytorch.utilities import model_summary
 
+        summary = str(model_summary.summarize(trainer.lightning_module, max_depth=1))
+        summary = "\n\r".join(summary.split("\n"))
         logging.info(
-            f"After applying model_transform:\n" f"{model_summary.summarize(trainer.lightning_module, max_depth=1)}"
+            f"After applying model_transform:\n\n\r{summary}"
         )
 
     @property

--- a/nemo/lightning/pytorch/callbacks/model_transform.py
+++ b/nemo/lightning/pytorch/callbacks/model_transform.py
@@ -63,7 +63,7 @@ class ModelTransform(pl.Callback):
         self.model_transform: Optional[Callable[[nn.Module], nn.Module]] = None
 
     def setup(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule", stage: str) -> None:
-        """ Setups model transform """
+        """Setups model transform"""
         logging.info(f"Setting up ModelTransform for stage: {stage}")
 
         if hasattr(pl_module, 'model_transform'):
@@ -75,32 +75,30 @@ class ModelTransform(pl.Callback):
             logging.info("No model_transform attribute found on pl_module")
 
     def on_train_epoch_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
-        """ event hook """
+        """event hook"""
         self._maybe_apply_transform(trainer)
 
     def on_validation_epoch_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule") -> None:
-        """ event hook """
+        """event hook"""
         self._maybe_apply_transform(trainer)
 
     def _maybe_apply_transform(self, trainer):
-        """ Applies transform if haven't already """
+        """Applies transform if haven't already"""
         if self._needs_to_call:
             self.apply_transform(trainer)
 
     def apply_transform(self, trainer):
-        """ Applies a model transform e.g., PeFT """
+        """Applies a model transform e.g., PeFT"""
         self.model_transform(trainer.model)
         from lightning.pytorch.utilities import model_summary
 
         summary = str(model_summary.summarize(trainer.lightning_module, max_depth=1))
         summary = "\n\r".join(summary.split("\n"))
-        logging.info(
-            f"After applying model_transform:\n\n\r{summary}"
-        )
+        logging.info(f"After applying model_transform:\n\n\r{summary}")
 
     @property
     def _needs_to_call(self) -> bool:
-        """ boolean var to indicate whether need to run transform based on call counter """
+        """boolean var to indicate whether need to run transform based on call counter"""
         return self.model_transform and self.model_transform.__num_calls__ == 0
 
 


### PR DESCRIPTION
Before:
<img width="688" alt="Screenshot 2025-02-06 at 10 37 49 AM" src="https://github.com/user-attachments/assets/08fd815e-57f7-49d7-a019-f842bc1bf192" />

After:
<img width="688" alt="Screenshot 2025-02-06 at 10 38 11 AM" src="https://github.com/user-attachments/assets/2e571689-fbd0-4505-ae37-df7ea77dde58" />


**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
