### PR TITLE
Add fp8_param argument back to mixed precision plugin for backward compatibility

### DIFF
--- a/nemo/lightning/fabric/plugins.py
+++ b/nemo/lightning/fabric/plugins.py
@@ -30,6 +30,7 @@ from nemo.lightning.pytorch.plugins.mixed_precision import (
     get_optim_config,
     update_config_with_dtype_overrides,
 )
+from nemo.utils import logging
 
 if TYPE_CHECKING:
     from megatron.core.model_parallel_config import ModelParallelConfig
@@ -65,13 +66,26 @@ class FabricMegatronMixedPrecision(MixedPrecision):
         fp8_wgrad: bool = True,
         fp8_dot_product_attention: bool = False,
         fp8_multi_head_attention: bool = False,
-        fp8_param_gather: bool = False,
+        fp8_params: bool = None,
+        fp8_param_gather: bool = None,
         fp16_loss_scale: float = None,
         fp16_initial_loss_scale: float = 4294967296,
         fp16_min_loss_scale: float = 1.0,
         fp16_loss_scale_window: int = 1000,
         fp16_hysteresis: int = 2,
     ) -> None:
+        if fp8_params is not None:
+            logging.warning(
+                "fp8_params is deprecated and will be removed in a future release, use fp8_param_gather instead"
+            )
+            if fp8_param_gather is not None and fp8_param_gather != fp8_params:
+                raise ValueError(
+                    "Getting conflicting values for fp8_params and fp8_param_gather. Please only set fp8_param_gather."
+                )
+            fp8_param_gather = fp8_params
+        elif fp8_param_gather is None:
+            fp8_param_gather = False
+
         if isinstance(precision, int):
             precision = str(precision)
 

--- a/nemo/lightning/pytorch/plugins/mixed_precision.py
+++ b/nemo/lightning/pytorch/plugins/mixed_precision.py
@@ -113,7 +113,8 @@ class MegatronMixedPrecision(Precision):
         fp8_wgrad: bool = True,
         fp8_dot_product_attention: bool = False,
         fp8_multi_head_attention: bool = False,
-        fp8_param_gather: bool = False,
+        fp8_params: bool = None,
+        fp8_param_gather: bool = None,
         fp16_loss_scale: float = None,
         fp16_initial_loss_scale: float = 4294967296,
         fp16_min_loss_scale: float = 1.0,
@@ -122,6 +123,17 @@ class MegatronMixedPrecision(Precision):
         num_layers_at_start_in_bf16: int = 0,
         num_layers_at_end_in_bf16: int = 0,
     ) -> None:
+        if fp8_params is not None:
+            logging.warning(
+                "fp8_params is deprecated and will be removed in a future release, use fp8_param_gather instead"
+            )
+            if fp8_param_gather is not None and fp8_param_gather != fp8_params:
+                raise ValueError(
+                    "Getting conflicting values for fp8_params and fp8_param_gather. Please only set fp8_param_gather."
+                )
+            fp8_param_gather = fp8_params
+        elif fp8_param_gather is None:
+            fp8_param_gather = False
 
         if isinstance(precision, int):
             precision = str(precision)


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Add fp8_param argument back to mixed precision plugin for backward compatibility

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
