### PR TITLE
Fix timestamps when cuda graphs enabled

### DIFF
--- a/nemo/collections/asr/parts/utils/rnnt_utils.py
+++ b/nemo/collections/asr/parts/utils/rnnt_utils.py
@@ -641,11 +641,15 @@ def batched_hyps_to_hypotheses(
     """
     assert batch_size is None or batch_size <= batched_hyps.scores.shape[0]
     num_hyps = batched_hyps.scores.shape[0] if batch_size is None else batch_size
+    # We clone `timestamps` and `y_sequence` to avoid keeping references
+    # to the tensors that can be allocated by CUDA graphs. If we don't do this,
+    # subsequent batches might reuse and overwrite the same memory,
+    # leading to unexpected results due to shared references.
     hypotheses = [
         Hypothesis(
             score=batched_hyps.scores[i].item(),
-            y_sequence=batched_hyps.transcript[i, : batched_hyps.current_lengths[i]],
-            timestamp=batched_hyps.timestamps[i, : batched_hyps.current_lengths[i]],
+            y_sequence=batched_hyps.transcript[i, : batched_hyps.current_lengths[i]].clone(),
+            timestamp=batched_hyps.timestamps[i, : batched_hyps.current_lengths[i]].clone(),
             token_duration=(
                 durations
                 if not torch.all(


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Added cloning for `timestamps` and `y_sequence` tensors of batched_hypotheses objects, as they are overwritten with every new batch when cuda graphs are enabled. See the related issue for more details.

**Collection**: ASR

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to [#12376](https://github.com/NVIDIA/NeMo/issues/12376)
