### PR TITLE
Add support for SentencePiece normalization rule in ASR tokenizer pipeline

### DIFF
--- a/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
+++ b/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
@@ -367,6 +367,7 @@ def create_spt_model(
     vocab_size: int,
     sample_size: int,
     do_lower_case: bool,
+    normalization_rule_name: Optional[str] = None,
     tokenizer_type: str = 'unigram',
     output_dir: Optional[str] = None,
     character_coverage: float = 1.0,
@@ -457,6 +458,9 @@ def create_spt_model(
 
     if do_lower_case:
         cmd += " --normalization_rule_name=nmt_nfkc_cf"
+
+    if normalization_rule_name:
+        cmd += f" --normalization_rule_name={normalization_rule_name}"
 
     if sample_size > 0:
         cmd += f" --input_sentence_size={sample_size}"

--- a/scripts/tokenizers/process_asr_text_tokenizer.py
+++ b/scripts/tokenizers/process_asr_text_tokenizer.py
@@ -144,6 +144,13 @@ parser.add_argument(
 )
 
 parser.add_argument(
+    "--spe_normalization_rule_name",
+    default=None,
+    type=str,
+    help="Normalization rule name for SentencePiece. If not provided, will use the default normalization rule.",
+)
+
+parser.add_argument(
     '--spe_sample_size',
     type=int,
     default=-1,
@@ -221,6 +228,7 @@ def __process_data(
     spe_type: str,
     spe_character_coverage: float,
     spe_train_extremely_large_corpus: bool,
+    spe_normalization_rule_name: str,
     spe_sample_size: int,
     spe_max_sentencepiece_length: int,
     spe_split_by_unicode_script: bool,
@@ -296,6 +304,7 @@ def __process_data(
             vocab_size=vocab_size,
             sample_size=spe_sample_size,
             do_lower_case=lower_case,
+            normalization_rule_name=spe_normalization_rule_name,
             output_dir=tokenizer_dir,
             tokenizer_type=spe_type,
             character_coverage=spe_character_coverage,
@@ -335,6 +344,7 @@ def main():
     spe_type = args.spe_type
     spe_character_coverage = args.spe_character_coverage
     spe_sample_size = args.spe_sample_size
+    spe_normalization_rule_name= args.spe_normalization_rule_name
     spe_train_extremely_large_corpus = args.spe_train_extremely_large_corpus
     spe_max_sentencepiece_length = args.spe_max_sentencepiece_length
     spe_split_by_unicode_script = args.spe_split_by_unicode_script
@@ -365,6 +375,7 @@ def main():
         lower_case=lower_case,
         spe_character_coverage=spe_character_coverage,
         spe_sample_size=spe_sample_size,
+        spe_normalization_rule_name=spe_normalization_rule_name,
         spe_train_extremely_large_corpus=spe_train_extremely_large_corpus,
         spe_max_sentencepiece_length=spe_max_sentencepiece_length,
         spe_split_by_unicode_script=spe_split_by_unicode_script,

--- a/scripts/tokenizers/process_asr_text_tokenizer.py
+++ b/scripts/tokenizers/process_asr_text_tokenizer.py
@@ -344,7 +344,7 @@ def main():
     spe_type = args.spe_type
     spe_character_coverage = args.spe_character_coverage
     spe_sample_size = args.spe_sample_size
-    spe_normalization_rule_name= args.spe_normalization_rule_name
+    spe_normalization_rule_name = args.spe_normalization_rule_name
     spe_train_extremely_large_corpus = args.spe_train_extremely_large_corpus
     spe_max_sentencepiece_length = args.spe_max_sentencepiece_length
     spe_split_by_unicode_script = args.spe_split_by_unicode_script


### PR DESCRIPTION
# What does this PR do ?

This PR adds support for the `normalization_rule_name` argument in the `SentencePieceTokenizer` to improve compatibility across different language use cases.

In particular, this is important for Korean, where characters can be represented in their decomposed Jamo form (e.g., ㅎㅏㄴㄱㅡㄹ) — a common representation in ASR tasks.
Currently, the tokenizer defaults to --normalization_rule_name=nmt_nfkc_cf, which automatically composes Jamos into full Hangul syllables (e.g., 한글), potentially leading to undesired behavior in these scenarios.

By allowing customization of the normalization rule, users can now disable this behavior (e.g., using identity) and preserve raw character-level inputs like Jamos.

**Collection**: [Note which collection this PR will affect]

# Changelog


Added support for the `--normalization_rule_name` optional argument in `nemo/collections/common/tokenizers/sentencepiece_tokenizer.py`.

Introduced the `--spe_normalization_rule_name` argument in `scripts/tokenizers/process_asr_text_tokenizer.py` to allow users to specify SentencePiece normalization behavior during tokenizer processing.

Note: Support for --spe_normalization_rule_name is currently limited to ASR-related scripts. Broader integration with other tokenization scripts can be considered in future updates.

# Usage


```python
python scripts/tokenizers /process_asr_text_tokenizer.py \
--manifest=path/to/your/manifest.json \
--vocab_size=512 \
--data_root=ko_jamo_tokenizer_bpe_maxlen_12 \
--tokenizer="spe" \
--spe_type=bpe \
--spe_character_coverage=1.0 \
--spe_max_sentencepiece_length=12 \
--spe_split_digits \
--normalization_rule_name="identity" \
--log


--normalization_rule_name="identity"  <- added

```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [  ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [  ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- https://github.com/google/sentencepiece/blob/master/doc/normalization.md
