### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `77537b9...` (2025-02-24)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "114fabee9fdb0e4b1f3d1cfae73e824a3d16fdc4"
+      "ref": "77537b98da08c4100a611f36af349f6651777a8a"
     }
   },
   "pypi-dependencies": {}


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `77537b98da08c4100a611f36af349f6651777a8a`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.