### PR TITLE
bugfix(llm/LLaMa) - dropout_position can never be equal to extended string

### DIFF
--- a/nemo/collections/llm/gpt/model/llama.py
+++ b/nemo/collections/llm/gpt/model/llama.py
@@ -847,8 +847,8 @@ class HFLlamaPEFTExporter(HFLlamaExporter):
 
         assert (
             not self.peft_obj.dropout
-            or self.peft_obj.dropout_position == 'pre' "LoRA dropout_position must be 'pre' to convert to HF."
-        )
+            or self.peft_obj.dropout_position == 'pre'
+        ), "LoRA dropout_position must be 'pre' to convert to HF."
 
         NEMO2HF = {
             'linear_q': ['q_proj'],


### PR DESCRIPTION
# What does this PR do ?

The assertion in the HF export for LLaMa always fails when dropout is defined because it is checking `pre` to `'preLoRA dropout_position must be 'pre' to convert to HF.'`

**Collection**: llm

# Changelog

- Updates assertion to check for pre


# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
