### PR TITLE
performance scripts: add custom mounts and wandb logger

### DIFF
--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -90,6 +90,36 @@ def parse_cli_args():
         action="store_true",
     )
     parser.add_argument(
+        "-wd",
+        "--wandb",
+        help="Enable wandb logging. Disabled by default",
+        action="store_true",
+    )
+    parser.add_argument(
+        "-wdk",
+        "--wandb_key",
+        type=str,
+        help="wandb key. Needed for wandb logger projetion to server",
+        required=False,
+        default=None,
+    )
+    parser.add_argument(
+        "-wdp",
+        "--wandb_prj_name",
+        type=str,
+        help="wandb project name",
+        required=False,
+        default=None,
+    )
+    parser.add_argument(
+        "-wdj",
+        "--wandb_job_name",
+        type=str,
+        help="wandb job name",
+        required=False,
+        default=None,
+    )
+    parser.add_argument(
         "-f",
         "--finetuning",
         choices=["sft", "lora"],
@@ -218,6 +248,16 @@ def parse_cli_args():
         help="Number of train steps. Defaults to 100",
         required=False,
         default=100,
+    )
+    def list_of_strings(arg):
+        return arg.split(',')
+    parser.add_argument(
+        "-cm",
+        "--custom_mounts",
+        type=list_of_strings,
+        help="Comma separated string of mounts",
+        required=False,
+        default=[],
     )
 
     return parser

--- a/scripts/performance/argument_parser.py
+++ b/scripts/performance/argument_parser.py
@@ -249,8 +249,10 @@ def parse_cli_args():
         required=False,
         default=100,
     )
+
     def list_of_strings(arg):
         return arg.split(',')
+
     parser.add_argument(
         "-cm",
         "--custom_mounts",

--- a/scripts/performance/llm/finetune_llama31_405b.py
+++ b/scripts/performance/llm/finetune_llama31_405b.py
@@ -29,6 +29,7 @@ from ..utils import (
     isfile_train_pack_metadata,
     set_primary_perf_configs,
     slurm_executor,
+    args_sanity_check,
 )
 
 HF_MODEL_URI = "meta-llama/Llama-3.1-405B"
@@ -55,6 +56,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -88,6 +92,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), args.finetuning, "llama31", "405b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, _ = kwargs
@@ -105,10 +110,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if pp_size > 1 else None)]

--- a/scripts/performance/llm/finetune_llama31_405b.py
+++ b/scripts/performance/llm/finetune_llama31_405b.py
@@ -23,13 +23,13 @@ from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
 from ..utils import (
+    args_sanity_check,
     get_user_configs,
     hf_tokenizer,
     import_ckpt_experiment,
     isfile_train_pack_metadata,
     set_primary_perf_configs,
     slurm_executor,
-    args_sanity_check,
 )
 
 HF_MODEL_URI = "meta-llama/Llama-3.1-405B"

--- a/scripts/performance/llm/finetune_llama3_70b.py
+++ b/scripts/performance/llm/finetune_llama3_70b.py
@@ -23,13 +23,13 @@ from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
 from ..utils import (
+    args_sanity_check,
     get_user_configs,
     hf_tokenizer,
     import_ckpt_experiment,
     isfile_train_pack_metadata,
     set_primary_perf_configs,
     slurm_executor,
-    args_sanity_check,
 )
 
 HF_MODEL_URI = "meta-llama/Meta-Llama-3-70B"

--- a/scripts/performance/llm/finetune_llama3_70b.py
+++ b/scripts/performance/llm/finetune_llama3_70b.py
@@ -29,6 +29,7 @@ from ..utils import (
     isfile_train_pack_metadata,
     set_primary_perf_configs,
     slurm_executor,
+    args_sanity_check,
 )
 
 HF_MODEL_URI = "meta-llama/Meta-Llama-3-70B"
@@ -62,6 +63,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -95,6 +99,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), args.finetuning, "llama3", "70b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, _ = kwargs
@@ -112,10 +117,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if pp_size > 1 else None)]

--- a/scripts/performance/llm/finetune_llama3_8b.py
+++ b/scripts/performance/llm/finetune_llama3_8b.py
@@ -23,13 +23,13 @@ from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
 from ..utils import (
+    args_sanity_check,
     get_user_configs,
     hf_tokenizer,
     import_ckpt_experiment,
     isfile_train_pack_metadata,
     set_primary_perf_configs,
     slurm_executor,
-    args_sanity_check,
 )
 
 HF_MODEL_URI = "meta-llama/Meta-Llama-3-8B"
@@ -115,7 +115,8 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        ccustom_mounts=args.custom_mounts,ustom_mounts=[],
+        ccustom_mounts=args.custom_mounts,
+        ustom_mounts=[],
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,

--- a/scripts/performance/llm/finetune_llama3_8b.py
+++ b/scripts/performance/llm/finetune_llama3_8b.py
@@ -29,6 +29,7 @@ from ..utils import (
     isfile_train_pack_metadata,
     set_primary_perf_configs,
     slurm_executor,
+    args_sanity_check,
 )
 
 HF_MODEL_URI = "meta-llama/Meta-Llama-3-8B"
@@ -60,6 +61,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -93,6 +97,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), args.finetuning, "llama3", "8b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, _ = kwargs
@@ -110,10 +115,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        ccustom_mounts=args.custom_mounts,ustom_mounts=[],
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if pp_size > 1 else None)]

--- a/scripts/performance/llm/mlperf_lora_llama2_70b.py
+++ b/scripts/performance/llm/mlperf_lora_llama2_70b.py
@@ -27,7 +27,7 @@ from nemo.lightning.pytorch.optim import CosineAnnealingScheduler
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import import_ckpt_experiment, slurm_executor, args_sanity_check
+from ..utils import args_sanity_check, import_ckpt_experiment, slurm_executor
 
 NUM_NODES = 1
 NUM_GPUS_PER_NODE = 8
@@ -338,7 +338,8 @@ if __name__ == "__main__":
         assert args.wandb_prj_name is not None
         assert args.wandb_job_name is not None
         from nemo.collections.llm.recipes.log.default import wandb_logger
-        recipe.log.wandb=wandb_logger(project=args.wandb_prj_name, name=args.wandb_job_name)
+
+        recipe.log.wandb = wandb_logger(project=args.wandb_prj_name, name=args.wandb_job_name)
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if PP_SIZE > 1 else None)]
     if args.enable_nsys:

--- a/scripts/performance/llm/mlperf_lora_llama2_70b.py
+++ b/scripts/performance/llm/mlperf_lora_llama2_70b.py
@@ -27,7 +27,7 @@ from nemo.lightning.pytorch.optim import CosineAnnealingScheduler
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import import_ckpt_experiment, slurm_executor
+from ..utils import import_ckpt_experiment, slurm_executor, args_sanity_check
 
 NUM_NODES = 1
 NUM_GPUS_PER_NODE = 8
@@ -252,14 +252,18 @@ def mlperf_lora_llama2_70b_recipe(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     if args.finetuning.lower() != "lora" or args.compute_dtype != "fp8":
         raise ValueError(
-            f"This example assumes LoRA and fp8; instead got --finetuning={args.finetuning} --compute_dtype={args.compute_dtype}"
+            "This example assumes LoRA and fp8; instead got "
+            f"--finetuning={args.finetuning} --compute_dtype={args.compute_dtype}"
         )
     if args.virtual_pipeline_parallel_size or args.expert_parallel_size:
         raise ValueError(
-            f"This example does not support virtual pipeline parallel or expert parallel; got --virtual_pipeline_parallel_size={args.virtual_pipeline_parallel_size} --expert_parallel_size={args.expert_parallel_size}"
+            "This example does not support virtual pipeline parallel or expert parallel; "
+            f"got --virtual_pipeline_parallel_size={args.virtual_pipeline_parallel_size} "
+            f"--expert_parallel_size={args.expert_parallel_size}"
         )
 
     num_gpus_per_node = NUM_GPUS_PER_NODE if args.gpus_per_node is None else args.gpus_per_node
@@ -284,10 +288,13 @@ if __name__ == "__main__":
     )
 
     env_vars = {
+        # pylint: disable=C0301
         "CUDA_DEVICE_MAX_CONNECTIONS": "1",  # Limit GPUs to one compute stream so that kernels will be executed in consistent order, for best performance with communication overlap configs
+        # pylint: disable=C0301
         "CUBLAS_FORCE_XMMA_KERNEL_INIT": "DEVICE",  # Use a device kernel instead of memset for matrix multiply initialization, which can help reduce CPU-side overhead
         "CUDNN_FRONTEND_ATTN_DP_WORKSPACE_LIMIT": "0",  # Reduce memory used by cuDNN attention
         "NVTE_FP8_DPA_BWD": "1",  # Enable TransformerEngine FP8 attention for bprop
+        # pylint: disable=C0301
         "NVTE_RS_STRIDED_ATOMIC": "2",  # Reduce-scatter communication will be done as a single kernel (with userbuffer TP communication overlap)
         "NCCL_MIN_CTAS": "32",  # Increase CTA resources available to NCCL to improve communication perf
         "NCCL_MIN_P2P_NCHANNELS": "32",  # Likewise, increase P2P channels availabe to NCCL
@@ -304,10 +311,11 @@ if __name__ == "__main__":
         num_gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars=env_vars,
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     recipe = mlperf_lora_llama2_70b_recipe(
@@ -326,6 +334,11 @@ if __name__ == "__main__":
         recipe.trainer.logger = False
     else:
         recipe.log.log_dir = "/nemo_run/lightning_logs"
+    if args.wandb:
+        assert args.wandb_prj_name is not None
+        assert args.wandb_job_name is not None
+        from nemo.collections.llm.recipes.log.default import wandb_logger
+        recipe.log.wandb=wandb_logger(project=args.wandb_prj_name, name=args.wandb_job_name)
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if PP_SIZE > 1 else None)]
     if args.enable_nsys:

--- a/scripts/performance/llm/pretrain_gpt3_175b.py
+++ b/scripts/performance/llm/pretrain_gpt3_175b.py
@@ -30,12 +30,12 @@ from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
 from ..utils import (
+    args_sanity_check,
     get_comm_overlap_callback_idx,
     get_user_configs,
     hf_tokenizer,
     set_primary_perf_configs,
     slurm_executor,
-    args_sanity_check,
 )
 
 

--- a/scripts/performance/llm/pretrain_gpt3_175b.py
+++ b/scripts/performance/llm/pretrain_gpt3_175b.py
@@ -35,6 +35,7 @@ from ..utils import (
     hf_tokenizer,
     set_primary_perf_configs,
     slurm_executor,
+    args_sanity_check,
 )
 
 
@@ -58,6 +59,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -106,6 +110,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), "pre_train", "gpt3", "175b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, _ = kwargs
@@ -123,10 +128,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if pp_size > 1 else None)]

--- a/scripts/performance/llm/pretrain_llama31_405b.py
+++ b/scripts/performance/llm/pretrain_llama31_405b.py
@@ -35,6 +35,7 @@ from ..utils import (
     hf_tokenizer,
     set_primary_perf_configs,
     slurm_executor,
+    args_sanity_check,
 )
 
 
@@ -58,6 +59,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -104,6 +108,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), "pre_train", "llama31", "405b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, _ = kwargs
@@ -121,10 +126,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if pp_size > 1 else None)]

--- a/scripts/performance/llm/pretrain_llama31_405b.py
+++ b/scripts/performance/llm/pretrain_llama31_405b.py
@@ -30,12 +30,12 @@ from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
 from ..utils import (
+    args_sanity_check,
     get_comm_overlap_callback_idx,
     get_user_configs,
     hf_tokenizer,
     set_primary_perf_configs,
     slurm_executor,
-    args_sanity_check,
 )
 
 

--- a/scripts/performance/llm/pretrain_llama3_70b.py
+++ b/scripts/performance/llm/pretrain_llama3_70b.py
@@ -35,6 +35,7 @@ from ..utils import (
     hf_tokenizer,
     set_primary_perf_configs,
     slurm_executor,
+    args_sanity_check,
 )
 
 
@@ -58,6 +59,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -108,6 +112,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), "pre_train", "llama3", "70b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, _ = kwargs
@@ -125,10 +130,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if pp_size > 1 else None)]

--- a/scripts/performance/llm/pretrain_llama3_70b.py
+++ b/scripts/performance/llm/pretrain_llama3_70b.py
@@ -30,12 +30,12 @@ from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
 from ..utils import (
+    args_sanity_check,
     get_comm_overlap_callback_idx,
     get_user_configs,
     hf_tokenizer,
     set_primary_perf_configs,
     slurm_executor,
-    args_sanity_check,
 )
 
 

--- a/scripts/performance/llm/pretrain_llama3_8b.py
+++ b/scripts/performance/llm/pretrain_llama3_8b.py
@@ -21,13 +21,7 @@ from nemo.collections.llm.recipes.precision.mixed_precision import bf16_with_fp8
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import (
-    get_user_configs,
-    hf_tokenizer,
-    set_primary_perf_configs,
-    slurm_executor,
-    args_sanity_check,
-)
+from ..utils import args_sanity_check, get_user_configs, hf_tokenizer, set_primary_perf_configs, slurm_executor
 
 
 def override_recipe_configs(

--- a/scripts/performance/llm/pretrain_llama3_8b.py
+++ b/scripts/performance/llm/pretrain_llama3_8b.py
@@ -21,7 +21,13 @@ from nemo.collections.llm.recipes.precision.mixed_precision import bf16_with_fp8
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import get_user_configs, hf_tokenizer, set_primary_perf_configs, slurm_executor
+from ..utils import (
+    get_user_configs,
+    hf_tokenizer,
+    set_primary_perf_configs,
+    slurm_executor,
+    args_sanity_check,
+)
 
 
 def override_recipe_configs(
@@ -45,6 +51,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -55,6 +64,7 @@ def override_recipe_configs(
         cp_size,
         vp_size,
         ep_size,
+        enable_wd=args.wandb,
     )
 
     # data module configs
@@ -75,6 +85,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), "pre_train", "llama3", "8b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, _ = kwargs
@@ -92,10 +103,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [

--- a/scripts/performance/llm/pretrain_mixtral_8x22b.py
+++ b/scripts/performance/llm/pretrain_mixtral_8x22b.py
@@ -22,7 +22,13 @@ from nemo.collections.llm.recipes.precision.mixed_precision import bf16_with_fp8
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import get_user_configs, hf_tokenizer, set_primary_perf_configs, slurm_executor
+from ..utils import (
+    get_user_configs,
+    hf_tokenizer,
+    set_primary_perf_configs,
+    slurm_executor,
+    args_sanity_check,
+)
 
 
 def override_recipe_configs(
@@ -46,6 +52,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -78,6 +87,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), "pre_train", "mixtral", "8x22b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, etp_size = kwargs
@@ -97,10 +107,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if pp_size > 1 else None)]

--- a/scripts/performance/llm/pretrain_mixtral_8x22b.py
+++ b/scripts/performance/llm/pretrain_mixtral_8x22b.py
@@ -22,13 +22,7 @@ from nemo.collections.llm.recipes.precision.mixed_precision import bf16_with_fp8
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import (
-    get_user_configs,
-    hf_tokenizer,
-    set_primary_perf_configs,
-    slurm_executor,
-    args_sanity_check,
-)
+from ..utils import args_sanity_check, get_user_configs, hf_tokenizer, set_primary_perf_configs, slurm_executor
 
 
 def override_recipe_configs(

--- a/scripts/performance/llm/pretrain_mixtral_8x7b.py
+++ b/scripts/performance/llm/pretrain_mixtral_8x7b.py
@@ -22,13 +22,7 @@ from nemo.collections.llm.recipes.precision.mixed_precision import bf16_with_fp8
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import (
-    get_user_configs,
-    hf_tokenizer,
-    set_primary_perf_configs,
-    slurm_executor,
-    args_sanity_check,
-)
+from ..utils import args_sanity_check, get_user_configs, hf_tokenizer, set_primary_perf_configs, slurm_executor
 
 
 def override_recipe_configs(

--- a/scripts/performance/llm/pretrain_mixtral_8x7b.py
+++ b/scripts/performance/llm/pretrain_mixtral_8x7b.py
@@ -22,7 +22,13 @@ from nemo.collections.llm.recipes.precision.mixed_precision import bf16_with_fp8
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import get_user_configs, hf_tokenizer, set_primary_perf_configs, slurm_executor
+from ..utils import (
+    get_user_configs,
+    hf_tokenizer,
+    set_primary_perf_configs,
+    slurm_executor,
+    args_sanity_check,
+)
 
 
 def override_recipe_configs(
@@ -46,6 +52,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -77,6 +86,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), "pre_train", "mixtral", "8x7b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, etp_size = kwargs
@@ -96,10 +106,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if pp_size > 1 else None)]

--- a/scripts/performance/llm/pretrain_nemotron3_22b.py
+++ b/scripts/performance/llm/pretrain_nemotron3_22b.py
@@ -22,7 +22,13 @@ from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenize
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import get_user_configs, hf_tokenizer, set_primary_perf_configs, slurm_executor
+from ..utils import (
+    get_user_configs,
+    hf_tokenizer,
+    set_primary_perf_configs,
+    slurm_executor,
+    args_sanity_check,
+)
 
 
 def override_recipe_configs(
@@ -45,6 +51,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -77,6 +86,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), "pre_train", "nemotron3", "22b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, _ = kwargs
@@ -94,10 +104,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if pp_size > 1 else None)]

--- a/scripts/performance/llm/pretrain_nemotron3_22b.py
+++ b/scripts/performance/llm/pretrain_nemotron3_22b.py
@@ -22,13 +22,7 @@ from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenize
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import (
-    get_user_configs,
-    hf_tokenizer,
-    set_primary_perf_configs,
-    slurm_executor,
-    args_sanity_check,
-)
+from ..utils import args_sanity_check, get_user_configs, hf_tokenizer, set_primary_perf_configs, slurm_executor
 
 
 def override_recipe_configs(

--- a/scripts/performance/llm/pretrain_nemotron3_8b.py
+++ b/scripts/performance/llm/pretrain_nemotron3_8b.py
@@ -22,7 +22,12 @@ from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenize
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import get_user_configs, set_primary_perf_configs, slurm_executor
+from ..utils import (
+    get_user_configs,
+    set_primary_perf_configs,
+    slurm_executor,
+    args_sanity_check,
+)
 
 
 def override_recipe_configs(
@@ -45,6 +50,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -73,6 +81,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), "pre_train", "nemotron3", "8b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, _ = kwargs
@@ -90,10 +99,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if pp_size > 1 else None)]

--- a/scripts/performance/llm/pretrain_nemotron3_8b.py
+++ b/scripts/performance/llm/pretrain_nemotron3_8b.py
@@ -22,12 +22,7 @@ from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenize
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import (
-    get_user_configs,
-    set_primary_perf_configs,
-    slurm_executor,
-    args_sanity_check,
-)
+from ..utils import args_sanity_check, get_user_configs, set_primary_perf_configs, slurm_executor
 
 
 def override_recipe_configs(

--- a/scripts/performance/llm/pretrain_nemotron4_15b.py
+++ b/scripts/performance/llm/pretrain_nemotron4_15b.py
@@ -25,7 +25,13 @@ from nemo.collections.nlp.modules.common.tokenizer_utils import get_nmt_tokenize
 from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
-from ..utils import get_comm_overlap_callback_idx, get_user_configs, set_primary_perf_configs, slurm_executor
+from ..utils import (
+    get_comm_overlap_callback_idx,
+    get_user_configs,
+    set_primary_perf_configs,
+    slurm_executor,
+    args_sanity_check,
+)
 
 
 def override_recipe_configs(
@@ -48,6 +54,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -90,6 +99,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), "pre_train", "nemotron4", "15b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, _ = kwargs
@@ -107,10 +117,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if pp_size > 1 else None)]

--- a/scripts/performance/llm/pretrain_nemotron4_15b.py
+++ b/scripts/performance/llm/pretrain_nemotron4_15b.py
@@ -26,11 +26,11 @@ from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
 from ..utils import (
+    args_sanity_check,
     get_comm_overlap_callback_idx,
     get_user_configs,
     set_primary_perf_configs,
     slurm_executor,
-    args_sanity_check,
 )
 
 

--- a/scripts/performance/llm/pretrain_nemotron4_340b.py
+++ b/scripts/performance/llm/pretrain_nemotron4_340b.py
@@ -33,6 +33,7 @@ from ..utils import (
     hf_tokenizer,
     set_primary_perf_configs,
     slurm_executor,
+    args_sanity_check,
 )
 
 
@@ -56,6 +57,9 @@ def override_recipe_configs(
     recipe = set_primary_perf_configs(
         recipe,
         args.tensorboard,
+        args.wandb,
+        args.wandb_prj_name,
+        args.wandb_job_name,
         num_nodes,
         args.gpus_per_node,
         mbs,
@@ -102,6 +106,7 @@ def override_recipe_configs(
 
 if __name__ == "__main__":
     args = parse_cli_args().parse_args()
+    args_sanity_check(args)
 
     kwargs = get_user_configs(args.gpu.lower(), "pre_train", "nemotron4", "340b", args)
     num_nodes, mbs, gbs, tp_size, pp_size, cp_size, vp_size, ep_size, _ = kwargs
@@ -119,10 +124,11 @@ if __name__ == "__main__":
         args.gpus_per_node,
         args.time_limit,
         args.container_image,
-        custom_mounts=[],
+        custom_mounts=args.custom_mounts,
         custom_env_vars={},
         hf_token=args.hf_token,
         nemo_home=args.nemo_home,
+        wandb_key=args.wandb_key,
     )
 
     plugins = [PerfEnvPlugin(enable_vboost=True, nccl_pp_comm_chunksize=2097152 if pp_size > 1 else None)]

--- a/scripts/performance/llm/pretrain_nemotron4_340b.py
+++ b/scripts/performance/llm/pretrain_nemotron4_340b.py
@@ -28,12 +28,12 @@ from nemo.lightning.run.plugins import NsysPlugin, PerfEnvPlugin
 
 from ..argument_parser import parse_cli_args
 from ..utils import (
+    args_sanity_check,
     get_comm_overlap_callback_idx,
     get_user_configs,
     hf_tokenizer,
     set_primary_perf_configs,
     slurm_executor,
-    args_sanity_check,
 )
 
 

--- a/scripts/performance/utils.py
+++ b/scripts/performance/utils.py
@@ -236,7 +236,8 @@ def set_primary_perf_configs(
         recipe.log.log_dir = "/nemo_run/lightning_logs"  # saves file at- `<log_dir>/lightning_logs/tb_logs
     if enable_wd:
         from nemo.collections.llm.recipes.log.default import wandb_logger
-        recipe.log.wandb=wandb_logger(project=wandb_prj_name, name=wandb_job_name)
+
+        recipe.log.wandb = wandb_logger(project=wandb_prj_name, name=wandb_job_name)
 
     # Misc. for overall faster experiment runtime
     recipe.log.ckpt = None


### PR DESCRIPTION
# What does this PR do ?

- Add the interface to add custom mounts to performance scripts
- Add wandb logger to the performance scripts

# Changelog

- Add the interface to add custom mounts to performance scripts
- Add wandb logger to the performance scripts

# Usage

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
