### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `26ad9b3...` (2025-02-11)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -1,18 +1,18 @@
 {
-    "ngc-pytorch": "nvcr.io/nvidia/pytorch:24.07-py3",
-    "vcs-dependencies": {
-        "apex": {
-            "repo": "https://github.com/NVIDIA/Apex",
-            "ref": "810ffae374a2b9cb4b5c5e28eaeca7d7998fca0c"
-        },
-        "transformer_engine": {
-            "repo": "https://github.com/NVIDIA/TransformerEngine",
-            "ref": "7d576ed25266a17a7b651f2c12e8498f67e0baea"
-        },
-        "megatron-lm": {
-            "repo": "https://github.com/NVIDIA/Megatron-LM",
-            "ref": "bcee0521dc886545a6af88a4e268715d99e03143"
-        }
+  "ngc-pytorch": "nvcr.io/nvidia/pytorch:24.07-py3",
+  "vcs-dependencies": {
+    "apex": {
+      "repo": "https://github.com/NVIDIA/Apex",
+      "ref": "810ffae374a2b9cb4b5c5e28eaeca7d7998fca0c"
     },
-    "pypi-dependencies": {}
+    "transformer_engine": {
+      "repo": "https://github.com/NVIDIA/TransformerEngine",
+      "ref": "7d576ed25266a17a7b651f2c12e8498f67e0baea"
+    },
+    "megatron-lm": {
+      "repo": "https://github.com/NVIDIA/Megatron-LM",
+      "ref": "26ad9b3f07a2b2137cacecb9bc8a3df8995401eb"
+    }
+  },
+  "pypi-dependencies": {}
 }


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `26ad9b3f07a2b2137cacecb9bc8a3df8995401eb`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.