### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `16aeade...` (2025-05-11)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "bcbede5f50198df37d2d933bb33551d76a023e88"
+      "ref": "16aeade1e401764584a783540411a01657304081"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `16aeade1e401764584a783540411a01657304081`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.