### PR TITLE
[audio] Increase threshold in unit tests to prevent intermittent failures

### DIFF
--- a/tests/collections/audio/test_audio_models_predictive.py
+++ b/tests/collections/audio/test_audio_models_predictive.py
@@ -246,7 +246,7 @@ class TestPredictiveModelNCSN:
         input_signal = torch.randn(size=(batch_size, 1, sample_len * sampling_rate), generator=rng)
         input_signal_length = (sample_len * sampling_rate) * torch.ones(batch_size, dtype=torch.int)
 
-        abs_tol = 1e-5
+        abs_tol = 5e-5
 
         with torch.no_grad():
             # batch size 1
@@ -305,7 +305,7 @@ class TestPredictiveModelConformer:
         input_signal = torch.randn(size=(batch_size, 1, sample_len * sampling_rate), generator=rng)
         input_signal_length = (sample_len * sampling_rate) * torch.ones(batch_size, dtype=torch.int)
 
-        abs_tol = 1e-5
+        abs_tol = 5e-5
 
         with torch.no_grad():
             # batch size 1


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

This PR increases absolute tolerance in a unit test to prevent intermittent failures.
In some CI runs we see tests failing because of differences a bit above 1e-5.

**Collection**: audio tests

# Changelog

- Changed `abs_tol = 1e-5` to `abs_tol = 5e-5`

# Usage

N/A

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to #13439
