### PR TITLE
Script name "speech_to_frame_label.py" fixed

### DIFF
--- a/examples/asr/speech_classification/README.md
+++ b/examples/asr/speech_classification/README.md
@@ -8,7 +8,7 @@ The frame-level VAD model predicts for each frame of the audio whether it has sp
 
 ### Training
 ```sh
-python speech_to_label.py \
+python speech_to_frame_label.py \
     --config-path=<path to directory of configs, e.g. "../conf/marblenet">
     --config-name=<name of config without .yaml, e.g. "marblenet_3x2x64_20ms"> \
     model.train_ds.manifest_filepath="[<path to train manifest1>,<path to train manifest2>]" \

--- a/examples/asr/speech_classification/speech_to_frame_label.py
+++ b/examples/asr/speech_classification/speech_to_frame_label.py
@@ -18,7 +18,7 @@ The default config (i.e., marblenet_3x2x64_20ms.yaml) outputs 20ms frames.
 
 ## Training
 ```sh
-python speech_to_label.py \
+python speech_to_frame_label.py \
     --config-path=<path to dir of configs e.g. "../conf/marblenet">
     --config-name=<name of config without .yaml e.g. "marblenet_3x2x64_20ms"> \
     model.train_ds.manifest_filepath="<path to train manifest>" \


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?
This PR fixes the script name for training Frame-VAD. In both the README and speech_to_frame_label.py, it said to run the training with "speech_to_label.py", which is used for Segment-VAD.

**Collection**: ASR, Speech Classification

# Changelog
From /NeMo/examples/asr/speech_classification/:
- In README.md: line 11 changed.
Before:
 python speech_to_label.py \ 
After:
python speech_to_frame_label.py \

- In speech_to_frame_label.py: same change but in line 21, where training section starts.


# Usage


# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [X] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [X] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
