### PR TITLE
fix[export]: reshard model correctly handles extra_state when it's a tensor

### DIFF
--- a/nemo/export/tensorrt_llm.py
+++ b/nemo/export/tensorrt_llm.py
@@ -687,7 +687,8 @@ class TensorRTLLM(ITritonDeployable):
         if vp_size > 1:  # consolidate params across model chunks
             for idx, model_chunk in enumerate(model):
                 for key, val in model_chunk.state_dict().items():
-                    if torch.is_tensor(val):
+                    # TODO: currently fp8 is not supported
+                    if torch.is_tensor(val) and '_extra_state' not in key:
                         if 'layers' in key:
                             key2 = rename_layer_num(key, get_layer_num(key) + idx * pp_size * layers_per_chunk)
                             tl_params[key2] = val
@@ -695,7 +696,8 @@ class TensorRTLLM(ITritonDeployable):
                             model_level_params[key] = val
         else:
             for key, val in model.state_dict().items():
-                if torch.is_tensor(val):
+                # TODO: currently fp8 is not supported
+                if torch.is_tensor(val) and '_extra_state' not in key:
                     if 'decoder.layers' in key:
                         tl_params[key] = val
                     else:

--- a/nemo/export/trt_llm/tensorrt_llm_run.py
+++ b/nemo/export/trt_llm/tensorrt_llm_run.py
@@ -550,7 +550,6 @@ def maybe_cast_to_trt_dtype(dtype):
     else:
         raise NotImplementedError(f"Expects the type to be a tensorrt.DataType or torch.dtype, but got {type(dtype)=}")
 
-
 def refit(weights_dict: dict):
     """
     Refit TensorRT-LLM by hot-swapping its engine weights.
@@ -601,7 +600,6 @@ def refit(weights_dict: dict):
 
     if not refitter.refit_cuda_engine():
         raise ValueError("Refit failed!")
-
 
 def unload_engine():
     """

--- a/nemo/export/trt_llm/tensorrt_llm_run.py
+++ b/nemo/export/trt_llm/tensorrt_llm_run.py
@@ -550,6 +550,7 @@ def maybe_cast_to_trt_dtype(dtype):
     else:
         raise NotImplementedError(f"Expects the type to be a tensorrt.DataType or torch.dtype, but got {type(dtype)=}")
 
+
 def refit(weights_dict: dict):
     """
     Refit TensorRT-LLM by hot-swapping its engine weights.
@@ -600,6 +601,7 @@ def refit(weights_dict: dict):
 
     if not refitter.refit_cuda_engine():
         raise ValueError("Refit failed!")
+
 
 def unload_engine():
     """


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

After this TE PR https://github.com/NVIDIA/TransformerEngine/pull/1335, we now need to check whether the FP8 metadata is a tensor or not b/c it's stored on the CPU and can't be broadcasted w/ the mcore pp nccl group. 

We haven't tested FP8 generation in Aligner, so for now we just ignore the extra_state as was the status quo before TE made this change. Left a comment to document that FP8 is not supported.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
