### PR TITLE
Prune docker images in GHA older than 8hrs

### DIFF
--- a/.github/workflows/_test_template.yml
+++ b/.github/workflows/_test_template.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Docker system cleanup
         run: |
-          docker system prune -af --filter "until=24h" --force || true
+          docker system prune -af --filter "until=8h" --force || true
 
       - name: Docker pull image
         run: |


### PR DESCRIPTION
# What does this PR do ?

Prune docker images in GHA older than 8hrs from 24hrs. The test container size is >90gb now possibly due to the recent addition of trt-llm. We'll want to build the container more efficiently, but this is intended as a stop-gap to minimize cases where we run out of space on the GHA runners for now.  Will cut an issue to follow-up on making the docker container more efficient.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Prune docker images in GHA older than 8hrs

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
