### PR TITLE
Expose NCCL timeout via existing env var

### DIFF
--- a/nemo/lightning/pytorch/strategies/megatron_strategy.py
+++ b/nemo/lightning/pytorch/strategies/megatron_strategy.py
@@ -21,6 +21,7 @@ import shutil
 from collections import OrderedDict
 from contextlib import ExitStack, contextmanager, nullcontext
 from dataclasses import dataclass
+from datetime import timedelta
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
@@ -516,9 +517,11 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         world_size = self.cluster_environment.world_size()
         os.environ["MASTER_ADDR"] = self.cluster_environment.main_address
         os.environ["MASTER_PORT"] = str(self.cluster_environment.main_port)
+        if timeout := os.getenv("TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC"):
+            timeout = timedelta(seconds=int(timeout))
         _logger.info(f"Initializing distributed: GLOBAL_RANK: {global_rank}, MEMBER: {global_rank + 1}/{world_size}")
         torch.distributed.init_process_group(
-            self._process_group_backend, rank=global_rank, world_size=world_size, store=self.store
+            self._process_group_backend, rank=global_rank, world_size=world_size, store=self.store, timeout=timeout
         )
 
         if self._process_group_backend == "nccl":

--- a/tests/collections/llm/gpt/data/test_hf_hellaswag.py
+++ b/tests/collections/llm/gpt/data/test_hf_hellaswag.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
-from nemo.collections.llm.gpt.data.hf_dataset import (
-    HellaSwagHFDataModule
-)
+
+from nemo.collections.llm.gpt.data.hf_dataset import HellaSwagHFDataModule
+
 
 @pytest.fixture
 def mock_tokenizer():

--- a/tests/collections/llm/gpt/data/test_hf_hellaswag.py
+++ b/tests/collections/llm/gpt/data/test_hf_hellaswag.py
@@ -41,6 +41,7 @@ def mock_tokenizer():
 
     return tokenizer
 
+
 @pytest.fixture
 def sample_doc():
     """
@@ -51,8 +52,9 @@ def sample_doc():
         "ctx_b": "continuation of the context.",
         "endings": ["Option 1 ending.", "Option 2 ending."],
         "label": 1,
-        "activity_label": "SampleActivity"
+        "activity_label": "SampleActivity",
     }
+
 
 @pytest.mark.parametrize(
     "input_text, expected",
@@ -60,7 +62,7 @@ def sample_doc():
         (" [title]  Something [extra] text ", " Something text"),
         ("Some text [title] [more]", "Some text. "),
         ("   [Foo]    [title]", "  . "),
-    ]
+    ],
 )
 def test_preprocess(input_text, expected):
     """
@@ -68,6 +70,7 @@ def test_preprocess(input_text, expected):
     """
     out = HellaSwagHFDataModule.preprocess(input_text)
     assert out == expected
+
 
 def test_process_doc(sample_doc):
     """
@@ -83,6 +86,7 @@ def test_process_doc(sample_doc):
     assert out_doc["gold"] == sample_doc["label"]
     assert len(out_doc["choices"]) == len(sample_doc["endings"])
     assert out_doc["query"].startswith("SampleActivity: ")
+
 
 @patch("nemo.collections.llm.gpt.data.hf_dataset.load_dataset")
 def test_preprocess_dataset(mock_load_dataset, mock_tokenizer):

--- a/tests/collections/llm/gpt/data/test_hf_mockdataset.py
+++ b/tests/collections/llm/gpt/data/test_hf_mockdataset.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 import torch
-from nemo.collections.llm.gpt.data.hf_dataset import (
-    HFMockDataModule, _MockGPTDataset
-)
+
+from nemo.collections.llm.gpt.data.hf_dataset import HFMockDataModule, _MockGPTDataset
 
 
 @pytest.fixture

--- a/tests/collections/llm/gpt/data/test_hf_mockdataset.py
+++ b/tests/collections/llm/gpt/data/test_hf_mockdataset.py
@@ -42,6 +42,7 @@ def mock_tokenizer():
     tokenizer.vocab_size = 1024
     return tokenizer
 
+
 @pytest.fixture
 def mock_data_module():
     """Fixture to create and set up a mock data module."""

--- a/tests/lightning/pytorch/callbacks/test_jit_transform.py
+++ b/tests/lightning/pytorch/callbacks/test_jit_transform.py
@@ -38,10 +38,12 @@ def test_extract_module_attr_name_with_module():
     mock_pl_module.module = MagicMock()
     assert extract_module_attr_name(mock_pl_module) == 'module', mock_pl_module
 
+
 def test_extract_module_attr_name_with_model():
     mock_pl_module = MagicMock(spec=[])
     mock_pl_module.model = MagicMock()
     assert extract_module_attr_name(mock_pl_module) == 'model', mock_pl_module
+
 
 def test_extract_module_attr_name_raises():
     mock_pl_module = MagicMock(spec=[])
@@ -49,26 +51,32 @@ def test_extract_module_attr_name_raises():
     with pytest.raises(ValueError, match="Expected lightning_module to have a .model or .module"):
         extract_module_attr_name(mock_pl_module)
 
+
 def test_listify_non_list():
     assert listify("test") == ["test"]
 
+
 def test_listify_list():
     assert listify(["test"]) == ["test"]
+
 
 def test_get_modules_from_selector_none_selector():
     model = MagicMock()
     collected = list(get_modules_from_selector(model, None))
     assert collected == [model]
 
+
 def test_get_modules_from_selector_empty_string():
     model = MagicMock()
     collected = list(get_modules_from_selector(model, ""))
     assert collected == [model]
 
+
 def test_get_modules_from_selector_star():
     model = MagicMock()
     collected = list(get_modules_from_selector(model, "*"))
     assert collected == [model]
+
 
 def test_get_modules_from_selector_exact_path():
     # Example: model.encoder.layer
@@ -80,17 +88,20 @@ def test_get_modules_from_selector_exact_path():
     collected = list(get_modules_from_selector(parent_module, "encoder.layer"))
     assert collected == [child_module]
 
+
 def test_get_modules_from_selector_non_existent_attr():
     parent_module = torch.nn.Module()
     parent_module.encoder = torch.nn.Module()
     with pytest.raises(AttributeError, match="has no attribute"):
         list(get_modules_from_selector(parent_module, "decoder"))
 
+
 def test_get_modules_from_selector_attr_is_not_module():
     parent_module = torch.nn.Module()
     parent_module.something = "I am not a module"
     with pytest.raises(AttributeError, match="is not an nn.Module"):
         list(get_modules_from_selector(parent_module, "something"))
+
 
 def test_get_modules_from_selector_wildcard_children():
     parent_module = torch.nn.Module()
@@ -99,10 +110,12 @@ def test_get_modules_from_selector_wildcard_children():
     collected = list(get_modules_from_selector(parent_module, "block*"))
     assert len(collected) == 2
 
+
 def test_jit_config_assertion():
     # Should raise if both use_torch and use_thunder
     with pytest.raises(AssertionError):
         JitConfig(use_torch=True, use_thunder=True)
+
 
 def test_compile_module_torch():
     mock_module = MagicMock()
@@ -111,12 +124,14 @@ def test_compile_module_torch():
     mock_module.compile.assert_called_once_with(some_arg=123)
     assert compiled
 
+
 def test_compile_module_thunder():
     mock_module = MagicMock()
     config = JitConfig(use_thunder=True)
     compiled = compile_module(config, mock_module)
     mock_module.compile.assert_called_once()
     assert compiled
+
 
 def test_compile_module_none():
     mock_module = MagicMock()
@@ -125,6 +140,7 @@ def test_compile_module_none():
     mock_module.compile.assert_not_called()
     assert not compiled
 
+
 def test_jit_transform_no_config():
     # If config is None, on_train_epoch_start returns early
     transform = JitTransform(JitConfig(use_thunder=False, use_torch=False))
@@ -132,6 +148,7 @@ def test_jit_transform_no_config():
     pl_module = MagicMock(spec=[])
     transform.on_train_epoch_start(trainer_mock, pl_module)
     assert not getattr(pl_module, '_compiled', False)
+
 
 def test_jit_transform_already_compiled():
     transform = JitTransform(JitConfig(use_torch=True))
@@ -143,6 +160,7 @@ def test_jit_transform_already_compiled():
     # Should remain True, and compile should not be called again
     assert pl_module._compiled is True
     assert pl_module.module == True
+
 
 def test_jit_transform_compile_once():
     # simulate successful compile (torch or thunder)

--- a/tests/lightning/pytorch/callbacks/test_jit_transform.py
+++ b/tests/lightning/pytorch/callbacks/test_jit_transform.py
@@ -16,12 +16,22 @@
 # limitations under the License.
 
 
-import pytest
-from unittest.mock import MagicMock
-import torch
 import re
 from dataclasses import dataclass, field
-from nemo.lightning.pytorch.callbacks.jit_transform import JitConfig, JitTransform, extract_module_attr_name, get_modules_from_selector, listify, compile_module
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from nemo.lightning.pytorch.callbacks.jit_transform import (
+    JitConfig,
+    JitTransform,
+    compile_module,
+    extract_module_attr_name,
+    get_modules_from_selector,
+    listify,
+)
+
 
 def test_extract_module_attr_name_with_module():
     mock_pl_module = MagicMock(spec=[])


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: Core

# Changelog

- Expose `torch.distributed.init_process_group()` timeout via the existing environment variable `TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC` (source: https://pytorch.org/docs/stable/torch_nccl_environment_variables.html)

# Usage

```bash
export TORCH_NCCL_HEARTBEAT_TIMEOUT_SEC=1000000

...  # rest of script
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
