### PR TITLE
ci: Fix mcore install in test container

### DIFF
--- a/.github/workflows/_test_template.yml
+++ b/.github/workflows/_test_template.yml
@@ -112,7 +112,7 @@ jobs:
             --env HF_HOME=/home/TestData/HF_HOME \
             --volume $(pwd)/${{ github.run_id }}/${{steps.uuid.outputs.id }}/NeMo:/workspace \
             --volume /mnt/datadrive/TestData:/home/TestData nemoci.azurecr.io/nemo_container:${{ github.run_id }} \
-            bash -c "sleep $(( ${{ inputs.TIMEOUT }} * 60 + 60 ))"
+            bash -c "cp -r /opt/Megatron-LM/ /workspace/ && sleep $(( ${{ inputs.TIMEOUT }} * 60 + 60 ))"
           RUN_TEST_EOF
           )
 

--- a/.github/workflows/_test_template.yml
+++ b/.github/workflows/_test_template.yml
@@ -213,5 +213,6 @@ jobs:
       - name: Container shutdown
         if: always()
         run: |
+          docker exec nemo_container_${{ github.run_id }}_${{ runner.name }} bash -c "chown -R $(id -u):$(id -g) /workspace"
           rm -rf $(pwd)/${{ github.run_id }}/${{steps.uuid.outputs.id }} || true
           docker container rm -f nemo_container_${{ github.run_id }}_${{ runner.name }} || true

--- a/.github/workflows/_test_template.yml
+++ b/.github/workflows/_test_template.yml
@@ -80,19 +80,6 @@ jobs:
           repository: NVIDIA/NeMo
           path: ${{ github.run_id }}/${{steps.uuid.outputs.id }}/NeMo
 
-      - name: Fetch Mcore tag from manifest.json
-        id: mcore
-        run: |
-          REF=$(cat ${{ github.run_id }}/${{steps.uuid.outputs.id }}/NeMo/requirements/manifest.json | ~/.local/bin/jq -r '."vcs-dependencies"."megatron-lm".ref')
-          echo "ref=$REF" | tee -a "$GITHUB_OUTPUT"
-
-      - name: Checkout Megatron-LM
-        uses: actions/checkout@v2
-        with:
-          repository: NVIDIA/Megatron-LM
-          path: ${{ github.run_id }}/${{steps.uuid.outputs.id }}/Megatron-LM
-          ref: ${{ steps.mcore.outputs.ref }}
-
       - name: Start container
         run: |
           mkdir -p $DIR
@@ -124,7 +111,6 @@ jobs:
             --env HYDRA_FULL_ERROR=1 \
             --env HF_HOME=/home/TestData/HF_HOME \
             --volume $(pwd)/${{ github.run_id }}/${{steps.uuid.outputs.id }}/NeMo:/workspace \
-            --volume $(pwd)/${{ github.run_id }}/${{steps.uuid.outputs.id }}/Megatron-LM:/workspace/Megatron-LM \
             --volume /mnt/datadrive/TestData:/home/TestData nemoci.azurecr.io/nemo_container:${{ github.run_id }} \
             bash -c "sleep $(( ${{ inputs.TIMEOUT }} * 60 + 60 ))"
           RUN_TEST_EOF

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -73,6 +73,8 @@ RUN \
     
     bash /tmp/NeMo/reinstall.sh --library all --mode install
     rm -rf $NEMO_DIR || true
+    cp -r /opt/Megatron-LM/ /workspace/
+    chmod 777 -R /workspace
 EOF
 
 

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -73,8 +73,6 @@ RUN \
     
     bash /tmp/NeMo/reinstall.sh --library all --mode install
     rm -rf $NEMO_DIR || true
-    cp -r /opt/Megatron-LM/ /workspace/
-    chmod 777 -R /workspace
 EOF
 
 


### PR DESCRIPTION
# What does this PR do ?

Fix mcore install in test container.

When mounting the megatron repo to the test container, the mcore install loses some built binary reference `megatron.core.datasets.helpers_cpp`, which causes tests to fail. Also, deleting repo files was failing because in the container, it adds some fails as root. So, the CI user does not have access to delete those files. So, we chown the files in `/workspace` in the container to the CI user before deleting them.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Fix mcore install in test container

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
