### PR TITLE
Fix TP for LoRA adapter on `linear_fc1`

### DIFF
--- a/nemo/collections/llm/peft/canonical_lora.py
+++ b/nemo/collections/llm/peft/canonical_lora.py
@@ -234,6 +234,7 @@ class CanonicalLoRA(PEFT, ModuleMatcher):
 
             adapter_kwargs = dict(
                 dim=self.dim,
+                base_linear_name=full_name,
                 activation='identity',
                 norm_position=None,
                 norm_type=None,

--- a/nemo/collections/llm/peft/dora.py
+++ b/nemo/collections/llm/peft/dora.py
@@ -186,6 +186,7 @@ class DoRA(PEFT, ModuleMatcher):
                 in_features,
                 out_features,
                 self.dim,
+                base_linear_name=full_name,
                 activation='identity',
                 norm_position=None,
                 norm_type=None,

--- a/nemo/collections/llm/peft/lora.py
+++ b/nemo/collections/llm/peft/lora.py
@@ -308,6 +308,7 @@ class LoRA(PEFT, ModuleMatcher):
                 in_features,
                 out_features,
                 self.dim,
+                base_linear_name=full_name,
                 activation='identity',
                 norm_position=None,
                 norm_type=None,


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

In `linear_fc1`, TP is sharded separately on the two logical matrices, gate and up. 

For example, naive TP splitting would be $W = [W_1 W_2 ... W_t]$

But the correct splitting should be $W = [W_{1,gate} W_{2,gate} ... W_{t,gate} W_{1,up} W_{2,up} ... W_{t,up}]$

This is already reflected in the [MLP sharded state dict in megatron core
](https://github.com/NVIDIA/Megatron-LM/blob/cda85ef950aebfb60145221b0eef3685f46f52eb/megatron/core/transformer/mlp.py#L146). This PR adds the same logic to LoRA B (`linear_out`) so that the resulting distributed checkpoint can be used with different TP sizes.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
