### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `47261db...` (2025-02-28)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "b5d90de8e7c7fae5f35be89d665f237970540bed"
+      "ref": "47261dbec4249d147766a6d209f4feb2d63008fa"
     }
   },
   "pypi-dependencies": {}


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `47261dbec4249d147766a6d209f4feb2d63008fa`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.