### PR TITLE
Added max_sentence_length support to sentencepiece builder

### DIFF
--- a/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
+++ b/nemo/collections/common/tokenizers/sentencepiece_tokenizer.py
@@ -372,6 +372,7 @@ def create_spt_model(
     character_coverage: float = 1.0,
     train_extremely_large_corpus: bool = False,
     max_sentencepiece_length: int = -1,
+    max_sentence_length: int = None,
     bos: bool = False,
     eos: bool = False,
     pad: bool = False,
@@ -398,6 +399,7 @@ def create_spt_model(
             to build the tokenizer.
         max_sentencepiece_length: Limits the maximum length of the SentencePiece subword that can be constructed.
             By default, no limit is placed.
+        max_sentence_length: Maximum number of bytes allowed in the input sentences.
         bos: when True, bos token "<s>" is added to the vocabulary.
         eos: when True, eos token "</s>" is added to the vocabulary.
         pad: when True, pad token "<pad>" is added to the vocabulary.
@@ -466,6 +468,9 @@ def create_spt_model(
 
     if max_sentencepiece_length >= 0:
         cmd += f" --max_sentencepiece_length={max_sentencepiece_length}"
+
+    if max_sentence_length:
+        cmd += f" --max_sentence_length={max_sentence_length}"
 
     if byte_fallback:
         cmd += " --byte_fallback=true"

--- a/scripts/tokenizers/process_asr_text_tokenizer.py
+++ b/scripts/tokenizers/process_asr_text_tokenizer.py
@@ -86,6 +86,9 @@
 #   --spe_max_sentencepiece_length: Limits the maximum length that any any SentencePiece subword can be.
 #       Using this will change the subword tokens generated.
 #
+#   --spe_max_sentence_length: Maximum number of bytes allowed in the input sentences.  
+#       This limits the size of sentences that can be processed during training.
+#
 #   --spe_pad: Adds <pad> as special token.
 #
 #   --spe_bos: Adds <s> as Begining-of-Sentence special token.
@@ -158,6 +161,12 @@ parser.add_argument(
     'Must be a positive integer > 0. By default places no limit on subword length.',
 )
 parser.add_argument(
+    '--spe_max_sentence_length', 
+    type=int,
+    default=None,
+    help="Maximum number of bytes allowed in the input sentences."
+    )
+parser.add_argument(
     '--spe_no_split_by_unicode_script',
     dest='spe_split_by_unicode_script',
     action='store_false',
@@ -223,6 +232,7 @@ def __process_data(
     spe_train_extremely_large_corpus: bool,
     spe_sample_size: int,
     spe_max_sentencepiece_length: int,
+    spe_max_sentence_length: int,
     spe_split_by_unicode_script: bool,
     spe_bos: bool,
     spe_eos: bool,
@@ -250,6 +260,8 @@ def __process_data(
             this flag can be set to try to trained the tokenizer. Will silently fail if it runs out of RAM.
         spe_max_sentencepiece_length: Limits the maximum length of the SentencePiece subword that can be constructed.
             By default, no limit is placed.
+        spe_max_sentence_length: Maximum number of bytes allowed in the input sentences.
+            This limits the size of sentences that can be processed during training.
         spe_bos: Bool flag, whether to add <s> to SentencePiece tokenizer vocabulary.
         spe_eos: Bool flag, whether to add </s> to SentencePiece tokenizer vocabulary.
         spe_pad: Bool flag, whether to add <pad> to SentencePiece tokenizer vocabulary.
@@ -301,6 +313,7 @@ def __process_data(
             character_coverage=spe_character_coverage,
             train_extremely_large_corpus=spe_train_extremely_large_corpus,
             max_sentencepiece_length=spe_max_sentencepiece_length,
+            max_sentence_length=spe_max_sentence_length,
             split_by_unicode_script=spe_split_by_unicode_script,
             bos=spe_bos,
             eos=spe_eos,
@@ -337,6 +350,7 @@ def main():
     spe_sample_size = args.spe_sample_size
     spe_train_extremely_large_corpus = args.spe_train_extremely_large_corpus
     spe_max_sentencepiece_length = args.spe_max_sentencepiece_length
+    spe_max_sentence_length = args.spe_max_sentence_length
     spe_split_by_unicode_script = args.spe_split_by_unicode_script
     spe_bos, spe_eos, spe_pad = args.spe_bos, args.spe_eos, args.spe_pad
     spe_control_symbols = args.spe_control_symbols
@@ -367,6 +381,7 @@ def main():
         spe_sample_size=spe_sample_size,
         spe_train_extremely_large_corpus=spe_train_extremely_large_corpus,
         spe_max_sentencepiece_length=spe_max_sentencepiece_length,
+        spe_max_sentence_length=spe_max_sentence_length,
         spe_split_by_unicode_script=spe_split_by_unicode_script,
         spe_bos=spe_bos,
         spe_eos=spe_eos,


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

You can now pass the --spe_max_sentence_length flag to the sentencepiece builder script, allowing for processing of longer text corpuses.

**Collection**: core

# Changelog

- Added max_sentence_length parameter to create_spt_model function in SentencePiece tokenizer
- Updated command-line argument generation to support the new parameter
- Added documentation for the new parameter in both implementation and CLI script
- Added the parameter to the relevant function calls in the tokenizer processing script

# Usage

Via cli script:

```bash
python3 process_asr_text_tokenizer.py \
    --manifest="path/to/manifest_test.json" \
    --data_root="." \
    --vocab_size=64 \
    --tokenizer="spe" \
    --spe_type="word" \
    --spe_max_sentence_length=4096 \
    --log
```
  
**PR Type**:

- [ ] New Feature
