### PR TITLE
fix speechlm import ckpt on slurm

### DIFF
--- a/nemo/collections/speechlm/models/speech_to_text_llm_model.py
+++ b/nemo/collections/speechlm/models/speech_to_text_llm_model.py
@@ -222,9 +222,26 @@ class SpeechToTextLLMConfig(TransformerConfig, io.IOMixin):
         logging.info(f"Restored language model weights from {self.language_model_from_pretrained}")
         return model
 
+    def _propagate_model_configs(self) -> TransformerConfig:
+        """
+        propagate key attributes to the language/speech model config
+        """
+        # LLM
+        self.language_model_config.tensor_model_parallel_size = self.tensor_model_parallel_size
+        self.language_model_config.sequence_parallel = self.sequence_parallel
+        self.language_model_config.pipeline_model_parallel_size = self.pipeline_model_parallel_size
+        self.language_model_config.context_parallel_size = self.context_parallel_size
+
+        # ASR
+        self.speech_model_config.tensor_model_parallel_size = self.tensor_model_parallel_size
+        self.speech_model_config.sequence_parallel = self.sequence_parallel
+        self.speech_model_config.pipeline_model_parallel_size = self.pipeline_model_parallel_size
+        self.speech_model_config.context_parallel_size = self.context_parallel_size
+
     def configure_model(
         self, tokenizer: TokenizerSpec, speech_model: Optional[ASRModel] = None
     ) -> "MCoreSpeechToTextLLM":
+        self._propagate_model_configs()
         language_model = self.language_model_config.configure_model(tokenizer=tokenizer)  # type: "MCoreGPTModel"
         language_model = self._maybe_load_pretrained_llm(language_model)
 

--- a/nemo/collections/speechlm/models/speech_to_text_llm_model.py
+++ b/nemo/collections/speechlm/models/speech_to_text_llm_model.py
@@ -55,6 +55,7 @@ from nemo.collections.nlp.parts.utils_funcs import get_last_rank
 from nemo.collections.speechlm.models.base import SpeechLanguageModel
 from nemo.collections.speechlm.modules.asr_module import ASRModuleConfig
 from nemo.collections.speechlm.modules.modality_adapter import ModalityAdapterConfig
+from nemo.collections.speechlm.utils.io import import_ckpt
 from nemo.collections.speechlm.utils.text_generation.audio_text_generation_strategy import (
     SpeechToTextGenerationStrategy,
 )
@@ -206,8 +207,8 @@ class SpeechToTextLLMConfig(TransformerConfig, io.IOMixin):
         time.sleep(rank / 2)
 
         llm_model_cls = model_utils.import_class_by_path(self.language_model_class)  # type: GPTModel
-        ckpt_path = io.import_ckpt(
-            llm_model_cls(self.language_model_config), f"{self.language_model_hub}{ckpt_path}", import_tokenizer=False
+        ckpt_path = import_ckpt(
+            llm_model_cls(self.language_model_config), f"{self.language_model_hub}{ckpt_path}", on_import_ckpt=False
         )
 
         sharded_state_dict = dict(state_dict=model.sharded_state_dict(prefix="module."))

--- a/nemo/collections/speechlm/models/speech_to_text_llm_model.py
+++ b/nemo/collections/speechlm/models/speech_to_text_llm_model.py
@@ -206,7 +206,9 @@ class SpeechToTextLLMConfig(TransformerConfig, io.IOMixin):
         time.sleep(rank / 2)
 
         llm_model_cls = model_utils.import_class_by_path(self.language_model_class)  # type: GPTModel
-        ckpt_path = io.import_ckpt(llm_model_cls(self.language_model_config), f"{self.language_model_hub}{ckpt_path}")
+        ckpt_path = io.import_ckpt(
+            llm_model_cls(self.language_model_config), f"{self.language_model_hub}{ckpt_path}", import_tokenizer=False
+        )
 
         sharded_state_dict = dict(state_dict=model.sharded_state_dict(prefix="module."))
 

--- a/nemo/collections/speechlm/utils/io.py
+++ b/nemo/collections/speechlm/utils/io.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from pathlib import Path
+from typing import Optional
+
+import lightning.pytorch as pl
+
+from nemo.lightning.io.mixin import ConnectorMixin, ModelConnector
+
+
+def import_ckpt(
+    model: pl.LightningModule,
+    source: str,
+    output_path: Optional[Path] = None,
+    overwrite: bool = False,
+    on_import_ckpt: bool = True,
+) -> Path:
+    """
+    Overriding nemo/lightning/io/api.py:import_ckpt to add on_import_ckpt flag, which is used to
+
+    Imports a checkpoint into a model using the model's associated importer, typically for
+    the purpose of fine-tuning a community model trained in an external framework, such as
+    Hugging Face. This function leverages the ConnectorMixin interface to integrate external
+    checkpoint data seamlessly into the specified model instance.
+
+    The importer component of the model reads the checkpoint data from the specified source
+    and transforms it into the right format. This is particularly useful for adapting
+    models that have been pre-trained in different environments or frameworks to be fine-tuned
+    or further developed within the current system. The function allows for specifying an output
+    path for the imported checkpoint; if not provided, the importer's default path will be used.
+    The 'overwrite' parameter enables the replacement of existing data at the output path, which
+    is useful when updating models with new data and discarding old checkpoint files.
+
+    For instance, using `import_ckpt(Mistral7BModel(), "hf")` initiates the import process
+    by searching for a registered model importer tagged with "hf". In NeMo, `HFMistral7BImporter`
+    is registered under this tag via:
+    `@io.model_importer(Mistral7BModel, "hf", default_path="mistralai/Mistral-7B-v0.1")`.
+    This links `Mistral7BModel` to `HFMistral7BImporter`, designed for HuggingFace checkpoints.
+    The importer then processes and integrates these checkpoints into `Mistral7BModel` for further
+    fine-tuning.
+
+    Args:
+        model (pl.LightningModule): The model into which the checkpoint will be imported.
+            This model must implement the ConnectorMixin, which includes the necessary
+            importer method for checkpoint integration.
+        source (str): The source from which the checkpoint will be imported. This can be
+            a file path, URL, or any other string identifier that the model's importer
+            can recognize.
+        output_path (Optional[Path]): The path where the imported checkpoint will be stored.
+            If not specified, the importer's default path is used.
+        overwrite (bool): If set to True, existing files at the output path will be overwritten.
+            This is useful for model updates where retaining old checkpoint files is not required.
+        on_import_ckpt (bool): If set to True, the importer will also call importer.on_import_ckpt(model),
+            which imports the tokenizer associated with the model. This is set to False for multi-modal LLMs
+            like SpeechLM, where the tokenizer is associated with the SpeechLM model instead of the internal LLM.
+
+    Returns
+    -------
+        Path: The path where the checkpoint has been saved after import. This path is determined
+            by the importer, based on the provided output_path and its internal logic.
+
+    Raises
+    ------
+        ValueError: If the model does not implement ConnectorMixin, indicating a lack of
+            necessary importer functionality.
+
+    Example:
+        model = Mistral7BModel()
+        imported_path = import_ckpt(model, "hf://mistralai/Mistral-7B-v0.1")
+    """
+    if not isinstance(model, ConnectorMixin):
+        raise ValueError("Model must be an instance of ConnectorMixin")
+
+    importer: ModelConnector = model.importer(source)
+    ckpt_path = importer(overwrite=overwrite, output_path=output_path)
+    if on_import_ckpt:
+        importer.on_import_ckpt(model)
+    return ckpt_path

--- a/nemo/lightning/io/api.py
+++ b/nemo/lightning/io/api.py
@@ -109,7 +109,11 @@ def model_exporter(target: Type[ConnectorMixin], ext: str) -> Callable[[Type[Con
 
 
 def import_ckpt(
-    model: pl.LightningModule, source: str, output_path: Optional[Path] = None, overwrite: bool = False
+    model: pl.LightningModule,
+    source: str,
+    output_path: Optional[Path] = None,
+    overwrite: bool = False,
+    import_tokenizer: bool = True,
 ) -> Path:
     """
     Imports a checkpoint into a model using the model's associated importer, typically for
@@ -144,6 +148,9 @@ def import_ckpt(
             If not specified, the importer's default path is used.
         overwrite (bool): If set to True, existing files at the output path will be overwritten.
             This is useful for model updates where retaining old checkpoint files is not required.
+        import_tokenizer (bool): If set to True, the importer will also import the tokenizer
+            associated with the model. This is set to False for multi-modal LLMs like SpeechLM,
+            where the tokenizer is associated with the SpeechLM model instead of the internal LLM.
 
     Returns
     -------
@@ -164,7 +171,8 @@ def import_ckpt(
 
     importer: ModelConnector = model.importer(source)
     ckpt_path = importer(overwrite=overwrite, output_path=output_path)
-    importer.on_import_ckpt(model)
+    if import_tokenizer:
+        importer.on_import_ckpt(model)
     return ckpt_path
 
 

--- a/nemo/lightning/io/api.py
+++ b/nemo/lightning/io/api.py
@@ -109,11 +109,7 @@ def model_exporter(target: Type[ConnectorMixin], ext: str) -> Callable[[Type[Con
 
 
 def import_ckpt(
-    model: pl.LightningModule,
-    source: str,
-    output_path: Optional[Path] = None,
-    overwrite: bool = False,
-    import_tokenizer: bool = True,
+    model: pl.LightningModule, source: str, output_path: Optional[Path] = None, overwrite: bool = False
 ) -> Path:
     """
     Imports a checkpoint into a model using the model's associated importer, typically for
@@ -148,9 +144,6 @@ def import_ckpt(
             If not specified, the importer's default path is used.
         overwrite (bool): If set to True, existing files at the output path will be overwritten.
             This is useful for model updates where retaining old checkpoint files is not required.
-        import_tokenizer (bool): If set to True, the importer will also import the tokenizer
-            associated with the model. This is set to False for multi-modal LLMs like SpeechLM,
-            where the tokenizer is associated with the SpeechLM model instead of the internal LLM.
 
     Returns
     -------
@@ -171,8 +164,7 @@ def import_ckpt(
 
     importer: ModelConnector = model.importer(source)
     ckpt_path = importer(overwrite=overwrite, output_path=output_path)
-    if import_tokenizer:
-        importer.on_import_ckpt(model)
+    importer.on_import_ckpt(model)
     return ckpt_path
 
 


### PR DESCRIPTION
Fix speechlm import ckpt on slurm multi-node setting, by adding the option to skip `importer.on_import_ckpt`.