### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `36753c7...` (2025-02-27)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "b5d90de8e7c7fae5f35be89d665f237970540bed"
+      "ref": "36753c7f7cf8c72b5a43c0ae309c36909ddf1b02"
     }
   },
   "pypi-dependencies": {}


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `36753c7f7cf8c72b5a43c0ae309c36909ddf1b02`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.