### PR TITLE
[audio] make some tests deterministic to avoid flakiness

### DIFF
--- a/tests/collections/audio/test_audio_mask_models.py
+++ b/tests/collections/audio/test_audio_mask_models.py
@@ -199,7 +199,9 @@ class TestMaskModelRNN:
         model = mask_model_rnn.eval()
         confdict = model.to_config_dict()
         sampling_rate = confdict['sample_rate']
-        input_signal = torch.randn(size=(batch_size, 1, sample_len * sampling_rate))
+        rng = torch.Generator()
+        rng.manual_seed(0)
+        input_signal = torch.randn(size=(batch_size, 1, sample_len * sampling_rate), generator=rng)
         input_signal_length = (sample_len * sampling_rate) * torch.ones(batch_size, dtype=torch.int)
 
         abs_tol = 1e-5
@@ -258,7 +260,9 @@ class TestMaskModelFlexArray:
         model = mask_model_flexarray.eval()
         confdict = model.to_config_dict()
         sampling_rate = confdict['sample_rate']
-        input_signal = torch.randn(size=(batch_size, num_channels, sample_len * sampling_rate))
+        rng = torch.Generator()
+        rng.manual_seed(0)
+        input_signal = torch.randn(size=(batch_size, num_channels, sample_len * sampling_rate), generator=rng)
         input_signal_length = (sample_len * sampling_rate) * torch.ones(batch_size, dtype=torch.int)
 
         abs_tol = 1e-5
@@ -319,7 +323,9 @@ class TestBFModelFlexArray:
         model = bf_model_flexarray.eval()
         confdict = model.to_config_dict()
         sampling_rate = confdict['sample_rate']
-        input_signal = torch.randn(size=(batch_size, num_channels, sample_len * sampling_rate))
+        rng = torch.Generator()
+        rng.manual_seed(0)
+        input_signal = torch.randn(size=(batch_size, num_channels, sample_len * sampling_rate), generator=rng)
         input_signal_length = (sample_len * sampling_rate) * torch.ones(batch_size, dtype=torch.int)
 
         abs_tol = 1e-5

--- a/tests/collections/audio/test_audio_predictive_models.py
+++ b/tests/collections/audio/test_audio_predictive_models.py
@@ -227,7 +227,6 @@ class TestPredictiveModelNCSN:
         instance2 = PredictiveAudioToAudioModel.from_config_dict(confdict)
         assert isinstance(instance2, PredictiveAudioToAudioModel)
 
-    @pytest.mark.pleasefixme
     @pytest.mark.unit
     @pytest.mark.parametrize(
         "batch_size, sample_len",
@@ -242,7 +241,9 @@ class TestPredictiveModelNCSN:
         model = predictive_model_ncsn.eval()
         confdict = model.to_config_dict()
         sampling_rate = confdict['sample_rate']
-        input_signal = torch.randn(size=(batch_size, 1, sample_len * sampling_rate))
+        rng = torch.Generator()
+        rng.manual_seed(0)
+        input_signal = torch.randn(size=(batch_size, 1, sample_len * sampling_rate), generator=rng)
         input_signal_length = (sample_len * sampling_rate) * torch.ones(batch_size, dtype=torch.int)
 
         abs_tol = 1e-5
@@ -298,7 +299,9 @@ class TestPredictiveModelConformer:
         model = predictive_model_conformer.eval()
         confdict = model.to_config_dict()
         sampling_rate = confdict['sample_rate']
-        input_signal = torch.randn(size=(batch_size, 1, sample_len * sampling_rate))
+        rng = torch.Generator()
+        rng.manual_seed(0)
+        input_signal = torch.randn(size=(batch_size, 1, sample_len * sampling_rate), generator=rng)
         input_signal_length = (sample_len * sampling_rate) * torch.ones(batch_size, dtype=torch.int)
 
         abs_tol = 1e-5
@@ -354,7 +357,9 @@ class TestPredictiveModelStreamingConformer:
         model = predictive_model_streaming_conformer.eval()
         confdict = model.to_config_dict()
         sampling_rate = confdict['sample_rate']
-        input_signal = torch.randn(size=(batch_size, 1, sample_len * sampling_rate))
+        rng = torch.Generator()
+        rng.manual_seed(0)
+        input_signal = torch.randn(size=(batch_size, 1, sample_len * sampling_rate), generator=rng)
         input_signal_length = (sample_len * sampling_rate) * torch.ones(batch_size, dtype=torch.int)
 
         abs_tol = 1e-5


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Some tests failed randomly, so I'm adding a local rng to `torch.randn` calls to avoid that

**Collection**: [Audio]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to 
  - https://github.com/NVIDIA/NeMo/pull/12823
  - https://github.com/NVIDIA/NeMo/pull/12913 
  - https://github.com/NVIDIA/NeMo/pull/13083
