### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `3235d43...` (2025-05-07)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "54afff44f29e1117b2057ced6fa5be583e35cb7b"
+      "ref": "3235d439c9d76b62cf34108abb366013b4833cbf"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `3235d439c9d76b62cf34108abb366013b4833cbf`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.