### PR TITLE
[automodel] fix validation_step

### DIFF
--- a/nemo/collections/llm/gpt/model/hf_auto_model_for_causal_lm.py
+++ b/nemo/collections/llm/gpt/model/hf_auto_model_for_causal_lm.py
@@ -180,7 +180,7 @@ class HFAutoModelForCausalLM(pl.LightningModule, io.IOMixin, fn.FNMixin):
             return auto_cls.from_pretrained(
                 self.model_name,
                 torch_dtype=torch.bfloat16,
-                device_map=self.device,
+                device_map="cpu",
                 trust_remote_code=self.trust_remote_code,
                 load_in_4bit=self.load_in_4bit,
                 attn_implementation=attn_implementation,

--- a/nemo/collections/llm/gpt/model/hf_auto_model_for_causal_lm.py
+++ b/nemo/collections/llm/gpt/model/hf_auto_model_for_causal_lm.py
@@ -180,7 +180,7 @@ class HFAutoModelForCausalLM(pl.LightningModule, io.IOMixin, fn.FNMixin):
             return auto_cls.from_pretrained(
                 self.model_name,
                 torch_dtype=torch.bfloat16,
-                device_map="cpu",
+                device_map=self.device,
                 trust_remote_code=self.trust_remote_code,
                 load_in_4bit=self.load_in_4bit,
                 attn_implementation=attn_implementation,
@@ -372,7 +372,7 @@ class HFAutoModelForCausalLM(pl.LightningModule, io.IOMixin, fn.FNMixin):
             batch['input_ids'] = batch['tokens']
         batch = self._remove_extra_batch_keys(batch)
 
-        outputs = self.forward(**batch)
+        outputs = self.forward(batch)
 
         logits = outputs.logits.float()
         n_cls = logits.shape[-1]
@@ -381,7 +381,7 @@ class HFAutoModelForCausalLM(pl.LightningModule, io.IOMixin, fn.FNMixin):
 
         assert logits.shape[-2] == labels.shape[-1], "Expected logits & labels to have the same length"
         loss = self.loss_fn(logits, labels, loss_mask)
-        self.log('val_loss', loss, on_step=True, on_epoch=True, prog_bar=True)
+        return loss
 
     def save_pretrained(self, path, state_dict):
         """

--- a/nemo/lightning/pytorch/strategies/fsdp2_strategy.py
+++ b/nemo/lightning/pytorch/strategies/fsdp2_strategy.py
@@ -53,7 +53,9 @@ MixedPrecisionPolicy, HAS_MIXED_PRECISION_POLICY = safe_import_from(
 
 CPUOffloadPolicy, HAS_CPU_OFFLOAD_POLICY = safe_import_from("torch.distributed.fsdp", "CPUOffloadPolicy")
 if not HAS_CPU_OFFLOAD_POLICY:
-    CPUOffloadPolicy, HAS_CPU_OFFLOAD_POLICY = safe_import_from("torch.distributed._composable.fsdp", "CPUOffloadPolicy")
+    CPUOffloadPolicy, HAS_CPU_OFFLOAD_POLICY = safe_import_from(
+        "torch.distributed._composable.fsdp", "CPUOffloadPolicy"
+    )
 
 _logger = _logging.getLogger(__name__)
 

--- a/nemo/lightning/pytorch/strategies/fsdp2_strategy.py
+++ b/nemo/lightning/pytorch/strategies/fsdp2_strategy.py
@@ -341,7 +341,8 @@ class FSDP2Strategy(PLModelParallelStrategy, io.IOMixin):
         assert self.model is not None
         with self.precision_plugin.val_step_context():
             loss, reduced = self._step_proxy("validation", batch, batch_idx)
-            self.lightning_module.log('val_loss', reduced['avg'], rank_zero_only=True, batch_size=1)
+            if reduced["avg"]:
+                self.lightning_module.log('val_loss', reduced['avg'], rank_zero_only=True, batch_size=1)
             return loss
 
     @override
@@ -444,15 +445,8 @@ class FSDP2Strategy(PLModelParallelStrategy, io.IOMixin):
         Only returns a non-empty state dict on rank 0 if ``save_distributed_checkpoint=False``.
 
         """
-        from nemo.lightning.pytorch.strategies.utils import to_cpu
-
         assert self.lightning_module is not None
         state_dict = self.lightning_module.state_dict()
-
-        module_names = list(state_dict.keys())
-        for name in module_names:
-            param = state_dict.pop(name)
-            state_dict[name] = to_cpu(param)
         return state_dict
 
     @override

--- a/nemo/lightning/pytorch/strategies/fsdp2_strategy.py
+++ b/nemo/lightning/pytorch/strategies/fsdp2_strategy.py
@@ -445,8 +445,15 @@ class FSDP2Strategy(PLModelParallelStrategy, io.IOMixin):
         Only returns a non-empty state dict on rank 0 if ``save_distributed_checkpoint=False``.
 
         """
+        from nemo.lightning.pytorch.strategies.utils import to_cpu
+
         assert self.lightning_module is not None
         state_dict = self.lightning_module.state_dict()
+
+        module_names = list(state_dict.keys())
+        for name in module_names:
+            param = state_dict.pop(name)
+            state_dict[name] = to_cpu(param)
         return state_dict
 
     @override


### PR DESCRIPTION
# What does this PR do ?

The default `hf_auto_model_for_causal_lm` recipe fails to run due to the model being loaded on CPU, the validation loss being logged twice with different values, the validation_loss not being returned from the hf_auto_model_for_causal_lm validation step, and the validation_step passing the wrong parameters to forward.

**Collection**: llm

# Changelog

- Removes the hardcoded "cpu" device for loading the model
- Fixes the validation loss in hf_auto_model_for_causal to ensure that it calls forward with the correct parameter
- Returns loss from valdiation_step in hf_auto_model_for_causal
- Adds a check on loss in FSDP2 to ensure that None losses are not logged.


# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
