### PR TITLE
feat: Allow reshaping of HF checkpoint when converting from .nemo

### DIFF
--- a/scripts/checkpoint_converters/convert_llama_nemo_to_hf.py
+++ b/scripts/checkpoint_converters/convert_llama_nemo_to_hf.py
@@ -19,7 +19,7 @@ from collections import OrderedDict
 import torch
 from lightning.pytorch import Trainer
 from omegaconf import open_dict
-from transformers import AutoModelForCausalLM, LlamaTokenizer, LlamaTokenizerFast, convert_slow_tokenizer, AutoConfig
+from transformers import AutoConfig, AutoModelForCausalLM, LlamaTokenizer, LlamaTokenizerFast, convert_slow_tokenizer
 
 from nemo.collections.nlp.models.language_modeling.megatron_gpt_model import MegatronGPTModel
 from nemo.collections.nlp.parts.nlp_overrides import NLPDDPStrategy
@@ -122,7 +122,7 @@ def convert(input_nemo_file, output_hf_file, precision=None, cpu_only=False) -> 
     model_config = MegatronGPTModel.restore_from(input_nemo_file, trainer=dummy_trainer, return_config=True)
     model_config.tensor_model_parallel_size = 1
     model_config.pipeline_model_parallel_size = 1
-    model_config.sequence_parallel = False # cannot convert with sequence parallel on
+    model_config.sequence_parallel = False  # cannot convert with sequence parallel on
     model_config.name = "te_gpt"
     if cpu_only:
         map_location = torch.device('cpu')


### PR DESCRIPTION
# What does this PR do ?

Allows the `convert_llama_nemo_to_hf.py` checkpoint converter to handle changes in MLP and hidden state dimensions post [distillation](https://github.com/NVIDIA/NeMo/tree/171a7af32c1422a264688fbd11f61bb9468999de/tutorials/llm/llama-3/pruning-distillation).

# Changelog

- Added optional `--allow-reshape` parameter to the script which will handle the changes in the Huggingface `config.json` and use an alternate method of replacing the weights.

# Usage

```bash
    python convert_llama_nemo_to_hf.py \
    --input_name_or_path NEMO_WITH_DIFFERENT_DIMENSIONS.nemo \
    --output_path /path/to/pytorch_model.bin \
    --hf_input_path /path/to/input_hf_folder \
    --hf_output_path /path/to/output_hf_folder \
    --allow_reshaping
```
# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
