### PR TITLE
Add fixes so far for update to Pytorch 25.01 container

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -3677,7 +3677,6 @@ jobs:
       SCRIPT: |
         python examples/nlp/language_modeling/megatron_t5_eval.py \
             --model_file /home/TestData/nlp/megatron_t5/220m/megatron_mcore_t5_220m_padding_attnmasktype.nemo \
-            ++model.dist_ckpt_load_strictness=log_all \
             --prompt "How do I fix my GPU memory issue? I am seeing <mask> out of memory." \
             --tensor_model_parallel_size 1
 

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -3767,7 +3767,7 @@ jobs:
     uses: ./.github/workflows/_test_template.yml
     if: contains(fromJSON(needs.pre-flight.outputs.test_to_run), 'L2_VLM_HF_Transformer_SFT_FSDP2')
     with:
-      RUNNER: self-hosted-azure-gpus
+      RUNNER: self-hosted-azure-gpus-1
       SCRIPT: |
         TRANSFORMERS_OFFLINE=1 python tests/collections/vlm/hf/sft_fsdp2.py --model /home/TestData/vlm/qwen2-2b/ --max-steps 3
       AFTER_SCRIPT: |

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -45,6 +45,19 @@ apt-get install -y bc libsox-fmt-all -y
 apt-get clean
 EOF
 
+ARG MAX_JOBS
+ARG TE_TAG
+ARG TE_REPO
+RUN --mount=type=bind,from=nemo-bump,source=/opt/NeMo/reinstall.sh,target=/opt/NeMo/reinstall.sh \
+  bash /opt/NeMo/reinstall.sh --library te --mode build && \
+  ls -al /opt/TransformerEngine || true
+
+ARG APEX_REPO
+ARG APEX_TAG
+RUN --mount=type=bind,from=nemo-bump,source=/opt/NeMo/reinstall.sh,target=/opt/NeMo/reinstall.sh \
+  bash /opt/NeMo/reinstall.sh --library apex --mode build && \
+  ls -al /opt/Apex || true
+
 ARG MLM_REPO
 ARG MLM_TAG
 RUN --mount=type=bind,from=nemo-bump,source=/opt/NeMo/reinstall.sh,target=/opt/NeMo/reinstall.sh \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -74,8 +74,7 @@ RUN \
   --mount=type=bind,from=nemo-bump,source=/opt/NeMo/nemo/package_info.py,target=/tmp/NeMo/nemo/package_info.py \
   --mount=type=bind,from=nemo-bump,source=/opt/NeMo/nemo/__init__.py,target=/tmp/NeMo/nemo/__init__.py <<"EOF" bash -ex
     export NEMO_DIR=/tmp/NeMo 
-    bash /tmp/NeMo/reinstall.sh --library mcore --mode install
-    bash /tmp/NeMo/reinstall.sh --library nemo --mode install
+    bash /tmp/NeMo/reinstall.sh --library all --mode install
     rm -rf $NEMO_DIR || true
 EOF
 
@@ -84,8 +83,7 @@ ARG NEMO_REPO
 ARG NEMO_TAG
 RUN \
   --mount=type=bind,from=nemo-bump,source=/opt/NeMo/reinstall.sh,target=/tmp/reinstall.sh <<"EOF" bash -ex
-  bash /tmp/reinstall.sh --library mcore --mode install
-  bash /tmp/reinstall.sh --library nemo --mode install
+    bash /tmp/reinstall.sh --library all --mode install
 
     # Copy into workspace
     cp -a /opt/NeMo/. /workspace/

--- a/reinstall.sh
+++ b/reinstall.sh
@@ -16,7 +16,7 @@ CURR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 WHEELS_DIR=${WHEELS_DIR:-'/tmp/wheels'}
 
 PIP=pip
-${PIP} install -U ${PIP} setuptools
+${PIP} install -U ${PIP}
 
 mcore() {
   local mode="$1"
@@ -125,14 +125,14 @@ nemo() {
 
   ${PIP} install --no-cache-dir virtualenv &&
     virtualenv /opt/venv &&
-    /opt/venv/bin/pip install --no-cache-dir setuptools &&
     /opt/venv/bin/pip install --no-cache-dir --no-build-isolation \
       -r $NEMO_DIR/requirements/requirements_vllm.txt \
       -r $NEMO_DIR/requirements/requirements_deploy.txt
 
   DEPS=(
     "nvidia-modelopt[torch]~=0.21.0; sys_platform == 'linux'"
-    "nemo_run@git+https://github.com/NVIDIA/NeMo-Run.git@f07f44688e42e5500bf28ff83dd3e0f4bead0c8d"
+    "nemo_run@git+https://github.com/NVIDIA/NeMo-Run.git@34259bd3e752fef94045a9a019e4aaf62bd11ce2"
+    "git+https://github.com/NVIDIA/nvidia-resiliency-ext.git@97aad77609d2e25ed38ac5c99f0c13f93c48464e"
     "onnxscript @ git+https://github.com/microsoft/onnxscript"
     "llama-index==0.10.43"
     "unstructured==0.14.9"
@@ -142,10 +142,6 @@ nemo() {
   echo 'Installing dependencies of nemo'
   ${PIP} install --no-cache-dir --extra-index-url https://pypi.nvidia.com "${DEPS[@]}"
 
-  # nvidia-resiliency is installeed with mcore but force-install a newer version for needed fixes
-  RESIL="git+https://github.com/NVIDIA/nvidia-resiliency-ext.git@b6eb61dbf9fe272b1a943b1b0d9efdde99df0737"
-  ${PIP} install --force-reinstall --no-deps --no-cache-dir --extra-index-url https://pypi.nvidia.com $RESIL
-
   echo 'Installing nemo itself'
   pip install --no-cache-dir --no-build-isolation $NEMO_DIR/.[all]
 }
@@ -153,8 +149,6 @@ nemo() {
 echo 'Uninstalling stuff'
 # Some of these packages are uninstalled for legacy purposes
 ${PIP} uninstall -y nemo_toolkit sacrebleu nemo_asr nemo_nlp nemo_tts
-
-${PIP} install setuptools
 
 if [ -n "${NVIDIA_PYTORCH_VERSION}" ]; then
   echo "Installing NeMo in NVIDIA PyTorch container: ${NVIDIA_PYTORCH_VERSION}"

--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -1,5 +1,5 @@
 {
-    "ngc-pytorch": "nvcr.io/nvidia/pytorch:25.01-py3",
+    "ngc-pytorch": "nvcr.io/nvidia/pytorch:24.07-py3",
     "vcs-dependencies": {
         "apex": {
             "repo": "https://github.com/NVIDIA/Apex",

--- a/scripts/llm/gpt_distillation.py
+++ b/scripts/llm/gpt_distillation.py
@@ -153,7 +153,7 @@ if __name__ == "__main__":
 
     # Load ckpt saved with TE < 1.14
     if args.legacy_ckpt:
-        trainer.strategy.ckpt_load_strictness = False
+        trainer.strategy.ckpt_load_strictness = "log_all"
 
     # Run
     llm.train(


### PR DESCRIPTION
# What does this PR do ?

* Add fixes so far for update to Pytorch 25.01 container
* Excludes the actual bump of the Pytorch container and the removal of the TE install in the Dockerfile
* Excludes an attempted fix on `L2_Megatron_Core_T5_Eval` because it also breaks current tests

Probably best to get these in as long as they don't break current tests so we can cherry-pick to the release branch.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add fixes so far for update to Pytorch 25.01 container

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
