### PR TITLE
Remove modelopt state when empty in NeMo 1.0 distillation

### DIFF
--- a/examples/nlp/language_modeling/megatron_gpt_distillation.py
+++ b/examples/nlp/language_modeling/megatron_gpt_distillation.py
@@ -468,7 +468,7 @@ def adjust_distillation_model_for_mcore(model: mtd.DistillationModel, distill_cf
     """Extra modifcations to ``mtd.DistillationModel`` requried for Megatron-Core."""
 
     # HACK: Get rid of ModelOpt Distillation state
-    modelopt_states = mto.ModeloptStateManager(model)._state
+    modelopt_states = mto.ModeloptStateManager(model).state_dict()
     if len(modelopt_states) > 1:
         modelopt_states.pop()
     else:

--- a/examples/nlp/language_modeling/megatron_gpt_distillation.py
+++ b/examples/nlp/language_modeling/megatron_gpt_distillation.py
@@ -468,7 +468,11 @@ def adjust_distillation_model_for_mcore(model: mtd.DistillationModel, distill_cf
     """Extra modifcations to ``mtd.DistillationModel`` requried for Megatron-Core."""
 
     # HACK: Get rid of ModelOpt Distillation state
-    mto.ModeloptStateManager(model)._state.pop()
+    modelopt_states = mto.ModeloptStateManager(model)._state
+    if len(modelopt_states) > 1:
+        modelopt_states.pop()
+    else:
+        delattr(model, mto.ModeloptStateManager._state_key)
 
     # HACK: Hide teacher during `sharded_state_dict` method.
     def _sharded_state_dict(self, *args, **kwargs) -> ShardedStateDict:


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Unblocks an issue where quantizing a distilled checkpoint leads to a ModelOpt state mismatch.

**Collection**: NLP

# Changelog

- Remove ModelOpt state altogether when it only contains a distillation state.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

https://nvbugspro.nvidia.com/bug/5116129
- Related to # (issue)
