### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `222adb8...` (2025-04-26)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "47b99b6ca0132a8d7c5321ac16a32a0ec9f9e192"
+      "ref": "222adb83439f3aac15e6e637a3fafc2929021948"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `222adb83439f3aac15e6e637a3fafc2929021948`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.