### PR TITLE
Minimize overhead from asynchronous checkpointing

### DIFF
--- a/nemo/utils/_ckpt_utils.py
+++ b/nemo/utils/_ckpt_utils.py
@@ -174,6 +174,28 @@ class _MegatronCompatibleAsyncCheckpointProcess(_AsyncCheckpointProcess):
 
 
 class TorchCompatiblePersistentAsyncCaller(_MegatronCompatibleAsyncCheckpointProcess, PersistentAsyncCaller):
+    """ Initializes a Torch-compatible persistent asynchronous caller.
+
+    This constructor first checks that a distributed process group is
+    initialized (via torch.distributed). It then calls the base class
+    initializer for _MegatronCompatibleAsyncCheckpointProcess with a freshly
+    created _ProcessGroupInitInfo object and the provided profile_dir.
+
+    Args:
+        profile_dir (Optional[str]): Directory for storing performance profiles
+            and diagnostic information. If None, no profile directory is used.
+
+    Raises:
+        AssertionError: If the distributed process group is not initialized.
+
+    Side Effects:
+        - Sets up internal queues (self.queue and self.comp_q) for sending and
+        receiving items for asynchronous operations.
+        - Initializes state variables (self.cur_item, self.cur_idx) to track the
+        current item being processed.
+        - Defines the process function (self.process) to be used for handling
+        async checkpoint saving tasks.
+    """
     def __init__(self, profile_dir: Optional[str] = None):
         assert dist.is_initialized(), "Process group must be initialized"
         _MegatronCompatibleAsyncCheckpointProcess.__init__(self, _ProcessGroupInitInfo(), profile_dir)

--- a/nemo/utils/_ckpt_utils.py
+++ b/nemo/utils/_ckpt_utils.py
@@ -137,10 +137,7 @@ class _MegatronCompatibleAsyncCheckpointProcess(_AsyncCheckpointProcess):
                     )
                     tracer.start()
 
-                    logger.info("Started profile in subprocess for checkpointing step {}.".format(
-                            global_step
-                        )
-                    )
+                    logger.info("Started profile in subprocess for checkpointing step {}.".format(global_step))
 
                 # Call the actual save function
                 obj.async_fn(*obj.async_fn_args)
@@ -153,16 +150,11 @@ class _MegatronCompatibleAsyncCheckpointProcess(_AsyncCheckpointProcess):
                         )
                     )
 
-                    logger.info(
-                        "Finished profile in subprocess for checkpointing step {}.".format(
-                            global_step
-                        )
-                    )
+                    logger.info("Finished profile in subprocess for checkpointing step {}.".format(global_step))
 
                 send.put(obj.call_idx)
-                logger.info("Submitted checkpoint save request for checkpoint_id={}".format(
-                    obj.call_idx
-                    )
+                logger.info(
+                    "Submitted checkpoint save request for checkpoint_id={}".format(obj.call_idx)
                 )  # noqa: G004
         except BaseException as e:
             logger.error("Checkpoint background process encountered an exception: {}".format(e))  # noqa: G004
@@ -174,7 +166,7 @@ class _MegatronCompatibleAsyncCheckpointProcess(_AsyncCheckpointProcess):
 
 
 class TorchCompatiblePersistentAsyncCaller(_MegatronCompatibleAsyncCheckpointProcess, PersistentAsyncCaller):
-    """ Initializes a Torch-compatible persistent asynchronous caller.
+    """Initializes a Torch-compatible persistent asynchronous caller.
 
     This constructor first checks that a distributed process group is
     initialized (via torch.distributed). It then calls the base class
@@ -196,6 +188,7 @@ class TorchCompatiblePersistentAsyncCaller(_MegatronCompatibleAsyncCheckpointPro
         - Defines the process function (self.process) to be used for handling
         async checkpoint saving tasks.
     """
+
     def __init__(self, profile_dir: Optional[str] = None):
         assert dist.is_initialized(), "Process group must be initialized"
         _MegatronCompatibleAsyncCheckpointProcess.__init__(self, _ProcessGroupInitInfo(), profile_dir)

--- a/nemo/utils/_ckpt_utils.py
+++ b/nemo/utils/_ckpt_utils.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 from logging import getLogger
 from pathlib import Path

--- a/nemo/utils/_ckpt_utils.py
+++ b/nemo/utils/_ckpt_utils.py
@@ -1,0 +1,310 @@
+import os
+from logging import getLogger
+from pathlib import Path
+from typing import Callable, Optional, Tuple, Union
+
+import torch
+import torch.distributed as dist
+from megatron.core.dist_checkpointing.strategies.async_utils import AsyncRequest, PersistentAsyncCaller
+from torch.distributed.checkpoint._async_process_executor import (
+    _AsyncCheckpointProcess,
+    _CheckpointRequestIdentifier,
+    _CheckpointSaveProcessControlOpts,
+    _ProcessGroupInitInfo,
+)
+from torch.distributed.checkpoint.logger import _init_logger
+from megatron.core.dist_checkpointing.core import CheckpointingConfig, save_config
+from megatron.core.dist_checkpointing.dict_utils import extract_matching_values
+from megatron.core.dist_checkpointing.mapping import (
+    CheckpointingException,
+    CommonStateDict,
+    ShardedObject,
+    ShardedStateDict,
+    StateDict,
+)
+from megatron.core.dist_checkpointing.serialization import (
+    get_default_save_common_strategy,
+    get_default_save_sharded_strategy,
+)
+from megatron.core.dist_checkpointing.strategies.base import (
+    AsyncSaveShardedStrategy,
+    SaveCommonStrategy,
+    SaveShardedStrategy,
+    StrategyAction,
+    get_default_strategy,
+)
+from megatron.core.dist_checkpointing.validation import (
+    validate_sharded_objects_handling,
+)
+from torch import multiprocessing as mp
+from torch.distributed.checkpoint.metadata import STATE_DICT_TYPE
+from torch.distributed.checkpoint.planner import SavePlanner
+from torch.distributed.checkpoint.storage import StorageWriter
+
+logger = getLogger(__name__)
+
+
+class _MegatronCompatibleAsyncCheckpointProcess(_AsyncCheckpointProcess):
+    """Async checkpoint process that calls megatron-based save function"""
+
+    def __init__(
+        self,
+        pg_init_info: _ProcessGroupInitInfo,
+        profile_dir: Optional[str] = None,
+    ):
+        self.ctx = mp.get_context("spawn")
+        self._mp_queue_send: mp.Queue = self.ctx.Queue()
+        self._mp_queue_recv: mp.Queue = self.ctx.Queue()
+
+        self._save_process = self.ctx.Process(
+            target=self._checkpointing_subprocess,
+            args=(
+                pg_init_info,
+                self._mp_queue_send,
+                self._mp_queue_recv,
+                profile_dir,
+            ),
+            daemon=True,
+        )
+
+        self._save_process.start()
+        response = self._wait_for_response()
+        assert response == _CheckpointSaveProcessControlOpts.INIT_COMPLETE
+
+    @staticmethod
+    def _execute_save(
+        state_dict: STATE_DICT_TYPE,
+        checkpoint_request_id: _CheckpointRequestIdentifier,
+        sharded_strategy: SaveShardedStrategy,
+        storage_writer: Optional[StorageWriter] = None,
+        planner: Optional[SavePlanner] = None,
+    ) -> None:
+        thread_count = state_dict.pop("thread_count")
+
+        save(
+            sharded_state_dict=state_dict,
+            checkpoint_dir=checkpoint_request_id.checkpoint_id,
+            sharded_strategy=sharded_strategy,
+        )
+
+    @staticmethod
+    def _checkpointing_subprocess(
+        pg_init_info: _ProcessGroupInitInfo,
+        recv: mp.Queue,
+        send: mp.Queue,
+        profile_dir: Optional[str] = None,
+    ) -> None:
+        try:
+            _init_logger(pg_init_info.global_rank)
+
+            # Setup environment variables for process group initialization.
+            os.environ["TORCHELASTIC_USE_AGENT_STORE"] = "False"
+            os.environ["MASTER_ADDR"] = pg_init_info.tcp_store_master_addr
+            os.environ["MASTER_PORT"] = str(pg_init_info.tcp_store_master_port)
+            os.environ["LOCAL_RANK"] = str(pg_init_info.local_rank)
+            os.environ["RANK"] = str(pg_init_info.global_rank)
+            os.environ["WORLD_SIZE"] = str(pg_init_info.world_size)
+
+            logger.info(
+                "Initializing dist.ProcessGroup in checkpoint background process"
+            )
+            # NOTE: GLOO backend is enforced here.
+            dist.init_process_group(backend=dist.Backend.GLOO)
+            dist.barrier()
+
+            logger.info("Checkpoint background process is running...")
+            send.put(_CheckpointSaveProcessControlOpts.INIT_COMPLETE)
+
+            # Serving loop.
+            while True:
+                logger.info("Waiting for checkpoint save request...")
+                obj = recv.get()
+                if (
+                    isinstance(obj, _CheckpointSaveProcessControlOpts)
+                    and obj == _CheckpointSaveProcessControlOpts.TERMINATE
+                ):
+                    logger.info("Terminating the checkpoint background process.")
+                    return
+                assert isinstance(obj, AsyncRequest)
+                logger.info(
+                    f"Received async checkpoint request with id={obj.call_idx}"  # noqa: G004
+                )
+
+                if profile_dir is not None and dist.get_rank() == 0:
+                    from custom_callbacks.profile import MAX_TRACE_ENTRIES
+                    from viztracer import VizTracer
+
+                    staged_state_dict = obj.async_fn_args[0]
+                    global_step = staged_state_dict["common"]["global_step"]
+                    tracer = VizTracer(
+                        tracer_entries=MAX_TRACE_ENTRIES,
+                        max_stack_depth=50,
+                        log_torch=True,
+                    )
+                    tracer.start()
+
+                    logger.info(
+                        f"Started profile in subprocess for checkpointing step {global_step}."
+                    )
+
+                # Call the actual save function
+                obj.async_fn(*obj.async_fn_args)
+
+                if profile_dir is not None and dist.get_rank() == 0:
+                    tracer.stop()
+                    tracer.save(
+                        output_file=f"{profile_dir}/profile/ckpt_subproc_rank{dist.get_rank()}_step{global_step}_trace.json"
+                    )
+
+                    logger.info(
+                        f"Finished profile in subprocess for checkpointing step {global_step}."
+                    )
+
+                send.put(obj.call_idx)
+                logger.info(
+                    f"Submitted checkpoint save request for checkpoint_id={obj.call_idx}"  # noqa: G004
+                )
+        except BaseException as e:
+            logger.error(
+                f"Checkpoint background process encountered an exception: {e}"  # noqa: G004
+            )
+            send.put(e)
+            raise
+        finally:
+            logger.info("Checkpoint background process is shutting down...")
+            dist.destroy_process_group()
+
+
+class TorchCompatiblePersistentAsyncCaller(
+    _MegatronCompatibleAsyncCheckpointProcess, PersistentAsyncCaller
+):
+    def __init__(self, profile_dir: Optional[str] = None):
+        assert dist.is_initialized(), "Process group must be initialized"
+        _MegatronCompatibleAsyncCheckpointProcess.__init__(
+            self, _ProcessGroupInitInfo(), profile_dir
+        )
+        self.queue = self._mp_queue_send
+        self.comp_q = self._mp_queue_recv
+        self.cur_item = None
+        self.cur_idx = -1
+        self.process = self._save_process
+
+
+def save(
+    sharded_state_dict: ShardedStateDict,
+    checkpoint_dir: str,
+    sharded_strategy: Union[SaveShardedStrategy, Tuple[str, int], None] = None,
+    common_strategy: Union[SaveCommonStrategy, Tuple[str, int], None] = None,
+    async_sharded_save: bool = False,
+    preprocess_common_before_consistancy_check: Callable[
+        [CommonStateDict], StateDict
+    ] = None,
+) -> Optional[AsyncRequest]:
+    """Saving entrypoint.
+
+    Extracts ShardedTensors from the given state dict. Rank 0 saves the
+    "regular" part of the checkpoint to common torch file.
+    The ShardedTensors are saved according to a strategy specified by the
+    config.
+
+    Steps:
+    1. Apply factories
+    2. Extract and discard LocalNonPersistentObject
+    3. Extract all ShardedBase object
+    4. Save all other objects to common.pt
+    5. (optional) Extract and save ShardedObjects
+    6. Save all ShardedBase objects
+    7. Write metadata.json file with backend and version metadata.
+
+    Step (6) can be performed asynchronously (see `async_sharded_save`), in this
+    case the actual save is embodied in the returned async request and can be
+    scheduled by the external caller. For async request, step (7) is added as
+    one of the finalization functions, so that metadata.json is written only
+    if the checkpoint is complete.
+
+    Args:
+        sharded_state_dict (ShardedStateDict): state dict of the populated with
+            ShardedTensors. Used as a mapping to determine how local tensors
+            should be saved as global tensors in the checkpoint.
+        checkpoint_dir (str): directory to save the checkpoint to
+        sharded_strategy (SaveShardedStrategy, Tuple[str, int], optional):
+            configures sharded tensors saving behavior and backend
+        common_strategy (SaveCommonStrategy, Tuple[str, int], optional):
+            configures common data saving behavior and backend
+        async_sharded_save (bool, optional): if True, for the sharded state dict part
+            an async save implementation will be called, with the AsyncRequest
+            being returned to the caller. Note that it is the caller responsibility to
+            actually schedule the async save. Defaults to False.
+        preprocess_common_before_consistancy_check (Callable[[CommonStateDict], StateDict], None):
+            A callable function that will preprocess the common state dict (i.e can be used  to
+            remove keys that we expect to be different in the state dict). The function must not
+            modify the original state dict
+
+    Returns:
+        AsyncRequest (optional): if `async_sharded_save` is True, returns
+            async request that should be scheduled by the caller of this function.
+            None otherwise.
+    """
+    checkpoint_dir = Path(checkpoint_dir)
+
+    if torch.distributed.get_rank() == 0:
+        if not checkpoint_dir.exists():
+            raise CheckpointingException(
+                f"Checkpoint destination directory does not exist: {checkpoint_dir}"
+            )
+
+        if next(checkpoint_dir.iterdir(), None) is not None:
+            raise CheckpointingException(
+                f"Checkpoint destination directory ({checkpoint_dir}) is not empty"
+            )
+
+    if common_strategy is not None:
+        raise NotImplementedError("The only supported common strategy is torch")
+
+    if sharded_strategy is None:
+        sharded_strategy = get_default_save_sharded_strategy()
+    if not isinstance(sharded_strategy, SaveShardedStrategy):
+        assert isinstance(sharded_strategy, tuple), type(sharded_strategy)
+        sharded_strategy = get_default_strategy(
+            StrategyAction.SAVE_SHARDED, *sharded_strategy
+        )
+
+    if common_strategy is None:
+        common_strategy = get_default_save_common_strategy()
+    if not isinstance(common_strategy, SaveCommonStrategy):
+        assert isinstance(common_strategy, tuple), type(common_strategy)
+        common_strategy = get_default_strategy(
+            StrategyAction.SAVE_COMMON, *common_strategy
+        )
+
+    common_state_dict = sharded_state_dict.pop("common")
+    common_strategy.save_common(common_state_dict, checkpoint_dir)
+
+    if not sharded_strategy.can_handle_sharded_objects:
+        validate_sharded_objects_handling(sharded_strategy, common_strategy)
+        sharded_objects_state_dict, sharded_state_dict = extract_matching_values(
+            sharded_state_dict, lambda v: isinstance(v, ShardedObject)
+        )
+        common_strategy.save_sharded_objects(sharded_objects_state_dict, checkpoint_dir)
+
+    def metadata_finalize_fn():
+        if torch.distributed.get_rank() == 0:
+            save_config(
+                CheckpointingConfig(sharded_strategy.backend, sharded_strategy.version),
+                checkpoint_dir,
+            )
+        torch.distributed.barrier()
+
+    if not async_sharded_save:
+        sharded_strategy.save(sharded_state_dict, checkpoint_dir)
+        metadata_finalize_fn()
+        return
+
+    if not isinstance(sharded_strategy, AsyncSaveShardedStrategy):
+        raise CheckpointingException(
+            f"Cannot apply async_save to non-async strategy {sharded_strategy}"
+        )
+
+    async_request = sharded_strategy.async_save(sharded_state_dict, checkpoint_dir)
+    async_request.finalize_fns.append(metadata_finalize_fn)
+    return async_request

--- a/nemo/utils/_state_dict_utils.py
+++ b/nemo/utils/_state_dict_utils.py
@@ -1,0 +1,353 @@
+# mypy: allow-untyped-defs
+import copy
+import io
+import weakref
+from typing import TYPE_CHECKING, Any, Callable, Dict, Optional, Tuple
+
+import torch
+import torch.distributed as dist
+
+if dist.is_available() or TYPE_CHECKING:
+    from torch.distributed._shard.sharded_tensor import ShardedTensor
+    from torch.distributed._tensor import DTensor
+
+
+def _identity_func(
+    obj: torch.Tensor,
+    pg: Optional[dist.ProcessGroup],
+    device: Optional[torch.device],
+    companion_obj: Any,
+) -> torch.Tensor:
+    return obj
+
+
+class CompanionMismatch(Exception): ...
+
+
+def _iterate_state_dict(
+    iter_object: Any,
+    sharded_tensor_func: Callable,
+    dtensor_func: Callable,
+    tensor_func: Callable,
+    *,
+    pg: Optional[dist.ProcessGroup] = None,
+    device: Optional[torch.device] = None,
+    cpu_offload: bool = False,
+    companion_obj: Any = None,
+    ranks_only: Tuple[int, ...] = (),
+    type_check: bool = True,
+    non_blocking: bool = True,
+) -> Dict[str, Any]:
+    """Iterate through the state dict, applying the given functions to each tensor type.
+
+    Args:
+        iter_object (Any): the target state_dict.
+        sharded_tensor_func (Callable): the function to apply to ShardedTensor
+        dtensor_func (Callable): the function to apply to DTensor
+        tensor_func (Callable): the function to apply to Tensor
+        pg (Optional[dist.ProcessGroup]): process group passed to tensor functions
+        device (Optional[torch.device]): device passed to tensor functions
+        cpu_offload (bool): whether to offload the tensors to CPU memory. This option is ignored
+            if a companion_obj is supplied.
+        companion_obj (Any): A companion object to the state dict. If this object
+            is supplied, we attempt to copy the tensor to the companion object.
+        ranks_only (Tuple[int, ...]): if this tuple is empty, all ranks will
+            have the same state_dicts. Otherwise only ranks that in ``ranks_only``
+            have the same state_dicts. Other ranks will get empty state_dicts.
+        type_check (bool): check if the instance data type is a supported type
+            that can be saved by DCP.  The current supported data types are
+            torch.Tensor, DTensor, int, float, str, list, dict, None.
+        non_blocking (bool): whether to use non-blocking copy when copying to the companion object.
+    """
+    # TODO: should we use pytree?
+    cpu_device = torch.device("cpu")
+    if isinstance(iter_object, ShardedTensor):
+        ret = sharded_tensor_func(iter_object, pg, device, companion_obj)
+    elif isinstance(iter_object, DTensor):
+        ret = dtensor_func(iter_object, pg, device, companion_obj)
+    elif isinstance(iter_object, torch.Tensor):
+        ret = tensor_func(iter_object, pg, device, companion_obj)
+    elif (
+        isinstance(iter_object, (int, float, str, bytes, io.BytesIO))
+        or iter_object is None
+    ):
+        ret = iter_object
+    elif isinstance(iter_object, dict):
+        if companion_obj is not None and (
+            not isinstance(companion_obj, dict)
+            or set(companion_obj.keys()) != set(iter_object.keys())
+        ):
+            msg = (
+                ""
+                if isinstance(companion_obj, dict)
+                else f"{set(companion_obj.keys())=} {set(iter_object.keys())=}"
+            )
+            raise CompanionMismatch(msg)
+
+        ret = {
+            key: _iterate_state_dict(
+                value,
+                sharded_tensor_func,
+                dtensor_func,
+                tensor_func,
+                pg=pg,
+                device=device,
+                cpu_offload=cpu_offload,
+                companion_obj=companion_obj[key] if companion_obj is not None else None,
+                ranks_only=ranks_only,
+                type_check=type_check,
+                non_blocking=non_blocking,
+            )
+            for key, value in iter_object.items()
+        }
+    elif isinstance(iter_object, (list, tuple)):
+        if companion_obj is not None and (
+            not isinstance(companion_obj, (list, tuple))
+            or len(companion_obj) != len(iter_object)
+        ):
+            raise CompanionMismatch
+
+        ret = [
+            _iterate_state_dict(
+                v,
+                sharded_tensor_func,
+                dtensor_func,
+                tensor_func,
+                pg=pg,
+                device=device,
+                cpu_offload=cpu_offload,
+                companion_obj=companion_obj[idx] if companion_obj is not None else None,
+                ranks_only=ranks_only,
+                type_check=type_check,
+                non_blocking=non_blocking,
+            )
+            for idx, v in enumerate(iter_object)
+        ]
+        if isinstance(iter_object, tuple):
+            ret = tuple(ret)
+    # Logic for Megatron ShardedTensor and ShardedObject abstractions
+    elif any(
+        _ in str(type(iter_object))
+        for _ in ["mapping.ShardedTensor", "mapping.ShardedObject"]
+    ):
+        if hasattr(iter_object, "data"):
+            if isinstance(iter_object.data, torch.Tensor):
+                ret_data = tensor_func(iter_object.data, pg, device, companion_obj)
+            else:
+                ret_data = copy.deepcopy(iter_object.data)
+            ret = copy.copy(iter_object)
+            ret_dict = {
+                k: copy.deepcopy(v)
+                for k, v in iter_object.__dict__.items()
+                if k != "data"
+            }
+            ret.__dict__.update(ret_dict)
+            ret.data = ret_data
+        else:
+            ret = copy.deepcopy(iter_object)
+    elif not type_check:
+        ret = copy.deepcopy(iter_object)
+    else:
+        raise ValueError(f"Unexpected value type {type(iter_object)}")
+
+    if not ranks_only or dist.get_rank(pg) in ranks_only:
+        if isinstance(ret, torch.Tensor):
+            if cpu_offload and companion_obj is None:
+                ret = ret.to(cpu_device)
+
+            if companion_obj is not None:
+                # TODO: support DTensor
+                companion_obj.copy_(ret, non_blocking=non_blocking)
+                ret = companion_obj
+
+        # Logic for Megatron ShardedTensor and ShardedObject abstractions
+        elif any(
+            _ in str(type(iter_object))
+            for _ in ["mapping.ShardedTensor", "mapping.ShardedObject"]
+        ):
+            if cpu_offload and companion_obj is None:
+                ret.data = ret.data.detach().to(cpu_device)
+
+            if companion_obj is not None:
+                companion_obj_dict = {
+                    k: copy.deepcopy(v) for k, v in ret.__dict__.items() if k != "data"
+                }
+                companion_obj.__dict__.update(ret_dict)
+                if isinstance(companion_obj.data, torch.Tensor):
+                    if ret.data.requires_grad:
+                        companion_obj.data.copy_(
+                            ret.data.detach(), non_blocking=non_blocking
+                        )
+                    elif (
+                        not companion_obj.data.requires_grad
+                        and not ret.data.requires_grad
+                    ):
+                        companion_obj.data.copy_(ret.data, non_blocking=non_blocking)
+                    else:
+                        raise ValueError("Incompatible requires_grad values")
+                else:
+                    companion_obj.data = copy.deepcopy(ret.data)
+                # TODO: support DTensor
+                ret = companion_obj
+    else:
+        ret = {} if isinstance(ret, dict) else None
+
+    return ret
+
+
+def _copy_state_dict(
+    state_dict: Dict[str, Any],
+    copy_state_dict: Dict[str, Any],
+    non_blocking: bool = False,
+    type_check: bool = True,
+) -> Dict[str, Any]:
+    """
+    Copies all tensors in a given state dict into a different state_dict with the
+    same structure. Additionally, a copied state dict with the same value references
+    is returned. Editing the keys on this state dict will not affect the
+    passed in copy_state_dict (but the value references are the same).
+
+    .. warning::
+        It is expected by this function that state_dict and copy_state_dict share
+        the same structure and data types.
+
+    .. warning::
+        The current supported data types are
+            torch.Tensor, DTensor, int, float, str, list, dict, None.
+
+    Args:
+        state_dict (Dict[str, Any]): the target state_dict.
+        copy_state_dict (Dict[str, Any]):
+            The state dict we are copying into. This state_dict must have exactly
+             the same structure as the source `state_dict`.
+        non_blocking: (bool): Whether copy ops should be performed asynchronously
+        type_check (bool): check if the instance data type is a supported type
+            that can be saved by DCP. The current supported data types are
+            torch.Tensor, DTensor, int, float, str, list, dict, None.
+
+    Returns:
+        State Dict copy
+    """
+
+    return _iterate_state_dict(
+        state_dict,
+        _identity_func,
+        _identity_func,
+        _identity_func,
+        pg=None,
+        device=None,
+        cpu_offload=False,
+        ranks_only=(),
+        companion_obj=copy_state_dict,
+        type_check=type_check,
+        non_blocking=non_blocking,
+    )
+
+
+def _create_cpu_state_dict(
+    state_dict: Dict[str, Any], pin_memory: bool = False, share_memory: bool = False
+) -> Dict[str, Any]:
+    """
+    Given a state_dict, create another state_dict with the same structure and elements.
+    However, all tensors in the returned state_dict are new tensors on CPU. These
+    tensors can be placed on pin_memory or share_memory based on the provided arguments.
+
+    .. warning::
+        Setting both `pin_memory` and `share_memory` to True significantly increases the
+        latency of this method because of the nuances which require us to register memory
+        as pinned directly as opposed to relying on the pin_memory cache allocator. This
+        option should only be used for long lived tensors which are required to be shared.
+        This is not the case as long as at least one of `pin_memory` or `share_memory` is
+         set to False.
+
+    """
+
+    def tensor_func(
+        obj: torch.Tensor,
+        pg: Optional[dist.ProcessGroup],
+        device: Optional[torch.device],
+        _: Any,
+    ) -> torch.Tensor:
+        if len(obj.size()) == 0:
+            return torch.tensor(0, dtype=obj.dtype)
+
+        if share_memory:
+            t = torch.empty(*tuple(obj.size()), dtype=obj.dtype)
+            t = t.share_memory_()
+            if pin_memory:
+
+                def unpin_memory(t):
+                    succ = int(torch.cuda.cudart().cudaHostUnregister(t.data_ptr()))
+                    assert (
+                        succ == 0
+                    ), f"Unpinning shared memory failed with error-code: {succ}"
+
+                weakref.finalize(t, unpin_memory, t)
+                succ = int(
+                    torch.cuda.cudart().cudaHostRegister(
+                        t.data_ptr(),
+                        t.numel() * t.element_size(),
+                        1,  # lines up with 'cudaHostRegisterPortable'
+                    )
+                )
+                assert (
+                    succ == 0
+                ), f"Pinning shared memory failed with error-code: {succ}"
+            return t
+        elif pin_memory:
+            return torch.empty(*tuple(obj.size()), dtype=obj.dtype).pin_memory()
+        else:
+            return torch.empty(*tuple(obj.size()), dtype=obj.dtype)
+
+    ret = _iterate_state_dict(
+        state_dict,
+        _identity_func,
+        _identity_func,
+        tensor_func,
+        pg=None,
+        device=None,
+        cpu_offload=False,
+        ranks_only=(),
+        type_check=False,
+    )
+    return ret
+
+
+def _offload_state_dict_to_cpu(
+    state_dict: Dict[str, Any],
+    *,
+    ranks_only: Tuple[int, ...] = (),
+    type_check: bool = True,
+) -> Dict[str, Any]:
+    """
+    Given a state_dict, this API offload all the tensors to CPU memory.
+
+    Args:
+        state_dict (Dict[str, Any]): the target state_dict.
+        pg (Optional[dist.ProcessGroup]): the process group that is used to
+            gather ShardedTensor. Note that gathering a DTensor will use
+            the DeviceMesh. So this argument will be ignored when gathering a
+            DTensor.
+        ranks_only: (Tuple[int, ...]): if this tuple is empty, all ranks will
+            have the same state_dicts. Otherwise only ranks that in ``ranks_only``
+            have the same state_dicts. Other ranks will get empty state_dicts.
+        type_check: (bool): check if the instance data type is a supported type
+            that can be saved by DCP.  The current supported data types are
+            torch.Tensor, DTensor, int, float, str, list, dict, None.
+
+    Returns:
+        The gathered state dictionary.
+    """
+
+    ret = _iterate_state_dict(
+        state_dict,
+        _identity_func,
+        _identity_func,
+        _identity_func,
+        pg=None,
+        device=None,
+        cpu_offload=True,
+        ranks_only=ranks_only,
+        type_check=type_check,
+    )
+    return ret

--- a/nemo/utils/_state_dict_utils.py
+++ b/nemo/utils/_state_dict_utils.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # mypy: allow-untyped-defs
 import copy
 import io

--- a/nemo/utils/_state_dict_utils.py
+++ b/nemo/utils/_state_dict_utils.py
@@ -22,8 +22,9 @@ def _identity_func(
     return obj
 
 
-class CompanionMismatch(Exception): ...
+class CompanionMismatch(Exception):
     """ """
+    ...
 
 def _iterate_state_dict(
     iter_object: Any,

--- a/nemo/utils/_state_dict_utils.py
+++ b/nemo/utils/_state_dict_utils.py
@@ -23,7 +23,7 @@ def _identity_func(
 
 
 class CompanionMismatch(Exception): ...
-
+    """ """
 
 def _iterate_state_dict(
     iter_object: Any,

--- a/nemo/utils/_state_dict_utils.py
+++ b/nemo/utils/_state_dict_utils.py
@@ -18,6 +18,7 @@ def _identity_func(
     device: Optional[torch.device],
     companion_obj: Any,
 ) -> torch.Tensor:
+    """ noop """
     return obj
 
 
@@ -150,7 +151,7 @@ def _iterate_state_dict(
                 ret.data = ret.data.detach().to(cpu_device)
 
             if companion_obj is not None:
-                companion_obj_dict = {k: copy.deepcopy(v) for k, v in ret.__dict__.items() if k != "data"}
+                # companion_obj_dict = {k: copy.deepcopy(v) for k, v in ret.__dict__.items() if k != "data"}
                 companion_obj.__dict__.update(ret_dict)
                 if isinstance(companion_obj.data, torch.Tensor):
                     if ret.data.requires_grad:

--- a/nemo/utils/_state_dict_utils.py
+++ b/nemo/utils/_state_dict_utils.py
@@ -18,13 +18,15 @@ def _identity_func(
     device: Optional[torch.device],
     companion_obj: Any,
 ) -> torch.Tensor:
-    """ noop """
+    """noop"""
     return obj
 
 
 class CompanionMismatch(Exception):
     """ """
+
     ...
+
 
 def _iterate_state_dict(
     iter_object: Any,

--- a/nemo/utils/callbacks/daemon_strategies.py
+++ b/nemo/utils/callbacks/daemon_strategies.py
@@ -94,7 +94,7 @@ class DaemonTorchDistSaveShardedStrategy(TorchDistSaveShardedStrategy):
 
     def save(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Path):
         """Each async strategy can be trivially used as a sync strategy."""
-        write_results_or_exc = async_request = self.async_save(sharded_state_dict, checkpoint_dir)
+        async_request = self.async_save(sharded_state_dict, checkpoint_dir)
         async_request.async_fn(*async_request.async_fn_args)
         for finalize_fn in async_request.finalize_fns:
             finalize_fn()

--- a/nemo/utils/callbacks/daemon_strategies.py
+++ b/nemo/utils/callbacks/daemon_strategies.py
@@ -32,8 +32,9 @@ from torch.distributed.checkpoint.storage import WriteResult
 
 logger = getLogger(__name__)
 
+
 class DaemonTorchDistSaveShardedStrategy(TorchDistSaveShardedStrategy):
-    """ An asynchronous strategy for saving PyTorch sharded state dictionaries in a dist env.
+    """An asynchronous strategy for saving PyTorch sharded state dictionaries in a dist env.
 
     This class extends TorchDistSaveShardedStrategy and provides methods to:
     1. Translate MCore sharded state dictionaries to PyTorch's native format.
@@ -74,6 +75,7 @@ class DaemonTorchDistSaveShardedStrategy(TorchDistSaveShardedStrategy):
             and caches checkpoint structures if enabled. Returns an AsyncRequest containing
             the necessary asynchronous callbacks for finalization.
     """
+
     def __init__(
         self,
         backend: str,
@@ -163,9 +165,10 @@ class DaemonTorchDistSaveShardedStrategy(TorchDistSaveShardedStrategy):
 
 
 class DaemonFileSystemWriterAsync(FileSystemWriterAsync):
-    """ DaemonFileSystemWriterAsync
-        TODO
+    """DaemonFileSystemWriterAsync
+    TODO
     """
+
     def __init__(self, *args, separation_hint: Optional[str] = None, **kwargs):
         super().__init__(*args, **kwargs)
         self.separation_hint = separation_hint

--- a/nemo/utils/callbacks/daemon_strategies.py
+++ b/nemo/utils/callbacks/daemon_strategies.py
@@ -1,0 +1,393 @@
+import os
+import queue
+import threading
+from itertools import chain
+from logging import getLogger
+from pathlib import Path
+from time import time
+from typing import Callable, List, Optional, Tuple, Union
+
+import torch
+from megatron.core.dist_checkpointing.strategies.async_utils import AsyncRequest
+from megatron.core.dist_checkpointing.mapping import ShardedStateDict
+from megatron.core.dist_checkpointing.strategies.filesystem_async import (
+    FileSystemWriterAsync,
+    WriteBucket,
+    _disable_gc,
+    _process_memory,
+    _split_by_separation_hint,
+    _split_by_size_and_type,
+)
+from megatron.core.dist_checkpointing.strategies.state_dict_saver import (
+    save_state_dict_async_plan,
+)
+from megatron.core.dist_checkpointing.strategies.torch import (
+    MCoreSavePlanner,
+    TorchDistSaveShardedStrategy,
+    _replace_state_dict_keys_with_sharded_keys,
+    mcore_to_pyt_state_dict,
+)
+from torch import multiprocessing as mp
+from torch.distributed.checkpoint.filesystem import (
+    DEFAULT_SUFFIX,
+    _StoragePrefix,
+    _write_item,
+)
+from torch.distributed.checkpoint.planner import SavePlan, SavePlanner, WriteItemType
+from torch.distributed.checkpoint.storage import WriteResult
+
+logger = getLogger(__name__)
+
+
+class DaemonTorchDistSaveShardedStrategy(TorchDistSaveShardedStrategy):
+    def __init__(
+        self,
+        backend: str,
+        version: int,
+        keep_only_main_replica: bool = True,
+        thread_count: int = 2,
+        cached_metadata: bool = False,
+        separation_hint: str = None,
+    ):
+        super().__init__(
+            backend,
+            version,
+            keep_only_main_replica,
+            thread_count,
+            cached_metadata,
+            separation_hint,
+        )
+
+    def save(self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Path):
+        """Each async strategy can be trivially used as a sync strategy."""
+        write_results_or_exc = async_request = self.async_save(
+            sharded_state_dict, checkpoint_dir
+        )
+        async_request.async_fn(*async_request.async_fn_args)
+        for finalize_fn in async_request.finalize_fns:
+            finalize_fn()
+
+    def async_save(
+        self, sharded_state_dict: ShardedStateDict, checkpoint_dir: Path
+    ) -> AsyncRequest:
+        """Translates MCore ShardedTensors to PyT ShardedTensors & saves in PyT Distributed format.
+
+        Args:
+            sharded_state_dict (ShardedStateDict): sharded state dict to save
+            checkpoint_dir (Path): checkpoint directory
+
+        Returns: None
+        """
+        # Translate the state dict
+        (sharded_state_dict, flat_mapping, rename_mapping) = (
+            _replace_state_dict_keys_with_sharded_keys(
+                sharded_state_dict, self.keep_only_main_replica
+            )
+        )
+        pyt_state_dict = mcore_to_pyt_state_dict(sharded_state_dict, False)
+        # Use PyT saving mechanism
+        writer = DaemonFileSystemWriterAsync(
+            checkpoint_dir,
+            separation_hint=self.separation_hint,
+            thread_count=self.thread_count,
+        )
+        # This should be set differently if we run in a smaller process group than the default
+        coordinator = 0
+        # Try twice to validate the generated `central_plan` is the same across iterations
+        # If so, reuse `cached_central_plan` and `cached_global_metadata`
+        # From the 3rd iteration, `save_state_dict_async_plan` will not generate `global_metadata`
+        # (return None) so `self.cached_global_metadata` is reused
+        args_cached_plans = None
+        if self.use_cached_ckpt_structure:
+            args_cached_plans = (
+                self.cached_central_plan,
+                self.cached_local_plan,
+                self.validated_cache_reuse,
+            )
+
+        (
+            save_state_dict_ret,
+            self.cached_central_plan,
+            self.cached_local_plan,
+            self.validated_cache_reuse,
+        ) = save_state_dict_async_plan(
+            pyt_state_dict,
+            writer,
+            None,
+            coordinator,
+            planner=MCoreSavePlanner(
+                dedup_replicated_tensors=not self.keep_only_main_replica
+            ),
+            cached_ckpt_structure=args_cached_plans,
+        )
+        rank = torch.distributed.get_rank()
+        if self.use_cached_ckpt_structure:
+            if self.validated_cache_reuse:
+                logger.debug(f"rank: {rank}, cache validated")
+                if save_state_dict_ret[1]:  # when global_metadata is not cached
+                    self.cached_global_metadata = save_state_dict_ret[
+                        1
+                    ]  # Cache Metadata
+                # Only Coordinator rank holds cached global_metadata
+                # (None is returned for global_metadata)
+                elif coordinator == rank:
+                    logger.debug(
+                        f"rank: {rank}, reuse metadata, {save_state_dict_ret[1]}"
+                    )
+                    save_state_dict_ret = list(save_state_dict_ret)
+                    save_state_dict_ret[1] = self.cached_global_metadata
+
+        return self._get_save_and_finalize_callbacks(writer, save_state_dict_ret)
+
+
+class DaemonFileSystemWriterAsync(FileSystemWriterAsync):
+    def __init__(self, *args, separation_hint: Optional[str] = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.separation_hint = separation_hint
+        self.write_results_or_exc_bucket = []
+
+    def prepare_write_data(self, plan: SavePlan, planner: SavePlanner) -> None:
+        """
+        First stage of async saving. Copy data to CPU and plan the local saving.
+
+        Args:
+            plan (SavePlan): save plan generated by the PyT Distributed compatible planner
+            planner (SavePlanner): save planner used to resolve the bytes and tensor data
+
+        Returns: None, but stores the save plan in `self.write_buckets`
+        """
+        storage_plan: _StoragePrefix = plan.storage_data
+        start = time()
+        logger.debug(f"thread_count: {self.thread_count}, time: {start}")
+        if self.separation_hint:
+            assert (
+                self.thread_count > 1
+            ), "thread_count must be at least 2 if separation_hint is provided"
+        bins = (
+            self.thread_count // 2
+            if self.separation_hint is not None
+            else self.thread_count
+        )
+        item_buckets = _split_by_size_and_type(bins, plan.items, self.separation_hint)
+        logger.debug(f"bucket_prep, time: {time() - start}")
+
+        start = time()
+        # move tensors from GPU to CPU before starting async writing
+        # We do D2H synchronously for now
+        file_count = 0
+
+        def gen_file(prefix=""):
+            nonlocal file_count
+            file_name = f"{prefix}{storage_plan.prefix}{file_count}{DEFAULT_SUFFIX}"
+            file_count += 1
+            return file_name
+
+        # Prepare bytes / tensor data in each bucket, which will be assigned to each writer process
+        self.write_buckets = []
+        for group_name, group_buckets in _split_by_separation_hint(
+            item_buckets, self.separation_hint
+        ).items():
+            for bucket in group_buckets:
+                bytes_data = [
+                    (item, planner.resolve_data(item))
+                    for item in bucket
+                    if item.type == WriteItemType.BYTE_IO
+                ]
+                tensor_data = [
+                    (
+                        item,
+                        planner.resolve_data(item)
+                        .detach()
+                        .to("cpu", non_blocking=True),
+                    )
+                    for item in bucket
+                    if item.type != WriteItemType.BYTE_IO
+                ]
+                if len(bytes_data) > 0 or len(tensor_data) > 0:
+                    file_name = gen_file(prefix=group_name)
+                    self.write_buckets.append(
+                        (self.path / file_name, file_name, (bytes_data, tensor_data))
+                    )
+
+        end = time()
+        logger.debug(f"D2H and push, time: {end - start}")
+
+    def get_save_function_and_args(self) -> Tuple[Optional[Callable], Tuple]:
+        """
+        Get function that saves the data to storage along with its arguments.
+        Allows the external caller to apply the save function synchronously or asynchronously.
+
+        Returns: None (if there is nothing to write on this rank) or a tuple of:
+            - the function that saves the data
+            - arguments to that function
+        """
+        if not self.write_buckets:
+            return None, ()
+        return (
+            self.write_preloaded_data_subproc,
+            (self.write_buckets, self.write_results_or_exc_bucket),
+        )
+
+    @staticmethod
+    @_disable_gc()
+    def write_preloaded_data_subproc(
+        write_buckets: List[WriteBucket],
+        write_results_or_exc_bucket: List[Union[dict, Exception]],
+    ) -> None:
+        """
+        Performs saving data to storage with multiple processes.
+
+        Starts predefined number of processes and uses 2 queues to make sure the results
+        are complete:
+        - local_results_queue - to send the actual results
+        - count_queue - small queue to mark worker as completed
+
+        Using just one queue disallowed proper exception handling.
+
+        This method is meant to be run in a forked subprocess.
+        Triggering GC during execution leads to CUDA errors
+        (cleaning up tensors owned by the parent process).
+        To prevent this, we disable the GC explicitly for this function with _disable_gc.
+
+        Args:
+            write_buckets (List[WriteBucket]): write plan
+        Returns: None
+        """
+        w_start = time()
+        write_results_or_exc: Union[dict, Exception] = dict()
+        ctx = mp.get_context("fork")
+        local_results_queue = ctx.Queue()
+        threads = []
+        for i, write_bucket in enumerate(write_buckets):
+            try:
+                threads.append(
+                    threading.Thread(
+                        target=DaemonFileSystemWriterAsync.write_preloaded_data,
+                        args=(i, write_bucket, local_results_queue, True),
+                    )
+                )
+            except Exception as e:
+                err_msg = f"An error is caught while a proc {i} is created, error: {e}"
+                logger.error(err_msg)
+                write_results_or_exc = RuntimeError(err_msg)
+
+        if not isinstance(write_results_or_exc, Exception):
+            for t in threads:
+                t.start()
+
+            logger.debug("FileSystemWriterAsync: collecting worker results...")
+
+            for t in threads:
+                t.join()
+
+            # At this point, all workers completed, so the queue should have exactly
+            # `len(write_buckets)` items
+            for proc_idx in range(len(write_buckets)):
+                try:
+                    local_proc_idx, local_results_or_exc = local_results_queue.get()
+                except queue.Empty:
+                    write_results_or_exc = RuntimeError(
+                        f"Unexpected empty `local_results_queue`"
+                        f" (got only {proc_idx}/{len(write_buckets)} items)"
+                    )
+                    break
+                else:
+                    if isinstance(local_results_or_exc, Exception):
+                        err_msg = (
+                            f"Local process {local_proc_idx} encountered"
+                            f" an error: {local_results_or_exc}"
+                        )
+                        logger.error(err_msg)
+                        write_results_or_exc = local_results_or_exc
+                        break
+                    else:
+                        assert isinstance(local_results_or_exc, list), type(
+                            local_results_or_exc
+                        )
+                        write_results_or_exc[local_proc_idx] = local_results_or_exc
+
+            logger.debug(
+                "DaemonFileSystemWriterAsync: collected worker results successfully"
+            )
+
+        w_end = time()
+        logger.debug(
+            f"{w_end}, rank: {torch.distributed.get_rank()},"
+            f" write(sync,parallel): {w_end - w_start}"
+        )
+
+        write_results_or_exc_bucket.append(write_results_or_exc)
+
+    @staticmethod
+    @_disable_gc()
+    def write_preloaded_data(
+        local_proc_idx: int,
+        write_bucket: WriteBucket,
+        results_queue: mp.Queue,
+        use_fsync: bool,
+    ) -> None:
+        """
+        Performs actual data saving to storage.
+
+        Args:
+            local_proc_idx (int): index of a local process that performs writing
+            write_bucket (WriteBucket): data to write to storage
+            results_queue (mp.Queue): queue to return the write results
+                to the proxy checkpoint process.
+            use_fsync (bool): if True, calls os.fsync at the end of saving
+
+        Returns: None, the write result are put into the `queue`
+        """
+        mem_before = _process_memory()
+
+        local_results = []
+        try:
+            file_name, storage_key, (bytes_data, tensor_data) = write_bucket
+            with open(file_name, "wb") as stream:
+                for write_item, data in bytes_data:
+                    local_results.append(
+                        _write_item(stream, data, write_item, storage_key)
+                    )
+
+                for write_item, tensor in tensor_data:
+                    assert tensor.is_cpu
+                    local_results.append(
+                        _write_item(stream, tensor, write_item, storage_key)
+                    )
+
+                if use_fsync:
+                    os.fsync(stream.fileno())
+            local_output = (local_proc_idx, local_results)
+        except Exception as e:
+            local_output = (local_proc_idx, e)
+
+        results_queue.put(local_output)
+
+        mem_after = _process_memory()
+        logger.debug(
+            f"{local_proc_idx} consumed: {mem_after - mem_before},"
+            f" before: {mem_before}, after: {mem_after}"
+        )
+
+    def retrieve_write_results(self) -> List[WriteResult]:
+        """
+        Turn the latest dict including write results from `self.write_results_or_exc`
+            into a single results lists. Includes error check.
+
+        Returns (List[WriteResult]): the list of write results
+            from all local processes performing the save.
+
+        """
+        write_results_or_exc = self.write_results_or_exc_bucket.pop()
+
+        if isinstance(write_results_or_exc, Exception):
+            raise RuntimeError(
+                f"Worker failure: {write_results_or_exc}"
+            ) from write_results_or_exc
+        write_results: dict = write_results_or_exc
+        if len(write_results) != len(self.write_buckets):
+            raise RuntimeError(
+                f"Incomplete worker results (expected {len(self.write_buckets)},"
+                f" got {len(write_results)}. This probably indicates a worker failure."
+            )
+        return list(chain.from_iterable(write_results.values()))

--- a/nemo/utils/callbacks/daemon_strategies.py
+++ b/nemo/utils/callbacks/daemon_strategies.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import os
 import queue
 import threading

--- a/nemo/utils/callbacks/min_ckpt_overhead.py
+++ b/nemo/utils/callbacks/min_ckpt_overhead.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from logging import getLogger
 from typing import Any, Dict, Optional
 

--- a/nemo/utils/callbacks/min_ckpt_overhead.py
+++ b/nemo/utils/callbacks/min_ckpt_overhead.py
@@ -1,0 +1,162 @@
+from logging import getLogger
+from typing import Any, Dict, Optional
+
+from megatron.core.dist_checkpointing.strategies.async_utils import AsyncRequest, debug_time
+from torch.distributed.checkpoint._async_process_executor import _CheckpointRequestIdentifier
+from lightning.fabric.utilities.cloud_io import get_filesystem
+from lightning.fabric.utilities.types import _PATH
+from megatron.core.dist_checkpointing.mapping import apply_factories
+from megatron.core.dist_checkpointing.state_dict_transformation import save_preprocess
+from megatron.core.dist_checkpointing.strategies.fully_parallel import (
+    FullyParallelSaveStrategyWrapper,
+)
+from nemo.utils import logging
+from nemo.utils.callbacks.dist_ckpt_io import DistributedCheckpointIO
+
+from nemo.utils._ckpt_utils import TorchCompatiblePersistentAsyncCaller
+from nemo.utils._state_dict_utils import (
+    _copy_state_dict,
+    _create_cpu_state_dict,
+    _offload_state_dict_to_cpu,
+)
+from nemo.utils.callbacks.daemon_strategies import DaemonTorchDistSaveShardedStrategy
+
+logger = getLogger(__name__)
+
+
+class MinCkptOverheadCheckpointIO(DistributedCheckpointIO):
+    def __init__(
+        self,
+        save_ckpt_format: str,
+        load_directly_on_device: bool = True,
+        load_strictness: Optional["StrictHandling"] = None,
+        async_save: bool = False,
+        torch_dist_multiproc: Optional[int] = None,
+        assume_constant_structure: bool = False,
+        parallel_save: bool = False,
+        parallel_save_within_dp: bool = False,
+        parallel_load: bool = False,
+    ):
+        super().__init__(
+            save_ckpt_format,
+            load_directly_on_device,
+            load_strictness,
+            async_save,
+            torch_dist_multiproc,
+            assume_constant_structure,
+            parallel_save,
+            parallel_save_within_dp,
+            parallel_load,
+        )
+
+        self._staged_state_dict = None
+
+    @debug_time("OptimizedD2HCheckpointIO.save_checkpoint")
+    def save_checkpoint(
+        self,
+        checkpoint: Dict[str, Any],
+        path: _PATH,
+        storage_options: Optional[Any] = None,
+    ) -> Optional["AsyncRequest"]:
+        """Saves a distributed checkpoint via checkpoint subprocess. Creates the checkpoint root directory if doesn't exist.
+
+        Args:
+            checkpoint (Dict[str, Any]): sharded state dict to save
+            path (_PATH): checkpoint directory
+            storage_options (Any, optional): Optional parameters when saving the checkpoint
+        """
+        fs = get_filesystem(path)
+        fs.makedirs(path, exist_ok=True)
+
+        validate_sharding_integrity = not (
+            self.validated_consistency and self.assume_constant_structure
+        )
+        self.validated_consistency = True
+
+        apply_factories(checkpoint)
+        sharded_state_dict, common_state_dict = save_preprocess(
+            checkpoint, validate_sharding_integrity, None
+        )
+
+        # TODO: Pin tensors to further improve d2h time
+        common_state_dict = _offload_state_dict_to_cpu(common_state_dict)
+
+        staged_state_dict = self._staged_state_dict
+        if staged_state_dict is None:
+            staged_state_dict = _create_cpu_state_dict(
+                sharded_state_dict, pin_memory=True, share_memory=True
+            )
+
+        _copy_state_dict(sharded_state_dict, staged_state_dict, False)
+
+        if self.assume_constant_structure:
+            self._staged_state_dict = staged_state_dict
+
+        staged_state_dict["common"] = common_state_dict
+        staged_state_dict["thread_count"] = self.torch_dist_multiproc or 1
+
+        def finalize_fn():
+            staged_state_dict.pop("common")
+            staged_state_dict.pop("thread_count")
+
+        checkpoint_request_id = _CheckpointRequestIdentifier(path)
+
+        self.async_request = AsyncRequest(
+            async_fn=TorchCompatiblePersistentAsyncCaller._execute_save,
+            async_fn_args=(
+                staged_state_dict,
+                checkpoint_request_id,
+                self.save_sharded_strategy,
+            ),
+            finalize_fns=[finalize_fn],
+        )
+
+        return self.async_request
+
+    def _determine_dist_ckpt_save_strategy(self):
+        """Determine the saving strategy based on constructor args.
+
+        Relies on the default MCore strategy unless extra PyT Distributed format arguments
+        are passed in config or in case of a fully parallel save in which case
+        a parallelization wrapper is applied.
+        """
+        if self.save_ckpt_format == "zarr":
+            logging.warning(
+                "`zarr` distributed checkpoint backend is deprecated."
+                " Distributed optimizer checkpoint saving might be extremely slow."
+                " Please switch to PyTorch Distributed format (model.dist_ckpt_format=torch_dist)."
+            )
+
+        if self.async_save and self.save_ckpt_format != "torch_dist":
+            raise ValueError(
+                "Async dist-ckpt save supported only for torch_dist format"
+            )
+
+        torch_dist_kwargs = (
+            {}
+            if self.torch_dist_multiproc is None
+            else dict(thread_count=self.torch_dist_multiproc)
+        )
+        if self.save_ckpt_format == "torch_dist" and torch_dist_kwargs:
+            save_strategy = DaemonTorchDistSaveShardedStrategy(
+                self.save_ckpt_format, 1, **torch_dist_kwargs
+            )
+        else:
+            save_strategy = get_default_save_sharded_strategy(self.save_ckpt_format, 1)
+
+        # MCore v0.8 introduces `use_cached_ckpt_structure` attribute
+        if hasattr(save_strategy, "use_cached_ckpt_structure"):
+            save_strategy.use_cached_ckpt_structure = self.assume_constant_structure
+
+        if self.parallel_save:
+            parallelization_group = (
+                get_data_parallel_group(with_context_parallel=True)
+                if self.parallel_save_within_dp
+                else None
+            )
+            save_strategy = FullyParallelSaveStrategyWrapper(
+                save_strategy, parallelization_group, self.assume_constant_structure
+            )
+
+        logging.info(f"Using {save_strategy} dist-ckpt save strategy.")
+        return save_strategy

--- a/nemo/utils/callbacks/persistent_ckpt_proc.py
+++ b/nemo/utils/callbacks/persistent_ckpt_proc.py
@@ -1,0 +1,72 @@
+import logging
+from logging import getLogger
+from typing import Any, Dict, Optional
+
+from megatron.core.dist_checkpointing.strategies.async_utils import AsyncCallsQueue, debug_time
+from lightning.fabric.utilities.types import _PATH
+from nemo.utils.callbacks.dist_ckpt_io import (
+    AsyncCompatibleCheckpointIO,
+    AsyncFinalizableCheckpointIO,
+    _WrappingCheckpointIO,
+)
+
+from nemo.uitls._ckpt_utils import TorchCompatiblePersistentAsyncCaller
+
+logger = getLogger(__name__)
+
+
+class PersistentCheckpointProcessIO(AsyncFinalizableCheckpointIO):
+    def __init__(
+        self,
+        checkpoint_io: AsyncCompatibleCheckpointIO,
+        profile_dir: Optional[str] = None,
+    ) -> None:
+        _WrappingCheckpointIO.__init__(self, checkpoint_io)
+        self.async_calls_queue = AsyncCallsQueue(persistent=True)
+        self.profile_dir = profile_dir
+
+    @debug_time("PersistentCheckpointProcessIO.save_checkpoint")
+    def save_checkpoint(
+        self,
+        checkpoint: Dict[str, Any],
+        path: _PATH,
+        storage_options: Optional[Any] = None,
+    ) -> None:
+        """Executes async request returned from the underlying checkpoint_io asynchronously.
+
+        Requires the underlying checkpoint_io.save_checkpoint to return an AsyncRequest.
+        It is then applied with `self.async_calls_queue` asynchronously.
+
+        Args:
+            checkpoint (Dict[str, Any]): checkpoint to save. Passed to underlying
+                checkpoint_io without modifications.
+            path (_PATH): path to save the checkpoint. Passed to underlying
+                checkpoint_io without modifications.
+            storage_options (Any, optional): storage control modifiers. This class
+                consumed the `finalize_fn` parameter (if any), which is expected to be
+                a callback and is appended to async finalization functions.
+
+        Applies underlying checkpoint_io finalize callback first, then the external one (postfix order).
+        """
+
+        external_finalize_fn = (storage_options or {}).pop("finalize_fn", None)
+        assert isinstance(self.checkpoint_io, AsyncCompatibleCheckpointIO), type(
+            self.checkpoint_io
+        )
+
+        if self.async_calls_queue.persistent_caller is None:
+            self.async_calls_queue.persistent_caller = (
+                TorchCompatiblePersistentAsyncCaller(self.profile_dir)
+            )
+
+        self.maybe_finalize_save_checkpoint(blocking=True)
+
+        async_req = self.checkpoint_io.save_checkpoint(
+            checkpoint, path, storage_options
+        )
+        if external_finalize_fn is not None:
+            async_req.add_finalize_fn(external_finalize_fn)
+
+        call_idx = self.async_calls_queue.schedule_async_request(async_req)
+
+        logging.debug(f"Scheduled an async call #{call_idx}")

--- a/nemo/utils/callbacks/persistent_ckpt_proc.py
+++ b/nemo/utils/callbacks/persistent_ckpt_proc.py
@@ -16,7 +16,7 @@ logger = getLogger(__name__)
 
 
 class PersistentCheckpointProcessIO(AsyncFinalizableCheckpointIO):
-    """ A checkpoint I/O handler that schedules and runs checkpoint-saving operations asynchronously,
+    """A checkpoint I/O handler that schedules and runs checkpoint-saving operations asynchronously,
     ensuring persistence and optional performance profiling.
 
     This class inherits from AsyncFinalizableCheckpointIO and wraps an underlying
@@ -47,6 +47,7 @@ class PersistentCheckpointProcessIO(AsyncFinalizableCheckpointIO):
         >>> # Use persistent_io.save_checkpoint in place of the underlying checkpoint_io.save_checkpoint
         >>> persistent_io.save_checkpoint(checkpoint_data, "/path/to/checkpoint")
     """
+
     def __init__(
         self,
         checkpoint_io: AsyncCompatibleCheckpointIO,

--- a/nemo/utils/callbacks/persistent_ckpt_proc.py
+++ b/nemo/utils/callbacks/persistent_ckpt_proc.py
@@ -1,3 +1,17 @@
+# Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 import logging
 from logging import getLogger
 from typing import Any, Dict, Optional


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Minimize overhead as a result of asynchronous checkpointing

**Collection**: [Note which collection this PR will affect]

# Context
I'm from the GPU Goodput & Resiliency team within Google Cloud CMCS. We are benchmarking goodput on nemo 2.0 recipes (in nemo:24.12.01 container) and noticed sub-optimal overhead when enabling asynchronous checkpointing for llama 3 70B and 405B. The observed overhead motivated the two plugins in this PR. These changes are copied from an internal codebase. If there is interest in these changes, we would be happy to clean up and formalize this PR.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
checkpoint_io = MinCkptOverheadCheckpointIO(
    save_ckpt_format='torch_dist',
    load_directly_on_device=True,
    async_save =args.enable_async_ckpt or args.enable_optimized_async_ckpt,
    torch_dist_multiproc = args.ckpt_threads_per_rank,
    assume_constant_structure = True,
    parallel_save = True,
    parallel_save_within_dp = False,
    parallel_load = True,
)

checkpoint_io = PersistentCheckpointProcessIO(
    checkpoint_io,
    profile_dir = args.trace_dir if args.profile_checkpoint_interval is not None else None,
)

plugins=[checkpoint_io]

trainer = nl.Trainer(
    accelerator="gpu",
    devices=args.num_gpus,
    num_nodes=args.num_nodes,
    max_steps=args.max_steps,
    max_time={"seconds": args.max_runtime},
    callbacks=callbacks,
    log_every_n_steps=None,
    val_check_interval=None, 
    limit_val_batches=None, 
    plugins=plugins,
    strategy=strategy,
    enable_progress_bar=False,
)
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [X] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
