### PR TITLE
[DEPRECATED] Add logs for checkpoint saving start and finalization - see https://github.com/NVIDIA/NeMo/pull/12697 instead

### DIFF
--- a/nemo/collections/llm/tools/auto_configurator/core/calculate_performance.py
+++ b/nemo/collections/llm/tools/auto_configurator/core/calculate_performance.py
@@ -14,12 +14,10 @@
 
 import os
 import re
-import pandas as pd
 from typing import Optional
 
-
+import pandas as pd
 from tensorboard.backend.event_processing import event_accumulator
-
 
 GPT_BASED_MODELS = [
     "gpt3",

--- a/nemo/collections/llm/tools/auto_configurator/core/calculate_performance.py
+++ b/nemo/collections/llm/tools/auto_configurator/core/calculate_performance.py
@@ -33,8 +33,8 @@ GPT_BASED_MODELS = [
 
 
 def get_results(
-    base_config = None,
-    train_config = None,
+    base_config=None,
+    train_config=None,
     path_to_save: str = None,
     output_top_n: Optional[int] = 10,
     log_file_prefix: Optional[str] = 'log-',

--- a/nemo/collections/llm/tools/auto_configurator/runner.py
+++ b/nemo/collections/llm/tools/auto_configurator/runner.py
@@ -15,13 +15,14 @@
 import copy
 import os
 import re
-import numpy as np
 from collections import OrderedDict
 from typing import List, Optional
 
+import numpy as np
+
 from nemo.collections.llm.api import pretrain
 from nemo.collections.llm.tools.auto_configurator.core.training_config import generate_grid_search_configs
-from nemo.collections.llm.tools.auto_configurator.core.utils import generic_base_config, _calculate_model_size
+from nemo.collections.llm.tools.auto_configurator.core.utils import _calculate_model_size, generic_base_config
 from nemo.collections.llm.utils import Config, Partial
 from nemo.utils import logging
 

--- a/nemo/collections/llm/tools/auto_configurator/runner.py
+++ b/nemo/collections/llm/tools/auto_configurator/runner.py
@@ -204,17 +204,17 @@ class AutoConfigurator:
                     return size / 1000  # Convert millions to billions
         elif model_type == "bert":
             return np.round(
-                    _calculate_model_size(
-                        vocab_size=vocab_size,
-                        seq_length=model.seq_length,
-                        hidden_size=model.hidden_size,
-                        num_layers=model.num_layers,
-                        ffn_size=model.ffn_hidden_size,
-                        att_heads=model.num_attention_heads,
-                        model_name=model_type,
-                    ),
-                    3,
-                )
+                _calculate_model_size(
+                    vocab_size=vocab_size,
+                    seq_length=model.seq_length,
+                    hidden_size=model.hidden_size,
+                    num_layers=model.num_layers,
+                    ffn_size=model.ffn_hidden_size,
+                    att_heads=model.num_attention_heads,
+                    model_name=model_type,
+                ),
+                3,
+            )
         return None
 
 

--- a/nemo/utils/callbacks/nemo_model_checkpoint.py
+++ b/nemo/utils/callbacks/nemo_model_checkpoint.py
@@ -15,6 +15,7 @@
 import os
 import re
 import shutil
+import time
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Union
@@ -542,6 +543,9 @@ class NeMoModelCheckpoint(ModelCheckpoint):
                 self.deferred_ckpts_to_remove.append([])
             else:
                 storage_options = None
+            logging.info(
+                f'Checkpoint async save for step {trainer.global_step} starts at {time.time()}.'
+            )
             trainer.save_checkpoint(filepath, self.save_weights_only, storage_options=storage_options)
             if self.async_save:
                 logging.info(f'Scheduled async checkpoint save for {filepath}')
@@ -573,7 +577,8 @@ class NeMoModelCheckpoint(ModelCheckpoint):
             if not self.async_save:
                 return
 
-            logging.info(f'Async checkpoint save for step {global_step} ({filepath}) finalized successfully.')
+            logging.info(
+                f'Async checkpoint save for step {global_step} ({filepath}) finalized successfully at {time.time()}.')
 
             # Remove checkpoints marked for removal by `self._remove_checkpoint`
             # For each finalization there is exactly one entry in self.deferred_ckpts_to_remove

--- a/nemo/utils/callbacks/nemo_model_checkpoint.py
+++ b/nemo/utils/callbacks/nemo_model_checkpoint.py
@@ -543,9 +543,7 @@ class NeMoModelCheckpoint(ModelCheckpoint):
                 self.deferred_ckpts_to_remove.append([])
             else:
                 storage_options = None
-            logging.info(
-                f'Checkpoint save for step {trainer.global_step} started at {time.time()}.'
-            )
+            logging.info(f'Checkpoint save for step {trainer.global_step} started at {time.time()}.')
             trainer.save_checkpoint(filepath, self.save_weights_only, storage_options=storage_options)
             if self.async_save:
                 logging.info(f'Scheduled async checkpoint save for {filepath}')
@@ -578,7 +576,8 @@ class NeMoModelCheckpoint(ModelCheckpoint):
                 return
 
             logging.info(
-                f'Async checkpoint save for step {global_step} ({filepath}) finalized successfully at {time.time()}.')
+                f'Async checkpoint save for step {global_step} ({filepath}) finalized successfully at {time.time()}.'
+            )
 
             # Remove checkpoints marked for removal by `self._remove_checkpoint`
             # For each finalization there is exactly one entry in self.deferred_ckpts_to_remove

--- a/nemo/utils/callbacks/nemo_model_checkpoint.py
+++ b/nemo/utils/callbacks/nemo_model_checkpoint.py
@@ -543,7 +543,9 @@ class NeMoModelCheckpoint(ModelCheckpoint):
                 self.deferred_ckpts_to_remove.append([])
             else:
                 storage_options = None
-            logging.info(f'Checkpoint async save for step {trainer.global_step} starts at {time.time()}.')
+            logging.info(
+                f'Checkpoint save for step {trainer.global_step} started at {time.time()}.'
+            )
             trainer.save_checkpoint(filepath, self.save_weights_only, storage_options=storage_options)
             if self.async_save:
                 logging.info(f'Scheduled async checkpoint save for {filepath}')
@@ -576,8 +578,7 @@ class NeMoModelCheckpoint(ModelCheckpoint):
                 return
 
             logging.info(
-                f'Async checkpoint save for step {global_step} ({filepath}) finalized successfully at {time.time()}.'
-            )
+                f'Async checkpoint save for step {global_step} ({filepath}) finalized successfully at {time.time()}.')
 
             # Remove checkpoints marked for removal by `self._remove_checkpoint`
             # For each finalization there is exactly one entry in self.deferred_ckpts_to_remove

--- a/nemo/utils/callbacks/nemo_model_checkpoint.py
+++ b/nemo/utils/callbacks/nemo_model_checkpoint.py
@@ -543,9 +543,7 @@ class NeMoModelCheckpoint(ModelCheckpoint):
                 self.deferred_ckpts_to_remove.append([])
             else:
                 storage_options = None
-            logging.info(
-                f'Checkpoint async save for step {trainer.global_step} starts at {time.time()}.'
-            )
+            logging.info(f'Checkpoint async save for step {trainer.global_step} starts at {time.time()}.')
             trainer.save_checkpoint(filepath, self.save_weights_only, storage_options=storage_options)
             if self.async_save:
                 logging.info(f'Scheduled async checkpoint save for {filepath}')
@@ -578,7 +576,8 @@ class NeMoModelCheckpoint(ModelCheckpoint):
                 return
 
             logging.info(
-                f'Async checkpoint save for step {global_step} ({filepath}) finalized successfully at {time.time()}.')
+                f'Async checkpoint save for step {global_step} ({filepath}) finalized successfully at {time.time()}.'
+            )
 
             # Remove checkpoints marked for removal by `self._remove_checkpoint`
             # For each finalization there is exactly one entry in self.deferred_ckpts_to_remove

--- a/tests/collections/llm/gpt/data/test_hf_hellaswag.py
+++ b/tests/collections/llm/gpt/data/test_hf_hellaswag.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
-from nemo.collections.llm.gpt.data.hf_dataset import (
-    HellaSwagHFDataModule
-)
+
+from nemo.collections.llm.gpt.data.hf_dataset import HellaSwagHFDataModule
+
 
 @pytest.fixture
 def mock_tokenizer():

--- a/tests/collections/llm/gpt/data/test_hf_hellaswag.py
+++ b/tests/collections/llm/gpt/data/test_hf_hellaswag.py
@@ -41,6 +41,7 @@ def mock_tokenizer():
 
     return tokenizer
 
+
 @pytest.fixture
 def sample_doc():
     """
@@ -51,8 +52,9 @@ def sample_doc():
         "ctx_b": "continuation of the context.",
         "endings": ["Option 1 ending.", "Option 2 ending."],
         "label": 1,
-        "activity_label": "SampleActivity"
+        "activity_label": "SampleActivity",
     }
+
 
 @pytest.mark.parametrize(
     "input_text, expected",
@@ -60,7 +62,7 @@ def sample_doc():
         (" [title]  Something [extra] text ", " Something text"),
         ("Some text [title] [more]", "Some text. "),
         ("   [Foo]    [title]", "  . "),
-    ]
+    ],
 )
 def test_preprocess(input_text, expected):
     """
@@ -68,6 +70,7 @@ def test_preprocess(input_text, expected):
     """
     out = HellaSwagHFDataModule.preprocess(input_text)
     assert out == expected
+
 
 def test_process_doc(sample_doc):
     """
@@ -83,6 +86,7 @@ def test_process_doc(sample_doc):
     assert out_doc["gold"] == sample_doc["label"]
     assert len(out_doc["choices"]) == len(sample_doc["endings"])
     assert out_doc["query"].startswith("SampleActivity: ")
+
 
 @patch("nemo.collections.llm.gpt.data.hf_dataset.load_dataset")
 def test_preprocess_dataset(mock_load_dataset, mock_tokenizer):

--- a/tests/collections/llm/gpt/data/test_hf_mockdataset.py
+++ b/tests/collections/llm/gpt/data/test_hf_mockdataset.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 
 
+from unittest.mock import MagicMock, patch
+
 import pytest
-from unittest.mock import patch, MagicMock
 import torch
-from nemo.collections.llm.gpt.data.hf_dataset import (
-    HFMockDataModule, _MockGPTDataset
-)
+
+from nemo.collections.llm.gpt.data.hf_dataset import HFMockDataModule, _MockGPTDataset
 
 
 @pytest.fixture

--- a/tests/collections/llm/gpt/data/test_hf_mockdataset.py
+++ b/tests/collections/llm/gpt/data/test_hf_mockdataset.py
@@ -42,6 +42,7 @@ def mock_tokenizer():
     tokenizer.vocab_size = 1024
     return tokenizer
 
+
 @pytest.fixture
 def mock_data_module():
     """Fixture to create and set up a mock data module."""

--- a/tests/lightning/pytorch/callbacks/test_jit_transform.py
+++ b/tests/lightning/pytorch/callbacks/test_jit_transform.py
@@ -38,10 +38,12 @@ def test_extract_module_attr_name_with_module():
     mock_pl_module.module = MagicMock()
     assert extract_module_attr_name(mock_pl_module) == 'module', mock_pl_module
 
+
 def test_extract_module_attr_name_with_model():
     mock_pl_module = MagicMock(spec=[])
     mock_pl_module.model = MagicMock()
     assert extract_module_attr_name(mock_pl_module) == 'model', mock_pl_module
+
 
 def test_extract_module_attr_name_raises():
     mock_pl_module = MagicMock(spec=[])
@@ -49,26 +51,32 @@ def test_extract_module_attr_name_raises():
     with pytest.raises(ValueError, match="Expected lightning_module to have a .model or .module"):
         extract_module_attr_name(mock_pl_module)
 
+
 def test_listify_non_list():
     assert listify("test") == ["test"]
 
+
 def test_listify_list():
     assert listify(["test"]) == ["test"]
+
 
 def test_get_modules_from_selector_none_selector():
     model = MagicMock()
     collected = list(get_modules_from_selector(model, None))
     assert collected == [model]
 
+
 def test_get_modules_from_selector_empty_string():
     model = MagicMock()
     collected = list(get_modules_from_selector(model, ""))
     assert collected == [model]
 
+
 def test_get_modules_from_selector_star():
     model = MagicMock()
     collected = list(get_modules_from_selector(model, "*"))
     assert collected == [model]
+
 
 def test_get_modules_from_selector_exact_path():
     # Example: model.encoder.layer
@@ -80,17 +88,20 @@ def test_get_modules_from_selector_exact_path():
     collected = list(get_modules_from_selector(parent_module, "encoder.layer"))
     assert collected == [child_module]
 
+
 def test_get_modules_from_selector_non_existent_attr():
     parent_module = torch.nn.Module()
     parent_module.encoder = torch.nn.Module()
     with pytest.raises(AttributeError, match="has no attribute"):
         list(get_modules_from_selector(parent_module, "decoder"))
 
+
 def test_get_modules_from_selector_attr_is_not_module():
     parent_module = torch.nn.Module()
     parent_module.something = "I am not a module"
     with pytest.raises(AttributeError, match="is not an nn.Module"):
         list(get_modules_from_selector(parent_module, "something"))
+
 
 def test_get_modules_from_selector_wildcard_children():
     parent_module = torch.nn.Module()
@@ -99,10 +110,12 @@ def test_get_modules_from_selector_wildcard_children():
     collected = list(get_modules_from_selector(parent_module, "block*"))
     assert len(collected) == 2
 
+
 def test_jit_config_assertion():
     # Should raise if both use_torch and use_thunder
     with pytest.raises(AssertionError):
         JitConfig(use_torch=True, use_thunder=True)
+
 
 def test_compile_module_torch():
     mock_module = MagicMock()
@@ -111,12 +124,14 @@ def test_compile_module_torch():
     mock_module.compile.assert_called_once_with(some_arg=123)
     assert compiled
 
+
 def test_compile_module_thunder():
     mock_module = MagicMock()
     config = JitConfig(use_thunder=True)
     compiled = compile_module(config, mock_module)
     mock_module.compile.assert_called_once()
     assert compiled
+
 
 def test_compile_module_none():
     mock_module = MagicMock()
@@ -125,6 +140,7 @@ def test_compile_module_none():
     mock_module.compile.assert_not_called()
     assert not compiled
 
+
 def test_jit_transform_no_config():
     # If config is None, on_train_epoch_start returns early
     transform = JitTransform(JitConfig(use_thunder=False, use_torch=False))
@@ -132,6 +148,7 @@ def test_jit_transform_no_config():
     pl_module = MagicMock(spec=[])
     transform.on_train_epoch_start(trainer_mock, pl_module)
     assert not getattr(pl_module, '_compiled', False)
+
 
 def test_jit_transform_already_compiled():
     transform = JitTransform(JitConfig(use_torch=True))
@@ -143,6 +160,7 @@ def test_jit_transform_already_compiled():
     # Should remain True, and compile should not be called again
     assert pl_module._compiled is True
     assert pl_module.module == True
+
 
 def test_jit_transform_compile_once():
     # simulate successful compile (torch or thunder)

--- a/tests/lightning/pytorch/callbacks/test_jit_transform.py
+++ b/tests/lightning/pytorch/callbacks/test_jit_transform.py
@@ -16,12 +16,22 @@
 # limitations under the License.
 
 
-import pytest
-from unittest.mock import MagicMock
-import torch
 import re
 from dataclasses import dataclass, field
-from nemo.lightning.pytorch.callbacks.jit_transform import JitConfig, JitTransform, extract_module_attr_name, get_modules_from_selector, listify, compile_module
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from nemo.lightning.pytorch.callbacks.jit_transform import (
+    JitConfig,
+    JitTransform,
+    compile_module,
+    extract_module_attr_name,
+    get_modules_from_selector,
+    listify,
+)
+
 
 def test_extract_module_attr_name_with_module():
     mock_pl_module = MagicMock(spec=[])


### PR DESCRIPTION
- Add logs to the start of checkpoint save with timestamp.
- Add logs to the checkpoint finalization function with timestamp.
- This helps evaluate the time taken to write a checkpoint into storage.
