### PR TITLE
Fixing a wrong Sortformer Tutorial Notebook path.

### DIFF
--- a/tutorials/speaker_tasks/End_to_End_Diarization_Training.ipynb
+++ b/tutorials/speaker_tasks/End_to_End_Diarization_Training.ipynb
@@ -478,7 +478,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!python ${NEMO_DIAR_PATH}/scripts/speaker_tasks/create_alignment_manifest.py \\\n",
+    "!python ${NEMO_DIR_PATH}/scripts/speaker_tasks/create_alignment_manifest.py \\\n",
     "  --input_manifest_filepath LibriSpeech/dev_clean.json \\\n",
     "  --base_alignment_path LibriSpeech_Alignments \\\n",
     "  --output_manifest_filepath ./dev-clean-align.json \\\n",


### PR DESCRIPTION

# What does this PR do ?

Fixing a wrong Sortformer Tutorial Notebook path.

**Collection**: [Note which collection this PR will affect]

ASR (Speaker Tasks)


# Changelog

`End_to_End_Diarization_Training.ipynb`

Line 481: 
`NEMO_DIAR_PATH` to `NEMO_DIR_PATH`

# Usage

- You can potentially add a usage example below

Run tutorial notebook `End_to_End_Diarization_Training.ipynb`.


# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in NeMo ASR.


