### PR TITLE
Fix llama4 test names

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -2302,8 +2302,8 @@ jobs:
       - L2_SpeechLM_LoRA_TP1PP1_MBS2
       - L2_NeMo_2_Export_HF_TRT_LLM
       - L2_NeMo_2_LLAMA4_MOCK_FINETUNE_PP2
-      - L2_NeMo_2_LLAMA4_MOCK_FINETUNE_CP2_EP2
-      - L2_NeMo_2_LLAMA4_ENERGON_FINETUNE_TP2_EP2
+      - L2_NeMo_2_LLAMA4_MOCK_FINETUNE_CP2
+      - L2_NeMo_2_LLAMA4_ENERGON_FINETUNE_EP2
     if: always() && github.event != 'push'
     runs-on: ubuntu-latest
     permissions: write-all


### PR DESCRIPTION
# What does this PR do ?

Fix llama4 test names

We retroactively fixed the llama4 test configs but we didn't update the names correctly in the old needs section.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Fix llama4 test names

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
