### PR TITLE
Fix masking of <pad> tokens in AED inference

### DIFF
--- a/nemo/collections/asr/modules/transformer/transformer_decoders.py
+++ b/nemo/collections/asr/modules/transformer/transformer_decoders.py
@@ -226,6 +226,7 @@ class TransformerDecoder(nn.Module):
         encoder_states,
         encoder_mask,
         decoder_mems_list=None,
+        diagonalize_decoder_mask=True,
         return_mems=False,
         return_mems_as_list=True,
     ):
@@ -238,11 +239,16 @@ class TransformerDecoder(nn.Module):
             decoder_mems_list: list of the cached decoder hidden states
                 for fast autoregressive generation which will be used instead
                 of decoder_states as keys and values if not None
+            diagonalize_decoder_mask: bool, whether to diagonalize the decoder mask, True during training and False during inference
             return_mems: bool, whether to return outputs of all decoder layers
                 or the last layer only
             return_mems_as_list: bool, when True, mems returned are as a list; otherwise mems are Tensor
         """
-        decoder_attn_mask = form_attention_mask(decoder_mask, diagonal=self.diagonal)
+        if diagonalize_decoder_mask:
+            decoder_attn_mask = form_attention_mask(decoder_mask, diagonal=self.diagonal)
+        else:
+            decoder_attn_mask = form_attention_mask(decoder_mask)
+        # breakpoint()
         encoder_attn_mask = form_attention_mask(encoder_mask)
         memory_states = self._get_memory_states(decoder_states, decoder_mems_list, 0)
         if return_mems:

--- a/nemo/collections/asr/modules/transformer/transformer_decoders.py
+++ b/nemo/collections/asr/modules/transformer/transformer_decoders.py
@@ -248,7 +248,7 @@ class TransformerDecoder(nn.Module):
             decoder_attn_mask = form_attention_mask(decoder_mask, diagonal=self.diagonal)
         else:
             decoder_attn_mask = form_attention_mask(decoder_mask)
-        # breakpoint()
+
         encoder_attn_mask = form_attention_mask(encoder_mask)
         memory_states = self._get_memory_states(decoder_states, decoder_mems_list, 0)
         if return_mems:

--- a/nemo/collections/asr/modules/transformer/transformer_generators.py
+++ b/nemo/collections/asr/modules/transformer/transformer_generators.py
@@ -239,14 +239,25 @@ class GreedySequenceGenerator(ConfidenceMethodMixin):
             else:
                 input_ids = tgt[:, -1:]
 
-            logits, decoder_mems_list, _ = self._one_step_forward(
-                input_ids,
-                encoder_hidden_states,
-                encoder_input_mask,
-                decoder_mems_list,
-                i,
-                return_scores=return_beam_scores,
-            )
+            if i == 0:
+                logits, decoder_mems_list, decoder_input_mask = self._one_step_forward(
+                    input_ids,
+                    encoder_hidden_states,
+                    encoder_input_mask,
+                    decoder_mems_list,
+                    i,
+                    return_scores=return_beam_scores,
+                )
+            else:
+                logits, decoder_mems_list, decoder_input_mask = self._one_step_forward(
+                    input_ids,
+                    encoder_hidden_states,
+                    encoder_input_mask,
+                    decoder_mems_list,
+                    i,
+                    decoder_input_mask,
+                    return_scores=return_beam_scores,
+                )
 
             if self.temperature is None:  # Greedy decoding
                 next_tokens = torch.argmax(logits[:, -1], dim=-1)

--- a/nemo/collections/asr/modules/transformer/transformer_generators.py
+++ b/nemo/collections/asr/modules/transformer/transformer_generators.py
@@ -420,7 +420,9 @@ class BeamSearchSequenceGenerator(GreedySequenceGenerator):
         tgt, batch_size, max_generation_length = self._prepare_for_search(decoder_input_ids, encoder_hidden_states)
 
         # generate initial buffer of beam_size prefixes-hypotheses
-        log_probs, decoder_mems_list, decoder_input_mask = self._one_step_forward(tgt, encoder_hidden_states, encoder_input_mask, None, 0)
+        log_probs, decoder_mems_list, decoder_input_mask = self._one_step_forward(
+            tgt, encoder_hidden_states, encoder_input_mask, None, 0
+        )
         scores, prefixes = torch.topk(log_probs.permute(0, 2, 1), self.beam_size, dim=1)
         scores, prefixes = scores.view(-1, 1), prefixes.view(-1, 1)
 
@@ -487,8 +489,8 @@ class BeamSearchSequenceGenerator(GreedySequenceGenerator):
             # select masks which correspond to the chosen hypotheses
             decoder_input_mask = decoder_input_mask.unsqueeze(1).repeat(1, self.beam_size, 1)
             decoder_input_mask = decoder_input_mask.view(batch_size, self.beam_size**2, -1)
-            mask_ids = indices_i.unsqueeze(2).repeat(1, 1, p_len-1)
-            decoder_input_mask = decoder_input_mask.gather(1, mask_ids).view(-1, p_len-1)
+            mask_ids = indices_i.unsqueeze(2).repeat(1, 1, p_len - 1)
+            decoder_input_mask = decoder_input_mask.gather(1, mask_ids).view(-1, p_len - 1)
 
             # reshuffle cached decoder memory states to restore the order
             # of hypotheses broken after top-k selection
@@ -556,7 +558,9 @@ class BeamSearchSequenceGeneratorWithNGramLM(BeamSearchSequenceGenerator):
         batch_lm_states = self.ngram_lm_batch.get_init_states(batch_size=batch_size, bos=True)
 
         # generate initial buffer of beam_size prefixes-hypotheses
-        log_probs, decoder_mems_list, _ = self._one_step_forward(tgt, encoder_hidden_states, encoder_input_mask, None, 0)
+        log_probs, decoder_mems_list, _ = self._one_step_forward(
+            tgt, encoder_hidden_states, encoder_input_mask, None, 0
+        )
         # get ngram lm scores
         lm_scores, batch_lm_states_candidates = self.ngram_lm_batch.advance(states=batch_lm_states, eos_id=self.eos)
         log_probs += self.ngram_lm_alpha * lm_scores[:, None, :]

--- a/tests/collections/asr/decoding/test_multi_task_decoding.py
+++ b/tests/collections/asr/decoding/test_multi_task_decoding.py
@@ -196,6 +196,7 @@ def prompted_inputs():
         torch.ones(B, T, dtype=torch.float),  # encoder_input_mask
     )
 
+
 @pytest.fixture()
 def batch_prompted_inputs():
     B, T, C = 2, 5, 2
@@ -204,6 +205,7 @@ def batch_prompted_inputs():
         torch.ones(B, T, C, dtype=torch.float),  # encoder_hidden_states
         torch.ones(B, T, dtype=torch.float),  # encoder_input_mask
     )
+
 
 def test_transformer_aed_beam_infer_strips_prompt(prompted_inputs, decoder_nm, nnet, tokenizer):
     decoder_input_ids, encoder_hidden_states, encoder_input_mask = prompted_inputs

--- a/tests/collections/asr/decoding/test_multi_task_decoding.py
+++ b/tests/collections/asr/decoding/test_multi_task_decoding.py
@@ -362,9 +362,13 @@ def test_transformer_aed_beam_infer_padded_prompt(prompted_inputs, decoder_nm, n
 
     # Number of output tokens may vary as the number of input tokens is different (5 without padding and 7 with padding)
     # and the randomly initialized model may decode for max_sequence_length steps.
-    assert res_with_padding.size(0) <= res.size(0), f"Expected len(res_with_padding) <= len(res), got {res_with_padding.size(0)} > {res.size(0)}"
+    assert res_with_padding.size(0) <= res.size(
+        0
+    ), f"Expected len(res_with_padding) <= len(res), got {res_with_padding.size(0)} > {res.size(0)}"
     min_length = res_with_padding.size(0)
-    assert torch.equal(res[:min_length], res_with_padding), f"Expected ans[:len(ans)] == ans_with_padding, got {res} != {res_with_padding[:res.size(0)]}"
+    assert torch.equal(
+        res[:min_length], res_with_padding
+    ), f"Expected ans[:len(ans)] == ans_with_padding, got {res} != {res_with_padding[:res.size(0)]}"
 
 
 def test_transformer_aed_greedy_infer_padded_prompt(prompted_inputs, decoder_nm, nnet, tokenizer):
@@ -387,13 +391,17 @@ def test_transformer_aed_greedy_infer_padded_prompt(prompted_inputs, decoder_nm,
         encoder_input_mask=encoder_input_mask,
         decoder_input_ids=decoder_input_ids_with_padding,
     )
-    
+
     # Extract result tensors
     res = ans[0][0].y_sequence
     res_with_padding = ans_with_padding[0][0].y_sequence
-    
+
     # Number of output tokens may vary as the number of input tokens is different (5 without padding and 7 with padding)
     # because the randomly initialized model may not generate EOS and thus, decode for max_sequence_length steps.
-    assert res_with_padding.size(0) <= res.size(0), f"Expected len(res_with_padding) <= len(res), got {res_with_padding.size(0)} > {res.size(0)}"
+    assert res_with_padding.size(0) <= res.size(
+        0
+    ), f"Expected len(res_with_padding) <= len(res), got {res_with_padding.size(0)} > {res.size(0)}"
     min_length = res_with_padding.size(0)
-    assert torch.equal(res[:min_length], res_with_padding), f"Expected ans[:len(ans)] == ans_with_padding, got {res} != {res_with_padding[:res.size(0)]}"
+    assert torch.equal(
+        res[:min_length], res_with_padding
+    ), f"Expected ans[:len(ans)] == ans_with_padding, got {res} != {res_with_padding[:res.size(0)]}"

--- a/tests/collections/asr/decoding/test_multi_task_decoding.py
+++ b/tests/collections/asr/decoding/test_multi_task_decoding.py
@@ -191,7 +191,7 @@ def test_beam_decoding_beam_scores_true_with_lm(inputs, nnet, tmp_path):
 def prompted_inputs():
     B, T, C = 1, 5, 2
     return (
-        torch.tensor([[1, 0, 2, 3, 4]], dtype=torch.long),  # prompt
+        torch.tensor([[1, 3, 4, 5, 6]], dtype=torch.long),  # prompt
         torch.ones(B, T, C, dtype=torch.float),  # encoder_hidden_states
         torch.ones(B, T, dtype=torch.float),  # encoder_input_mask
     )

--- a/tests/collections/asr/decoding/test_multi_task_decoding.py
+++ b/tests/collections/asr/decoding/test_multi_task_decoding.py
@@ -201,7 +201,7 @@ def prompted_inputs():
 def batch_prompted_inputs():
     B, T, C = 2, 5, 2
     return (
-        torch.tensor([[1, 0, 2, 3, 4, 5, 6], [1, 0, 2, 3, 4, 0, 0]], dtype=torch.long),  # prompt
+        torch.tensor([[1, 3, 4, 5, 6], [1, 5, 6, 4, 7]], dtype=torch.long),  # prompt
         torch.ones(B, T, C, dtype=torch.float),  # encoder_hidden_states
         torch.ones(B, T, dtype=torch.float),  # encoder_input_mask
     )
@@ -236,7 +236,6 @@ def test_transformer_aed_beam_infer_strips_prompt(prompted_inputs, decoder_nm, n
 
 def test_transformer_aed_greedy_infer_strips_prompt(prompted_inputs, decoder_nm, nnet, tokenizer):
     decoder_input_ids, encoder_hidden_states, encoder_input_mask = prompted_inputs
-    decoder_input_ids = torch.tensor([[1, 0, 2, 3, 4]], dtype=torch.long)  # prompt
     *_, classifier = nnet
 
     # Run the actual top-level module used by MultiTask AED model for decoding.
@@ -263,6 +262,7 @@ def test_transformer_aed_greedy_infer_strips_prompt(prompted_inputs, decoder_nm,
 
 
 def test_transformer_aed_beam_infer_strips_batch_prompt(batch_prompted_inputs, decoder_nm, nnet, tokenizer):
+    """Test batch_size > 1"""
     decoder_input_ids, encoder_hidden_states, encoder_input_mask = batch_prompted_inputs
     *_, classifier = nnet
 
@@ -298,6 +298,7 @@ def test_transformer_aed_beam_infer_strips_batch_prompt(batch_prompted_inputs, d
 
 
 def test_transformer_aed_greedy_infer_strips_batch_prompt(batch_prompted_inputs, decoder_nm, nnet, tokenizer):
+    """Test batch_size > 1"""
     decoder_input_ids, encoder_hidden_states, encoder_input_mask = batch_prompted_inputs
     *_, classifier = nnet
 
@@ -329,5 +330,5 @@ def test_transformer_aed_greedy_infer_strips_batch_prompt(batch_prompted_inputs,
     )  # stripped the prompt from the beggining
 
     torch.testing.assert_close(
-        untrimmed1[decoder_input_ids.shape[1] :], best_path2
+        untrimmed2[decoder_input_ids.shape[1] :], best_path2
     )  # stripped the prompt from the beggining


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Corrects masking of `<pad>` tokens in the autoregressive decoding of AED multitask models. 

Without this fix, the inference code cannot be correctly used for decoding with context.

**Further explanation for why this fix is needed**:

When using Canary model with `decodercontext`, the decoder prompts can be of varying lengths. So, the prompts will be padded during inference: `<prompt><padding><pred_transcript>`. These `<pad>` tokens should be appropriately masked by the Transformer decoder's self-attention. 

In the current implementation, the `<pad>` tokens are not masked out after step 1 of autoregressive decoding. So, the decoder's self-attention attends to the `<pad>` tokens during inference. This PR fixes that by creating a correct mask at every decoding step.

Note that this is not an issue during training as the `<pad>` tokens will be appended at the end when the dataset object is created: `<prompt><gt_transcript><padding>`.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
