### PR TITLE
Fix has_global_batch_sampler to handle datamodules without data_sampler attribute

### DIFF
--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -1408,7 +1408,7 @@ class MegatronStep(Generic[ModelT, DataT]):
         # FIXME: cleanup the following code is here for backwards compatibility with nemo1.
         # The "batch" sampler is a nemo1 sampler. It requires some custom code here to use
         # (if use_global_batch_sampler), by default we shouldn't use this "batch" sampler probably.
-        if getattr(self.trainer, "datamodule", None) is not None:
+        if getattr(self.trainer, "datamodule", None) is not None and hasattr(self.trainer.datamodule, "data_sampler"):
             use_global_batch_sampler = self.trainer.datamodule.data_sampler.dataloader_type == 'batch'
         elif getattr(self.trainer, "predict_dataloaders", None) is not None:
             from nemo.collections.nlp.data.language_modeling.megatron.megatron_batch_samplers import (  # noqa: I001


### PR DESCRIPTION
has_global_batch_sampler now accounts for scenario where there is datamodule present but not data_sampler. 

> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
