### PR TITLE
Fix eval_beamsearch_ngram_ctc.py for hybrid models

### DIFF
--- a/scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram_ctc.py
+++ b/scripts/asr_language_modeling/ngram_lm/eval_beamsearch_ngram_ctc.py
@@ -318,7 +318,17 @@ def main(cfg: EvalBeamSearchNGramConfig):
             with torch.no_grad():
                 if isinstance(asr_model, EncDecHybridRNNTCTCModel):
                     asr_model.cur_decoder = 'ctc'
-                all_logits = asr_model.transcribe(audio_file_paths, batch_size=cfg.acoustic_batch_size, logprobs=True)
+                    # The EncDecHybridRNNTCTCModel doesn't support the 'logprobs' parameter in its transcribe method
+                    # Unlike other ASR models that have classification capabilities
+                    # This is because the method directly inherits from ASRTranscriptionMixin.transcribe
+                    # which doesn't have the logprobs parameter
+                    all_logits = asr_model.transcribe(audio_file_paths, batch_size=cfg.acoustic_batch_size)
+                else:
+                    # For ASR models with classification capabilities that support the logprobs parameter
+                    # This includes models like EncDecClassificationModel and EncDecRegressionModel
+                    all_logits = asr_model.transcribe(
+                        audio_file_paths, batch_size=cfg.acoustic_batch_size, logprobs=True
+                    )
 
         all_probs = all_logits
         if cfg.probs_cache_file:


### PR DESCRIPTION
## Description

This PR fixes issue #13064 where the `eval_beamsearch_ngram_ctc.py` script fails with hybrid models due to the unsupported `logprobs` parameter.

## Problem

The script unconditionally passes `logprobs=True` to the [transcribe()](cci:1://file:///Users/dipam.paul/Downloads/nvidia-nemo/test_data/test_fix.py:17:4-20:51) method, but the `EncDecHybridRNNTCTCModel` class doesn't support this parameter. This causes the script to fail when used with hybrid models.

## Solution

Added conditional logic to check the model type before calling the [transcribe()](cci:1://file:///Users/dipam.paul/Downloads/nvidia-nemo/test_data/test_fix.py:17:4-20:51) method:
- For `EncDecHybridRNNTCTCModel`, call [transcribe()](cci:1://file:///Users/dipam.paul/Downloads/nvidia-nemo/test_data/test_fix.py:17:4-20:51) without the `logprobs` parameter
- For other ASR models, continue to use `logprobs=True` as before

## Testing

Created a test framework that simulates both hybrid and non-hybrid model behaviors to verify the fix works as expected. The solution ensures that:
1. The hybrid model's [transcribe()](cci:1://file:///Users/dipam.paul/Downloads/nvidia-nemo/test_data/test_fix.py:17:4-20:51) method is called without the `logprobs` parameter
2. Other model types continue to use the `logprobs=True` parameter

## Fixes

Fixes #13064