### PR TITLE
Add Fréchet codec distance metric

### DIFF
--- a/examples/tts/README_magpietts_legacy_checkpoints.md
+++ b/examples/tts/README_magpietts_legacy_checkpoints.md
@@ -3,7 +3,7 @@ Magpie-TTS uses special tokens like AUDIO_BOS and AUDIO_EOS for its operation. T
 
 In April 2025 we changed the layout of the embedding table in a non-backwards compatible way:
 
-## Old Layout
+## Old Layout (until April 16)
 With the most common codec configuration (2016 codes), the layout used to look like this:
 ```
 | Index   | Token Description    | Comments                                                                                                  |
@@ -55,6 +55,8 @@ For checkpoints created before the change you can force legacy codebook layout i
 Just set the `--legacy_codebooks` command line option. No need to update your YAML file – The script will automatically add the overrides.
 
 ## If using a Hydra command line
+This scenario would happen when either finetuning with an old checkpoint or doing data generation with an old checkpoint.
+
 You have two options:
 ### Add these to your command line
 ```
@@ -80,3 +82,14 @@ forced_audio_bos_id: ${sum:${model.forced_num_all_tokens_per_codebook}, -2}     
 #forced_context_audio_eos_id: ${sum:${model.forced_num_all_tokens_per_codebook}, -3}   # 2045
 #forced_context_audio_bos_id: ${sum:${model.forced_num_all_tokens_per_codebook}, -4}   # 2044
 ```
+
+# Additional Details
+Over the last few weeks we have gone through a few embedding table layouts. When using an old checkpoint it's important to know which layout your checkpoint was trained with and configuring the system accordingly.
+
+* Layout 1: used until April 16 (described in the table above). Add `--legacy-codebooks` to the `infer_and_evaluate.py` command line to inference using this layout.
+
+* Layout 2: after the [config changes](https://github.com/blisc/NeMo/commit/7e2cdca74a866ecefdbe01c0076ad9b5d140ac61): 2018 tokens with special tokens at the end 2017, 2016, 2015, 2014 (the last two being overwrites of codec tokens). This is an invalid layout and these checkpoints should not be used.
+
+* Layout 3: after the [bugfix](https://github.com/blisc/NeMo/commit/23e299a0bd14b666543b4bbcc7783f783acb0bd3) but before the [refactoring](https://github.com/blisc/NeMo/commit/8ba55061a0ebb161abff4b329e402d5307f4af98): 2024 tokens with special tokens at the end (2023, 2022, 2021, 2020). There are no automatic options provided for using this layout but it can be manually configured by updating the `hparams.yaml` file with the `forced_*` options. Set `forced_num_all_tokens_per_codebook` to `2024` and set the rest of the overrides as defined under section `# Or, add these overrides to your YAML file` above.
+
+* Layout 4: The new layout, [from this commit onwards](https://github.com/blisc/NeMo/commit/8ba55061a0ebb161abff4b329e402d5307f4af98): 2024 tokens but with special tokens immediately after codec tokens (2016, 2017, 2018, 2019). Training and inference with the latest version of the code automatically use this layout.

--- a/nemo/collections/tts/modules/fcd_metric.py
+++ b/nemo/collections/tts/modules/fcd_metric.py
@@ -1,0 +1,269 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+
+import torch
+import torch.nn.functional as F
+from torch import nn, Tensor
+from torchmetrics import Metric
+
+from nemo.collections.tts.models import AudioCodecModel
+from nemo.collections.tts.parts.utils.tts_dataset_utils import _read_audio
+
+
+class CodecEmbedder(nn.Module):
+    def __init__(self, codec: AudioCodecModel):
+        super().__init__()
+        self.codec = codec
+
+    def codes_to_emedding(self, x: Tensor, x_len: Tensor) -> Tensor:
+        # x: (B, T, C)
+        # x_len: (B,)
+        return self.codec.dequantize(tokens=x, tokens_len=x_len)
+
+    def encode_from_file(self, audio_path: str) -> Tensor:
+        print(f"Encoding audio {audio_path}")
+        audio_segment = _read_audio(
+            audio_filepath=audio_path, sample_rate=self.codec.sample_rate, offset=0, duration=0
+        )
+        samples = samples = torch.tensor(audio_segment.samples, device=self.codec.device).unsqueeze(0)
+        audio_len = torch.tensor(samples.shape[1], device=self.codec.device).unsqueeze(0)
+        codes, codes_len = self.codec.encode(audio=samples, audio_len=audio_len)
+        return codes, codes_len
+
+
+class FrechetCodecDistance(Metric):
+    def __init__(
+        self,
+        codec,
+        feature_dim: int,
+    ) -> None:
+        """
+        This class is adapted from an implementation of FID on images:
+            https://github.com/pytorch/torcheval/blob/main/torcheval/metrics/image/fid.py
+            
+            Copyright notice:
+
+                # Copyright (c) Meta Platforms, Inc. and affiliates.
+                # All rights reserved.
+                #
+                # This source code is licensed under the BSD-style license found in the
+                # LICENSE file in the root directory of this source tree.
+
+            Contents of original LICENSE file:
+                #  BSD License
+                #                
+                #  For torcheval software
+                #
+                #  Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
+                #
+                #  Redistribution and use in source and binary forms, with or without modification,
+                #  are permitted provided that the following conditions are met:
+                #         
+                #  * Redistributions of source code must retain the above copyright notice, this
+                #  list of conditions and the following disclaimer.
+                #
+                #  * Redistributions in binary form must reproduce the above copyright notice,
+                #  this list of conditions and the following disclaimer in the documentation
+                #  and/or other materials provided with the distribution.
+                #
+                #  * Neither the name Meta nor the names of its contributors may be used to
+                #  endorse or promote products derived from this software without specific
+                #  prior written permission.
+                #
+                #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+                #  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+                #  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+                #  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+                #  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+                #  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+                #  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+                #  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+                #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+                #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.            
+
+        Computes the Frechet Codec Distance between two distributions of audio codec codes (real and generated).
+        This is done in codec embedding space. We name this metric the Frechet Codec Distance (FCD).
+
+        The original paper (FID on images): https://arxiv.org/pdf/1706.08500.pdf
+
+        Args:
+            codec (AudioCodecModel): The codec model to use.
+            feature_dim (int): The number of features in the codec embedding space (usually 4*num_codebooks)
+        """
+        super().__init__()
+
+        # Set the model and put it in evaluation mode
+        self.model = CodecEmbedder(codec)
+        self.model = self.model.to(device)
+        self.model.eval()
+        self.model.requires_grad_(False)
+
+        # Initialize state variables used to compute FID
+        self.add_state("real_sum", default=torch.zeros(feature_dim), dist_reduce_fx="sum")
+        self.add_state("real_cov_sum", default=torch.zeros((feature_dim, feature_dim)), dist_reduce_fx="sum")
+        self.add_state("fake_sum", default=torch.zeros(feature_dim), dist_reduce_fx="sum")
+        self.add_state("fake_cov_sum", default=torch.zeros((feature_dim, feature_dim)), dist_reduce_fx="sum")
+        self.add_state("num_real_frames", default=torch.tensor(0).int(), dist_reduce_fx="sum")
+        self.add_state("num_fake_frames", default=torch.tensor(0).int(), dist_reduce_fx="sum")
+
+    def update_from_audio_file(self, audio_path: str, is_real: bool) -> Tensor:
+        """
+        Takes a path to an audio file, embeds it, and updates the FID metric.
+        """
+        codes, codes_len = self.model.encode_from_file(audio_path)
+        self.update_from_codes(codes, codes_len, is_real)
+
+    def update(self, codes: Tensor, codes_len: Tensor, is_real: bool):
+        # alias for update_from_codes
+        self.update_from_codes(codes, codes_len, is_real)
+
+    def update_from_codes(self, codes: Tensor, codes_len: Tensor, is_real: bool):
+        """
+        Update the states with a batch of real and fake codes.
+        Takes pre-computed codec codes, embeds them, and updates the FID metric.
+
+        Args:
+            codes (Tensor): A batch of codec frames of shape (B, C, T).
+            is_real (Boolean): Denotes if images are real or not.
+        """
+        assert codes.ndim == 3
+        codes = codes.to(self.device)
+
+        # Dequantize the codes to a continuous representation
+        embeddings = self.model.codes_to_emedding(
+            codes, codes_len
+        )  # B, E, T where E is the codec's embedding dimension, usually 4*num_codebooks
+
+        # keep only the valid frames
+        valid_frames = []
+        for i in range(codes.shape[0]):
+            valid_frames.append(embeddings[i, :, : codes_len[i]].T)  # T', E
+        embeddings = torch.cat(valid_frames, dim=0)  # total_valid_frames, E
+        valid_frame_count = embeddings.shape[0]
+
+        # Update the state variables used to compute FID
+        if is_real:
+            self.num_real_frames += valid_frame_count
+            self.real_sum += torch.sum(embeddings, dim=0)
+            self.real_cov_sum += torch.matmul(embeddings.T, embeddings)
+        else:
+            self.num_fake_frames += valid_frame_count
+            self.fake_sum += torch.sum(embeddings, dim=0)
+            self.fake_cov_sum += torch.matmul(embeddings.T, embeddings)
+
+        return self
+
+    def compute(self) -> Tensor:
+        """
+        Compute the FCD.
+
+        Returns:
+            tensor: The FCD.
+        """
+
+        # If the user has not already updated with at lease one
+        # image from each distribution, then we raise an Error.
+        if (self.num_real_frames == 0) or (self.num_fake_frames == 0):
+            warnings.warn(
+                "Computing FD requires at least 1 real image and 1 fake image,"
+                f"but currently running with {self.num_real_frames} real images and {self.num_fake_frames} fake images."
+                "Returning 0.0",
+                RuntimeWarning,
+            )
+
+            return torch.tensor(0.0)
+
+        # Compute the mean activations for each distribution
+        real_mean = (self.real_sum / self.num_real_frames).unsqueeze(0)
+        fake_mean = (self.fake_sum / self.num_fake_frames).unsqueeze(0)
+
+        # Compute the covariance matrices for each distribution
+        real_cov_num = self.real_cov_sum - self.num_real_frames * torch.matmul(real_mean.T, real_mean)
+        real_cov = real_cov_num / (self.num_real_frames - 1)
+        fake_cov_num = self.fake_cov_sum - self.num_fake_frames * torch.matmul(fake_mean.T, fake_mean)
+        fake_cov = fake_cov_num / (self.num_fake_frames - 1)
+
+        # Compute the Frechet Distance between the distributions
+        fd = self.calculate_frechet_distance(real_mean.squeeze(), real_cov, fake_mean.squeeze(), fake_cov)
+        # FD should be non-negative but due to numerical errors, it can be slightly negative
+        # Have seen -0.0011 in the past
+        assert fd >= -0.005
+        return torch.max(torch.tensor(0.0), fd)
+
+    def calculate_frechet_distance(
+        self,
+        mu1: Tensor,
+        sigma1: Tensor,
+        mu2: Tensor,
+        sigma2: Tensor,
+    ) -> Tensor:
+        """
+        Calculate the Frechet Distance between two multivariate Gaussian distributions.
+
+        Args:
+            mu1 (Tensor): The mean of the first distribution.
+            sigma1 (Tensor): The covariance matrix of the first distribution.
+            mu2 (Tensor): The mean of the second distribution.
+            sigma2 (Tensor): The covariance matrix of the second distribution.
+
+        Returns:
+            tensor: The Frechet Distance between the two distributions.
+        """
+
+        # Compute the squared distance between the means
+        mean_diff = mu1 - mu2
+        mean_diff_squared = mean_diff.square().sum(dim=-1)
+
+        # Calculate the sum of the traces of both covariance matrices
+        trace_sum = sigma1.trace() + sigma2.trace()
+
+        # Compute the eigenvalues of the matrix product of the real and fake covariance matrices
+        sigma_mm = torch.matmul(sigma1, sigma2)
+        eigenvals = torch.linalg.eigvals(sigma_mm)
+
+        # Take the square root of each eigenvalue and take its sum
+        sqrt_eigenvals_sum = eigenvals.sqrt().real.sum(dim=-1)
+
+        # Calculate the FID using the squared distance between the means,
+        # the sum of the traces of the covariance matrices, and the sum of the square roots of the eigenvalues
+        fid = mean_diff_squared + trace_sum - 2 * sqrt_eigenvals_sum
+
+        return fid
+
+
+if __name__ == "__main__":
+    device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    codec_path = "/datap/misc/checkpoints/AudioCodec_21Hz_no_eliz.nemo"
+    codec = AudioCodecModel.restore_from(codec_path, strict=False)
+    codec.to(device)
+    codec_feature_dim = codec.num_codebooks * codec.vector_quantizer.codebook_dim_per_group
+    metric = FrechetCodecDistance(codec=codec, feature_dim=codec_feature_dim).to(device)
+
+    B = 3
+    T = 20
+    C = 8
+    codes = torch.randint(low=0, high=codec.codebook_size, size=(B, C, T), device=device)
+    codes_len = torch.randint(low=1, high=T, size=(B,), device=device)
+    metric.update_from_codes(codes, codes_len, is_real=True)
+    metric.update_from_codes(codes, codes_len, is_real=True)
+    metric.update_from_audio_file(
+        "/datap/misc/Datasets/LibriTTS/dev-clean/1272/141231/1272_141231_000013_000002.wav", is_real=True
+    )
+
+    codes = torch.randint(low=0, high=2048, size=(B, C, T), device=device)
+    codes_len = torch.randint(low=1, high=T, size=(B,), device=device)
+    metric.update(codes, codes_len, is_real=False)
+    print(metric.compute())

--- a/nemo/collections/tts/modules/fcd_metric.py
+++ b/nemo/collections/tts/modules/fcd_metric.py
@@ -46,8 +46,8 @@ class CodecEmbedder(nn.Module):
 
 class FrechetCodecDistance(Metric):
     """
-    Computes the Frechet Codec Distance between two distributions of audio codec codes (real and generated).
-    This is done in codec embedding space. We name this metric the Frechet Codec Distance (FCD).
+    Computes the Frechet Codec Distance between two distributions of audio codec frames (real and generated).
+    This is done in codec embedding space, one frame at a time. We name this metric the Frechet Codec Distance (FCD).
     """
 
     """

--- a/nemo/collections/tts/modules/fcd_metric.py
+++ b/nemo/collections/tts/modules/fcd_metric.py
@@ -49,11 +49,11 @@ class FrechetCodecDistance(Metric):
     Computes the Frechet Codec Distance between two distributions of audio codec codes (real and generated).
     This is done in codec embedding space. We name this metric the Frechet Codec Distance (FCD).
     """
-    
+
     """
-    This class is adapted from the following implementation of FID (Frechet Inception Distance) on images:
+    Parts of this are based on the following implementation of FID (Frechet Inception Distance) on images:
     
-    https://github.com/pytorch/torcheval/blob/main/torcheval/metrics/image/fid.py
+        https://github.com/pytorch/torcheval/blob/main/torcheval/metrics/image/fid.py
 
         # Copyright (c) Meta Platforms, Inc. and affiliates.
         # All rights reserved.

--- a/scripts/magpietts/evaluate_generated_audio.py
+++ b/scripts/magpietts/evaluate_generated_audio.py
@@ -119,8 +119,7 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
         codec = AudioCodecModel.restore_from(codecmodel_path, strict=False)
         codec = codec.to(device)
         codec.eval()
-        num_codebooks = codec.num_codebooks
-        codec_feature_dim = num_codebooks * codec.vector_quantizer.codebook_dim_per_group # only works for Group FSQ quantizers
+        codec_feature_dim = codec.vector_quantizer.codebook_dim
         fcd_metric = FrechetCodecDistance(codec=codec, feature_dim=codec_feature_dim).to(device)
     else:
         print("No codec model provided, skipping FCD metric")

--- a/scripts/magpietts/evaluate_generated_audio.py
+++ b/scripts/magpietts/evaluate_generated_audio.py
@@ -8,9 +8,11 @@ import torch
 
 import nemo.collections.asr as nemo_asr
 from nemo.collections.asr.metrics.wer import word_error_rate_detail
+from nemo.collections.tts.modules.fcd_metric import FrechetCodecDistance
+from nemo.collections.tts.models import AudioCodecModel
 from transformers import WhisperProcessor, WhisperForConditionalGeneration
 import librosa
-import evalset_config
+import scripts.magpietts.evalset_config as evalset_config
 from transformers import Wav2Vec2FeatureExtractor, WavLMForXVector
 
 def find_sample_audios(audio_dir):
@@ -77,7 +79,8 @@ def extract_embedding(model, extractor, audio_path, device, sv_model_type):
 
     return embeddings.squeeze()
 
-def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_model_type="titanet", asr_model_name="stt_en_conformer_transducer_large"):
+def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_model_type="titanet", asr_model_name="stt_en_conformer_transducer_large",
+             codecmodel_path=None, predicted_codes=None, predicted_codes_lens=None):
     audio_file_lists = find_sample_audios(generated_audio_dir)
     records = read_manifest(manifest_path)
     assert len(audio_file_lists) == len(records)
@@ -112,7 +115,16 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
     speaker_verification_model_alternate = speaker_verification_model_alternate.to(device)
     speaker_verification_model_alternate.eval()
 
-
+    if codecmodel_path is not None:
+        codec = AudioCodecModel.restore_from(codecmodel_path, strict=False)
+        codec = codec.to(device)
+        codec.eval()
+        num_codebooks = codec.num_codebooks
+        codec_feature_dim = num_codebooks * codec.vector_quantizer.codebook_dim_per_group # only works for Group FSQ quantizers
+        fcd_metric = FrechetCodecDistance(codec=codec, feature_dim=codec_feature_dim).to(device)
+    else:
+        print("No codec model provided, skipping FCD metric")
+        fcd_metric = None
 
     filewise_metrics = []
     pred_texts = []
@@ -125,11 +137,13 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
             gt_audio_filepath = os.path.join(audio_dir, gt_audio_filepath)
             if context_audio_filepath is not None:
                 context_audio_filepath = os.path.join(audio_dir, context_audio_filepath)
+            # Update the FCD metric for *real* codes
+            if fcd_metric is not None:
+                 fcd_metric.update_from_audio_file(gt_audio_filepath, True)
 
         pred_audio_filepath = audio_file_lists[ridx]
         if language == "en":
             with torch.no_grad():
-                # import ipdb; ipdb.set_trace()
                 pred_text = asr_model.transcribe([pred_audio_filepath])[0].text
                 pred_text = process_text(pred_text)
                 gt_audio_text = asr_model.transcribe([gt_audio_filepath])[0].text
@@ -178,7 +192,10 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
                 pred_context_ssim_alternate = torch.nn.functional.cosine_similarity(pred_speaker_embedding_alternate, context_speaker_embedding_alternate, dim=0).item()
                 gt_context_ssim_alternate = torch.nn.functional.cosine_similarity(gt_speaker_embedding_alternate, context_speaker_embedding_alternate, dim=0).item()
 
-
+        # update FCD metric for all generated codes
+        if fcd_metric is not None:
+            for i in range(predicted_codes.shape[0]):
+                fcd_metric.update_from_codes(predicted_codes[i:i+1], predicted_codes_lens[i:i+1], False)
 
         filewise_metrics.append({
             'gt_text': gt_text,
@@ -207,6 +224,13 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
     # Sort filewise metrics by cer in reverse
     filewise_metrics.sort(key=lambda x: x['cer'], reverse=True)
 
+    # compute frechet distance for the whole test set
+    if fcd_metric is not None:
+        fcd = fcd_metric.compute().cpu().item()
+        fcd_metric.reset()
+    else:
+        fcd = 0.0
+
     avg_metrics = {}
     avg_metrics['cer_filewise_avg'] = sum([m['detailed_cer'][0] for m in filewise_metrics]) / len(filewise_metrics)
     avg_metrics['wer_filewise_avg'] = sum([m['detailed_wer'][0] for m in filewise_metrics]) / len(filewise_metrics)
@@ -220,6 +244,7 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
     avg_metrics['ssim_gt_context_avg_alternate'] = sum([m['gt_context_ssim_alternate'] for m in filewise_metrics]) / len(filewise_metrics)
     avg_metrics["cer_gt_audio_cumulative"] = word_error_rate_detail(hypotheses=gt_audio_texts, references=gt_texts, use_cer=True)[0]
     avg_metrics["wer_gt_audio_cumulative"] = word_error_rate_detail(hypotheses=gt_audio_texts, references=gt_texts, use_cer=False)[0]
+    avg_metrics["frechet_codec_distance"] = fcd
 
     pprint.pprint(avg_metrics)
 

--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -446,7 +446,8 @@ def main():
                 apply_prior_to_layers=apply_prior_to_layers,
                 start_prior_after_n_audio_steps=args.start_prior_after_n_audio_steps,
                 confidence_level=args.confidence_level,
-                use_local_transformer=args.use_local_transformer
+                use_local_transformer=args.use_local_transformer,
+                legacy_codebooks=args.legacy_codebooks
             )
 
 


### PR DESCRIPTION
This PR adds the Fréchet Codec Distance metric. This is a new metric we are experimenting with which is based on the Fréchet Inception Distance (FID).

We compute the distance between the distribution of real codec frames and generated codec frames. The distance is computed in the (dequantized) embedding space of the codec.

Note that FD distances are computed at the dataset level. The number of real and generated frames should large for a reliable metric.

The metric is now called from `infer_and_evaluate.py` and included in our standard set of reported metrics.