### PR TITLE
Account for grad acc during tokens calculation in the TimingCallback

### DIFF
--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -343,7 +343,7 @@ class TimingCallback(Callback):
             if "text" in batch:
                 batch['tokens'] = batch['text']
             tokens_per_gpu = (
-                get_current_global_batch_size() * batch["tokens"].shape[1] / torch.distributed.get_world_size()
+                (get_current_global_batch_size() // trainer.accumulate_grad_batches) * batch["tokens"].shape[1] / torch.distributed.get_world_size()
             )
             pl_module.log(
                 "tokens_per_sec_per_gpu",

--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -343,7 +343,9 @@ class TimingCallback(Callback):
             if "text" in batch:
                 batch['tokens'] = batch['text']
             tokens_per_gpu = (
-                (get_current_global_batch_size() // trainer.accumulate_grad_batches) * batch["tokens"].shape[1] / torch.distributed.get_world_size()
+                (get_current_global_batch_size() // trainer.accumulate_grad_batches)
+                * batch["tokens"].shape[1]
+                / torch.distributed.get_world_size()
             )
             pl_module.log(
                 "tokens_per_sec_per_gpu",


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Account for grad accumulation where each step does not process the full global batch size, but instead only global_batch_size // grad_accumulation is processed. So tokens should be calculated based on that. 

Here is an example setup where I am running on 2 GPUs with global_batch_size 512, grad_accumulation 4 and seq_length 128

```
run/0 [default0]:Training epoch 0, iteration 0/9 | lr: 1.499e-07 | global_batch_size: 512 | global_step: 0 | reduced_train_loss: 11.03 | train_step_timing in s: 21.05 | tokens_per_sec_per_gpu: 1.557e+03 | tokens_per_sec_per_gpu_refined: 389.1 
run/0 [default0]:Training epoch 0, iteration 0/9 | lr: 2.999e-07 | global_batch_size: 512 | global_step: 1 | reduced_train_loss: 11.03 | train_step_timing in s: 22.11 | tokens_per_sec_per_gpu: 1.482e+03 | tokens_per_sec_per_gpu_refined: 370.6 
run/0 [default0]:Training epoch 0, iteration 0/9 | lr: 2.999e-07 | global_batch_size: 512 | global_step: 1 | reduced_train_loss: 11.03 | train_step_timing in s: 21.08 | tokens_per_sec_per_gpu: 1.554e+03 | tokens_per_sec_per_gpu_refined: 388.6 
run/0 [default0]:Training epoch 0, iteration 0/9 | lr: 2.999e-07 | global_batch_size: 512 | global_step: 1 | reduced_train_loss: 11.03 | train_step_timing in s: 21.82 | tokens_per_sec_per_gpu: 1.502e+03 | tokens_per_sec_per_gpu_refined: 375.5
```
In the above log's first line it takes 21.05s to train. So tokens_per_sec_per_gpu = ( GBS 512 // grad_acc of 4 ) * seqLen 128 / step_time 21.05 / nGPUs 2 = 389.1 tokens/sec/gpu whereas it used to be computed as 512 * 128 / 21.05 / 2 = 1557 tokens/sec/gpu


**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
