### PR TITLE
Squashed commit of the following:

### DIFF
--- a/nemo/collections/tts/modules/fcd_metric.py
+++ b/nemo/collections/tts/modules/fcd_metric.py
@@ -1,0 +1,263 @@
+# Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import warnings
+
+import torch
+import torch.nn.functional as F
+from torch import nn, Tensor
+from torchmetrics import Metric
+
+from nemo.collections.tts.models import AudioCodecModel
+from nemo.collections.tts.parts.utils.tts_dataset_utils import _read_audio
+
+
+class CodecEmbedder(nn.Module):
+    """
+    Embeds audio codec codes into the codec's continuous embedding space.
+    Accepts as input either a batch of codes or a path to an audio file.
+    """
+    def __init__(self, codec: AudioCodecModel):
+        super().__init__()
+        self.codec = codec
+
+    def codes_to_emedding(self, x: Tensor, x_len: Tensor) -> Tensor:
+        """
+        Embeds a batch of audio codec codes into the codec's continuous embedding space.
+        """
+        # x: (B, T, C)
+        # x_len: (B,)
+        return self.codec.dequantize(tokens=x, tokens_len=x_len)
+
+    def encode_from_file(self, audio_path: str) -> Tensor:
+        """
+        Encodes an audio file into audio codec codes.
+        """
+        print(f"Encoding audio {audio_path}")
+        audio_segment = _read_audio(
+            audio_filepath=audio_path, sample_rate=self.codec.sample_rate, offset=0, duration=0
+        )
+        samples = samples = torch.tensor(audio_segment.samples, device=self.codec.device).unsqueeze(0)
+        audio_len = torch.tensor(samples.shape[1], device=self.codec.device).unsqueeze(0)
+        codes, codes_len = self.codec.encode(audio=samples, audio_len=audio_len)
+        return codes, codes_len
+
+
+class FrechetCodecDistance(Metric):
+    """
+    Computes the Frechet Codec Distance between two distributions of audio codec frames (real and generated).
+    This is done in codec embedding space, one frame at a time. We name this metric the Frechet Codec Distance (FCD).
+    """
+
+    """
+    Parts of this are based on the following implementation of FID (Frechet Inception Distance) on images:
+    
+        https://github.com/pytorch/torcheval/blob/main/torcheval/metrics/image/fid.py
+
+        # Copyright (c) Meta Platforms, Inc. and affiliates.
+        # All rights reserved.
+        #
+        # This source code is licensed under the BSD-style license found in the
+        # LICENSE file in the root directory of this source tree.
+
+    Contents of original LICENSE file:
+
+        #  BSD License
+        #                
+        #  For torcheval software
+        #
+        #  Copyright (c) Meta Platforms, Inc. and affiliates. All rights reserved.
+        #
+        #  Redistribution and use in source and binary forms, with or without modification,
+        #  are permitted provided that the following conditions are met:
+        #         
+        #  * Redistributions of source code must retain the above copyright notice, this
+        #  list of conditions and the following disclaimer.
+        #
+        #  * Redistributions in binary form must reproduce the above copyright notice,
+        #  this list of conditions and the following disclaimer in the documentation
+        #  and/or other materials provided with the distribution.
+        #
+        #  * Neither the name Meta nor the names of its contributors may be used to
+        #  endorse or promote products derived from this software without specific
+        #  prior written permission.
+        #
+        #  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+        #  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+        #  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+        #  DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+        #  ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+        #  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+        #  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+        #  ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+        #  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+        #  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+    """
+    is_differentiable = False
+    higher_is_better = False
+    full_state_update = False
+
+    def __init__(
+        self,
+        codec,
+        feature_dim: int,
+    ) -> None:
+        """
+        Computes the Frechet Codec Distance between two distributions of audio codec codes (real and generated).
+        The original paper (FID on images): https://arxiv.org/pdf/1706.08500.pdf
+
+        Args:
+            codec (AudioCodecModel): The codec model to use.
+            feature_dim (int): The number of features in the codec embedding space (usually 4*num_codebooks)
+        """
+        super().__init__()
+
+        # Set the model and put it in evaluation mode
+        self.model = CodecEmbedder(codec)
+        self.model.eval()
+        self.model.requires_grad_(False)
+
+        # Initialize state variables used to compute FCD
+        self.add_state("real_sum", default=torch.zeros(feature_dim), dist_reduce_fx="sum")
+        self.add_state("real_cov_sum", default=torch.zeros((feature_dim, feature_dim)), dist_reduce_fx="sum")
+        self.add_state("fake_sum", default=torch.zeros(feature_dim), dist_reduce_fx="sum")
+        self.add_state("fake_cov_sum", default=torch.zeros((feature_dim, feature_dim)), dist_reduce_fx="sum")
+        self.add_state("num_real_frames", default=torch.tensor(0).int(), dist_reduce_fx="sum")
+        self.add_state("num_fake_frames", default=torch.tensor(0).int(), dist_reduce_fx="sum")
+
+    def update_from_audio_file(self, audio_path: str, is_real: bool) -> Tensor:
+        """
+        Takes a path to an audio file, embeds it, and updates the FCD metric.
+        """
+        codes, codes_len = self.model.encode_from_file(audio_path)
+        self.update_from_codes(codes, codes_len, is_real)
+
+    def update(self, codes: Tensor, codes_len: Tensor, is_real: bool):
+        # The torchmetrics.Metric interface requires an `update()` method which we override here.
+        # Alias for `update_from_codes()`
+        self.update_from_codes(codes, codes_len, is_real)
+
+    def update_from_codes(self, codes: Tensor, codes_len: Tensor, is_real: bool):
+        """
+        Update the states with a batch of real and fake codes.
+        Takes pre-computed codec codes, embeds them, and updates the FCD metric.
+
+        Args:
+            codes (Tensor): A batch of codec frames of shape (B, C, T).
+            is_real (Boolean): Denotes if images are real or not.
+        """
+        assert codes.ndim == 3
+        codes = codes.to(self.device)
+
+        # Dequantize the codes to a continuous representation
+        embeddings = self.model.codes_to_emedding(
+            codes, codes_len
+        )  # B, E, T where E is the codec's embedding dimension, usually 4*num_codebooks
+
+        # keep only the valid frames
+        valid_frames = []
+        for i in range(codes.shape[0]):
+            valid_frames.append(embeddings[i, :, : codes_len[i]].T)  # T', E
+        embeddings = torch.cat(valid_frames, dim=0)  # total_valid_frames, E
+        valid_frame_count = embeddings.shape[0]
+
+        # Update the state variables used to compute FCD
+        if is_real:
+            self.num_real_frames += valid_frame_count
+            self.real_sum += torch.sum(embeddings, dim=0)
+            self.real_cov_sum += torch.matmul(embeddings.T, embeddings)
+        else:
+            self.num_fake_frames += valid_frame_count
+            self.fake_sum += torch.sum(embeddings, dim=0)
+            self.fake_cov_sum += torch.matmul(embeddings.T, embeddings)
+
+        return self
+
+    def compute(self) -> Tensor:
+        """
+        Compute the FCD.
+
+        Returns:
+            tensor: The FCD.
+        """
+
+        # If the user has not already updated with at lease one
+        # image from each distribution, then we raise an Error.
+        if (self.num_real_frames == 0) or (self.num_fake_frames == 0):
+            warnings.warn(
+                "Computing FD requires at least 1 real image and 1 fake image,"
+                f"but currently running with {self.num_real_frames} real images and {self.num_fake_frames} fake images."
+                "Returning 0.0",
+                RuntimeWarning,
+            )
+
+            return torch.tensor(0.0)
+
+        # Compute the mean activations for each distribution
+        real_mean = (self.real_sum / self.num_real_frames).unsqueeze(0)
+        fake_mean = (self.fake_sum / self.num_fake_frames).unsqueeze(0)
+
+        # Compute the covariance matrices for each distribution
+        real_cov_num = self.real_cov_sum - self.num_real_frames * torch.matmul(real_mean.T, real_mean)
+        real_cov = real_cov_num / (self.num_real_frames - 1)
+        fake_cov_num = self.fake_cov_sum - self.num_fake_frames * torch.matmul(fake_mean.T, fake_mean)
+        fake_cov = fake_cov_num / (self.num_fake_frames - 1)
+
+        # Compute the Frechet Distance between the distributions
+        fd = self.calculate_frechet_distance(real_mean.squeeze(), real_cov, fake_mean.squeeze(), fake_cov)
+        # FD should be non-negative but due to numerical errors, it can be slightly negative
+        # Have seen -0.0011 in the past
+        assert fd >= -0.005
+        return torch.max(torch.tensor(0.0), fd)
+
+    def calculate_frechet_distance(
+        self,
+        mu1: Tensor,
+        sigma1: Tensor,
+        mu2: Tensor,
+        sigma2: Tensor,
+    ) -> Tensor:
+        """
+        Calculate the Frechet Distance between two multivariate Gaussian distributions.
+
+        Args:
+            mu1 (Tensor): The mean of the first distribution.
+            sigma1 (Tensor): The covariance matrix of the first distribution.
+            mu2 (Tensor): The mean of the second distribution.
+            sigma2 (Tensor): The covariance matrix of the second distribution.
+
+        Returns:
+            tensor: The Frechet Distance between the two distributions.
+        """
+
+        # Compute the squared distance between the means
+        mean_diff = mu1 - mu2
+        mean_diff_squared = mean_diff.square().sum(dim=-1)
+
+        # Calculate the sum of the traces of both covariance matrices
+        trace_sum = sigma1.trace() + sigma2.trace()
+
+        # Compute the eigenvalues of the matrix product of the real and fake covariance matrices
+        sigma_mm = torch.matmul(sigma1, sigma2)
+        eigenvals = torch.linalg.eigvals(sigma_mm)
+
+        # Take the square root of each eigenvalue and take its sum
+        sqrt_eigenvals_sum = eigenvals.sqrt().real.sum(dim=-1)
+
+        # Calculate the FCD using the squared distance between the means,
+        # the sum of the traces of the covariance matrices, and the sum of the square roots of the eigenvalues
+        fcd = mean_diff_squared + trace_sum - 2 * sqrt_eigenvals_sum
+
+        return fcd
+

--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -5,8 +5,8 @@ import json
 import os
 import shutil
 
-import evalset_config
-import evaluate_generated_audio
+import scripts.magpietts.evalset_config as evalset_config
+import scripts.magpietts.evaluate_generated_audio as evaluate_generated_audio
 import numpy as np
 import scipy.stats as stats
 import soundfile as sf
@@ -17,7 +17,6 @@ from PIL import Image
 from nemo.collections.asr.parts.utils.manifest_utils import read_manifest
 from nemo.collections.tts.data.text_to_speech_dataset import MagpieTTSDataset
 from nemo.collections.tts.models import MagpieTTSModel
-
 
 def compute_mean_and_confidence_interval(metrics_list, metric_keys, confidence=0.90):
     metrics = {}
@@ -226,7 +225,7 @@ def run_inference(
 
                 import time
                 st = time.time()
-                predicted_audio, predicted_audio_lens, _, _, rtf_metrics, cross_attention_maps, _  = model.infer_batch(
+                predicted_audio, predicted_audio_lens, predicted_codes, predicted_codes_lens, rtf_metrics, cross_attention_maps, _  = model.infer_batch(
                     batch_cuda,
                     max_decoder_steps=440,
                     temperature=temperature,
@@ -277,6 +276,9 @@ def run_inference(
                 language=language,
                 sv_model_type=sv_model,
                 asr_model_name=asr_model_name,
+                predicted_codes=predicted_codes,
+                predicted_codes_lens=predicted_codes_lens,
+                codecmodel_path=codecmodel_path
             )
             metrics_n_repeated.append(metrics)
             with open(os.path.join(eval_dir, f"{dataset}_metrics_{repeat_idx}.json"), "w") as f:
@@ -292,23 +294,23 @@ def run_inference(
             all_experiment_csv = os.path.join(eval_dir, "all_experiment_metrics.csv")
             if not os.path.exists(all_experiment_csv):
                 with open(all_experiment_csv, "w") as f:
-                    f.write("checkpoint_name,dataset,cer_filewise_avg,wer_filewise_avg,cer_cumulative,wer_cumulative,ssim_pred_gt_avg,ssim_pred_context_avg,ssim_gt_context_avg,ssim_pred_gt_avg_alternate,ssim_pred_context_avg_alternate,ssim_gt_context_avg_alternate,cer_gt_audio_cumulative,wer_gt_audio_cumulative\n")
+                    f.write("checkpoint_name,dataset,cer_filewise_avg,wer_filewise_avg,cer_cumulative,wer_cumulative,ssim_pred_gt_avg,ssim_pred_context_avg,ssim_gt_context_avg,ssim_pred_gt_avg_alternate,ssim_pred_context_avg_alternate,ssim_gt_context_avg_alternate,cer_gt_audio_cumulative,wer_gt_audio_cumulative,frechet_codec_distance\n")
             with open(all_experiment_csv, "a") as f:
-                f.write(f"{checkpoint_name},{dataset},{metrics['cer_filewise_avg']},{metrics['wer_filewise_avg']},{metrics['cer_cumulative']},{metrics['wer_cumulative']},{metrics['ssim_pred_gt_avg']},{metrics['ssim_pred_context_avg']},{metrics['ssim_gt_context_avg']},{metrics['ssim_pred_gt_avg_alternate']},{metrics['ssim_pred_context_avg_alternate']},{metrics['ssim_gt_context_avg_alternate']},{metrics['cer_gt_audio_cumulative']},{metrics['wer_gt_audio_cumulative']}\n")
+                f.write(f"{checkpoint_name},{dataset},{metrics['cer_filewise_avg']},{metrics['wer_filewise_avg']},{metrics['cer_cumulative']},{metrics['wer_cumulative']},{metrics['ssim_pred_gt_avg']},{metrics['ssim_pred_context_avg']},{metrics['ssim_gt_context_avg']},{metrics['ssim_pred_gt_avg_alternate']},{metrics['ssim_pred_context_avg_alternate']},{metrics['ssim_gt_context_avg_alternate']},{metrics['cer_gt_audio_cumulative']},{metrics['wer_gt_audio_cumulative']},{metrics['frechet_codec_distance']}\n")
                 print(f"Wrote metrics for {checkpoint_name} and {dataset} to {all_experiment_csv}")
 
         metric_keys = ['cer_filewise_avg', 'wer_filewise_avg', 'cer_cumulative', 'wer_cumulative',
                        'ssim_pred_gt_avg', 'ssim_pred_context_avg', 'ssim_gt_context_avg',
                        'ssim_pred_gt_avg_alternate', 'ssim_pred_context_avg_alternate', 'ssim_gt_context_avg_alternate',
-                       'cer_gt_audio_cumulative', 'wer_gt_audio_cumulative'
+                       'cer_gt_audio_cumulative', 'wer_gt_audio_cumulative', 'frechet_codec_distance'
                        ]
         metrics_mean_ci = compute_mean_and_confidence_interval(metrics_n_repeated, metric_keys, confidence=confidence_level)
         all_experiment_csv_with_ci = os.path.join(out_dir, "all_experiment_metrics_with_ci.csv")
         if not os.path.exists(all_experiment_csv_with_ci):
             with open(all_experiment_csv_with_ci, "w") as f:
-                f.write("checkpoint_name,dataset,cer_filewise_avg,wer_filewise_avg,cer_cumulative,wer_cumulative,ssim_pred_gt_avg,ssim_pred_context_avg,ssim_gt_context_avg,ssim_pred_gt_avg_alternate,ssim_pred_context_avg_alternate,ssim_gt_context_avg_alternate,cer_gt_audio_cumulative,wer_gt_audio_cumulative\n")
+                f.write("checkpoint_name,dataset,cer_filewise_avg,wer_filewise_avg,cer_cumulative,wer_cumulative,ssim_pred_gt_avg,ssim_pred_context_avg,ssim_gt_context_avg,ssim_pred_gt_avg_alternate,ssim_pred_context_avg_alternate,ssim_gt_context_avg_alternate,cer_gt_audio_cumulative,wer_gt_audio_cumulative,frechet_codec_distance\n")
         with open(all_experiment_csv_with_ci, "a") as f:
-            f.write(f"{checkpoint_name},{dataset},{metrics_mean_ci['cer_filewise_avg']},{metrics_mean_ci['wer_filewise_avg']},{metrics_mean_ci['cer_cumulative']},{metrics_mean_ci['wer_cumulative']},{metrics_mean_ci['ssim_pred_gt_avg']},{metrics_mean_ci['ssim_pred_context_avg']},{metrics_mean_ci['ssim_gt_context_avg']},{metrics_mean_ci['ssim_pred_gt_avg_alternate']},{metrics_mean_ci['ssim_pred_context_avg_alternate']},{metrics_mean_ci['ssim_gt_context_avg_alternate']},{metrics_mean_ci['cer_gt_audio_cumulative']},{metrics_mean_ci['wer_gt_audio_cumulative']}\n")
+            f.write(f"{checkpoint_name},{dataset},{metrics_mean_ci['cer_filewise_avg']},{metrics_mean_ci['wer_filewise_avg']},{metrics_mean_ci['cer_cumulative']},{metrics_mean_ci['wer_cumulative']},{metrics_mean_ci['ssim_pred_gt_avg']},{metrics_mean_ci['ssim_pred_context_avg']},{metrics_mean_ci['ssim_gt_context_avg']},{metrics_mean_ci['ssim_pred_gt_avg_alternate']},{metrics_mean_ci['ssim_pred_context_avg_alternate']},{metrics_mean_ci['ssim_gt_context_avg_alternate']},{metrics_mean_ci['cer_gt_audio_cumulative']},{metrics_mean_ci['wer_gt_audio_cumulative']},{metrics_mean_ci['frechet_codec_distance']}\n")
             print(f"Wrote metrics with CI for {checkpoint_name} and {dataset} to {all_experiment_csv_with_ci}")
 
 def main():


### PR DESCRIPTION
This PR adds the Fréchet Codec Distance metric. This is a new metric we are experimenting with which is based on the Fréchet Inception Distance (FID).

We compute the distance between the distribution of real codec frames and generated codec frames. The distance is computed in the (dequantized) embedding space of the codec.

Note that FD distances are computed at the dataset level. The number of real and generated frames should large for a reliable metric.

The metric is now called from `infer_and_evaluate.py` and included in our standard set of reported metrics.