### PR TITLE
[automodel] add cpu:gloo to backend

### DIFF
--- a/examples/llm/peft/automodel.py
+++ b/examples/llm/peft/automodel.py
@@ -70,7 +70,7 @@ def make_squad_hf_dataset(tokenizer, batch_size, fp8=False):
     return datamodule
 
 
-def make_strategy(strategy, model, devices, num_nodes, adapter_only=False):
+def make_strategy(strategy, model, devices, num_nodes, adapter_only=False, enable_cpu_offload=False):
     if strategy == 'auto':
         return pl.strategies.SingleDeviceStrategy(
             device='cuda:0',
@@ -81,10 +81,18 @@ def make_strategy(strategy, model, devices, num_nodes, adapter_only=False):
             checkpoint_io=model.make_checkpoint_io(adapter_only=adapter_only),
         )
     elif strategy == 'fsdp2':
+        offload_policy = None
+        if enable_cpu_offload:
+            from nemo.lightning.pytorch.strategies.fsdp2_strategy import HAS_CPU_OFFLOAD_POLICY, CPUOffloadPolicy
+
+            assert HAS_CPU_OFFLOAD_POLICY, "Could not import offload policy"
+            offload_policy = CPUOffloadPolicy()
+
         return nl.FSDP2Strategy(
             data_parallel_size=devices * num_nodes,
             tensor_parallel_size=1,
             checkpoint_io=model.make_checkpoint_io(adapter_only=adapter_only),
+            offload_policy=offload_policy,
         )
     else:
         raise NotImplementedError("Encountered unknown strategy")
@@ -133,7 +141,9 @@ def main():
     parser.add_argument('--wandb-project', type=str, default=None, help='Wandb project to use')
     parser.add_argument('--use-torch-jit', action='store_true', help='Enables torch.compile on model')
     parser.add_argument('--auto-resume', action='store_true', help='Enables autoresume from a previous training job')
+    parser.add_argument('--enable-cpu-offload', action='store_true', help='Enabled cpu offloading; requires FSDP2')
     parser.add_argument('--liger', action='store_true', help='Enables Liger-Kernels')
+    parser.add_argument('--enable-grad-ckpt', action='store_true', help='Enables gradient checkpoint')
     parser.add_argument(
         '--ckpt-folder', type=str, default=tempfile.TemporaryDirectory().name, help='Directory to save checkpoints'
     )
@@ -146,6 +156,10 @@ def main():
     parser.add_argument('--fp8', action='store_true', help='Enables fp8 training')
     parser.add_argument('--lr', type=float, default=5e-5, help='Learning rate')
     args = parser.parse_args()
+
+    # CPUOffload WA for known issue
+    if args.enable_cpu_offload and args.use_te_optimizer:
+        args.use_te_optimizer = False
 
     wandb = None
     if args.wandb_project is not None:
@@ -178,8 +192,9 @@ def main():
         model_accelerator=model_accelerator,
         trust_remote_code=args.trust_remote_code,
         use_liger_kernel=args.liger,
+        enable_grad_ckpt=args.enable_grad_ckpt,
     )
-    strategy = make_strategy(args.strategy, model, args.devices, args.num_nodes, True)
+    strategy = make_strategy(args.strategy, model, args.devices, args.num_nodes, True, args.enable_cpu_offload)
 
     resume = (
         nl.AutoResume(

--- a/examples/llm/sft/automodel.py
+++ b/examples/llm/sft/automodel.py
@@ -203,9 +203,6 @@ def main():
         if args.auto_resume
         else None
     )
-    # CPUOffload WA
-    if args.enable_cpu_offload:
-        args.grad_clip = 0.0
 
     llm.api.finetune(
         model=model,

--- a/nemo/lightning/pytorch/strategies/fsdp2_strategy.py
+++ b/nemo/lightning/pytorch/strategies/fsdp2_strategy.py
@@ -224,6 +224,10 @@ class FSDP2Strategy(PLModelParallelStrategy, io.IOMixin):
         reset_seed()
         self.set_world_ranks()
         self._process_group_backend = self._get_process_group_backend()
+        # See https://github.com/pytorch/pytorch/issues/148532 for details.
+        if self.offload_policy is not None:
+            self._process_group_backend = "cuda:nccl,cpu:gloo"
+
         assert self.cluster_environment is not None
         if not torch.distributed.is_available():
             raise RuntimeError("torch.distributed is not available. Cannot initialize distributed process group")


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fixes the following error

Stack:
```
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/optim/adam.py", line 223, in step
[rank1]:     loss = closure()
[rank1]:            ^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/lightning/pytorch/plugins/precision/precision.py", line 109, in _wrap_closure
[rank1]:     self._after_closure(model, optimizer)
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/lightning/pytorch/plugins/precision/precision.py", line 88, in _after_closure
[rank1]:     self._clip_gradients(
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/lightning/pytorch/plugins/precision/precision.py", line 135, in _clip_gradients
[rank1]:     call._call_lightning_module_hook(
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/lightning/pytorch/trainer/call.py", line 167, in _call_lightning_module_hook
[rank1]:     output = fn(*args, **kwargs)
[rank1]:              ^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/lightning/pytorch/core/module.py", line 1243, in configure_gradient_clipping
[rank1]:     self.clip_gradients(
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/lightning/pytorch/core/module.py", line 1214, in clip_gradients
[rank1]:     self.trainer.precision_plugin.clip_gradients(optimizer, gradient_clip_val, gradient_clip_algorithm)
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/lightning/pytorch/plugins/precision/amp.py", line 111, in clip_gradients
[rank1]:     super().clip_gradients(optimizer=optimizer, clip_val=clip_val, gradient_clip_algorithm=gradient_clip_algorithm)
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/lightning/pytorch/plugins/precision/precision.py", line 155, in clip_gradients
[rank1]:     self.clip_grad_by_norm(optimizer, clip_val)
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/lightning/pytorch/plugins/precision/precision.py", line 165, in clip_grad_by_norm
[rank1]:     torch.nn.utils.clip_grad_norm_(parameters, clip_val)
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/nn/utils/clip_grad.py", line 34, in _no_grad_wrapper
[rank1]:     return func(*args, **kwargs)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/nn/utils/clip_grad.py", line 216, in clip_grad_norm_
[rank1]:     _clip_grads_with_norm_(parameters, max_norm, total_norm, foreach)
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/nn/utils/clip_grad.py", line 34, in _no_grad_wrapper
[rank1]:     return func(*args, **kwargs)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/nn/utils/clip_grad.py", line 155, in _clip_grads_with_norm_
[rank1]:     clip_coef = max_norm / (total_norm + 1e-6)
[rank1]:                 ~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/_tensor.py", line 39, in wrapped
[rank1]:     return f(*args, **kwargs)
[rank1]:            ^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/_tensor.py", line 1077, in __rdiv__
[rank1]:     return self.reciprocal() * other
[rank1]:            ^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/_compile.py", line 32, in inner
[rank1]:     return disable_fn(*args, **kwargs)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/_dynamo/eval_frame.py", line 738, in _fn
[rank1]:     return fn(*args, **kwargs)
[rank1]:            ^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_api.py", line 343, in __torch_dispatch__
[rank1]:     return DTensor._op_dispatcher.dispatch(
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_dispatch.py", line 181, in dispatch
[rank1]:     self.redistribute_local_args(
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_dispatch.py", line 317, in redistribute_local_args
[rank1]:     resharded_local_tensor = redistribute_local_tensor(
[rank1]:                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_redistribute.py", line 208, in redistribute_local_tensor
[rank1]:     new_local_tensor = partial_spec._reduce_value(
[rank1]:                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/_ops/_math_ops.py", line 126, in _reduce_value
[rank1]:     reduced_tensor = super()._reduce_value(tensor, mesh, mesh_dim)
[rank1]:                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/tensor/placement_types.py", line 599, in _reduce_value
[rank1]:     return funcol.all_reduce(
[rank1]:            ^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/distributed/_functional_collectives.py", line 176, in all_reduce
[rank1]:     tensor = torch.ops._c10d_functional.all_reduce(self, reduceOp.lower(), group_name)
[rank1]:              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "/usr/local/lib/python3.12/dist-packages/torch/_ops.py", line 1123, in __call__
[rank1]:     return self._op(*args, **(kwargs or {}))
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]: RuntimeError: No backend type associated with device type cpu
```
**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
