### PR TITLE
fix: add default kwargs for trtllm model runner

### DIFF
--- a/nemo/export/trt_llm/tensorrt_llm_run.py
+++ b/nemo/export/trt_llm/tensorrt_llm_run.py
@@ -498,17 +498,34 @@ def load_distributed(engine_dir, model_parallel_rank, gpus_per_node):
 
     if not TRTLLM_SUPPORTS_DEVICE_DISABLE:
         raise RuntimeError(
-            "TensorRT-LLM does not support torch device disabling. Please upgrade TensorRT-LLM to make use of this feature."
+            "TensorRT-LLM does not support torch device disabling. "
+            "Please upgrade TensorRT-LLM to make use of this feature."
         )
     elif not DISABLE_TORCH_DEVICE_SET:
         raise RuntimeError(
-            "To use TensorRT-LLM's python ModelRunner API in load_distributed(...) you must set the env var DISABLE_TORCH_DEVICE_SET=1"
+            "To use TensorRT-LLM's python ModelRunner API in load_distributed(...) "
+            "you must set the env var DISABLE_TORCH_DEVICE_SET=1"
         )
+
+    default_kwargs = {
+        "max_output_len": None,
+        "lora_dir": None,
+        "debug_mode": False,
+        "lora_ckpt_source": "hf",
+        "medusa_choices": None,
+        "stream": None,
+        "gpu_weights_percent": 1.0,
+        "enable_context_fmha_fp32_acc": False,
+        "multi_block_mode": True,
+    }
+
     decoder = ModelRunner.from_engine(
         engine=engine,
-        # We want the engine to have the mp_rank, but the python runtime to not resassign the device of the current process
+        # We want the engine to have the mp_rank,
+        # but the python runtime to not resassign the device of the current process
         # So we will set it to the current device
         rank=torch.cuda.current_device(),
+        **default_kwargs,
     )
 
     tensorrt_llm_worker_context.decoder = decoder
@@ -517,6 +534,15 @@ def load_distributed(engine_dir, model_parallel_rank, gpus_per_node):
 
 
 def maybe_cast_to_trt_dtype(dtype):
+    """
+    Cast input dtype to TensorRT dtype if applicable.
+
+    Args:
+        dtype: Input dtype (torch.dtype or trt.DataType)
+
+    Returns:
+        trt.DataType: Corresponding TensorRT dtype
+    """
     if isinstance(dtype, trt.DataType):
         return dtype
     elif isinstance(dtype, torch.dtype):
@@ -526,6 +552,12 @@ def maybe_cast_to_trt_dtype(dtype):
 
 
 def refit(weights_dict: dict):
+    """
+    Refit TensorRT-LLM by hot-swapping its engine weights.
+
+    Args:
+        weights_dict: Dictionary containing new weights
+    """
     global tensorrt_llm_worker_context
     decoder = tensorrt_llm_worker_context.decoder
     if not isinstance(decoder, ModelRunner):
@@ -549,7 +581,12 @@ def refit(weights_dict: dict):
         trt_wt_location = trt.TensorLocation.DEVICE if weight.is_cuda else trt.TensorLocation.HOST
         assert (
             model_dtype == refitter.get_weights_prototype(trt_name).dtype == maybe_cast_to_trt_dtype(weight.dtype)
-        ), f"Expected all three of these dtypes to be the same {model_dtype=} {refitter.get_weights_prototype(trt_name).dtype=} weight.dtype={maybe_cast_to_trt_dtype(weight.dtype)}"
+        ), (
+            f"Expected all three of these dtypes to be the same:\n"
+            f"  {model_dtype=}\n"
+            f"  {refitter.get_weights_prototype(trt_name).dtype=}\n"
+            f"  weight.dtype={maybe_cast_to_trt_dtype(weight.dtype)}"
+        )
 
         refitter.set_named_weights(
             trt_name, trt_weight, trt_wt_location
@@ -590,6 +627,20 @@ def prepare_input_tensors(
     task_vtoken_counts: List[int] = None,
     task_ids: List[int] = None,
 ):
+    """
+    Prepare input tensors from text input.
+
+    Args:
+        input_texts: List of input text strings
+        host_context: Context containing tokenizer and configuration
+        prompt_table: a lookup table containing trained embeddings for vtoken used in p-tuning
+        task_vtoken_counts: Optional list of vtoken counts per task
+        task_ids: Optional list of task IDs
+
+    Returns:
+        dict: Prepared input tensors for model
+    """
+
     tokenizer = host_context.tokenizer
 
     if host_context.add_bos:
@@ -836,7 +887,7 @@ def to_word_list_format(
     flat_ids = []
     offsets = []
     # The encoding of a single word can't always be trusted. See
-    #   https://github.com/NVIDIA/NeMo/blob/bb575b72fd0be51ae10cc77d9f89ddb9e9d3b96d/nemo/collections/nlp/modules/common/text_generation_strategy.py#L229
+    #   https://github.com/NVIDIA/NeMo/blob/bb575b72fd0be51ae10cc77d9f89ddb9e9d3b96d/nemo/collections/nlp/modules/common/text_generation_strategy.py#L229  # pylint: disable=C0301
     ids_ref = tokenizer.encode(ref_str)
     for word_dict_item in word_dict:
         item_flat_ids = []


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

The following nemo aligner ppo test failure is blocking Nemo 25.02 container release.
```
[rank1]: Traceback (most recent call last):
[rank1]:   File "/opt/NeMo-Aligner/examples/nlp/gpt/train_gpt_ppo_actor.py", line 198, in <module>
[rank1]:     main()
[rank1]:   File "/opt/NeMo/nemo/core/config/hydra_runner.py", line 129, in wrapper
[rank1]:     _run_hydra(
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/hydra/_internal/utils.py", line 394, in _run_hydra
[rank1]:     _run_app(
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/hydra/_internal/utils.py", line 457, in _run_app
[rank1]:     run_and_report(
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/hydra/_internal/utils.py", line 223, in run_and_report
[rank1]:     raise ex
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/hydra/_internal/utils.py", line 220, in run_and_report
[rank1]:     return func()
[rank1]:            ^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/hydra/_internal/utils.py", line 458, in <lambda>
[rank1]:     lambda: hydra.run(
[rank1]:             ^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/hydra/_internal/hydra.py", line 132, in run
[rank1]:     _ = ret.return_value
[rank1]:         ^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/hydra/core/utils.py", line 260, in return_value
[rank1]:     raise self._return_value
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/hydra/core/utils.py", line 186, in run_job
[rank1]:     ret.return_value = task_function(task_cfg)
[rank1]:                        ^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/opt/NeMo-Aligner/examples/nlp/gpt/train_gpt_ppo_actor.py", line 185, in main
[rank1]:     ppo_trainer.fit()
[rank1]:   File "/opt/NeMo-Aligner/nemo_aligner/algorithms/ppo.py", line 498, in fit
[rank1]:     ppo_rollout_data, metrics, rollout_timer_metrics = self.generate_rollouts()
[rank1]:                                                        ^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/utils/_contextlib.py", line 116, in decorate_context
[rank1]:     return func(*args, **kwargs)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/opt/NeMo-Aligner/nemo_aligner/algorithms/ppo.py", line 409, in generate_rollouts
[rank1]:     self.model.prepare_for_inference()
[rank1]:   File "/opt/NeMo-Aligner/nemo_aligner/models/nlp/gpt/megatron_gpt_ppo_actor.py", line 301, in prepare_for_inference
[rank1]:     self.trtllm_generate.refit(self.model)
[rank1]:   File "/opt/NeMo-Aligner/nemo_aligner/utils/trt_llm.py", line 159, in refit
[rank1]:     self.trt_llm_exporter.build(
[rank1]:   File "/opt/NeMo/nemo/export/tensorrt_llm.py", line 924, in build
[rank1]:     load_distributed(self.model_dir, self.mp_rank, gpus_per_node)
[rank1]:   File "/opt/NeMo/nemo/export/trt_llm/tensorrt_llm_run.py", line 507, in load_distributed
[rank1]:     decoder = ModelRunner.from_engine(
[rank1]:               ^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]: TypeError: ModelRunner.from_engine() missing 9 required keyword-only arguments: 'max_output_len', 'lora_dir', 'debug_mode', 'lora_ckpt_source', 'medusa_choices', 'stream', 'gpu_weights_percent', 'enable_context_fmha_fp32_acc', and 'multi_block_mode'
```

This MR is to resolve the args missing issue by assigning defaults of [`ModelRunner`](https://github.com/NVIDIA/TensorRT-LLM/blob/16d2467ea8e3b45d7d9555010c2ad018d006d5c1/tensorrt_llm/runtime/model_runner.py#L559). The defaults values are the same as that in [`from_dir`](https://github.com/NVIDIA/TensorRT-LLM/blob/16d2467ea8e3b45d7d9555010c2ad018d006d5c1/tensorrt_llm/runtime/model_runner.py#L635)

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [X] Did you add or update any necessary documentation?
- [X] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [X] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?
@terrykong 

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.
