### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `d580efc...` (2025-05-07)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "3cdfd613e68e8b734a3b9e28de579daaf81f4503"
+      "ref": "d580efc68a9f0dbf1945f834f6f6200cd01d3343"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `d580efc68a9f0dbf1945f834f6f6200cd01d3343`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.