### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `9a496c9...` (2025-02-17)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "55cdfc1e8bfe116f54dbe6e48ff70cc92c9f4a91"
+      "ref": "9a496c976e12a62ce8e39e14496e52a985588730"
     }
   },
   "pypi-dependencies": {}


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `9a496c976e12a62ce8e39e14496e52a985588730`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.