### PR TITLE
Update recompute_num_layers in the Hyena 1b config so it works with the model

### DIFF
--- a/nemo/collections/llm/gpt/model/hyena.py
+++ b/nemo/collections/llm/gpt/model/hyena.py
@@ -316,6 +316,7 @@ class Hyena1bConfig(HyenaConfig):
 
     hybrid_override_pattern: str = "SDH*SDHSDH*SDHSDH*SDHSDH*"
     num_layers: int = 25
+    recompute_num_layers: int = 5  # needs to be a multiple of num_layers
     seq_length: int = 8192
     hidden_size: int = 1920
     num_groups_hyena: int = 1920


### PR DESCRIPTION
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [x] Documentation

Fixes errors like the following when using the 1b config and not overriding this value's default (4) which is not a multiple of num_layers for this config:
```
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/nemo/collections/llm/gpt/model/megatron/hyena/hyena_block.py", line 294, in forward
[rank6]:     hidden_states = self._checkpointed_forward(
[rank6]:                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/nemo/collections/llm/gpt/model/megatron/hyena/hyena_block.py", line 220, in _checkpointed_forward
[rank6]:     hidden_states = checkpoint_handler(custom(layer_idx, layer_idx + self.config.recompute_num_layers))
[rank6]:                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/nemo/collections/llm/gpt/model/megatron/hyena/hyena_block.py", line 192, in checkpoint_handler
[rank6]:     return te_checkpoint(
[rank6]:            ^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/megatron/core/extensions/transformer_engine.py", line 1235, in te_checkpoint
[rank6]:     return checkpoint(
[rank6]:            ^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/torch/_compile.py", line 32, in inner
[rank6]:     return disable_fn(*args, **kwargs)
[rank6]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 738, in _fn
[rank6]:     return fn(*args, **kwargs)
[rank6]:            ^^^^^^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/transformer_engine/pytorch/distributed.py", line 668, in checkpoint
[rank6]:     return _CheckpointFunction.apply(
[rank6]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/torch/autograd/function.py", line 575, in apply
[rank6]:     return super().apply(*args, **kwargs)  # type: ignore[misc]
[rank6]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/transformer_engine/pytorch/distributed.py", line 310, in forward
[rank6]:     outputs = run_function(*args, **kwargs)
[rank6]:               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/nemo/collections/llm/gpt/model/megatron/hyena/hyena_block.py", line 176, in custom_forward
[rank6]:     layer = self._get_layer(index)
[rank6]:             ^^^^^^^^^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/nemo/collections/llm/gpt/model/megatron/hyena/hyena_block.py", line 163, in _get_layer
[rank6]:     return self.layers[layer_number]
[rank6]:            ~~~~~~~~~~~^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/container.py", line 334, in __getitem__
[rank6]:     return self._modules[self._get_abs_string_index(idx)]
[rank6]:                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank6]:   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/container.py", line 316, in _get_abs_string_index
[rank6]:     raise IndexError(f"index {idx} is out of range")
[rank6]: IndexError: index 25 is out of range
```