### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `c91756d...` (2025-02-21)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -1,18 +1,18 @@
 {
-    "ngc-pytorch": "nvcr.io/nvidia/pytorch:24.07-py3",
-    "vcs-dependencies": {
-        "apex": {
-            "repo": "https://github.com/NVIDIA/Apex",
-            "ref": "810ffae374a2b9cb4b5c5e28eaeca7d7998fca0c"
-        },
-        "transformer_engine": {
-            "repo": "https://github.com/NVIDIA/TransformerEngine",
-            "ref": "7d576ed25266a17a7b651f2c12e8498f67e0baea"
-        },
-        "megatron-lm": {
-            "repo": "https://github.com/NVIDIA/Megatron-LM",
-            "ref": "1e24413e3a3ea7eafc5fd66654cc6c93247f6f45"
-        }
+  "ngc-pytorch": "nvcr.io/nvidia/pytorch:24.07-py3",
+  "vcs-dependencies": {
+    "apex": {
+      "repo": "https://github.com/NVIDIA/Apex",
+      "ref": "810ffae374a2b9cb4b5c5e28eaeca7d7998fca0c"
     },
-    "pypi-dependencies": {}
+    "transformer_engine": {
+      "repo": "https://github.com/NVIDIA/TransformerEngine",
+      "ref": "7d576ed25266a17a7b651f2c12e8498f67e0baea"
+    },
+    "megatron-lm": {
+      "repo": "https://github.com/NVIDIA/Megatron-LM",
+      "ref": "c91756d28f58fa1ef9ae988e5a73abfce9fc07a7"
+    }
+  },
+  "pypi-dependencies": {}
 }


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `c91756d28f58fa1ef9ae988e5a73abfce9fc07a7`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.