### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `114fabe...` (2025-02-23)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -1,18 +1,18 @@
 {
-    "ngc-pytorch": "nvcr.io/nvidia/pytorch:25.01-py3",
-    "vcs-dependencies": {
-        "apex": {
-            "repo": "https://github.com/NVIDIA/Apex",
-            "ref": "810ffae374a2b9cb4b5c5e28eaeca7d7998fca0c"
-        },
-        "transformer_engine": {
-            "repo": "https://github.com/NVIDIA/TransformerEngine",
-            "ref": "7d576ed25266a17a7b651f2c12e8498f67e0baea"
-        },
-        "megatron-lm": {
-            "repo": "https://github.com/NVIDIA/Megatron-LM",
-            "ref": "59505b31eab8250a981adc96115387a1aa846159"
-        }
+  "ngc-pytorch": "nvcr.io/nvidia/pytorch:25.01-py3",
+  "vcs-dependencies": {
+    "apex": {
+      "repo": "https://github.com/NVIDIA/Apex",
+      "ref": "810ffae374a2b9cb4b5c5e28eaeca7d7998fca0c"
     },
-    "pypi-dependencies": {}
+    "transformer_engine": {
+      "repo": "https://github.com/NVIDIA/TransformerEngine",
+      "ref": "7d576ed25266a17a7b651f2c12e8498f67e0baea"
+    },
+    "megatron-lm": {
+      "repo": "https://github.com/NVIDIA/Megatron-LM",
+      "ref": "114fabee9fdb0e4b1f3d1cfae73e824a3d16fdc4"
+    }
+  },
+  "pypi-dependencies": {}
 }


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `114fabee9fdb0e4b1f3d1cfae73e824a3d16fdc4`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.