### PR TITLE
Fixing keyword argument for rerun state machine's state dict method

### DIFF
--- a/nemo/tron/checkpointing.py
+++ b/nemo/tron/checkpointing.py
@@ -462,7 +462,7 @@ def save_checkpoint(
     # Collect rerun state across all ranks
     rerun_state_machine = get_rerun_state_machine()
     rerun_state = rerun_state_machine.state_dict(
-        data_iterator=train_data_iterator, use_dist_ckpt=ckpt_type != CheckpointType.LEGACY
+        data_iterator=train_data_iterator, ckpt_format=ckpt_cfg.ckpt_format,
     )
 
     # Checkpoint name.

--- a/nemo/tron/checkpointing.py
+++ b/nemo/tron/checkpointing.py
@@ -462,7 +462,8 @@ def save_checkpoint(
     # Collect rerun state across all ranks
     rerun_state_machine = get_rerun_state_machine()
     rerun_state = rerun_state_machine.state_dict(
-        data_iterator=train_data_iterator, ckpt_format=ckpt_cfg.ckpt_format,
+        data_iterator=train_data_iterator,
+        ckpt_format=ckpt_cfg.ckpt_format,
     )
 
     # Checkpoint name.


### PR DESCRIPTION
# What does this PR do ?

I think the current codebase uses an old API version of MCore's `RerunStateMachine` `state_dict` method. Changing out the way we call it with the correct kwargs.
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation
