### PR TITLE
Avoid rewrapping modules with DDP/FSDP if already wrapped

### DIFF
--- a/nemo/lightning/fabric/plugins.py
+++ b/nemo/lightning/fabric/plugins.py
@@ -146,9 +146,10 @@ class FabricMegatronMixedPrecision(MixedPrecision):
             config = get_model_config(module.module)
             config.fp16 = self.dtype_config.fp16
             config.bf16 = self.dtype_config.bf16
-            if hasattr(module, 'module'):
+            # Avoid rewrapping the module if it's already of type Float16Module
+            if hasattr(module, 'module') and not isinstance(module.module, Float16Module):
                 module.module = Float16Module(config, module.module)
-            else:
+            elif not isinstance(module, Float16Module):
                 module = Float16Module(config, module)
 
         return module

--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -632,6 +632,9 @@ class MegatronParallel(nn.ModuleList, Generic[ModelT]):
             return
 
         from megatron.core import parallel_state
+        from megatron.core.transformer.module import Float16Module
+
+        from nemo.utils.model_utils import unwrap_model
 
         for model_chunk_idx, model_chunk in enumerate(self):
             module = model_chunk.module
@@ -650,7 +653,8 @@ class MegatronParallel(nn.ModuleList, Generic[ModelT]):
 
             with init_ddp_context():
                 # Avoid rewrapping the module if it's already wrapped with FSDP
-                if HAVE_CUSTOM_FSDP and self.ddp_config.use_custom_fsdp and not isinstance(module, FullyShardedDataParallel):
+                unwrapped_module = unwrap_model(module, Float16Module)
+                if HAVE_CUSTOM_FSDP and self.ddp_config.use_custom_fsdp and not isinstance(unwrapped_module, FullyShardedDataParallel):
                     FSDP = FullyShardedDataParallel
                     dist_module = FSDP(
                         module.config,
@@ -658,7 +662,7 @@ class MegatronParallel(nn.ModuleList, Generic[ModelT]):
                         module,
                         disable_bucketing=disable_bucketing,
                     )
-                elif not isinstance(module, DDP):
+                elif not isinstance(unwrapped_module, DDP):
                     dist_module = DDP(
                         module.config,
                         self.ddp_config,

--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -632,9 +632,6 @@ class MegatronParallel(nn.ModuleList, Generic[ModelT]):
             return
 
         from megatron.core import parallel_state
-        from megatron.core.transformer.module import Float16Module
-
-        from nemo.utils.model_utils import unwrap_model
 
         for model_chunk_idx, model_chunk in enumerate(self):
             module = model_chunk.module
@@ -653,8 +650,7 @@ class MegatronParallel(nn.ModuleList, Generic[ModelT]):
 
             with init_ddp_context():
                 # Avoid rewrapping the module if it's already wrapped with FSDP
-                unwrapped_module = unwrap_model(module, Float16Module)
-                if HAVE_CUSTOM_FSDP and self.ddp_config.use_custom_fsdp and not isinstance(unwrapped_module, FullyShardedDataParallel):
+                if HAVE_CUSTOM_FSDP and self.ddp_config.use_custom_fsdp and not isinstance(module, FullyShardedDataParallel):
                     FSDP = FullyShardedDataParallel
                     dist_module = FSDP(
                         module.config,
@@ -662,7 +658,7 @@ class MegatronParallel(nn.ModuleList, Generic[ModelT]):
                         module,
                         disable_bucketing=disable_bucketing,
                     )
-                elif not isinstance(unwrapped_module, DDP):
+                elif not isinstance(module, DDP):
                     dist_module = DDP(
                         module.config,
                         self.ddp_config,


### PR DESCRIPTION
# What does this PR do ?
In case of multiple `trainer.fit` calls for the same LightningModule, it's possible the underlying module was wrapped with DDP/FSDP multiple times. This adds a check to ensure that for such cases, the module is wrapped only once.

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
