### PR TITLE
Enable vortex style fp8 as an option in evo2

### DIFF
--- a/nemo/collections/llm/gpt/model/hyena.py
+++ b/nemo/collections/llm/gpt/model/hyena.py
@@ -216,6 +216,9 @@ class HyenaConfig(TransformerConfig, io.IOMixin):
     use_te: bool = True
     to_upper: str = "normalized_weighted"  # choose between "weighted" and "normalized_weighted"
     use_short_conv_bias: bool = False
+    # Use this if you want to turn FP8 on for the linear layer in the mixer only. When using this, do not set
+    #  Fp8 in the mixed precision plugin.
+    vortex_style_fp8: bool = False
 
     def __post_init__(self):
         """

--- a/nemo/collections/llm/gpt/model/megatron/hyena/hyena_mixer.py
+++ b/nemo/collections/llm/gpt/model/megatron/hyena/hyena_mixer.py
@@ -48,15 +48,21 @@ try:
 except ImportError:
 
     def DelayedScaling(*args, **kwargs):
+        """Not imported: DelayedScaling. An error will be raised if this is called."""
         raise ImportError("transformer_engine not installed. Using default recipe.")
 
     def Format(*args, **kwargs):
+        """Not imported: Format. An error will be raised if this is called."""
         raise ImportError("transformer_engine not installed. Using default recipe.")
 
-    class te:
+    class _te:
+        """If this dummy module is accessed, a not imported error will be raised."""
+
         def __getattribute__(self, name: str) -> None:
+            """Not imported: te. An error will be raised if this is called like a module."""
             raise ImportError("transformer_engine not installed. Using default recipe.")
 
+    te = _te()  # if a user accesses anything in this module, an error will be raised
     logger.warning("WARNING: transformer_engine not installed. Using default recipe.")
 
 

--- a/nemo/collections/llm/gpt/model/megatron/hyena/hyena_mixer.py
+++ b/nemo/collections/llm/gpt/model/megatron/hyena/hyena_mixer.py
@@ -43,8 +43,20 @@ from nemo.collections.llm.gpt.model.megatron.hyena.hyena_utils import (
 logger = logging.getLogger(__name__)
 
 try:
+    import transformer_engine.pytorch as te
     from transformer_engine.common.recipe import DelayedScaling, Format
 except ImportError:
+
+    def DelayedScaling(*args, **kwargs):
+        raise ImportError("transformer_engine not installed. Using default recipe.")
+
+    def Format(*args, **kwargs):
+        raise ImportError("transformer_engine not installed. Using default recipe.")
+
+    class te:
+        def __getattribute__(self, name: str) -> None:
+            raise ImportError("transformer_engine not installed. Using default recipe.")
+
     logger.warning("WARNING: transformer_engine not installed. Using default recipe.")
 
 
@@ -241,8 +253,11 @@ class HyenaMixer(MegatronModule):
             _proj_use_cp = True
         else:
             _proj_use_cp = False
-
-        features, _ = self.dense_projection(x)
+        if self.transformer_config.vortex_style_fp8:
+            with te.fp8_autocast(enabled=True, fp8_recipe=set_format_recipe()):
+                features, _ = self.dense_projection(x)
+        else:
+            features, _ = self.dense_projection(x)
         features = rearrange(features, "l b d -> b l d").contiguous()
         features_L_last = features.permute(0, 2, 1)
         features_D_last = self.hyena_proj_conv(features_L_last, _use_cp=_proj_use_cp).permute(0, 2, 1)


### PR DESCRIPTION
This particular form of FP8 is needed to replicate a number of results in the Evo2 paper. 

**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

Without it we get random AUCs, with it we can recover the results reported in the arc notebooks.