### PR TITLE
Re-add reverted commits after 2.2.0 and set next version to be 2.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ multi-GPU/multi-node training.
 ## Requirements
 
 - Python 3.10 or above
-- Pytorch 1.13.1 or above
+- Pytorch 2.5 or above
 - NVIDIA GPU (if you intend to do model training)
 
 ## Developer Documentation

--- a/nemo/package_info.py
+++ b/nemo/package_info.py
@@ -15,7 +15,7 @@
 
 MAJOR = 2
 MINOR = 2
-PATCH = 0
+PATCH = 1
 PRE_RELEASE = ''
 
 # Use the following formatting: (major, minor, patch, pre-release)

--- a/scripts/speech_recognition/convert_hf_dataset_to_nemo.py
+++ b/scripts/speech_recognition/convert_hf_dataset_to_nemo.py
@@ -84,14 +84,13 @@ python convert_hf_dataset_to_nemo.py \
 import json
 import os
 import traceback
-from dataclasses import dataclass, is_dataclass
+from dataclasses import dataclass, field, is_dataclass
 from typing import Optional
 
 import hydra
 import librosa
 import soundfile
 import tqdm
-from datasets import Audio, Dataset, IterableDataset, load_dataset
 from hydra.conf import HydraConf, RunDir
 from hydra.core.config_store import ConfigStore
 from omegaconf import OmegaConf
@@ -118,7 +117,7 @@ class HFDatasetConversionConfig:
     resolved_output_dir: str = ''
     split_output_dir: Optional[str] = None
 
-    hydra: HydraConf = HydraConf(run=RunDir(dir="."))
+    hydra: HydraConf = field(default_factory=lambda: HydraConf(run=RunDir(dir=".")))
 
 
 def prepare_output_dirs(cfg: HFDatasetConversionConfig):


### PR DESCRIPTION
# What does this PR do ?

Re-add reverted commits after 2.2.0 and set next version to be 2.2.1

**Collection**: [Note which collection this PR will affect]

# Changelog

- Re-add reverted commits after 2.2.0 and set next version to be 2.2.1

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
