### PR TITLE
[Eval bugfix] Change default val of parallel_requests in eval script

### DIFF
--- a/scripts/llm/evaluation.py
+++ b/scripts/llm/evaluation.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 # NOTE: This script is only an example of using NeMo with NeMo-Run's APIs and is subject to change without notice.
-# This script is used for evaluation on local and slurm executors.
-# It uses deploy method from nemo/llm/collections/api.py to deploy nemo2.0 ckpt on PyTriton server by converting to
-# trtllm, uses evaluate method from nemo/llm/collections/api.py to run evaluation on it and uses NeMo-Run
+# This script is used for evaluation on local and slurm executors using NeMo-Run.
+# It uses deploy method from nemo/llm/collections/api.py to deploy nemo2.0 ckpt on PyTriton server and uses evaluate
+# method from nemo/llm/collections/api.py to run evaluation on it.
 # (https://github.com/NVIDIA/NeMo-Run) to configure and execute the runs.
 
 import argparse
@@ -107,7 +107,7 @@ def get_parser():
     parser.add_argument(
         "--parallel_requests",
         type=int,
-        default=None,
+        default=1,
         help="Number of parallel requests to send to server. Default: use default for the task.",
     )
     parser.add_argument(


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Changes the default val of `parallel_requests` in eval script to 1, since None default leads to error on the core-evals side and can be hard for the user to debug that its coming from `parallel_requests=None`.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
