### PR TITLE
Deepseek Aligner Support

### DIFF
--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -582,7 +582,7 @@ class MegatronBaseModel(NLPModel):
         }
 
         transformer_config_cls = TransformerConfig
-        if self.cfg.get('name', None) == 'decoder_block_gpt':
+        if self.cfg.get('multi_latent_attention', False):
             transformer_config_cls = MLATransformerConfig
 
         # populate the transformer config dict

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -581,7 +581,7 @@ class MegatronBaseModel(NLPModel):
             'attention_backend': attention_backend,
         }
 
-        transformer_confg_cls = TransformerConfig
+        transformer_config_cls = TransformerConfig
         if self.cfg.get('name', None) == 'decoder_block_gpt':
             transformer_config_cls = MLATransformerConfig
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -52,7 +52,7 @@ try:
     from megatron.core.distributed import DistributedDataParallel as McoreDDP
     from megatron.core.transformer.enums import AttnBackend
     from megatron.core.transformer.module import Float16Module as MCoreFloat16Module
-    from megatron.core.transformer.transformer_config import TransformerConfig, MLATransformerConfig
+    from megatron.core.transformer.transformer_config import MLATransformerConfig, TransformerConfig
     from megatron.core.utils import init_method_normal, scaled_init_method_normal
 
     HAVE_MEGATRON_CORE = True

--- a/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_base_model.py
@@ -52,7 +52,7 @@ try:
     from megatron.core.distributed import DistributedDataParallel as McoreDDP
     from megatron.core.transformer.enums import AttnBackend
     from megatron.core.transformer.module import Float16Module as MCoreFloat16Module
-    from megatron.core.transformer.transformer_config import TransformerConfig
+    from megatron.core.transformer.transformer_config import TransformerConfig, MLATransformerConfig
     from megatron.core.utils import init_method_normal, scaled_init_method_normal
 
     HAVE_MEGATRON_CORE = True
@@ -581,8 +581,12 @@ class MegatronBaseModel(NLPModel):
             'attention_backend': attention_backend,
         }
 
+        transformer_confg_cls = TransformerConfig
+        if self.cfg.get('name', None) == 'decoder_block_gpt':
+            transformer_config_cls = MLATransformerConfig
+
         # populate the transformer config dict
-        for field in fields(TransformerConfig):
+        for field in fields(transformer_config_cls):
             # config mapping has second highest priority
             if field.name in config_mapping:
                 transformer_config_dict[field.name] = config_mapping[field.name]
@@ -598,7 +602,7 @@ class MegatronBaseModel(NLPModel):
                     f"Add this key to cfg or config_mapping to make to make it configurable."
                 )
 
-        transformer_config = TransformerConfig(**transformer_config_dict)
+        transformer_config = transformer_config_cls(**transformer_config_dict)
 
         return transformer_config
 

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -2211,10 +2211,15 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
             self.cfg.get('account_for_embedding_in_pipeline_split', False)
             and self.cfg.get('account_for_loss_in_pipeline_split', False)
         ):
-            if self.cfg.num_layers % self.cfg.get('pipeline_model_parallel_size', 1) != 0:
+            # Check that number of layers is compatible with pipeline parallelism
+            num_layers_first = self.cfg.get('num_layers_in_first_pipeline_stage', 0)
+            num_layers_last = self.cfg.get('num_layers_in_last_pipeline_stage', 0)
+            remaining_layers = self.cfg.num_layers - num_layers_first - num_layers_last
+            if remaining_layers % self.cfg.get('pipeline_model_parallel_size', 1) != 0:
                 raise ValueError(
-                    f"num_layers ({self.cfg.num_layers}) should be divisible by "
-                    f"pipeline_model_parallel_size ({self.cfg.get('pipeline_model_parallel_size', 1)})"
+                    f"num_layers ({self.cfg.num_layers}) minus num_layers_in_first_pipeline_stage ({num_layers_first}) "
+                    f"and num_layers_in_last_pipeline_stage ({num_layers_last}) should be divisible by "
+                    f"pipeline_model_parallel_size ({self.cfg.get('pipeline_model_parallel_size', 1)})."
                 )
 
         normalization = self.cfg.get('normalization', 'layernorm').lower()

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -90,6 +90,7 @@ try:
     from megatron.core.models.gpt.gpt_layer_specs import (
         get_gpt_layer_local_spec,
         get_gpt_layer_with_transformer_engine_spec,
+        get_gpt_decoder_block_spec,
     )
     from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
     from megatron.core.transformer.module import Float16Module as MCoreFloat16Module
@@ -161,6 +162,7 @@ def get_specs(spec_name, transformer_config=None, use_te=True, hyena_cfg: Dict =
         "megatron_gpt_full_te_layer_autocast": get_gpt_full_te_layer_autocast_spec(transformer_config),
         "modelopt": get_gpt_layer_modelopt_spec(num_experts),
         "te_gpt_hyena": get_gpt_layer_with_te_and_hyena_spec(hyena_cfg),
+        "decoder_block_gpt": get_gpt_decoder_block_spec(transformer_config, use_te),
     }
     if spec_name not in name_spec_dict:
         raise ValueError(f"Spec name '{spec_name}' is not recognized.")

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -2225,7 +2225,8 @@ class MegatronGPTModel(MegatronBaseModel, TextGeneration):
 
             if remaining_layers % pipeline_size != 0:
                 raise ValueError(
-                    f"num_layers ({self.cfg.num_layers}) minus num_layers_in_first_pipeline_stage ({num_layers_first}) "
+                    f"num_layers ({self.cfg.num_layers}) minus "
+                    f"num_layers_in_first_pipeline_stage ({num_layers_first}) "
                     f"and num_layers_in_last_pipeline_stage ({num_layers_last}) should be divisible by "
                     f"remaining pipeline stages ({pipeline_size})."
                 )

--- a/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
+++ b/nemo/collections/nlp/models/language_modeling/megatron_gpt_model.py
@@ -88,9 +88,9 @@ try:
     # from megatron.core.inference.gpt.model_specs import get_gpt_layer_ammo_spec
     from megatron.core.models.gpt import GPTModel as MCoreGPTModel
     from megatron.core.models.gpt.gpt_layer_specs import (
+        get_gpt_decoder_block_spec,
         get_gpt_layer_local_spec,
         get_gpt_layer_with_transformer_engine_spec,
-        get_gpt_decoder_block_spec,
     )
     from megatron.core.pipeline_parallel.schedules import get_forward_backward_func
     from megatron.core.transformer.module import Float16Module as MCoreFloat16Module

--- a/nemo/collections/nlp/parts/nlp_overrides.py
+++ b/nemo/collections/nlp/parts/nlp_overrides.py
@@ -1408,7 +1408,8 @@ class NLPSaveRestoreConnector(SaveRestoreConnector):
                 checkpoint['state_dict'] = sharded_state_dict
                 if replace_sharded_tensor_key:
                     for v in checkpoint["state_dict"].values():
-                        v.key = v.key.replace("model", replace_sharded_tensor_key)
+                        if hasattr(v, "key"):
+                            v.key = v.key.replace("model", replace_sharded_tensor_key)
 
                 checkpoint_io = DistributedCheckpointIO.from_config(conf)
                 checkpoint = checkpoint_io.load_checkpoint(

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -24,8 +24,9 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import hydra
-from nemo.core.classes.module import NeuralModule
 import torch
+
+from nemo.core.classes.module import NeuralModule
 
 try:
     from megatron.core.optimizer import OptimizerConfig, get_megatron_optimizer
@@ -1789,6 +1790,7 @@ class ModelPT(LightningModule, Model):
             if self.cfg.chakra_profile.get('enabled', False):
 
                 from torch.profiler import ExecutionTraceObserver
+
                 from nemo.utils.env_var_parsing import get_envint
 
                 self._chakra_profile_enabled = True

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import copy
 import inspect
 import os
+import pathlib
 import uuid
 from abc import abstractmethod
 from os import path
@@ -23,6 +24,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Union
 
 import hydra
+from nemo.core.classes.module import NeuralModule
 import torch
 
 try:
@@ -79,7 +81,8 @@ class ModelPT(LightningModule, Model):
         """
         if trainer is not None and not isinstance(trainer, Trainer):
             raise ValueError(
-                f"trainer constructor argument must be either None or lightning.pytorch.Trainer. But got {type(trainer)} instead."
+                f"trainer constructor argument must be either None or lightning.pytorch.Trainer. "
+                f"But got {type(trainer)} instead."
             )
         super().__init__()
 
@@ -174,14 +177,15 @@ class ModelPT(LightningModule, Model):
         else:
             if 'train_ds' in self._cfg and self._cfg.train_ds is not None:
                 logging.warning(
-                    f"If you intend to do training or fine-tuning, please call the ModelPT.setup_training_data() method "
-                    f"and provide a valid configuration file to setup the train data loader.\n"
+                    f"If you intend to do training or fine-tuning, please call the ModelPT.setup_training_data() "
+                    f"method and provide a valid configuration file to setup the train data loader.\n"
                     f"Train config : \n{OmegaConf.to_yaml(self._cfg.train_ds)}"
                 )
 
             if 'validation_ds' in self._cfg and self._cfg.validation_ds is not None:
                 logging.warning(
-                    f"If you intend to do validation, please call the ModelPT.setup_validation_data() or ModelPT.setup_multiple_validation_data() method "
+                    f"If you intend to do validation, please call the ModelPT.setup_validation_data() or "
+                    f"ModelPT.setup_multiple_validation_data() method "
                     f"and provide a valid configuration file to setup the validation data loader(s). \n"
                     f"Validation config : \n{OmegaConf.to_yaml(self._cfg.validation_ds)}"
                 )
@@ -255,11 +259,12 @@ class ModelPT(LightningModule, Model):
         Args:
             config_path (str): Artifact key. Usually corresponds to the model config.
             src (str): Path to artifact.
-            verify_src_exists (bool): If set to False, then the artifact is optional and register_artifact will return None even if
-                                      src is not found. Defaults to True.
+            verify_src_exists (bool): If set to False, then the artifact is optional and register_artifact will return
+                                      None even if src is not found. Defaults to True.
 
         Returns:
-            str: If src is not None or empty it always returns absolute path which is guaranteed to exist during model instance life
+            str: If src is not None or empty it always returns absolute path which is guaranteed to exist during model
+                 instance life
         """
 
         if src is None or src == "":
@@ -307,7 +312,8 @@ class ModelPT(LightningModule, Model):
 
     def register_nemo_submodule(self, name: str, config_field: str, model: "ModelPT") -> None:
         """
-        Adds a NeMo model as a submodule. Submodule can be accessed via the `name` attribute on the parent NeMo model this submodule was registered on (`self`).
+        Adds a NeMo model as a submodule. Submodule can be accessed via the `name` attribute on the parent NeMo model
+        this submodule was registered on (`self`).
         In the saving process, the whole parent model (self) is held as a solid model with artifacts
         from the child submodule, the submodule config will be saved to the `config_field` of the parent model.
         This method is necessary to create a nested model, e.g.
@@ -387,7 +393,8 @@ class ModelPT(LightningModule, Model):
          You can use "restore_from" method to fully restore instance from .nemo file.
 
         .nemo file is an archive (tar.gz) with the following:
-            model_config.yaml - model configuration in .yaml format. You can deserialize this into cfg argument for model's constructor
+            model_config.yaml - model configuration in .yaml format. You can deserialize this into cfg argument for
+                                model's constructor
             model_wights.ckpt - model checkpoint
 
         Args:
@@ -670,7 +677,7 @@ class ModelPT(LightningModule, Model):
             optim_config = OmegaConf.to_container(optim_config, resolve=True)
 
         if self._trainer is None:
-            logging.warning(f"Trainer wasn't specified in model constructor. Make sure that you really wanted it.")
+            logging.warning("Trainer wasn't specified in model constructor. Make sure that you really wanted it.")
 
         if 'sched' in optim_config and self._trainer is not None:
 
@@ -1239,9 +1246,10 @@ class ModelPT(LightningModule, Model):
             logging.info(f'Model checkpoint partially restored from {load_from_string}')
             if len(excluded_param_names) > 0:
                 logging.info(
-                    f'The following parameters were excluded when loading from {load_from_string} : {excluded_param_names}'
+                    'The following parameters were excluded when loading from '
+                    f'{load_from_string} : {excluded_param_names}'
                 )
-                logging.info(f'Make sure that this is what you wanted!')
+                logging.info('Make sure that this is what you wanted!')
         else:
             if len(excluded_param_names) > 0:
                 logging.info(
@@ -1476,7 +1484,11 @@ class ModelPT(LightningModule, Model):
 
             To convert the .nemo tarfile into multiple Module level PyTorch checkpoints
             ::
-            state_dict = nemo.collections.asr.models.EncDecCTCModel.extract_state_dict_from('asr.nemo', './asr_ckpts', split_by_module=True)
+            state_dict = nemo.collections.asr.models.EncDecCTCModel.extract_state_dict_from(
+                            'asr.nemo',
+                            './asr_ckpts',
+                            split_by_module=True
+                        )
 
 
             To restore a module from a Module level checkpoint
@@ -1565,7 +1577,7 @@ class ModelPT(LightningModule, Model):
                 if trainer.num_devices and trainer.num_nodes:
                     self.world_size = trainer.num_devices * trainer.num_nodes
             else:
-                logging.warning(f'World size can only be set by PyTorch Lightning Trainer.')
+                logging.warning('World size can only be set by PyTorch Lightning Trainer.')
         app_state = AppState()
         app_state.world_size = self.world_size
 
@@ -1687,8 +1699,8 @@ class ModelPT(LightningModule, Model):
 
         # Initialize new output list
         self._validation_step_outputs = []
-        # Check len(self._validation_dl) > 1 as sometimes single dataloader can be in a list: [<Dataloader obj>] when ds_item in
-        # config has 1 item passed in a list
+        # Check len(self._validation_dl) > 1 as sometimes single dataloader can be in a
+        # list: [<Dataloader obj>] when ds_item in config has 1 item passed in a list
         if (
             self._validation_dl is not None
             and isinstance(self._validation_dl, (list, tuple))
@@ -1706,7 +1718,8 @@ class ModelPT(LightningModule, Model):
     @property
     def test_step_outputs(self):
         """
-        Cached outputs of test_step. It can be a list of items (for single data loader) or a list of lists (for multiple data loaders).
+        Cached outputs of test_step. It can be a list of items (for single data loader) or a list of
+        lists (for multiple data loaders).
 
         Returns:
             List of outputs of test_step.
@@ -1716,8 +1729,8 @@ class ModelPT(LightningModule, Model):
 
         # Initialize new output list
         self._test_step_outputs = []
-        # Check len(self._test_dl) > 1 as sometimes single dataloader can be in a list: [<Dataloader obj>] when ds_item in
-        # config has 1 item passed in a list
+        # Check len(self._test_dl) > 1 as sometimes single dataloader can be in a list: [<Dataloader obj>]
+        # when ds_item in config has 1 item passed in a list
         if self._test_dl is not None and isinstance(self._test_dl, (list, tuple)) and len(self._test_dl) > 1:
             for _ in range(len(self._test_dl)):
                 self._test_step_outputs.append([])
@@ -1815,11 +1828,11 @@ class ModelPT(LightningModule, Model):
                 if self._chakra_profile_end_step >= self._chakra_profile_start_step:
                     pass
                 else:
-                    raise ValueError(f'chakra end_step must be greater than or equal to chakra start_step')
+                    raise ValueError('chakra end_step must be greater than or equal to chakra start_step')
 
                 if self.cfg.nsys_profile.get('enabled', False):
                     raise Exception(
-                        f"Profiler conflict: Chakra profiling and Nsys profiling cannot be enabled at the same time."
+                        "Profiler conflict: Chakra profiling and Nsys profiling cannot be enabled at the same time."
                     )
 
                 self._et = ExecutionTraceObserver()
@@ -1842,7 +1855,8 @@ class ModelPT(LightningModule, Model):
             ranks: [0] # Global rank IDs to profile
             gen_shape: False # Generate model and kernel details including input shapes
         And then wrap the model training script with:
-        nsys profile -s none -o <profile filepath>  -t cuda,nvtx --force-overwrite true --capture-range=cudaProfilerApi --capture-range-end=stop python ./examples/...
+        nsys profile -s none -o <profile filepath>  -t cuda,nvtx --force-overwrite true
+            --capture-range=cudaProfilerApi --capture-range-end=stop python ./examples/...
         See more options at: https://docs.nvidia.com/nsight-systems/UserGuide/index.html#cli-profiling
 
         Enables CUDA memory profiling
@@ -1879,7 +1893,7 @@ class ModelPT(LightningModule, Model):
                 if self._nsys_profile_end_step >= self._nsys_profile_start_step:
                     pass
                 else:
-                    raise ValueError(f'Nsys end_step must be greater than or equal to nsys start_step')
+                    raise ValueError('Nsys end_step must be greater than or equal to nsys start_step')
 
         if self.cfg.get('memory_profile', None) is not None:
             if self.cfg.memory_profile.get('enabled', False):
@@ -1907,11 +1921,12 @@ class ModelPT(LightningModule, Model):
                 if self._memory_profile_end_step >= self._memory_profile_start_step:
                     pass
                 else:
-                    raise ValueError(f'CUDA memory end_step must be greater than or equal to memory start_step')
+                    raise ValueError('CUDA memory end_step must be greater than or equal to memory start_step')
 
                 if self._memory_profile_output_path is None or not os.path.isdir(self._memory_profile_output_path):
                     raise ValueError(
-                        f'Memory profile output path ({self._memory_profile_output_path}) is not set or does not exist.'
+                        f'Memory profile output path ({self._memory_profile_output_path}) is not set '
+                        'or does not exist.'
                     )
 
     def on_train_start(self):
@@ -2065,7 +2080,8 @@ class ModelPT(LightningModule, Model):
     def cuda(self, device=None):
         """PTL is overriding this method and changing the pytorch behavior of a module.
             The PTL LightingModule override will move the module to device 0 if device is None.
-            See the PTL method here: https://github.com/Lightning-AI/lightning/blob/master/src/pytorch_lightning/core/mixins/device_dtype_mixin.py#L113
+            See the PTL method here:
+            https://github.com/Lightning-AI/lightning/blob/master/src/pytorch_lightning/core/mixins/device_dtype_mixin.py#L113
 
             Here we are overriding this to maintain the default Pytorch nn.module behavior:
             https://github.com/pytorch/pytorch/blob/master/torch/nn/modules/module.py#L728

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -619,7 +619,7 @@ class ModelPT(LightningModule, Model):
             weight_decay=optim_config['weight_decay'],
             adam_beta1=optim_config['betas'][0],
             adam_beta2=optim_config['betas'][1],
-            adam_eps=optim_config['eps'],
+            adam_eps=optim_config.get('eps', OptimizerConfig.adam_eps),
             clip_grad=self.trainer.gradient_clip_val,
             use_distributed_optimizer=self.use_mcore_dist_optim,
             overlap_param_gather_with_optimizer_step=self.cfg.optim.get(

--- a/nemo/core/classes/modelPT.py
+++ b/nemo/core/classes/modelPT.py
@@ -619,6 +619,7 @@ class ModelPT(LightningModule, Model):
             weight_decay=optim_config['weight_decay'],
             adam_beta1=optim_config['betas'][0],
             adam_beta2=optim_config['betas'][1],
+            adam_eps=optim_config['eps'],
             clip_grad=self.trainer.gradient_clip_val,
             use_distributed_optimizer=self.use_mcore_dist_optim,
             overlap_param_gather_with_optimizer_step=self.cfg.optim.get(


### PR DESCRIPTION
# What does this PR do ?

Add support for loading and training Deepseek-V2 NeMo 2 checkpoint in Aligner.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add option to use `get_gpt_decoder_block_spec`, which is required for DeepSeek models
- Use `MLATransformerConfig` when `multi_latent_attention=True`
- Fix pipeline parallelism check to take into account `num_layers_in_first_pipeline_stage` and `num_layers_in_last_pipeline_stage`
- Add option to override `adam_eps` - This was used to verify Aligner SFT training matched with DPO

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
