### PR TITLE
Fix: 'IterableDatasetWrapper' has no len() when using Lhotse datasets

### DIFF
--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -414,8 +414,8 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
             # If it's an int, we assume that the user has set it to something sane, i.e. <= # training batches,
             # and don't change it. Otherwise, adjust batches accordingly if it's a float (including 1.0).
             if (
-                self._trainer is not None 
-                and isinstance(self._trainer.limit_train_batches, float) 
+                self._trainer is not None
+                and isinstance(self._trainer.limit_train_batches, float)
                 and not isinstance(self._train_dl.dataset.dataset, LhotseSpeechToTextBpeDataset)
             ):
                 self._trainer.limit_train_batches = int(
@@ -423,8 +423,8 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
                     * ceil((len(self._train_dl.dataset) / self.world_size) / train_data_config['batch_size'])
                 )
             elif (
-                self._trainer is not None 
-                and isinstance(self._trainer.limit_train_batches, float) 
+                self._trainer is not None
+                and isinstance(self._trainer.limit_train_batches, float)
                 and isinstance(self._train_dl.dataset.dataset, LhotseSpeechToTextBpeDataset)
             ):
                 logging.warning(f"Lhotse dataset don't have length attribute, limit_train_batches is ignored.")

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -416,7 +416,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
             if (
                 self._trainer is not None
                 and isinstance(self._trainer.limit_train_batches, float)
-                and not isinstance(self._train_dl.dataset.dataset, LhotseSpeechToTextBpeDataset)
+                and (not hasattr(self._train_dl.dataset, 'dataset') or not isinstance(self._train_dl.dataset.dataset, LhotseSpeechToTextBpeDataset))
             ):
                 self._trainer.limit_train_batches = int(
                     self._trainer.limit_train_batches
@@ -425,7 +425,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
             elif (
                 self._trainer is not None
                 and isinstance(self._trainer.limit_train_batches, float)
-                and isinstance(self._train_dl.dataset.dataset, LhotseSpeechToTextBpeDataset)
+                and (hasattr(self._train_dl.dataset, 'dataset') and isinstance(self._train_dl.dataset.dataset, LhotseSpeechToTextBpeDataset))
             ):
                 logging.warning(f"Lhotse dataset don't have length attribute, limit_train_batches is ignored.")
             elif self._trainer is None:

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -416,18 +416,17 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
             if (
                 self._trainer is not None
                 and isinstance(self._trainer.limit_train_batches, float)
-                and (not hasattr(self._train_dl.dataset, 'dataset') or not isinstance(self._train_dl.dataset.dataset, LhotseSpeechToTextBpeDataset))
+                and (hasattr(self._train_dl.dataset, 'dataset') and isinstance(self._train_dl.dataset.dataset, LhotseSpeechToTextBpeDataset))
+            ):
+                logging.warning(f"Lhotse dataset don't have length attribute, limit_train_batches is ignored.")
+            elif (
+                self._trainer is not None
+                and isinstance(self._trainer.limit_train_batches, float)
             ):
                 self._trainer.limit_train_batches = int(
                     self._trainer.limit_train_batches
                     * ceil((len(self._train_dl.dataset) / self.world_size) / train_data_config['batch_size'])
                 )
-            elif (
-                self._trainer is not None
-                and isinstance(self._trainer.limit_train_batches, float)
-                and (hasattr(self._train_dl.dataset, 'dataset') and isinstance(self._train_dl.dataset.dataset, LhotseSpeechToTextBpeDataset))
-            ):
-                logging.warning(f"Lhotse dataset don't have length attribute, limit_train_batches is ignored.")
             elif self._trainer is None:
                 logging.warning(
                     "Model Trainer was not set before constructing the dataset, incorrect number of "

--- a/nemo/collections/asr/models/ctc_models.py
+++ b/nemo/collections/asr/models/ctc_models.py
@@ -418,7 +418,7 @@ class EncDecCTCModel(ASRModel, ExportableEncDecModel, ASRModuleMixin, InterCTCMi
                 and isinstance(self._trainer.limit_train_batches, float)
                 and (hasattr(self._train_dl.dataset, 'dataset') and isinstance(self._train_dl.dataset.dataset, LhotseSpeechToTextBpeDataset))
             ):
-                logging.warning(f"Lhotse dataset don't have length attribute, limit_train_batches is ignored.")
+                logging.warning("Lhotse dataset don't have length attribute, limit_train_batches is ignored.")
             elif (
                 self._trainer is not None
                 and isinstance(self._trainer.limit_train_batches, float)

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -574,7 +574,16 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
             # We also need to check if limit_train_batches is already set.
             # If it's an int, we assume that the user has set it to something sane, i.e. <= # training batches,
             # and don't change it. Otherwise, adjust batches accordingly if it's a float (including 1.0).
-            if self._trainer is not None and isinstance(self._trainer.limit_train_batches, float):
+            if (
+                self._trainer is not None
+                and isinstance(self._trainer.limit_train_batches, float)
+                and (hasattr(self._train_dl.dataset, 'dataset') and isinstance(self._train_dl.dataset.dataset, LhotseSpeechToTextBpeDataset))
+            ):
+                logging.warning(f"Lhotse dataset don't have length attribute, limit_train_batches is ignored.")
+            elif (
+                self._trainer is not None
+                and isinstance(self._trainer.limit_train_batches, float)
+            ):
                 self._trainer.limit_train_batches = int(
                     self._trainer.limit_train_batches
                     * ceil((len(self._train_dl.dataset) / self.world_size) / train_data_config['batch_size'])

--- a/nemo/collections/asr/models/rnnt_models.py
+++ b/nemo/collections/asr/models/rnnt_models.py
@@ -579,7 +579,7 @@ class EncDecRNNTModel(ASRModel, ASRModuleMixin, ExportableEncDecModel, ASRTransc
                 and isinstance(self._trainer.limit_train_batches, float)
                 and (hasattr(self._train_dl.dataset, 'dataset') and isinstance(self._train_dl.dataset.dataset, LhotseSpeechToTextBpeDataset))
             ):
-                logging.warning(f"Lhotse dataset don't have length attribute, limit_train_batches is ignored.")
+                logging.warning("Lhotse dataset don't have length attribute, limit_train_batches is ignored.")
             elif (
                 self._trainer is not None
                 and isinstance(self._trainer.limit_train_batches, float)


### PR DESCRIPTION
# What does this PR do ?

This PR fixes the error #12093. As said in the doc, lhotse datasets don't have a length associated, so it is impossible to set `_trainer.limit_train_batches`. Instead of throwing an error it will just show a warning saying that `_trainer.limit_train_batches` is not compatible with lhotse datasets

**Collection**:  ASR

# Changelog

- Fix bug with Lhotse datasets and ctc models

# Usage

```yaml
init_from_nemo_model: ".cache/huggingface/hub/models--nvidia--parakeet-ctc-0.6b/snapshots/16ca39445465932bfbaeb5126933d5ce8bd43a77/parakeet-ctc-0.6b.nemo" # path to nemo model
model:
  sample_rate: 16000
  compute_eval_loss: true
  log_prediction: false     # enables logging sample predictions in the output during training
  ctc_reduction: 'mean_volume'
  skip_nan_grad: false
  seed: 42
  train_ds:
    sample_rate: ${model.sample_rate}
    batch_size: 1 # must be 1 if using bucketing_batch_size
    shuffle: true
    pin_memory: true
    max_duration: 30.1
    min_duration: 0.1
    shuffle_n: 2048
    num_workers: 8
    manifest_filepath:
    manifest_filepath: tarred_datasets/sharded_manifests/manifest__OP_0..95_CL_.json
    tarred_audio_filepaths: tarred_datasets/audio__OP_0..95_CL_.tar
    use_lhotse: true
    batch_duration: 1100
    quadratic_duration: 30
    num_buckets: 30
    num_cuts_for_bins_estimate: 10000
    bucket_buffer_size: 10000
    shuffle_buffer_size: 10000
    use_bucketing: true
````

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to #12093