### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `05ac33c...` (2025-02-20)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "61b2c4f9c6607e242ef9af44c2926a923f12a5af"
+      "ref": "05ac33c6aa5b7e7712907e10401fa4726b694655"
     }
   },
   "pypi-dependencies": {}


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `05ac33c6aa5b7e7712907e10401fa4726b694655`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.