### PR TITLE
Pass tensor instead of raw number in _mock_loss_function in PTQ

### DIFF
--- a/nemo/collections/llm/modelopt/quantization/quantizer.py
+++ b/nemo/collections/llm/modelopt/quantization/quantizer.py
@@ -286,7 +286,7 @@ class Quantizer:
             output_tensor = model(data, position_ids, None)
 
             def _mock_loss_function(tensor):
-                return 0, {}
+                return torch.zeros(1), {}
 
             return output_tensor, _mock_loss_function
 

--- a/nemo/export/__init__.py
+++ b/nemo/export/__init__.py
@@ -11,10 +11,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-use_tensorrt = True
-try:
-    from nemo.export.tensorrt_lazy_compiler import trt_compile
-except Exception as e:
-    use_tensorrt = False


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

1. Addressing the following issue observed in Mixtral PTQ which is a consequence of recent changes in Megatron-LM added in [MR-2204](https://github.com/NVIDIA/Megatron-LM/commit/a606486ecefa46eafafe771cf8177195099f11e7):
```
[rank0]:   File "/opt/NeMo/nemo/collections/llm/modelopt/quantization/quantizer.py", line 296, in loop
[rank0]:     forward_backward_func(
[rank0]:   File "/opt/megatron-lm/megatron/core/pipeline_parallel/schedules.py", line 462, in forward_backward_no_pipelining
[rank0]:     output_tensor, num_tokens = forward_step(
[rank0]:                                 ^^^^^^^^^^^^^
[rank0]:   File "/opt/megatron-lm/megatron/core/pipeline_parallel/schedules.py", line 314, in forward_step
[rank0]:     else torch.ones(1, device=output_tensor.device)
[rank0]:                               ^^^^^^^^^^^^^^^^^^^^
[rank0]: AttributeError: 'float' object has no attribute 'device'
```

2. Removing import from `nemo.export.tensorrt_lazy_compiler` from `nemo.export.__init__.py` as it triggers a [breakpoint(?)](https://github.com/pytorch/TensorRT/blob/4a66f58d0dd44cbafa3dae4334161d72449e4606/py/torch_tensorrt/dynamo/conversion/custom_ops_converters.py#L57) in the latest containers.

**Collection**: NLP

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
