### PR TITLE
Add docs external links false positives

### DIFF
--- a/docs/false_positives.json
+++ b/docs/false_positives.json
@@ -6,3 +6,97 @@
   "uri": "https://research.fb.com/wp-content/uploads/2019/03/Neural-Models-of-Text-Normalization-for-Speech-Applications.pdf",
   "info": "400 Client Error: Bad Request for url: https://research.facebook.com/wp-content/uploads/2019/03/Neural-Models-of-Text-Normalization-for-Speech-Applications.pdf"
 }
+{
+  "filename": "tts/models.rst",
+  "lineno": 155,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://doi.org/10.1109/TASLP.2021.3129994",
+  "info": "403 Client Error: Forbidden for url: https://ieeexplore.ieee.org/document/9625818/"
+}
+{
+  "filename": "multimodal/mllm/datasets.rst",
+  "lineno": 23,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/datasets/liuhaotian/LLaVA-Instruct-150K/tree/main",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/datasets/liuhaotian/LLaVA-Instruct-150K/tree/main"
+}
+{
+  "filename": "core/core.rst",
+  "lineno": 639,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/"
+}
+{
+  "filename": "nlp/spellchecking_asr_customization.rst",
+  "lineno": 41,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/bene-ges/spellmapper_asr_customization_en",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/bene-ges/spellmapper_asr_customization_en"
+}
+{
+  "filename": "evaluation/evaluation_doc.rst",
+  "lineno": 25,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/docs/huggingface_hub/quick-start#authentication",
+{
+  "filename": "tools/nemo_forced_aligner.rst",
+  "lineno": 15,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/spaces/erastorgueva-nv/NeMo-Forced-Aligner",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/spaces/erastorgueva-nv/NeMo-Forced-Aligner"
+}
+{
+  "filename": "asr/models.rst",
+  "lineno": 25,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/spaces/nvidia/canary-1b",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/spaces/nvidia/canary-1b"
+}
+{
+  "filename": "asr/intro.rst",
+  "lineno": 189,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/spaces/hf-audio/open_asr_leaderboard",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/spaces/hf-audio/open_asr_leaderboard"
+}
+{
+  "filename": "asr/models.rst",
+  "lineno": 46,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/spaces/nvidia/parakeet-tdt-1.1b",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/spaces/nvidia/parakeet-tdt-1.1b"
+}
+{
+  "filename": "asr/api.rst",
+  "lineno": 24,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://ieeexplore.ieee.org/document/9053040",
+  "info": "403 Client Error: Forbidden for url: https://ieeexplore.ieee.org/document/9053040"
+}
+{
+  "filename": "asr/api.rst",
+  "lineno": 47,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://ieeexplore.ieee.org/document/9250505",
+  "info": "403 Client Error: Forbidden for url: https://ieeexplore.ieee.org/document/9250505"
+}
+{
+  "filename": "audio/api.rst",
+  "lineno": 9,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8462081",
+  "info": "403 Client Error: Forbidden for url: https://ieeexplore.ieee.org/stamp/stamp.jsp?arnumber=8462081"
+}

--- a/docs/false_positives.json
+++ b/docs/false_positives.json
@@ -44,6 +44,56 @@
   "status": "broken",
   "code": 0,
   "uri": "https://huggingface.co/docs/huggingface_hub/quick-start#authentication",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/docs/huggingface_hub/quick-start"
+}
+{
+  "filename": "multimodal/mllm/datasets.rst",
+  "lineno": 17,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/datasets/liuhaotian/LLaVA-Pretrain/blob/main/images.zip",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/datasets/liuhaotian/LLaVA-Pretrain/blob/main/images.zip"
+}
+{
+  "filename": "multimodal/mllm/datasets.rst",
+  "lineno": 81,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/liuhaotian/llava-llama-2-13b-chat-lightning-preview/blob/main/tokenizer.model",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/liuhaotian/llava-llama-2-13b-chat-lightning-preview/blob/main/tokenizer.model"
+}
+{
+  "filename": "nlp/machine_translation/machine_translation.rst",
+  "lineno": 664,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/models",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/models"
+}
+{
+  "filename": "asr/intro.rst",
+  "lineno": 163,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/models?library=nemo&sort=downloads&search=nvidia",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/models?library=nemo&sort=downloads&search=nvidia"
+}
+{
+  "filename": "asr/results.rst",
+  "lineno": 43,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/models?pipeline_tag=automatic-speech-recognition&sort=trending&author=nvidia",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/models?pipeline_tag=automatic-speech-recognition&sort=trending&author=nvidia"
+}
+{
+  "filename": "starthere/intro.rst",
+  "lineno": 19,
+  "status": "broken",
+  "code": 0,
+  "uri": "https://huggingface.co/nvidia",
+  "info": "403 Client Error: Forbidden for url: https://huggingface.co/nvidia"
+}
 {
   "filename": "tools/nemo_forced_aligner.rst",
   "lineno": 15,


### PR DESCRIPTION
# What does this PR do ?

These external links sometimes get a 403 from a GHA job when we do the docs link checks. It's intermittent, so they work. But let's add them to the `docs/false_positives.json` file so others do not run into it.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add docs external links false positives

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
