### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `11996c9...` (2025-03-22)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -1,26 +1,26 @@
 {
-    "ngc-pytorch": "nvcr.io/nvidia/pytorch:25.01-py3",
-    "vcs-dependencies": {
-        "apex": {
-            "repo": "https://github.com/NVIDIA/Apex",
-            "ref": "810ffae374a2b9cb4b5c5e28eaeca7d7998fca0c"
-        },
-        "transformer_engine": {
-            "repo": "https://github.com/NVIDIA/TransformerEngine",
-            "ref": "3b2a7b00f336aea39000073547410e6ac3727fbf"
-        },
-        "megatron-lm": {
-            "repo": "https://github.com/NVIDIA/Megatron-LM",
-            "ref": "810ffae374a2b9cb4b5c5e28eaeca7d7998fca0c"
-        }
+  "ngc-pytorch": "nvcr.io/nvidia/pytorch:25.01-py3",
+  "vcs-dependencies": {
+    "apex": {
+      "repo": "https://github.com/NVIDIA/Apex",
+      "ref": "810ffae374a2b9cb4b5c5e28eaeca7d7998fca0c"
     },
     "transformer_engine": {
       "repo": "https://github.com/NVIDIA/TransformerEngine",
-      "ref": "7d576ed25266a17a7b651f2c12e8498f67e0baea"
+      "ref": "3b2a7b00f336aea39000073547410e6ac3727fbf"
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "8a5521ac4226fbefeeb2a102ebecac32a01d4852"
-    },
+      "ref": "11996c9fd1a2d0aaef6dafc1fd4219aa795f188f"
+    }
+  },
+  "transformer_engine": {
+    "repo": "https://github.com/NVIDIA/TransformerEngine",
+    "ref": "7d576ed25266a17a7b651f2c12e8498f67e0baea"
+  },
+  "megatron-lm": {
+    "repo": "https://github.com/NVIDIA/Megatron-LM",
+    "ref": "8a5521ac4226fbefeeb2a102ebecac32a01d4852"
+  },
   "pypi-dependencies": {}
 }


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `11996c9fd1a2d0aaef6dafc1fd4219aa795f188f`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.