### PR TITLE
ci: Improve `Run CICD` experience

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -3162,7 +3162,7 @@ jobs:
         id: pipeline-conclusion
         run: |
           # Slack notifications are send only on test failure (not cancelled):
-          FAILED=${{ contains(needs.*.outputs.conclusion, 'failure') }}
+          FAILED=${{ contains(needs.*.outputs.conclusion, 'failure') && github.event.label.name == 'Run CICD'}}
           echo "FAILED=$FAILED" >> $GITHUB_OUTPUT
 
           # Mark as successful if no job was cancelled:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -3153,6 +3153,7 @@ jobs:
 
     if: always() && github.event != 'push'
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - name: Evaluate conclusion
         if: ${{ always() }}
@@ -3165,6 +3166,16 @@ jobs:
           # Mark as successful if no job was cancelled:
           SUCCESS=${{ !contains(needs.*.outputs.conclusion, 'failure') && !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'skipped') }}
           echo "SUCCESS=$SUCCESS" >> $GITHUB_OUTPUT
+
+      - name: Checkout for GH CLI
+        uses: actions/checkout@v4
+
+      - name: Remove label if not cancelled
+        if: ${{ !contains(needs.*.result, 'cancelled') }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: gh pr edit "$PR_NUMBER" --remove-label "Run CICD"
 
       # This should depend on all the tests so we block/unblock based on all tests passing
       - name: Pipeline successful, set exit code to 0

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -31,7 +31,7 @@ on:
         description: Comma-separated list of tests to run. Use "all" to run the full test suite.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name | 'main' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -31,7 +31,7 @@ on:
         description: Comma-separated list of tests to run. Use "all" to run the full test suite.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name | 'main' }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-${{ github.event.label.name || 'main' }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -3162,7 +3162,7 @@ jobs:
         id: pipeline-conclusion
         run: |
           # Slack notifications are send only on test failure (not cancelled):
-          FAILED=${{ contains(needs.*.outputs.conclusion, 'failure') && github.event.label.name == 'Run CICD'}}
+          FAILED=${{ contains(needs.*.outputs.conclusion, 'failure') && github.event.label.name == 'Run CICD' }}
           echo "FAILED=$FAILED" >> $GITHUB_OUTPUT
 
           # Mark as successful if no job was cancelled:
@@ -3173,7 +3173,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Remove label if not cancelled
-        if: ${{ !contains(needs.*.result, 'cancelled') }}
+        if: ${{ !contains(needs.*.result, 'cancelled') && github.event.label.name == 'Run CICD' }}
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -98,10 +98,13 @@ jobs:
           echo "$BUILD_ARGS" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
+  code-linting:
+    uses: ./.github/workflows/code-linting.yml
+
   cicd-test-container-build:
     if: ${{ needs.pre-flight.outputs.test_to_run != '' }}
     uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_build_container.yml@v0.14.0
-    needs: pre-flight
+    needs: [pre-flight, code-linting]
     with:
       image-name: nemo_container
       dockerfile: Dockerfile.ci

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -102,7 +102,7 @@ jobs:
     uses: ./.github/workflows/code-linting.yml
 
   cicd-test-container-build:
-    if: ${{ needs.pre-flight.outputs.test_to_run != '' }}
+    if: ${{ needs.pre-flight.outputs.test_to_run != '[]' }}
     uses: NVIDIA/NeMo-FW-CI-templates/.github/workflows/_build_container.yml@v0.14.0
     needs: [pre-flight, code-linting]
     with:
@@ -117,7 +117,7 @@ jobs:
       prune-filter-timerange: 24h
 
   cicd-import-tests:
-    if: ${{ needs.pre-flight.outputs.test_to_run != '' }}
+    if: ${{ needs.pre-flight.outputs.test_to_run != '[]' }}
     needs: [cicd-test-container-build, pre-flight]
     runs-on: self-hosted-azure-gpus-1
     steps:

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -99,6 +99,8 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
   code-linting:
+    if: ${{ needs.pre-flight.outputs.test_to_run != '[]' }}
+    needs: [pre-flight]
     uses: ./.github/workflows/code-linting.yml
 
   cicd-test-container-build:

--- a/.github/workflows/cicd-relabel-bot.yml
+++ b/.github/workflows/cicd-relabel-bot.yml
@@ -1,0 +1,32 @@
+# If the PR get's updated by a new commit, it prevents auto-merges
+# since there's no CI event attached to the commit anymore.
+# This workflow re-attaches the label after a push, if the PR
+# was already labeled prior to the push.
+
+name: CICD Relabel bot
+
+on:
+  pull_request: # So that this mechanism works on forks, we must remove this trigger later
+  pull_request_target:
+
+jobs:
+  relabel:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR was already labeled with `Run CICD`
+        id: pre-flight
+        env:
+          GH_TOKEN: ${{ secrets.NEMO_REFORMAT_TOKEN }}
+        run: |
+          LABELS=$(gh pr view --json labels)
+          HAS_LABEL=$(echo $LABELS \
+            | jq '[.labels[].name] | any(. == "Run CICD")'
+          )
+
+          echo "has-label=$HAS_LABEL" | tee -a "$GITHUB_OUTPUT"
+
+      - name: Relabel PR
+        if: ${{ steps.pre-flight.outputs.has-label == 'true' }}
+        run: |
+          gh pr edit --remove-label "Run CICD"
+          gh pr edit --add-label "Run CICD"

--- a/.github/workflows/cicd-relabel-bot.yml
+++ b/.github/workflows/cicd-relabel-bot.yml
@@ -12,13 +12,20 @@ on:
 jobs:
   relabel:
     runs-on: ubuntu-latest
+    env:
+      PR_NUMBER: ${{ github.event.number }}
+      GH_TOKEN: ${{ secrets.PAT }}
+      HOSTNAME: ${{ github.server_url }}
+    permissions: write-all
+    environment: main
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
       - name: Check if PR was already labeled with `Run CICD`
         id: pre-flight
-        env:
-          GH_TOKEN: ${{ secrets.NEMO_REFORMAT_TOKEN }}
         run: |
-          LABELS=$(gh pr view --json labels)
+          LABELS=$(gh pr view "$PR_NUMBER" --json labels)
           HAS_LABEL=$(echo $LABELS \
             | jq '[.labels[].name] | any(. == "Run CICD")'
           )
@@ -28,5 +35,5 @@ jobs:
       - name: Relabel PR
         if: ${{ steps.pre-flight.outputs.has-label == 'true' }}
         run: |
-          gh pr edit --remove-label "Run CICD"
-          gh pr edit --add-label "Run CICD"
+          gh pr edit "$PR_NUMBER" --remove-label "Run CICD"
+          gh pr edit "$PR_NUMBER" --add-label "Run CICD"

--- a/.github/workflows/cicd-relabel-bot.yml
+++ b/.github/workflows/cicd-relabel-bot.yml
@@ -14,10 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PR_NUMBER: ${{ github.event.number }}
-      GH_TOKEN: ${{ secrets.PAT }}
+      GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
       HOSTNAME: ${{ github.server_url }}
     permissions: write-all
-    environment: main
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/cicd-relabel-bot.yml
+++ b/.github/workflows/cicd-relabel-bot.yml
@@ -2,7 +2,6 @@
 # since there's no CI event attached to the commit anymore.
 # This workflow re-attaches the label after a push, if the PR
 # was already labeled prior to the push.
-
 name: CICD Relabel bot
 
 on:

--- a/.github/workflows/code-linting.yml
+++ b/.github/workflows/code-linting.yml
@@ -3,10 +3,11 @@ name: PyLint and flake8 linting
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_call:
 
 jobs:
   linting:
-    name: 'Domain: ${{ matrix.domain }}'
+    name: "Domain: ${{ matrix.domain }}"
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -48,8 +49,8 @@ jobs:
         uses: tj-actions/changed-files@v44
         with:
           files: ${{ steps.filter.outputs.main }}
-          files_separator: ','
-          separator: ' '
+          files_separator: ","
+          separator: " "
 
       - name: Run PyLint
         id: pylint


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

We have few scenarios where a PR gets updated:

* reformat code with auto-commit
* update PR button
* Modify the concurrency control so that adding more labels to the PR won't cancel the `Run CICD` workflow

If this happens while a `Run CICD` workflow is running, the check suite won't be representative anymore since the metadata is overwritten by the updated commit.
This PR adds a relabel bot that re-attaches the `Run CICD` label, if the label was attached prior to the update event.

Furthermore, it removes the `Run CICD` label after the CI has finished (success or failure, cancel will not remove it).

**Considerations:**

* Reformat is an action that users don't have (much) control over. So running the relabel bot after reformat makes a lot of sense to me
* Updating the PR (accidentially) is a real threat and so also re-running the CI after this seems plausible to me
* However, the re-label bot will also re-label if "normal" commits are being added. So pratically, once the `Run CICD` label is attached we will re-run the CI with each attached commit up until the CI finishes (success or failure). **At this point the author will need to label the PR again.** 
* I think this is fine, since one of the events that we want to catch with this automation is the accidental "Update PR" button. From git perspective, it is difficult to distinguish between this button and a "normal" commit. So in order to have a robust mechanism, I would suggest to always restart the CI with a new commit.


**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
