### PR TITLE
Resolve an issue in custom megatron FSDP config setting

### DIFF
--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -674,7 +674,7 @@ class MegatronParallel(nn.ModuleList, Generic[ModelT]):
                     and self.fsdp == "megatron"
                     and not isinstance(unwrapped_module, FullyShardedDataParallel)
                 ):
-                    if not module.config.use_custom_fsdp:
+                    if not setattr(module.config, "use_custom_fsdp", False):
                         from nemo.utils import logging
 
                         module.config.use_custom_fsdp = True

--- a/nemo/lightning/megatron_parallel.py
+++ b/nemo/lightning/megatron_parallel.py
@@ -674,10 +674,10 @@ class MegatronParallel(nn.ModuleList, Generic[ModelT]):
                     and self.fsdp == "megatron"
                     and not isinstance(unwrapped_module, FullyShardedDataParallel)
                 ):
-                    if not setattr(module.config, "use_custom_fsdp", False):
+                    if not getattr(module.config, "use_custom_fsdp", False):
                         from nemo.utils import logging
 
-                        module.config.use_custom_fsdp = True
+                        setattr(module.config, "use_custom_fsdp", True)
                         logging.warning("Setting module.config.use_custom_fsdp to True for MCore FSDP.")
 
                     assert module.config.use_custom_fsdp, "Custom FSDP is not enabled in module.config."

--- a/scripts/performance/utils.py
+++ b/scripts/performance/utils.py
@@ -289,7 +289,7 @@ def set_primary_perf_configs(
     # FSDP configs
     if use_mcore_fsdp:
         recipe.model.config.init_model_with_meta_device = True
-        recipe.trainer.strategy.ddp.use_custom_fsdp = True
+        recipe.trainer.strategy.fsdp = "megatron"
         recipe.trainer.strategy.ddp.data_parallel_sharding_strategy = "optim_grads_params"
         recipe.trainer.strategy.ddp.average_in_collective = False
         recipe.trainer.strategy.ddp.keep_fp8_transpose_cache_when_using_custom_fsdp = False


### PR DESCRIPTION
# What does this PR do ?

Resolve an issue in custom megatron FSDP config setting

# Changelog

- Set `use_custom_fsdp` in module attribute
- Use `strategy.fsdp="megatron"`  instead of `use_custom_fsdp=true` in external interface

# Usage

- Set `strategy.fsdp="megatron"`  instead of `use_custom_fsdp=true` at run script

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
