### PR TITLE
Cherry pick `build: Exclude tensorstore 0.1.72 (12317)` into `r2.2.0`

### DIFF
--- a/requirements/requirements_deploy.txt
+++ b/requirements/requirements_deploy.txt
@@ -1,6 +1,6 @@
 fastapi
 nvidia-pytriton
 pydantic-settings
-tensorstore
+tensorstore<0.1.72
 uvicorn
 zarr>=2.18.2,<3.0.0

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -20,6 +20,6 @@ rapidfuzz
 rouge_score
 sacrebleu  # manually install sacrebleu[ja] for Japanese support; MeCab is unsupported in Python 3.11+
 sentence_transformers
-tensorstore
+tensorstore<0.1.72
 tiktoken==0.7.0
 zarr>=2.18.2,<3.0.0


### PR DESCRIPTION
beep boop [🤖]: Hi @ko3n1g 👋,
    
    we've cherry picked #12317 into  for you! 🚀
    
    Please review and approve this cherry pick by your convenience!