### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `d6985c4...` (2025-02-15)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "55cdfc1e8bfe116f54dbe6e48ff70cc92c9f4a91"
+      "ref": "d6985c42932534db198e222e2e37cce74661f545"
     }
   },
   "pypi-dependencies": {}


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `d6985c42932534db198e222e2e37cce74661f545`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.