### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `b5d90de...` (2025-02-26)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "82217b8b95b15e5c573868ff2fc7c61de0b24f1b"
+      "ref": "b5d90de8e7c7fae5f35be89d665f237970540bed"
     }
   },
   "pypi-dependencies": {}


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `b5d90de8e7c7fae5f35be89d665f237970540bed`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.