### PR TITLE
Update LLaVA's next HF exporter to load ViT checkpoint from YAML

### DIFF
--- a/nemo/collections/vlm/llava_next/model/llava_next.py
+++ b/nemo/collections/vlm/llava_next/model/llava_next.py
@@ -436,7 +436,8 @@ class HFLlavaNextExporter(io.ModelConnector[LlavaNextModel, "LlavaNextForConditi
 
         source = io.load_context(str(self), subpath="model.config")
         language_config = source.language_transformer_config
-        vision_config = CLIPVisionConfig.from_pretrained("openai/clip-vit-large-patch14-336")
+        vit_path = getattr(source.vision_transformer_config, "pretrained_model_name_or_path", "openai/clip-vit-large-patch14-336")
+        vision_config = CLIPVisionConfig.from_pretrained(vit_path)
 
         # Create text config for HuggingFace model
         text_config = HFLlamaConfig(

--- a/nemo/collections/vlm/llava_next/model/llava_next.py
+++ b/nemo/collections/vlm/llava_next/model/llava_next.py
@@ -436,7 +436,9 @@ class HFLlavaNextExporter(io.ModelConnector[LlavaNextModel, "LlavaNextForConditi
 
         source = io.load_context(str(self), subpath="model.config")
         language_config = source.language_transformer_config
-        vit_path = getattr(source.vision_transformer_config, "pretrained_model_name_or_path", "openai/clip-vit-large-patch14-336")
+        vit_path = getattr(
+            source.vision_transformer_config, "pretrained_model_name_or_path", "openai/clip-vit-large-patch14-336"
+        )
         vision_config = CLIPVisionConfig.from_pretrained(vit_path)
 
         # Create text config for HuggingFace model


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

- Modify the implementation to support exporting the ViT path from a checkpoint YAML file when using different CLIP versions, such as `microsoft/LLM2CLIP-Openai-L-14-336`, instead of the default `openai/clip-vit-large-patch14-336`.

**Collection**: [Note which collection this PR will affect]

# Changelog

```
diff --git a/nemo/collections/vlm/llava_next/model/llava_next.py b/nemo/collections/vlm/llava_next/model/llava_next.py
index 423930286..564938c74 100644
--- a/nemo/collections/vlm/llava_next/model/llava_next.py
+++ b/nemo/collections/vlm/llava_next/model/llava_next.py
@@ -436,7 +436,8 @@ class HFLlavaNextExporter(io.ModelConnector[LlavaNextModel, "LlavaNextForConditi
 
         source = io.load_context(str(self), subpath="model.config")
         language_config = source.language_transformer_config
-        vision_config = CLIPVisionConfig.from_pretrained("openai/clip-vit-large-patch14-336")
+        vit_path = getattr(source.vision_transformer_config, "pretrained_model_name_or_path", "openai/clip-vit-large-patch14-336")
+        vision_config = CLIPVisionConfig.from_pretrained(vit_path)
 
         # Create text config for HuggingFace model
         text_config = HFLlamaConfig(
```

# Usage


```bash
torchrun /opt/NeMo/scripts/vlm/llava_next_export_hf.py \
    --path <input_nemo_ckpt_path> \
    --output_path <output_hf_ckpt_path>
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.
@abhinavg4 

# Additional Information

- Related to # (issue)
