### PR TITLE
Bugfix in load_state_dict()

### DIFF
--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -264,8 +264,9 @@ class MagpieTTSModel(ModelPT):
                 # Ex: state_dict[encoder.position_embeddings.weight] -> new_state_dict[position_embeddings.weight]
                 new_state_dict = {}
                 for key in state_dict.keys():
-                    if key.startswith(f"{name}."):
-                        new_state_dict[key[len(name)+1:]] = state_dict[key]  # +1 for '.'
+                    name_with_dot = f"{name}."
+                    if key.startswith(name_with_dot):
+                        new_state_dict[key[len(name_with_dot):]] = state_dict[key]
                 child.load_state_dict(new_state_dict)
 
     def audio_to_codes(self, audio, audio_len, audio_type='target'):

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -264,7 +264,7 @@ class MagpieTTSModel(ModelPT):
                 # Ex: state_dict[encoder.position_embeddings.weight] -> new_state_dict[position_embeddings.weight]
                 new_state_dict = {}
                 for key in state_dict.keys():
-                    if key.startswith(name):
+                    if key.startswith(f"{name}."):
                         new_state_dict[key[len(name)+1:]] = state_dict[key]  # +1 for '.'
                 child.load_state_dict(new_state_dict)
 


### PR DESCRIPTION
In `load_state_dict()`, the check for child parameters would sometimes detect incorrect keys. For example, a key named `local_transformer_out_projections.2.weight` would get detected as a child of `local_transformer` -- but it isn't. This was making LT checkpoints not load. Fixed by ensuring the prefix ends with at `.` to make sure it's a module name.