### PR TITLE
Update nvidia-resiliency-ext to be >= 0.3.0

### DIFF
--- a/reinstall.sh
+++ b/reinstall.sh
@@ -246,12 +246,6 @@ nemo() {
     "nemo_run"                                                                                 # Not compatible in Python 3.12
   )
 
-  if [[ -n "${NVIDIA_PYTORCH_VERSION}" ]]; then
-    DEPS+=(
-      "git+https://github.com/NVIDIA/nvidia-resiliency-ext.git@e7e7a05a404451ab3bc9ee156b939d1a777dca48 ; platform_machine == 'x86_64'" # Compiling NvRX requires CUDA
-    )
-  fi
-
   echo 'Installing dependencies of nemo'
   pip install --force-reinstall --no-deps --no-cache-dir "${DEPS[@]}"
   pip install --no-cache-dir "${DEPS[@]}"

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -13,7 +13,7 @@ megatron_core
 nltk>=3.6.5
 numpy<2  # tensorstore has an implicit compiled dependency on numpy<2
 nvidia-modelopt[torch]>=0.23.2,<=0.27.0 ; platform_system != 'Darwin'
-nvidia-resiliency-ext; (platform_machine == 'x86_64' and platform_system != 'Darwin')
+nvidia-resiliency-ext>=0.3.0,<1.0.0; platform_system != 'Darwin'
 opencc
 pangu
 prettytable


### PR DESCRIPTION
# What does this PR do ?

Update nvidia-resiliency-ext to be >= 0.3.0. Also, allow this to be installed on arm platforms.

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Update nvidia-resiliency-ext to be >= 0.3.0

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
