### PR TITLE
fix adapter in/out_features size for share_expert when use overlap.

### DIFF
--- a/nemo/collections/llm/peft/utils.py
+++ b/nemo/collections/llm/peft/utils.py
@@ -75,11 +75,7 @@ def get_adapter_attributes_from_linear(m: nn.Module):
     disable_sequence_parallel_comm = not m.config.sequence_parallel
 
     # check if open overlap for share expert
-    moe_shared_expert_overlap = (
-        True
-        if is_share_expert_linear(m) and m.config.moe_shared_expert_overlap
-        else False
-    )
+    moe_shared_expert_overlap = True if is_share_expert_linear(m) and m.config.moe_shared_expert_overlap else False
 
     if HAVE_TE and any(isinstance(m, te_column_parallel) for te_column_parallel in TECL):
         input_is_parallel = False


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fix adapter in/out_features size for share_expert when open `moe_shared_expert_overlap` in DeepSeekConfig.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
#12960