### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `a3609ee...` (2025-05-13)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "16aeade1e401764584a783540411a01657304081"
+      "ref": "a3609eeaffab384826a1380d511ffffb4ff2be47"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `a3609eeaffab384826a1380d511ffffb4ff2be47`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.