### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `8a5521a...` (2025-03-02)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "d002453cf152e6fb6c94d949326da587745c51de"
+      "ref": "8a5521ac4226fbefeeb2a102ebecac32a01d4852"
     }
   },
   "pypi-dependencies": {}


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `8a5521ac4226fbefeeb2a102ebecac32a01d4852`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.