### PR TITLE
Magpietts 2503 frechet distance v3

### DIFF
--- a/examples/tts/README_magpietts_legacy_checkpoints.md
+++ b/examples/tts/README_magpietts_legacy_checkpoints.md
@@ -3,7 +3,7 @@ Magpie-TTS uses special tokens like AUDIO_BOS and AUDIO_EOS for its operation. T
 
 In April 2025 we changed the layout of the embedding table in a non-backwards compatible way:
 
-## Old Layout
+## Old Layout (until April 16)
 With the most common codec configuration (2016 codes), the layout used to look like this:
 ```
 | Index   | Token Description    | Comments                                                                                                  |
@@ -55,6 +55,8 @@ For checkpoints created before the change you can force legacy codebook layout i
 Just set the `--legacy_codebooks` command line option. No need to update your YAML file – The script will automatically add the overrides.
 
 ## If using a Hydra command line
+This scenario would happen when either finetuning with an old checkpoint or doing data generation with an old checkpoint.
+
 You have two options:
 ### Add these to your command line
 ```
@@ -80,3 +82,14 @@ forced_audio_bos_id: ${sum:${model.forced_num_all_tokens_per_codebook}, -2}     
 #forced_context_audio_eos_id: ${sum:${model.forced_num_all_tokens_per_codebook}, -3}   # 2045
 #forced_context_audio_bos_id: ${sum:${model.forced_num_all_tokens_per_codebook}, -4}   # 2044
 ```
+
+# Additional Details
+Over the last few weeks we have gone through a few embedding table layouts. When using an old checkpoint it's important to know which layout your checkpoint was trained with and configuring the system accordingly.
+
+* Layout 1: used until April 16 (described in the table above). Add `--legacy-codebooks` to the `infer_and_evaluate.py` command line to inference using this layout.
+
+* Layout 2: after the [config changes](https://github.com/blisc/NeMo/commit/7e2cdca74a866ecefdbe01c0076ad9b5d140ac61): 2018 tokens with special tokens at the end 2017, 2016, 2015, 2014 (the last two being overwrites of codec tokens). This is an invalid layout and these checkpoints should not be used.
+
+* Layout 3: after the [bugfix](https://github.com/blisc/NeMo/commit/23e299a0bd14b666543b4bbcc7783f783acb0bd3) but before the [refactoring](https://github.com/blisc/NeMo/commit/8ba55061a0ebb161abff4b329e402d5307f4af98): 2024 tokens with special tokens at the end (2023, 2022, 2021, 2020). There are no automatic options provided for using this layout but it can be manually configured by updating the `hparams.yaml` file with the `forced_*` options. Set `forced_num_all_tokens_per_codebook` to `2024` and set the rest of the overrides as defined under section `# Or, add these overrides to your YAML file` above.
+
+* Layout 4: The new layout, [from this commit onwards](https://github.com/blisc/NeMo/commit/8ba55061a0ebb161abff4b329e402d5307f4af98): 2024 tokens but with special tokens immediately after codec tokens (2016, 2017, 2018, 2019). Training and inference with the latest version of the code automatically use this layout.

--- a/examples/tts/conf/magpietts/magpietts_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_dc_en.yaml
@@ -50,7 +50,7 @@ model:
   aligner_encoder_train_steps: 50000
 
   # Local transformer parameters for autoregressive codebook prediction within a frame
-  use_local_transformer: false
+  local_transformer_type: "none" # "none", "autoregressive", "maskgit"
   # Below args are only relevant if use_local_transformer is true
   local_transformer_loss_scale: 1.0
   local_transformer_n_layers: 1

--- a/examples/tts/conf/magpietts/magpietts_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_en.yaml
@@ -52,7 +52,7 @@ model:
   aligner_encoder_train_steps: 50000
 
   # Local transformer parameters for autoregressive codebook prediction within a frame
-  use_local_transformer: false
+  local_transformer_type: "none" # "none", "autoregressive", "maskgit"
   # Below args are only relevant if use_local_transformer is true
   local_transformer_loss_scale: 1.0
   local_transformer_n_layers: 1

--- a/examples/tts/conf/magpietts/magpietts_inference_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_inference_en.yaml
@@ -60,7 +60,7 @@ model:
   aligner_encoder_train_steps: 50000
 
   # Local transformer parameters for autoregressive codebook prediction within a frame
-  use_local_transformer: false
+  local_transformer_type: "none" # "none", "autoregressive", "maskgit"
   # Below args are only relevant if use_local_transformer is true
   local_transformer_loss_scale: 1.0
   local_transformer_n_layers: 1

--- a/examples/tts/conf/magpietts/magpietts_inference_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_inference_multilingual_v1.yaml
@@ -60,7 +60,7 @@ model:
   aligner_encoder_train_steps: 50000
 
   # Local transformer parameters for autoregressive codebook prediction within a frame
-  use_local_transformer: false
+  local_transformer_type: "none" # "none", "autoregressive", "maskgit"
   # Below args are only relevant if use_local_transformer is true
   local_transformer_loss_scale: 1.0
   local_transformer_n_layers: 1

--- a/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
@@ -38,7 +38,7 @@ model:
   aligner_encoder_train_steps: 50_000
 
   # Local transformer parameters for autoregressive codebook prediction within a frame
-  use_local_transformer: false
+  local_transformer_type: "none" # "none", "autoregressive", "maskgit"
   # Below args are only relevant if use_local_transformer is true
   local_transformer_loss_scale: 1.0
   local_transformer_n_layers: 1

--- a/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
@@ -53,7 +53,7 @@ model:
   aligner_encoder_train_steps: 50000
 
   # Local transformer parameters for autoregressive codebook prediction within a frame
-  use_local_transformer: false
+  local_transformer_type: "none" # "none", "autoregressive", "maskgit"
   # Below args are only relevant if use_local_transformer is true
   local_transformer_loss_scale: 1.0
   local_transformer_n_layers: 1

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -1590,7 +1590,7 @@ class MagpieTTSModel(ModelPT):
         dataset = MagpieTTSLhotseDataset(
             sample_rate=self.cfg.sample_rate,
             volume_norm=dataset_cfg.volume_norm,
-            codec_model_samples_per_frame=self.codec_model_samples_per_framed,
+            codec_model_samples_per_frame=self.codec_model_samples_per_frame,
             codec_model_name=self.cfg.codec_model_name,
             audio_bos_id=self.audio_bos_id,
             audio_eos_id=self.audio_eos_id,

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -17,7 +17,6 @@ import random
 import string
 import time
 from typing import List
-from enum import Enum, verify, CONTINUOUS, UNIQUE
 
 import librosa
 import numpy as np
@@ -39,6 +38,7 @@ from nemo.collections.tts.losses.aligner_loss import ForwardSumLoss
 from nemo.collections.tts.models import AudioCodecModel
 from nemo.collections.tts.modules import transformer_2501
 from nemo.collections.tts.modules.aligner import AlignmentEncoder
+from nemo.collections.tts.modules.magpietts_modules import SpecialAudioToken, LocalTransformerType, cosine_schedule
 from nemo.collections.tts.parts.utils.helpers import (
     binarize_attention_parallel,
     get_mask_from_lengths,
@@ -61,7 +61,6 @@ def worker_init_fn(worker_id):
     )
     dataset.text_tokenizer = tokenizer
     dataset.text_conditioning_tokenizer = text_conditioning_tokenizer
-
 
 class MagpieTTSModel(ModelPT):
     """
@@ -98,32 +97,19 @@ class MagpieTTSModel(ModelPT):
         # del codec discriminator to free memory
         del codec_model.discriminator
 
-        # Reserve special tokens (appended at the end of the codebook after the actual audio codec tokens)
-        # (the actual index is this value plus the number of codec tokens - do not use the Enum directy)
-        @verify(CONTINUOUS, UNIQUE)
-        class SpecialAudioToken(Enum):
-            AUDIO_BOS = 0
-            AUDIO_EOS = 1
-            AUDIO_CONTEXT_BOS = 2
-            AUDIO_CONTEXT_EOS = 3
-            MASK_TOKEN = 4
-            # Reserved so that if we need to add more special tokens in the future the codebook size will remain the same
-            RESERVED_1 = 5
-            RESERVED_2 = 6
-            RESERVED_3 = 7
-
         # Set up codebook configuration
         self.num_audio_codebooks = codec_model.num_codebooks
         self.codec_model_samples_per_frame = codec_model.samples_per_frame
         # Our codebooks start with actual audio codec tokens, followed by special tokens. 
         # The `forced_*` options are for backward compatibility for models trained with older code.
         num_audio_tokens = codec_model.codebook_size
-        self.audio_bos_id = cfg.get('forced_audio_bos_id',num_audio_tokens + SpecialAudioToken.AUDIO_BOS.value)
+        self.audio_bos_id = cfg.get('forced_audio_bos_id', num_audio_tokens + SpecialAudioToken.AUDIO_BOS.value)
         self.audio_eos_id = cfg.get('forced_audio_eos_id', num_audio_tokens + SpecialAudioToken.AUDIO_EOS.value)
         self.context_audio_bos_id = cfg.get('forced_context_audio_bos_id', num_audio_tokens + SpecialAudioToken.AUDIO_CONTEXT_BOS.value)
         self.context_audio_eos_id = cfg.get('forced_context_audio_eos_id', num_audio_tokens + SpecialAudioToken.AUDIO_CONTEXT_EOS.value)
         self.num_all_tokens_per_codebook = cfg.get('forced_num_all_tokens_per_codebook',num_audio_tokens + len(SpecialAudioToken))
-
+        self.mask_token_id = cfg.get('forced_mask_token_id', num_audio_tokens + SpecialAudioToken.MASK_TOKEN.value)
+    
         # Setup tokenizer
         if hasattr(cfg, 'text_tokenizer'):
             # For backward compatibility for English-only models
@@ -172,7 +158,10 @@ class MagpieTTSModel(ModelPT):
 
         self.decoder = transformer_2501.Transformer(**dict(cfg.decoder))
         self.final_proj = nn.Linear(cfg.decoder.d_model, self.num_audio_codebooks * self.num_all_tokens_per_codebook)
-        if cfg.get('use_local_transformer', False):
+
+        self.local_transformer_type = LocalTransformerType(cfg.get('local_transformer_type', 'none').lower())
+        logging.info(f"Local transformer type: {self.local_transformer_type}")
+        if self.local_transformer_type != LocalTransformerType.NO_LT:
             local_transformer_hidden_dim = cfg.get('local_transformer_hidden_dim', 256)
             if local_transformer_hidden_dim != cfg.decoder.d_model:
                 self.local_transformer_in_projection = nn.Linear(cfg.decoder.d_model, local_transformer_hidden_dim)
@@ -184,7 +173,7 @@ class MagpieTTSModel(ModelPT):
                 d_ffn=local_transformer_hidden_dim*4,
                 sa_n_heads=self.cfg.get('local_transformer_n_heads', 1),
                 kernel_size=1,
-                is_causal=True,
+                is_causal=self.local_transformer_type == LocalTransformerType.AR,
                 max_length_causal_mask=self.num_audio_codebooks+2,
                 use_learnable_pos_emb=True,
             )
@@ -240,6 +229,8 @@ class MagpieTTSModel(ModelPT):
         if alignment_encoder_loss_scale > 0.0:
             self.alignment_encoder_loss = ForwardSumLoss(loss_scale=alignment_encoder_loss_scale)
 
+
+
     def state_dict(self, destination=None, prefix='', keep_vars=False):
         if hasattr(self, '_no_state_dict') and self._no_state_dict:
             return {}
@@ -250,7 +241,7 @@ class MagpieTTSModel(ModelPT):
             if any([substring in key for substring in keys_substrings_to_exclude]):
                 del state_dict[key]
         return state_dict
-
+    
     def load_state_dict(self, state_dict, strict=True):
         # Override to load all the keys except _speaker_verification_model and _codec_model
         super().load_state_dict(state_dict, strict=False)
@@ -325,12 +316,28 @@ class MagpieTTSModel(ModelPT):
             )
             return speaker_embeddings
 
-    def compute_local_transformer_logits(self, dec_out, audio_codes_target):
+    def compute_local_transformer_logits(self, dec_out, audio_codes_target, targets_offset_by_one=False):
         """
-        Loss from the autoregressive codebook predictor (used per frame)
+        Predicts the logits for all codebooks using the local transformer. Used in both autoregressive (AR) and MaskGit (MG) modes.
+        This function is used in training and validation, not inference/sampling.
+        The sequence layout is slightly different between AR and MG modes, as shown in the diagram below,
+        (using an 8-codebook setup as an example):
+        +------------+---------+---------+---------+---------+---------+---------+---------+---------+---------+
+        | AR target  |    0    |    1    |    2    |    3    |    4    |    5    |    6    |    7    |   none  |
+        +------------+---------+---------+---------+---------+---------+---------+---------+---------+---------+
+        | MG target  |  none   |    0    |    1    |    2    |    3    |    4    |    5    |    6    |    7    |
+        +------------+---------+---------+---------+---------+---------+---------+---------+---------+---------+
+        |   Input    | Magpie  |    0    |    1    |    2    |    3    |    4    |    5    |    6    |    7    |
+        |            | Latent  | or MASK | or MASK | or MASK | or MASK | or MASK | or MASK | or MASK | or MASK |
+        +------------+---------+---------+---------+---------+---------+---------+---------+---------+---------+
+        | Seq. Index |    0    |    1    |    2    |    3    |    4    |    5    |    6    |    7    |    8    |
+        +------------+---------+---------+---------+---------+---------+---------+---------+---------+---------+
+        
+        dec_out: (B, T', E)
+        audio_codes_target: (B, C, T')
+        targets_offset_by_one: bool, if False, the target for index 0 is codebook 0, for index 1 is codebook 1, etc. (autoregressive)
+                                     if True,  the target for index 1 is codebook 0, for index 2 is codebook 1, etc. (MaskGit)
         """
-        # dec_out: (B, T', E)
-        # audio_codes: (B, C, T')
         dec_out_all = dec_out.reshape(-1, dec_out.size(-1)) # (B*T', E)
         local_transformer_input = [dec_out_all]
         for codebook_num in range(audio_codes_target.size(1)):
@@ -343,7 +350,12 @@ class MagpieTTSModel(ModelPT):
         local_transformer_input = self.local_transformer_in_projection(local_transformer_input) # (B*T', C+1, 128)
         _mask = torch.ones( local_transformer_input.size(0), local_transformer_input.size(1), device=local_transformer_input.device)
         local_transformer_output = self.local_transformer(local_transformer_input, _mask)['output'] # (B*T', C+1, E)
-        local_transformer_output = local_transformer_output[:, :-1, :] # (B*T', C, E)
+        if not targets_offset_by_one:
+            # for autoregressive local transformer the target for index 0 is codebook 0, for index 1 is codebook 1, etc.
+            local_transformer_output = local_transformer_output[:, :-1, :] # (B*T', C, E)
+        else:
+            # for MaskGit the target for index **1** is codebook 0, for index 2 is codebook 1, etc.
+            local_transformer_output = local_transformer_output[:, 1:, :] # (B*T', C, E)
         all_code_logits = []
         for codebook_num in range(audio_codes_target.size(1)):
             # Using a separate projection layer for each codebook (to distinguish between them)
@@ -358,11 +370,73 @@ class MagpieTTSModel(ModelPT):
 
         return all_code_logits
 
-    def compute_loss(self, logits, audio_codes, audio_codes_lens):
-        # logits: (B, T', num_codebooks * num_tokens_per_codebook)
-        # audio_codes: (B, C, T')
-        # audio_codes_lens: (B,)
+    def maskgit_create_random_mask(self, codes):
+        """
+        Creates a mask where True indicates the positions that should be replaced with a MASK_TOKEN.
+        """
+        # Codes: (B, C, T)
+        B,C,T = codes.shape
+        # get a uniform random vector uniformly sampled from [0,1) ## Todo does it need to be inclusive on the right?
+        rand_values = torch.rand(B,T, device=codes.device)
+        # apply the cosine schedule 
+        frac_masked = cosine_schedule(rand_values)
+        # how many positions to mask
+        n_masked = torch.ceil(frac_masked * C).long() # B,T
+        # start from all unmasked
+        mask = torch.zeros_like(codes, dtype=torch.bool)
+        # The code further below is the vectorized version of this:
+        #  for b in range(B):
+        #      for t in range(T):
+        #          if n_masked[b,t] > 0:
+        #              # get a random permutation of the codebook indices
+        #              perm = torch.randperm(C)
+        #              # mask the top n_masked positions
+        #              mask[b, perm[:n_masked[b,t]], t] = True
+        #
+        # Create random permutations 
+        random_permutations = torch.argsort(torch.rand(B, C, T, device=codes.device), dim=1)  # (B, C, T)        
+        # Create a mask tensor where each position indicates if it should be masked        
+        mask_indices = torch.arange(C, device=codes.device).view(1, C, 1)
+        mask = mask_indices < n_masked.view(B, 1, T) # (B, C, T)
+        # Apply the random permutations to the mask
+        mask = torch.gather(mask, 1, random_permutations)
+    
+        return mask # (B, C, T)
+    
+    def maskgit_apply_random_mask(self, codes):
+        # Randomly replaces some codes with the MASK_TOKEN with a proportion following the cosine schedule.
+        # Codes: (B, C, T)        
+        mask = self.maskgit_create_random_mask(codes)
+        ## replace some tokens with MASK_TOKEN
+        codes_with_mask = torch.where(mask, self.mask_token_id, codes)
+        return codes_with_mask, mask
+
+    def compute_loss(self, logits, audio_codes, audio_codes_lens, mask_tokens_mask=None):
+        """
+        Computes the audio codebook loss. Used by
+        (1) The main Magpie-TTS transformer
+        (2) The local transformer, for both autoregressive and MaskGit methods
+        
+        logits: (B, T', num_codebooks * num_tokens_per_codebook)
+        audio_codes: (B, C, T')
+        audio_codes_lens: (B,)
+        mask_tokens_mask: (B, C, T') True for tokens that were replaced with the MASK_TOKEN and should
+                                     therefore be the only ones included in the loss computation.
+        """
         loss_mask = get_mask_from_lengths(audio_codes_lens)
+        if mask_tokens_mask is not None:
+            # For MaskGit we only compute loss for the masked tokens.
+            # *Both* conditions must be true:
+            # 1. the token is masked
+            # 2. the token is not padding
+            loss_mask = loss_mask.unsqueeze(1) * mask_tokens_mask
+            if not loss_mask.any():
+                # Without this we were very rarely getting NaNs in the loss
+                logging.warning("No tokens valid were found in compute_loss()!")
+                return torch.tensor(0.0, device=loss_mask.device), loss_mask 
+        else:            
+            # repeat loss mask for each codebook to simplify code below
+            loss_mask = loss_mask.unsqueeze(1).repeat(1, audio_codes.size(1), 1)
         total_codebook_loss = None
         for codebook in range(audio_codes.size(1)):
             si = codebook * self.num_all_tokens_per_codebook
@@ -372,8 +446,8 @@ class MagpieTTSModel(ModelPT):
             codebook_loss = self.cross_entropy_loss(
                 codebook_logits.permute(0, 2, 1), codebook_targets  # (B, num_tokens_per_codebook, T')
             )  # (B, T')
-            codebook_loss = codebook_loss * loss_mask
-            codebook_loss = codebook_loss.sum() / loss_mask.sum()
+            codebook_loss = codebook_loss * loss_mask[:, codebook, :]
+            codebook_loss = codebook_loss.sum() / loss_mask[:, codebook, :].sum()
             if total_codebook_loss is None:
                 total_codebook_loss = codebook_loss
             else:
@@ -414,7 +488,99 @@ class MagpieTTSModel(ModelPT):
 
         return all_preds
 
-    def sample_codes_from_local_transformer(self, dec_output, temperature=0.7, topk=80, unfinished_items={}, finished_items={}, use_cfg=False, cfg_scale=1.0):
+    def local_transformer_sample_maskgit(self, dec_output, temperature=0.7, topk=80, unfinished_items={}, finished_items={}, use_cfg=False, cfg_scale=1.0, n_steps=3):
+        """
+        Sample codes for one timestep from the local transformer using MaskGit.
+        """
+        # dec_output: (B, E)
+        device = dec_output.device
+        # disable KV cache since our transformer is not causal
+        self.local_transformer.reset_cache(use_cache=False)
+        dec_output = dec_output.unsqueeze(1) # (B, 1, E)
+        local_transformer_input_init = self.local_transformer_in_projection(dec_output) # (B, 1, D) where D is the dimension of the local transformer
+        C = self.num_audio_codebooks
+        B = dec_output.size(0)
+
+        min_confidence = float("-inf")
+        max_confidence = 10000 # this needs to be large enough that unmasked items will always remain unmasked. # TODO @rfejgin: use float('inf')?
+        confidences = min_confidence * torch.ones(B, C, device=device)
+        # initialize to all masked
+        codes = self.mask_token_id * torch.ones((B, C), device=device, dtype=torch.long)
+        sampled_codes = codes.clone()
+        for step in range(n_steps):
+            # get mask fraction
+            frac_masked = cosine_schedule(torch.tensor(step / (n_steps)))
+            # how many codebooks to mask
+            n_masked = torch.ceil(C * frac_masked).long() # TODO @rfejgin: should we force this to be initialized to exactly `C` (to avoid numerical issues)?
+            n_unmasked = C - n_masked
+            # pick top-confidence codebooks up to n_unmasked
+            _, topk_indices = torch.topk(confidences, k=n_unmasked, dim=1)
+
+            # replace masks of the top-k confident codebooks with the the codes that were sampled for them
+            unmasked_codes = torch.gather(sampled_codes, dim=1, index=topk_indices)
+            codes.scatter_(dim=1, index=topk_indices, src=unmasked_codes)
+            
+            # build transformer input 
+            local_transformer_input = local_transformer_input_init
+            for codebook_num in range(C):
+                next_local_transformer_input = self.audio_embeddings[codebook_num](codes[:, codebook_num]).unsqueeze(1) # (B, 1, 768)
+                next_local_transformer_input = self.local_transformer_in_projection(next_local_transformer_input) # (B, 1, d_local)
+                local_transformer_input = torch.cat([local_transformer_input, next_local_transformer_input], dim=1) # (B, codebook_num+1, d_local)
+
+            # run transformer
+            _mask = torch.ones(B, C+1, device=device)
+            local_transformer_output = self.local_transformer(local_transformer_input, _mask)['output'] # (B, C+1, d_local)
+            
+            # get logits
+            logits = []
+            for codebook_num in range(C):
+                # The `codebook_num+1` is to drop first position which corresponds to the magpie latent
+                codebook_logits = self.local_transformer_out_projections[codebook_num](local_transformer_output[:, codebook_num+1, :]) # (B, num_audio_tokens_per_codebook)
+                logits.append(codebook_logits)
+            logits = torch.stack(logits, dim=1) # (B, C, num_audio_tokens_per_codebook)
+
+            # apply CFG
+            if use_cfg:
+                actual_batch_size = logits.size(0) // 2
+                conditional_logits = logits[:actual_batch_size]
+                unconditional_logits = logits[actual_batch_size:]
+                cfg_logits = cfg_scale * conditional_logits +  (1.0 - cfg_scale) * unconditional_logits
+                logits[:actual_batch_size] = cfg_logits
+
+            # handle unfinished and finished items
+            for item_idx in unfinished_items:
+                logits[item_idx, self.audio_eos_id] = float('-inf')
+            for item_idx in finished_items:
+                logits[item_idx, :, :] = float('-inf')
+                logits[item_idx, :, self.audio_eos_id] = 0.0
+            
+            # sample with top-k
+            logits_topk = torch.topk(logits, topk, dim=-1)[0] # (B, C, topk)
+            indices_to_remove = logits < logits_topk[:, :, -1].unsqueeze(-1) # (B, C, num_audio_tokens_per_codebook)
+            logits_rescored = logits.clone()
+            logits_rescored[indices_to_remove] = float('-inf')
+            probs = torch.softmax(logits_rescored / temperature, dim=-1) # (B, C, num_audio_tokens_per_codebook)
+            sampled_codes = torch.multinomial(probs.view(B*C, -1), 1).view(B, C)
+            if use_cfg:
+                # TODO @rfejgin: why do we need to keep second half of the batch? can probably optimize this
+                sampled_codes[actual_batch_size:] = sampled_codes[:actual_batch_size]
+                probs[actual_batch_size:] = probs[:actual_batch_size]
+            confidences  = torch.gather(probs, dim=2, index=sampled_codes.unsqueeze(-1)).squeeze(-1)
+
+            # set confidence to max for unmasked codebooks so that they will remain unmasked
+            confidences.scatter_(index=topk_indices, dim=1, src=max_confidence*torch.ones_like(topk_indices, dtype=torch.float))
+
+            # replace entries in sampled_codes with previously unmasked codebooks
+            sampled_codes.scatter_(dim=1, index=topk_indices, src=unmasked_codes)
+            # optionally: add noise to confidences here (as in token-critic paper) (not implemented)
+        
+        codes = sampled_codes
+        assert not (codes == self.mask_token_id).any(), f"Codes contain mask tokens after completion of MaskGit sampling"
+        if use_cfg:
+            codes = codes[:actual_batch_size]
+        return codes
+
+    def local_transformer_sample_autoregressive(self, dec_output, temperature=0.7, topk=80, unfinished_items={}, finished_items={}, use_cfg=False, cfg_scale=1.0):
         # dec_output: (B, E)
         self.local_transformer.reset_cache(use_cache=True)
         dec_output = dec_output.unsqueeze(1) # (B, 1, E)
@@ -979,9 +1145,18 @@ class MagpieTTSModel(ModelPT):
 
         local_transformer_loss = None
         local_transformer_logits = None
-        if self.cfg.get('use_local_transformer', False):
-            local_transformer_logits = self.compute_local_transformer_logits(dec_out[:,dec_context_size:,:], audio_codes_target)
-            local_transformer_loss, _ = self.compute_loss(local_transformer_logits, audio_codes_target, audio_codes_lens_target)
+        if self.local_transformer_type != LocalTransformerType.NO_LT:
+            if self.local_transformer_type == LocalTransformerType.MASKGIT:
+                # randomly replace some positions with MASK_TOKEN
+                audio_codes_masked, mask_tokens_mask = self.maskgit_apply_random_mask(audio_codes_target)
+                local_transformer_logits = self.compute_local_transformer_logits(dec_out[:,dec_context_size:,:], audio_codes_masked, targets_offset_by_one=True)
+                #audio_codes_masked = audio_codes_masked[:, 1:, :]
+                local_transformer_loss, _ = self.compute_loss(local_transformer_logits, audio_codes_target, audio_codes_lens_target, mask_tokens_mask)
+            else:
+                # autoregressive
+                assert self.local_transformer_type == LocalTransformerType.AR, "Unexpected local transformer type"
+                local_transformer_logits = self.compute_local_transformer_logits(dec_out[:,dec_context_size:,:], audio_codes_target, targets_offset_by_one=False)
+                local_transformer_loss, _ = self.compute_loss(local_transformer_logits, audio_codes_target, audio_codes_lens_target, None)
             local_transformer_loss_scale = self.cfg.get('local_transformer_loss_scale', 1.0)
             loss = loss + local_transformer_loss_scale * local_transformer_loss
 
@@ -1281,6 +1456,7 @@ class MagpieTTSModel(ModelPT):
             start_prior_after_n_audio_steps=10,
             compute_all_heads_attn_maps=False,
             use_local_transformer_for_inference=False,
+            maskgit_n_steps=3
         ):
         with torch.no_grad():
             start_time = time.time()
@@ -1430,18 +1606,35 @@ class MagpieTTSModel(ModelPT):
                 unifinished_items = {k: v for k, v in unfinished_texts.items() if v}
 
                 all_code_logits_t = all_code_logits[:, -1, :] # (B, num_codebooks * num_tokens_per_codebook)
-                if self.cfg.get('use_local_transformer', False) and use_local_transformer_for_inference:
-                    audio_codes_next = self.sample_codes_from_local_transformer(
-                        dec_output=dec_out[:,-1,:],
-                        temperature=temperature,
-                        topk=topk,
-                        unfinished_items=unifinished_items,
-                        finished_items=finished_items,
-                        use_cfg=use_cfg,
-                        cfg_scale=cfg_scale
-                    )
+                if use_local_transformer_for_inference:
+                    if self.local_transformer_type == LocalTransformerType.AR :
+                        # Autoregressive sampling with local transformer
+                        audio_codes_next = self.local_transformer_sample_autoregressive(
+                            dec_output=dec_out[:,-1,:],
+                            temperature=temperature,
+                            topk=topk,
+                            unfinished_items=unifinished_items,
+                            finished_items=finished_items,
+                            use_cfg=use_cfg,
+                            cfg_scale=cfg_scale
+                        )
+                    elif self.local_transformer_type == LocalTransformerType.MASKGIT:
+                        audio_codes_next = self.local_transformer_sample_maskgit(
+                            dec_output=dec_out[:,-1,:],
+                            temperature=temperature,
+                            topk=topk,
+                            unfinished_items=unifinished_items,
+                            finished_items=finished_items,
+                            use_cfg=use_cfg,
+                            cfg_scale=cfg_scale,
+                            n_steps=maskgit_n_steps
+                        )
+                    else:
+                        raise ValueError(f"Local transformer inference requested by but local transformer type is {self.local_transformer_type}")
+                    # TODO @rfejgin: should we add argmax sampling for EOS here too?
                     all_codes_next_argmax = audio_codes_next
                 else:
+                    # Parallel sampling from all codebooks
                     audio_codes_next = self.sample_codes_from_logits(all_code_logits_t, temperature=temperature, topk=topk, unfinished_items=unifinished_items, finished_items=finished_items) # (B, num_codebooks)
                     all_codes_next_argmax = self.sample_codes_from_logits(all_code_logits_t, temperature=0.01, unfinished_items=unifinished_items, finished_items=finished_items) # (B, num_codebooks)
 
@@ -1554,7 +1747,7 @@ class MagpieTTSModel(ModelPT):
         self.log("val/codebook_loss", val_codebook_loss, prog_bar=True, sync_dist=True)
         self.log("val/alignment_loss", val_alignment_loss, prog_bar=True, sync_dist=True)
         self.log("val/aligner_encoder_loss", val_aligner_encoder_loss, prog_bar=True, sync_dist=True)
-        if self.cfg.get('use_local_transformer', False):
+        if self.local_transformer_type != LocalTransformerType.NO_LT:
             val_local_transformer_loss = collect("val_local_transformer_loss")
             self.log("val/local_transformer_loss", val_local_transformer_loss, prog_bar=True, sync_dist=True)
         self.validation_step_outputs.clear()  # free memory

--- a/nemo/collections/tts/modules/fcd_metric.py
+++ b/nemo/collections/tts/modules/fcd_metric.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+
+import torch
+import torch.nn.functional as F
+from torch import nn, Tensor
+from torchmetrics import Metric
+
+from nemo.collections.tts.models import AudioCodecModel
+from nemo.collections.tts.parts.utils.tts_dataset_utils import _read_audio
+
+
+class CodecEmbedder(nn.Module):
+    def __init__(self, codec: AudioCodecModel):
+        super().__init__()
+        self.codec = codec
+
+    def codes_to_emedding(self, x: Tensor, x_len: Tensor) -> Tensor:
+        # x: (B, T, C)
+        # x_len: (B,)
+        return self.codec.dequantize(tokens=x, tokens_len=x_len)
+
+    def encode_from_file(self, audio_path: str) -> Tensor:
+        print(f"Encoding audio {audio_path}")
+        audio_segment = _read_audio(
+            audio_filepath=audio_path, sample_rate=self.codec.sample_rate, offset=0, duration=0
+        )
+        samples = samples = torch.tensor(audio_segment.samples, device=self.codec.device).unsqueeze(0)
+        audio_len = torch.tensor(samples.shape[1], device=self.codec.device).unsqueeze(0)
+        codes, codes_len = self.codec.encode(audio=samples, audio_len=audio_len)
+        return codes, codes_len
+
+
+class FrechetCodecDistance(Metric):
+    def __init__(
+        self,
+        codec,
+        feature_dim: int,
+    ) -> None:
+        """
+        This class is adapted from an implementation of FID on images:
+            https://github.com/pytorch/torcheval/blob/main/torcheval/metrics/image/fid.py
+            
+            Copyright notice:
+
+                # Copyright (c) Meta Platforms, Inc. and affiliates.
+                # All rights reserved.
+                #
+                # This source code is licensed under the BSD-style license found in the
+                # LICENSE file in the root directory of this source tree.
+
+            Contents of original LICENSE file:
+                #  BSD License
+                #                
+                #  For torcheval software
+                #
+                #  Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
+                #
+                #  Redistribution and use in source and binary forms, with or without modification,
+                #  are permitted provided that the following conditions are met:
+                #         
+                #  * Redistributions of source code must retain the above copyright notice, this
+                #  list of conditions and the following disclaimer.
+                #
+                #  * Redistributions in binary form must reproduce the above copyright notice,
+                #  this list of conditions and the following disclaimer in the documentation
+                #  and/or other materials provided with the distribution.
+                #
+                #  * Neither the name Meta nor the names of its contributors may be used to
+                #  endorse or promote products derived from this software without specific
+                #  prior written permission.
+                #
+                #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+                #  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+                #  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+                #  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+                #  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+                #  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+                #  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+                #  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+                #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+                #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.            
+
+        Computes the Frechet Codec Distance between two distributions of audio codec codes (real and generated).
+        This is done in codec embedding space. We name this metric the Frechet Codec Distance (FCD).
+
+        The original paper (FID on images): https://arxiv.org/pdf/1706.08500.pdf
+
+        Args:
+            codec (AudioCodecModel): The codec model to use.
+            feature_dim (int): The number of features in the codec embedding space (usually 4*num_codebooks)
+        """
+        super().__init__()
+
+        # Set the model and put it in evaluation mode
+        self.model = CodecEmbedder(codec)
+        self.model = self.model.to(device)
+        self.model.eval()
+        self.model.requires_grad_(False)
+
+        # Initialize state variables used to compute FID
+        self.add_state("real_sum", default=torch.zeros(feature_dim), dist_reduce_fx="sum")
+        self.add_state("real_cov_sum", default=torch.zeros((feature_dim, feature_dim)), dist_reduce_fx="sum")
+        self.add_state("fake_sum", default=torch.zeros(feature_dim), dist_reduce_fx="sum")
+        self.add_state("fake_cov_sum", default=torch.zeros((feature_dim, feature_dim)), dist_reduce_fx="sum")
+        self.add_state("num_real_frames", default=torch.tensor(0).int(), dist_reduce_fx="sum")
+        self.add_state("num_fake_frames", default=torch.tensor(0).int(), dist_reduce_fx="sum")
+
+    def update_from_audio_file(self, audio_path: str, is_real: bool) -> Tensor:
+        """
+        Takes a path to an audio file, embeds it, and updates the FID metric.
+        """
+        codes, codes_len = self.model.encode_from_file(audio_path)
+        self.update_from_codes(codes, codes_len, is_real)
+
+    def update(self, codes: Tensor, codes_len: Tensor, is_real: bool):
+        # alias for update_from_codes
+        self.update_from_codes(codes, codes_len, is_real)
+
+    def update_from_codes(self, codes: Tensor, codes_len: Tensor, is_real: bool):
+        """
+        Update the states with a batch of real and fake codes.
+        Takes pre-computed codec codes, embeds them, and updates the FID metric.
+
+        Args:
+            codes (Tensor): A batch of codec frames of shape (B, C, T).
+            is_real (Boolean): Denotes if images are real or not.
+        """
+        assert codes.ndim == 3
+        codes = codes.to(self.device)
+
+        # Dequantize the codes to a continuous representation
+        embeddings = self.model.codes_to_emedding(
+            codes, codes_len
+        )  # B, E, T where E is the codec's embedding dimension, usually 4*num_codebooks
+
+        # keep only the valid frames
+        valid_frames = []
+        for i in range(codes.shape[0]):
+            valid_frames.append(embeddings[i, :, : codes_len[i]].T)  # T', E
+        embeddings = torch.cat(valid_frames, dim=0)  # total_valid_frames, E
+        valid_frame_count = embeddings.shape[0]
+
+        # Update the state variables used to compute FID
+        if is_real:
+            self.num_real_frames += valid_frame_count
+            self.real_sum += torch.sum(embeddings, dim=0)
+            self.real_cov_sum += torch.matmul(embeddings.T, embeddings)
+        else:
+            self.num_fake_frames += valid_frame_count
+            self.fake_sum += torch.sum(embeddings, dim=0)
+            self.fake_cov_sum += torch.matmul(embeddings.T, embeddings)
+
+        return self
+
+    def compute(self) -> Tensor:
+        """
+        Compute the FCD.
+
+        Returns:
+            tensor: The FCD.
+        """
+
+        # If the user has not already updated with at lease one
+        # image from each distribution, then we raise an Error.
+        if (self.num_real_frames == 0) or (self.num_fake_frames == 0):
+            warnings.warn(
+                "Computing FD requires at least 1 real image and 1 fake image,"
+                f"but currently running with {self.num_real_frames} real images and {self.num_fake_frames} fake images."
+                "Returning 0.0",
+                RuntimeWarning,
+            )
+
+            return torch.tensor(0.0)
+
+        # Compute the mean activations for each distribution
+        real_mean = (self.real_sum / self.num_real_frames).unsqueeze(0)
+        fake_mean = (self.fake_sum / self.num_fake_frames).unsqueeze(0)
+
+        # Compute the covariance matrices for each distribution
+        real_cov_num = self.real_cov_sum - self.num_real_frames * torch.matmul(real_mean.T, real_mean)
+        real_cov = real_cov_num / (self.num_real_frames - 1)
+        fake_cov_num = self.fake_cov_sum - self.num_fake_frames * torch.matmul(fake_mean.T, fake_mean)
+        fake_cov = fake_cov_num / (self.num_fake_frames - 1)
+
+        # Compute the Frechet Distance between the distributions
+        fd = self.calculate_frechet_distance(real_mean.squeeze(), real_cov, fake_mean.squeeze(), fake_cov)
+        # FD should be non-negative but due to numerical errors, it can be slightly negative
+        # Have seen -0.0011 in the past
+        assert fd >= -0.005
+        return torch.max(torch.tensor(0.0), fd)
+
+    def calculate_frechet_distance(
+        self,
+        mu1: Tensor,
+        sigma1: Tensor,
+        mu2: Tensor,
+        sigma2: Tensor,
+    ) -> Tensor:
+        """
+        Calculate the Frechet Distance between two multivariate Gaussian distributions.
+
+        Args:
+            mu1 (Tensor): The mean of the first distribution.
+            sigma1 (Tensor): The covariance matrix of the first distribution.
+            mu2 (Tensor): The mean of the second distribution.
+            sigma2 (Tensor): The covariance matrix of the second distribution.
+
+        Returns:
+            tensor: The Frechet Distance between the two distributions.
+        """
+
+        # Compute the squared distance between the means
+        mean_diff = mu1 - mu2
+        mean_diff_squared = mean_diff.square().sum(dim=-1)
+
+        # Calculate the sum of the traces of both covariance matrices
+        trace_sum = sigma1.trace() + sigma2.trace()
+
+        # Compute the eigenvalues of the matrix product of the real and fake covariance matrices
+        sigma_mm = torch.matmul(sigma1, sigma2)
+        eigenvals = torch.linalg.eigvals(sigma_mm)
+
+        # Take the square root of each eigenvalue and take its sum
+        sqrt_eigenvals_sum = eigenvals.sqrt().real.sum(dim=-1)
+
+        # Calculate the FID using the squared distance between the means,
+        # the sum of the traces of the covariance matrices, and the sum of the square roots of the eigenvalues
+        fid = mean_diff_squared + trace_sum - 2 * sqrt_eigenvals_sum
+
+        return fid
+
+
+if __name__ == "__main__":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    codec_path = "/datap/misc/checkpoints/AudioCodec_21Hz_no_eliz.nemo"
+    codec = AudioCodecModel.restore_from(codec_path, strict=False)
+    codec.to(device)
+    codec_feature_dim = codec.num_codebooks * codec.vector_quantizer.codebook_dim_per_group
+    metric = FrechetCodecDistance(codec=codec, feature_dim=codec_feature_dim).to(device)
+
+    B = 3
+    T = 20
+    C = 8
+    codes = torch.randint(low=0, high=codec.codebook_size, size=(B, C, T), device=device)
+    codes_len = torch.randint(low=1, high=T, size=(B,), device=device)
+    metric.update_from_codes(codes, codes_len, is_real=True)
+    metric.update_from_codes(codes, codes_len, is_real=True)
+    metric.update_from_audio_file(
+        "/datap/misc/Datasets/LibriTTS/dev-clean/1272/141231/1272_141231_000013_000002.wav", is_real=True
+    )
+
+    codes = torch.randint(low=0, high=2048, size=(B, C, T), device=device)
+    codes_len = torch.randint(low=1, high=T, size=(B,), device=device)
+    metric.update(codes, codes_len, is_real=False)
+    print(metric.compute())

--- a/nemo/collections/tts/modules/fcd_metric.py
+++ b/nemo/collections/tts/modules/fcd_metric.py
@@ -46,8 +46,8 @@ class CodecEmbedder(nn.Module):
 
 class FrechetCodecDistance(Metric):
     """
-    Computes the Frechet Codec Distance between two distributions of audio codec codes (real and generated).
-    This is done in codec embedding space. We name this metric the Frechet Codec Distance (FCD).
+    Computes the Frechet Codec Distance between two distributions of audio codec frames (real and generated).
+    This is done in codec embedding space, one frame at a time. We name this metric the Frechet Codec Distance (FCD).
     """
 
     """

--- a/nemo/collections/tts/modules/fcd_metric.py
+++ b/nemo/collections/tts/modules/fcd_metric.py
@@ -49,11 +49,11 @@ class FrechetCodecDistance(Metric):
     Computes the Frechet Codec Distance between two distributions of audio codec codes (real and generated).
     This is done in codec embedding space. We name this metric the Frechet Codec Distance (FCD).
     """
-    
+
     """
-    This class is adapted from the following implementation of FID (Frechet Inception Distance) on images:
+    Parts of this are based on the following implementation of FID (Frechet Inception Distance) on images:
     
-    https://github.com/pytorch/torcheval/blob/main/torcheval/metrics/image/fid.py
+        https://github.com/pytorch/torcheval/blob/main/torcheval/metrics/image/fid.py
 
         # Copyright (c) Meta Platforms, Inc. and affiliates.
         # All rights reserved.

--- a/nemo/collections/tts/modules/magpietts_modules.py
+++ b/nemo/collections/tts/modules/magpietts_modules.py
@@ -1,0 +1,54 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import Enum, StrEnum, verify, CONTINUOUS, UNIQUE
+import torch
+
+
+class LocalTransformerType(StrEnum):
+    """
+    Enum for the type of local transformer to use in the MagpieTTS model.
+    These strings are the values allowed in the YAML config file.
+    """
+
+    NO_LT = "none"
+    AR = "autoregressive"
+    MASKGIT = "maskgit"
+
+
+@verify(CONTINUOUS, UNIQUE)
+class SpecialAudioToken(Enum):
+    """
+    Enum for the special tokens to use in the MagpieTTS model.
+    The special tokens are appended at the end of the codebook after the actual audio codec tokens.
+    The actual codeco index is this value below plus the number of codec tokens - do not use the Enum directly.
+    """
+
+    AUDIO_BOS = 0
+    AUDIO_EOS = 1
+    AUDIO_CONTEXT_BOS = 2
+    AUDIO_CONTEXT_EOS = 3
+    MASK_TOKEN = 4
+    # Reserve these values so that if we need to add more special tokens in the future the codebook size will remain the same
+    RESERVED_1 = 5
+    RESERVED_2 = 6
+    RESERVED_3 = 7
+
+
+def cosine_schedule(x: torch.Tensor):
+    """
+    Maps input values from [0, 1] to [1, 0] using the first quadrant of the cosine function.
+    Used for MaskGit mask scheduling.
+    """
+    return torch.cos(x * (torch.pi / 2))

--- a/scripts/magpietts/evalset_config.py
+++ b/scripts/magpietts/evalset_config.py
@@ -264,4 +264,9 @@ dataset_meta_info = {
         'whisper_language': 'pl',
         'load_cached_codes_if_available': False
     },
+    'j_libri_unseen_test_no_codes': {
+        'manifest_path' : '/home/jasoli/data_prime/manifests/test_clean_withContextAudioPaths.json',
+        'audio_dir' : '/mnt/drive1/data/LibriTTS/',
+        'feature_dir' : None,
+    },
 }

--- a/scripts/magpietts/evalset_config.py
+++ b/scripts/magpietts/evalset_config.py
@@ -20,6 +20,21 @@ dataset_meta_info = {
         'audio_dir' : '/datap/misc/Datasets/riva',
         'feature_dir' : '/datap/misc/Datasets/riva',
     },
+    'libri_dev_clean_eval_large': {
+        'manifest_path' : '/datap/misc/speechllm_codecdatasets/manifests/t5_exp/dev_clean_withContextAudioPaths_withTargetCodes_evalset_large.json',
+        'audio_dir' : '/datap/misc/Datasets/LibriTTS',
+        'feature_dir' : '/datap/misc/Datasets/LibriTTS',
+    },
+    'libri_dev_clean_eval_mid': {
+        'manifest_path' : '/datap/misc/speechllm_codecdatasets/manifests/t5_exp/dev_clean_withContextAudioPaths_withTargetCodes_evalset_mid.json',
+        'audio_dir' : '/datap/misc/Datasets/LibriTTS',
+        'feature_dir' : '/datap/misc/Datasets/LibriTTS',
+    },    
+    'libri_dev_clean_eval_tiny': {
+        'manifest_path' : '/datap/misc/speechllm_codecdatasets/manifests/t5_exp/dev_clean_withContextAudioPaths_withTargetCodes_evalset_tiny.json',
+        'audio_dir' : '/datap/misc/Datasets/LibriTTS',
+        'feature_dir' : '/datap/misc/Datasets/LibriTTS',
+    },     
     'libri_val': {
         'manifest_path' : '/home/pneekhara/2023/SimpleT5NeMo/manifests/libri360_val.json',
         'audio_dir' : '/datap/misc/LibriTTSfromNemo/LibriTTS',
@@ -46,6 +61,11 @@ dataset_meta_info = {
         'audio_dir' : '/datap/misc/LibriTTSfromNemo/LibriTTS',
         'feature_dir' : '/datap/misc/LibriTTSfromNemo/LibriTTS',
         'load_cached_codes_if_available': False
+    },
+    'riva_val_text_context': {
+        'manifest_path' : '/datap/misc/speechllm_codecdatasets/manifests/t5_exp/RivattsEnglishLindyRodney21fps_val_nemo_audio_21fps_8codebooks_2kcodes_v2bWithWavLM_phoneme_tts_TextContext.json',
+        'audio_dir' : "/datap/misc/Datasets/riva/RivattsEnglish",
+        'feature_dir' : '/',
     },
     'libri_unseen_test_shehzeen_phoneme': {
         'manifest_path' : '/home/shehzeenh/Code/NewT5TTS/manifests/test_clean_withContextAudioPaths.json',

--- a/scripts/magpietts/evaluate_generated_audio.py
+++ b/scripts/magpietts/evaluate_generated_audio.py
@@ -119,8 +119,7 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
         codec = AudioCodecModel.restore_from(codecmodel_path, strict=False)
         codec = codec.to(device)
         codec.eval()
-        num_codebooks = codec.num_codebooks
-        codec_feature_dim = num_codebooks * codec.vector_quantizer.codebook_dim_per_group # only works for Group FSQ quantizers
+        codec_feature_dim = codec.vector_quantizer.codebook_dim
         fcd_metric = FrechetCodecDistance(codec=codec, feature_dim=codec_feature_dim).to(device)
     else:
         print("No codec model provided, skipping FCD metric")

--- a/scripts/magpietts/evaluate_generated_audio.py
+++ b/scripts/magpietts/evaluate_generated_audio.py
@@ -8,9 +8,11 @@ import torch
 
 import nemo.collections.asr as nemo_asr
 from nemo.collections.asr.metrics.wer import word_error_rate_detail
+from nemo.collections.tts.modules.fcd_metric import FrechetCodecDistance
+from nemo.collections.tts.models import AudioCodecModel
 from transformers import WhisperProcessor, WhisperForConditionalGeneration
 import librosa
-import evalset_config
+import scripts.magpietts.evalset_config as evalset_config
 from transformers import Wav2Vec2FeatureExtractor, WavLMForXVector
 
 def find_sample_audios(audio_dir):
@@ -77,7 +79,8 @@ def extract_embedding(model, extractor, audio_path, device, sv_model_type):
 
     return embeddings.squeeze()
 
-def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_model_type="titanet", asr_model_name="stt_en_conformer_transducer_large"):
+def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_model_type="titanet", asr_model_name="stt_en_conformer_transducer_large",
+             codecmodel_path=None, predicted_codes=None, predicted_codes_lens=None):
     audio_file_lists = find_sample_audios(generated_audio_dir)
     records = read_manifest(manifest_path)
     assert len(audio_file_lists) == len(records)
@@ -112,7 +115,16 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
     speaker_verification_model_alternate = speaker_verification_model_alternate.to(device)
     speaker_verification_model_alternate.eval()
 
-
+    if codecmodel_path is not None:
+        codec = AudioCodecModel.restore_from(codecmodel_path, strict=False)
+        codec = codec.to(device)
+        codec.eval()
+        num_codebooks = codec.num_codebooks
+        codec_feature_dim = num_codebooks * codec.vector_quantizer.codebook_dim_per_group # only works for Group FSQ quantizers
+        fcd_metric = FrechetCodecDistance(codec=codec, feature_dim=codec_feature_dim).to(device)
+    else:
+        print("No codec model provided, skipping FCD metric")
+        fcd_metric = None
 
     filewise_metrics = []
     pred_texts = []
@@ -125,11 +137,13 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
             gt_audio_filepath = os.path.join(audio_dir, gt_audio_filepath)
             if context_audio_filepath is not None:
                 context_audio_filepath = os.path.join(audio_dir, context_audio_filepath)
+            # Update the FCD metric for *real* codes
+            if fcd_metric is not None:
+                 fcd_metric.update_from_audio_file(gt_audio_filepath, True)
 
         pred_audio_filepath = audio_file_lists[ridx]
         if language == "en":
             with torch.no_grad():
-                # import ipdb; ipdb.set_trace()
                 pred_text = asr_model.transcribe([pred_audio_filepath])[0].text
                 pred_text = process_text(pred_text)
                 gt_audio_text = asr_model.transcribe([gt_audio_filepath])[0].text
@@ -178,7 +192,10 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
                 pred_context_ssim_alternate = torch.nn.functional.cosine_similarity(pred_speaker_embedding_alternate, context_speaker_embedding_alternate, dim=0).item()
                 gt_context_ssim_alternate = torch.nn.functional.cosine_similarity(gt_speaker_embedding_alternate, context_speaker_embedding_alternate, dim=0).item()
 
-
+        # update FCD metric for all generated codes
+        if fcd_metric is not None:
+            for i in range(predicted_codes.shape[0]):
+                fcd_metric.update_from_codes(predicted_codes[i:i+1], predicted_codes_lens[i:i+1], False)
 
         filewise_metrics.append({
             'gt_text': gt_text,
@@ -207,6 +224,13 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
     # Sort filewise metrics by cer in reverse
     filewise_metrics.sort(key=lambda x: x['cer'], reverse=True)
 
+    # compute frechet distance for the whole test set
+    if fcd_metric is not None:
+        fcd = fcd_metric.compute().cpu().item()
+        fcd_metric.reset()
+    else:
+        fcd = 0.0
+
     avg_metrics = {}
     avg_metrics['cer_filewise_avg'] = sum([m['detailed_cer'][0] for m in filewise_metrics]) / len(filewise_metrics)
     avg_metrics['wer_filewise_avg'] = sum([m['detailed_wer'][0] for m in filewise_metrics]) / len(filewise_metrics)
@@ -220,6 +244,7 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
     avg_metrics['ssim_gt_context_avg_alternate'] = sum([m['gt_context_ssim_alternate'] for m in filewise_metrics]) / len(filewise_metrics)
     avg_metrics["cer_gt_audio_cumulative"] = word_error_rate_detail(hypotheses=gt_audio_texts, references=gt_texts, use_cer=True)[0]
     avg_metrics["wer_gt_audio_cumulative"] = word_error_rate_detail(hypotheses=gt_audio_texts, references=gt_texts, use_cer=False)[0]
+    avg_metrics["frechet_codec_distance"] = fcd
 
     pprint.pprint(avg_metrics)
 

--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -46,7 +46,12 @@ def update_config(model_cfg, codecmodel_path, legacy_codebooks=False):
     if "t5_decoder" in model_cfg:
         model_cfg.decoder = model_cfg.t5_decoder
         del model_cfg.t5_decoder
+    if hasattr(model_cfg, 'decoder') and hasattr(model_cfg.decoder, 'prior_eps'):
+        # Added to prevent crash after removing arg from transformer_2501.py in https://github.com/blisc/NeMo/pull/56
+        del model_cfg.decoder.prior_eps
     if legacy_codebooks:
+        # Added to address backward compatibility arising from
+        #  https://github.com/blisc/NeMo/pull/64
         print("WARNING: Using legacy codebook indices for backward compatibility. Should only be used with old checkpoints.")
         num_audio_tokens_per_codebook = model_cfg.num_audio_tokens_per_codebook
         model_cfg.forced_num_all_tokens_per_codebook = num_audio_tokens_per_codebook
@@ -177,7 +182,7 @@ def run_inference(
                 context_duration_max=context_durration_max,
             )
             assert len(test_dataset) == len(manifest_records), "Dataset length and manifest length should be the same. Dataset length: {}, Manifest length: {}".format(len(test_dataset), len(manifest_records))
-            
+
             test_dataset.text_tokenizer = model.tokenizer
             test_dataset.text_conditioning_tokenizer = model.text_conditioning_tokenizer
 

--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -67,6 +67,19 @@ def update_config(model_cfg, codecmodel_path, legacy_codebooks=False):
 
     return model_cfg
 
+def update_ckpt(state_dict):
+    new_state_dict = {}
+    for key in state_dict.keys():
+        if 't5_encoder' in key:
+            new_key = key.replace('t5_encoder', 'encoder')
+            new_state_dict[new_key] = state_dict[key]
+        elif 't5_decoder' in key:
+            new_key = key.replace('t5_decoder', 'decoder')
+            new_state_dict[new_key] = state_dict[key]
+        else:
+            new_state_dict[key] = state_dict[key]
+    return new_state_dict
+
 def run_inference(
         hparams_file,
         checkpoint_file,
@@ -108,7 +121,8 @@ def run_inference(
         # Load weights from checkpoint file
         print("Loading weights from checkpoint")
         ckpt = torch.load(checkpoint_file, weights_only=False)
-        model.load_state_dict(ckpt['state_dict'])
+        state_dict = update_ckpt(ckpt['state_dict'])
+        model.load_state_dict(state_dict)
         checkpoint_name = checkpoint_file.split("/")[-1].split(".ckpt")[0]
     elif nemo_file is not None:
         model_cfg = MagpieTTSModel.restore_from(nemo_file, return_config=True)

--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -446,7 +446,8 @@ def main():
                 apply_prior_to_layers=apply_prior_to_layers,
                 start_prior_after_n_audio_steps=args.start_prior_after_n_audio_steps,
                 confidence_level=args.confidence_level,
-                use_local_transformer=args.use_local_transformer
+                use_local_transformer=args.use_local_transformer,
+                legacy_codebooks=args.legacy_codebooks
             )
 
 


### PR DESCRIPTION
This PR adds the Fréchet Codec Distance metric. This is a new metric we are experimenting with which is based on the Fréchet Inception Distance (FID).

We compute the distance between the distribution of real codec frames and generated codec frames. The distance is computed in the (dequantized) embedding space of the codec.

Note that FD distances are computed at the dataset level. The number of real and generated frames should large for a reliable metric.

The metric is now called from `infer_and_evaluate.py` and included in our standard set of reported metrics.