### PR TITLE
remove PytorchOptimizerModule connect

### DIFF
--- a/nemo/lightning/pytorch/optim/pytorch.py
+++ b/nemo/lightning/pytorch/optim/pytorch.py
@@ -126,11 +126,3 @@ class PytorchOptimizerModule(OptimizerModule):
             return optim
         else:
             return [self.lr_scheduler.scheduler(model, opt) for opt in optim]
-
-    def connect(self, model: L.LightningModule) -> None:
-        """Connects the optimizer module to the model.
-
-        Args:
-            model (L.LightningModule): The model to which the optimizer module is being connected.
-        """
-        model.configure_optimizers = lambda: self.optimizers(model)


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fix a bug that make lr be consistent value, will not be updated with training step

**Collection**: llm hf_auto_model_for_causal_lm.py

```
optim=pytorch_adam_with_cosine_annealing(max_lr=3e-4),
```