### PR TITLE
Cherry-pick `[automodel] fallback FP8 + LCE -> FP8 + CE`  (#13349) into `r2.3.0`

### DIFF
--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -923,7 +923,6 @@ jobs:
     with:
       RUNNER: azure-gpu-vm-runner1-h100
       SCRIPT: L2_HF_Transformer_PEFT_2gpu_FSDP2_fp8
-      IS_OPTIONAL: true
 
   L2_HF_Transformer_PEFT_2gpu_FSDP2:
     needs: [pre-flight, cicd-test-container-build]
@@ -973,7 +972,6 @@ jobs:
     with:
       RUNNER: azure-gpu-vm-runner1-h100
       SCRIPT: L2_HF_Transformer_SFT_2gpu_FSDP2_fp8
-      IS_OPTIONAL: true
 
   L2_HF_Transformer_SFT_2gpu_nemorun:
     needs: [pre-flight, cicd-test-container-build]

--- a/nemo/collections/llm/gpt/model/hf_auto_model_for_causal_lm.py
+++ b/nemo/collections/llm/gpt/model/hf_auto_model_for_causal_lm.py
@@ -233,6 +233,14 @@ class HFAutoModelForCausalLM(pl.LightningModule, io.IOMixin, fn.FNMixin):
 
             te_accelerate(self.model, self.model_accelerator.fp8_autocast)
 
+        if self.use_linear_ce_loss:
+            # scan the model for fp8 layers, if found disable lce
+            for module in self.model.modules():
+                if hasattr(module, 'fp8'):
+                    logging.warning("LCE does not support FP8, switching to regular CE.")
+                    self.use_linear_ce_loss = False
+                    break
+
         if self.enable_grad_ckpt:
             if getattr(self.model, 'supports_gradient_checkpointing', False):
                 self.model.gradient_checkpointing_enable()

--- a/tests/functional_tests/L2_HF_Transformer_PEFT_2gpu_FSDP2_fp8.sh
+++ b/tests/functional_tests/L2_HF_Transformer_PEFT_2gpu_FSDP2_fp8.sh
@@ -1,7 +1,7 @@
 export TRANSFORMERS_OFFLINE=1
 export HF_HOME=/home/TestData/automodel/hf_home
 coverage run -a --data-file=/workspace/.coverage --source=/workspace/nemo examples/llm/peft/automodel.py \
-    --model /home/TestData/akoumparouli/hf_mixtral_2l/ \
+    --model /home/TestData/akoumparouli/hf_gemma_38m/ \
     --max-steps 3 \
     --devices 2 \
     --strategy fsdp2 --fp8


### PR DESCRIPTION
Cherry-pick `[automodel] fallback FP8 + LCE -> FP8 + CE`  (#13349) into `r2.3.0`


---------

> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
