### PR TITLE
Cherry pick `Use explicitly cached canary-1b-flash in CI tests (13237)` into `r2.3.0`

### DIFF
--- a/tests/functional_tests/L2_Speech_Transcription_Canary_Transcribe_Audio_Dir.sh
+++ b/tests/functional_tests/L2_Speech_Transcription_Canary_Transcribe_Audio_Dir.sh
@@ -15,7 +15,7 @@ coverage run -a --data-file=/workspace/.coverage --source=/workspace/nemo exampl
     audio_dir=/home/TestData/asr/canary/dev-other-wav \
     output_filename=preds.json \
     batch_size=10 \
-    pretrained_name=nvidia/canary-1b \
+    model_path=/home/TestData/asr/canary/models/canary-1b-flash_HF_20250318.nemo \
     num_workers=0 \
     amp=false \
     compute_dtype=bfloat16 \

--- a/tests/functional_tests/L2_Speech_Transcription_Canary_Transcribe_Full_Manifest.sh
+++ b/tests/functional_tests/L2_Speech_Transcription_Canary_Transcribe_Full_Manifest.sh
@@ -15,7 +15,7 @@ coverage run -a --data-file=/workspace/.coverage --source=/workspace/nemo exampl
     dataset_manifest=/home/TestData/asr/canary/dev-other-wav-10-canary-fields.json \
     output_filename=/tmp/preds.json \
     batch_size=10 \
-    pretrained_name=nvidia/canary-1b \
+    model_path=/home/TestData/asr/canary/models/canary-1b-flash_HF_20250318.nemo \
     num_workers=0 \
     amp=false \
     compute_dtype=bfloat16 \

--- a/tests/functional_tests/L2_Speech_Transcription_Canary_Transcribe_With_Prompt.sh
+++ b/tests/functional_tests/L2_Speech_Transcription_Canary_Transcribe_With_Prompt.sh
@@ -15,12 +15,11 @@ coverage run -a --data-file=/workspace/.coverage --source=/workspace/nemo exampl
     dataset_manifest=/home/TestData/asr/canary/dev-other-wav-10.json \
     output_filename=preds.json \
     batch_size=10 \
-    pretrained_name=nvidia/canary-1b \
+    model_path=/home/TestData/asr/canary/models/canary-1b-flash_HF_20250318.nemo \
     num_workers=0 \
     amp=false \
     compute_dtype=bfloat16 \
     matmul_precision=medium \
     +prompt.source_lang="en" \
     +prompt.target_lang="en" \
-    +prompt.task="asr" \
     +prompt.pnc="no"


### PR DESCRIPTION
beep boop [🤖]: Hi @pzelasko 👋,
    
    we've cherry picked #13237 into  for you! 🚀
    
    Please review and approve this cherry pick by your convenience!