### PR TITLE
Temporary disable CUDA graphs in DDP mode for transducer decoding

### DIFF
--- a/nemo/collections/asr/parts/submodules/rnnt_loop_labels_computer.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_loop_labels_computer.py
@@ -33,6 +33,7 @@ from nemo.core.utils.cuda_python_utils import (
 )
 from nemo.utils import logging
 from nemo.utils.enum import PrettyStrEnum
+from nemo.utils.nemo_logging import LogMode
 
 try:
     from cuda import cudart
@@ -994,7 +995,12 @@ class GreedyBatchedRNNTLoopLabelsComputer(WithOptionalCudaGraphs, ConfidenceMeth
         x: torch.Tensor,
         out_len: torch.Tensor,
     ) -> Tuple[rnnt_utils.BatchedHyps, Optional[rnnt_utils.BatchedAlignments], Any]:
+        # TODO(vbataev): Fix CUDA graphs in distributed environment and re-enable decoding with CUDA graphs
+        is_ddp = torch.distributed.is_available() and torch.distributed.is_initialized()
         if self.cuda_graphs_mode is not None and x.device.type == "cuda":
-            return self.loop_labels_cuda_graphs(encoder_output=x, encoder_output_length=out_len)
+            if not is_ddp:
+                return self.loop_labels_cuda_graphs(encoder_output=x, encoder_output_length=out_len)
+            else:
+                logging.warning("CUDA graphs are temporary disabled in distributed environment", mode=LogMode.ONCE)
 
         return self.loop_labels_torch(encoder_output=x, encoder_output_length=out_len)

--- a/nemo/collections/asr/parts/submodules/tdt_loop_labels_computer.py
+++ b/nemo/collections/asr/parts/submodules/tdt_loop_labels_computer.py
@@ -34,6 +34,7 @@ from nemo.core.utils.cuda_python_utils import (
 )
 from nemo.utils import logging
 from nemo.utils.enum import PrettyStrEnum
+from nemo.utils.nemo_logging import LogMode
 
 try:
     from cuda import cudart
@@ -1118,7 +1119,12 @@ class GreedyBatchedTDTLoopLabelsComputer(WithOptionalCudaGraphs, ConfidenceMetho
         x: torch.Tensor,
         out_len: torch.Tensor,
     ) -> Tuple[rnnt_utils.BatchedHyps, Optional[rnnt_utils.BatchedAlignments], Any]:
+        # TODO(vbataev): Fix CUDA graphs in distributed environment and re-enable decoding with CUDA graphs
+        is_ddp = torch.distributed.is_available() and torch.distributed.is_initialized()
         if self.cuda_graphs_mode is not None and x.device.type == "cuda":
-            return self.loop_labels_cuda_graphs(encoder_output=x, encoder_output_length=out_len)
+            if not is_ddp:
+                return self.loop_labels_cuda_graphs(encoder_output=x, encoder_output_length=out_len)
+            else:
+                logging.warning("CUDA graphs are temporary disabled in distributed environment", mode=LogMode.ONCE)
 
         return self.loop_labels_torch(encoder_output=x, encoder_output_length=out_len)


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Temporary disable decoding with CUDA graphs in distributed environment due to multiple reported issues.
I tried large number of warmup steps and different tricks, but still observe the issues.

**Collection**: [ASR]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
