### PR TITLE
Patch Mcore load_state_dict at runtime for TE 1.14

### DIFF
--- a/nemo/core/optim/mcore_optim.py
+++ b/nemo/core/optim/mcore_optim.py
@@ -40,7 +40,7 @@ except (ImportError, ModuleNotFoundError):
 
 def load_state_dict(self, state_dict):
     """This is a patch to use FusedAdam.load_state_dict from TE 2.0
-    
+
     There is an issue when state dict value is None in TE 1.14.
     """
     super().load_state_dict(state_dict)
@@ -60,11 +60,7 @@ def load_state_dict(self, state_dict):
             for name in v:
                 if v[name] is None:
                     continue
-                if (
-                    self.store_param_remainders
-                    and name == "master_param"
-                    and param.dtype == torch.bfloat16
-                ):
+                if self.store_param_remainders and name == "master_param" and param.dtype == torch.bfloat16:
                     self.set_scaled_state(param, name, v[name])
                     assert v[name].dtype == torch.int16
                 else:


### PR DESCRIPTION
# What does this PR do ?

Attempt to patch the load_state_dict method for Mcore optimizer for TE 1.14 to address a bug where state values may be None.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Patch Mcore load_state_dict at runtime for TE 1.14

# Usage

n/a

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
