### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `55cdfc1...` (2025-02-12)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "26ad9b3f07a2b2137cacecb9bc8a3df8995401eb"
+      "ref": "55cdfc1e8bfe116f54dbe6e48ff70cc92c9f4a91"
     }
   },
   "pypi-dependencies": {}


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `55cdfc1e8bfe116f54dbe6e48ff70cc92c9f4a91`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.