### PR TITLE
ci: Skip link check on github links

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -188,6 +188,14 @@ exclude_patterns = []
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "default"
 
+# Ignore Github links and downloading a large file
+# Github links are now getting rate limited from the Github Actions
+linkcheck_ignore = [
+    "https://zenodo.org/record/5525342/files/thorsten-neutral_v03.tgz?download=1",
+    ".*github\\.com.*",
+    ".*githubusercontent\\.com.*",
+]
+
 ### Previous NeMo theme
 # # NVIDIA theme settings.
 # html_theme = 'nvidia_theme'


### PR DESCRIPTION
# What does this PR do ?

Skip link check on github links

We're being heavily rate limited by Github during our linkchecks.  Unless we can resolve this, we'll need to skip checking these links, at least in an automated way.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Skip link check on github links

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
