### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `78fc935...` (2025-02-14)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "55cdfc1e8bfe116f54dbe6e48ff70cc92c9f4a91"
+      "ref": "78fc935d0e70ff7846fe658b596a32a7bff2f92c"
     }
   },
   "pypi-dependencies": {}


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `78fc935d0e70ff7846fe658b596a32a7bff2f92c`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.