### PR TITLE
Update TTS code to remove calls to deprecated functions

### DIFF
--- a/nemo/collections/tts/data/dataset.py
+++ b/nemo/collections/tts/data/dataset.py
@@ -190,10 +190,10 @@ class TTSDataset(Dataset):
             self.phoneme_probability = getattr(self.text_tokenizer, "phoneme_probability", None)
         else:
             if text_tokenizer_pad_id is None:
-                raise ValueError(f"text_tokenizer_pad_id must be specified if text_tokenizer is not BaseTokenizer")
+                raise ValueError("text_tokenizer_pad_id must be specified if text_tokenizer is not BaseTokenizer")
 
             if tokens is None:
-                raise ValueError(f"tokens must be specified if text_tokenizer is not BaseTokenizer")
+                raise ValueError("tokens must be specified if text_tokenizer is not BaseTokenizer")
 
             self.text_tokenizer_pad_id = text_tokenizer_pad_id
         self.cache_text = True if self.phoneme_probability is None else False
@@ -679,7 +679,7 @@ class TTSDataset(Dataset):
                     sample_pitch_mean = pitch_stats["pitch_mean"]
                     sample_pitch_std = pitch_stats["pitch_std"]
                 else:
-                    raise ValueError(f"Missing statistics for pitch normalization.")
+                    raise ValueError("Missing statistics for pitch normalization.")
 
                 pitch -= sample_pitch_mean
                 pitch[pitch == -sample_pitch_mean] = 0.0  # Zero out values that were previously zero

--- a/nemo/collections/tts/data/dataset.py
+++ b/nemo/collections/tts/data/dataset.py
@@ -496,7 +496,7 @@ class TTSDataset(Dataset):
                 speaker_to_index_map[d["speaker_id"]].add(i)
             # Random sample a reference audio from the same speaker
             self.get_reference_for_sample = lambda sample: self.data[
-                random.sample(speaker_to_index_map[sample["speaker_id"]], 1)[0]
+                random.choice(speaker_to_index_map[tuple(sample["speaker_id"])])
             ]
         elif reference_audio_type == "ground-truth":
             # Use ground truth audio as reference audio

--- a/nemo/collections/tts/parts/utils/helpers.py
+++ b/nemo/collections/tts/parts/utils/helpers.py
@@ -799,6 +799,11 @@ def clip_grad_value_(parameters, clip_value, norm_type=2):
     return total_norm
 
 
+def convert_pad_shape(pad_shape):
+    pad_shape = [item for sublist in pad_shape[::-1] for item in sublist]
+    return pad_shape
+
+
 def generate_path(duration, mask):
     """
     duration: [b, 1, t_x]
@@ -811,9 +816,7 @@ def generate_path(duration, mask):
     path = get_mask_from_lengths(cum_duration_flat, torch.Tensor(t_y).reshape(1, 1, -1)).to(mask.dtype)
     path = path.view(b, t_x, t_y)
     pad_shape = [[0, 0], [1, 0], [0, 0]]
-    pad_shape = [item for sublist in pad_shape[::-1] for item in sublist]
-    path = path - torch.nn.functional.pad(path, pad_shape)[:, :-1]
-    path = path.unsqueeze(1).transpose(2, 3) * mask
+    path = path - torch.nn.functional.pad(path, convert_pad_shape([[0, 0], [1, 0], [0, 0]]))[:, :-1]
     return path
 
 

--- a/nemo/collections/tts/parts/utils/helpers.py
+++ b/nemo/collections/tts/parts/utils/helpers.py
@@ -815,8 +815,8 @@ def generate_path(duration, mask):
     cum_duration_flat = cum_duration.view(b * t_x)
     path = get_mask_from_lengths(cum_duration_flat, torch.Tensor(t_y).reshape(1, 1, -1)).to(mask.dtype)
     path = path.view(b, t_x, t_y)
-    pad_shape = [[0, 0], [1, 0], [0, 0]]
-    path = path - torch.nn.functional.pad(path, convert_pad_shape([[0, 0], [1, 0], [0, 0]]))[:, :-1]
+    path = path - torch.nn.functional.pad(path, convert_pad_shape(pad_shape))[:, :-1]
+    path = path.unsqueeze(1).transpose(2, 3) * mask
     return path
 
 

--- a/nemo/collections/tts/parts/utils/helpers.py
+++ b/nemo/collections/tts/parts/utils/helpers.py
@@ -42,6 +42,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import io
 from enum import Enum
 from typing import Optional, Tuple
 
@@ -632,10 +633,15 @@ def plot_gate_outputs_to_numpy(gate_targets, gate_outputs):
 
 
 def save_figure_to_numpy(fig):
+    # buf = io.BytesIO()
+    # plt.savefig(buf, format='png')
+    # plt.close(figure)
+    # buf.seek(0)
     # save it to a numpy array.
-    data = np.fromstring(fig.canvas.tostring_rgb(), dtype=np.uint8, sep='')
-    data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
-    return data
+    # data = np.fromstring(fig.canvas.buffer_rgba(), dtype=np.uint8, sep='')
+    # data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
+    img_array = np.array(fig.canvas.renderer.buffer_rgba())
+    return img_array
 
 
 @rank_zero_only

--- a/nemo/collections/tts/parts/utils/helpers.py
+++ b/nemo/collections/tts/parts/utils/helpers.py
@@ -815,7 +815,7 @@ def generate_path(duration, mask):
     cum_duration_flat = cum_duration.view(b * t_x)
     path = get_mask_from_lengths(cum_duration_flat, torch.Tensor(t_y).reshape(1, 1, -1)).to(mask.dtype)
     path = path.view(b, t_x, t_y)
-    path = path - torch.nn.functional.pad(path, convert_pad_shape(pad_shape))[:, :-1]
+    path = path - torch.nn.functional.pad(path, convert_pad_shape([[0, 0], [1, 0], [0, 0]]))[:, :-1]
     path = path.unsqueeze(1).transpose(2, 3) * mask
     return path
 

--- a/nemo/collections/tts/parts/utils/helpers.py
+++ b/nemo/collections/tts/parts/utils/helpers.py
@@ -42,7 +42,6 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-import io
 from enum import Enum
 from typing import Optional, Tuple
 
@@ -633,13 +632,6 @@ def plot_gate_outputs_to_numpy(gate_targets, gate_outputs):
 
 
 def save_figure_to_numpy(fig):
-    # buf = io.BytesIO()
-    # plt.savefig(buf, format='png')
-    # plt.close(figure)
-    # buf.seek(0)
-    # save it to a numpy array.
-    # data = np.fromstring(fig.canvas.buffer_rgba(), dtype=np.uint8, sep='')
-    # data = data.reshape(fig.canvas.get_width_height()[::-1] + (3,))
     img_array = np.array(fig.canvas.renderer.buffer_rgba())
     return img_array
 

--- a/nemo/collections/tts/parts/utils/helpers.py
+++ b/nemo/collections/tts/parts/utils/helpers.py
@@ -799,12 +799,6 @@ def clip_grad_value_(parameters, clip_value, norm_type=2):
     return total_norm
 
 
-def convert_pad_shape(pad_shape):
-    l = pad_shape[::-1]
-    pad_shape = [item for sublist in l for item in sublist]
-    return pad_shape
-
-
 def generate_path(duration, mask):
     """
     duration: [b, 1, t_x]
@@ -816,7 +810,9 @@ def generate_path(duration, mask):
     cum_duration_flat = cum_duration.view(b * t_x)
     path = get_mask_from_lengths(cum_duration_flat, torch.Tensor(t_y).reshape(1, 1, -1)).to(mask.dtype)
     path = path.view(b, t_x, t_y)
-    path = path - torch.nn.functional.pad(path, convert_pad_shape([[0, 0], [1, 0], [0, 0]]))[:, :-1]
+    pad_shape = [[0, 0], [1, 0], [0, 0]]
+    pad_shape = [item for sublist in pad_shape[::-1] for item in sublist]
+    path = path - torch.nn.functional.pad(path, pad_shape)[:, :-1]
     path = path.unsqueeze(1).transpose(2, 3) * mask
     return path
 


### PR DESCRIPTION
# What does this PR do ?

Fixes 25.02 bugs

**Collection**: tts

# Changelog

- Removes calls in tts collection to deprecated tostring_rgb; updates call to random.sample as it no longer supports dicts

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.