### PR TITLE
Add more flexibility to peft

### DIFF
--- a/nemo/lightning/pytorch/callbacks/peft.py
+++ b/nemo/lightning/pytorch/callbacks/peft.py
@@ -133,6 +133,13 @@ class PEFT(IOMixin, ABC, ModelTransform):
         if is_trainer_attached(model) and model.trainer.state.fn == TrainerFn.FITTING:
             model.train(mode=True)
 
+    def get_wrappped_io(self):
+        """
+        This is a helper function to return a partial function that wraps the checkpoint I/O with the PEFT adapter.
+        Can be overridden in each PEFT method class.
+        """
+        return partial(WrappedAdapterIO, peft=self)
+
     def setup(self, trainer: pl.Trainer, pl_module: pl.LightningModule, stage: str) -> None:
         """PTL callback setup function."""
         from nemo.lightning.pytorch.strategies.utils import create_checkpoint_io
@@ -142,7 +149,7 @@ class PEFT(IOMixin, ABC, ModelTransform):
 
         self._is_fsdp_v1 = type(trainer.strategy).__name__ == 'FSDPStrategy'
         trainer.strategy.trainer = trainer
-        wrapped_io = partial(WrappedAdapterIO, peft=self)
+        wrapped_io = self.get_wrappped_io()
 
         # automodel_setup_optimizers is either None or holds a reference to trainer.strategy.setup_optimizers
         self.automodel_setup_optimizers = None
@@ -178,6 +185,15 @@ class PEFT(IOMixin, ABC, ModelTransform):
         trainer.strategy._init_model_parallel = False
         trainer.strategy._setup_optimizers = False
 
+    def set_trainable_params(self, trainer: pl.Trainer) -> None:
+        """
+        Set params to be saved for PEFT. This function is called in apply_transform.
+        Can be overridden in each PEFT method class.
+        """
+        self.trainable_params = set(
+            name for name, param in trainer.lightning_module.named_parameters() if param.requires_grad
+        )
+
     def apply_transform(self, trainer):
         """
         This function does the following:
@@ -187,6 +203,7 @@ class PEFT(IOMixin, ABC, ModelTransform):
         4. Set up `finalize_model_grads` from mcore.
         """
         super().apply_transform(trainer)
+        self.set_trainable_params(trainer)
         # @akoumparouli: only used with automodel + FSDP2Strategy.
         if callable(getattr(trainer.strategy, 'parallelize', None)):
             trainer.strategy.parallelize()

--- a/nemo/lightning/pytorch/callbacks/peft.py
+++ b/nemo/lightning/pytorch/callbacks/peft.py
@@ -208,10 +208,6 @@ class PEFT(IOMixin, ABC, ModelTransform):
         if callable(getattr(trainer.strategy, 'parallelize', None)):
             trainer.strategy.parallelize()
 
-        self.trainable_params = set(
-            name for name, param in trainer.lightning_module.named_parameters() if param.requires_grad
-        )
-
         # Handle automodel and return early.
         if (
             self.wrapped_io.adapter_ckpt_path is not None


### PR DESCRIPTION
Current PEFT in nemo only saves parameters that require gradients. However, there are other params that don't require gradients but still need to be saved, such as the running mean/var of batch norm. Therefore, this PR separates setting `self.trainable_params` to a new member function `set_trainable_params()`, so that it can be customized for different use cases.

Another change is putting `partial(WrappedAdapterIO, peft=self)` into another member function `get_wrappped_io`, so that it can be customized by other use cases in SpeechLM.

The PR doesn't change the default behavior of the original code.