### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `d6eb60b...` (2025-05-14)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "a3609eeaffab384826a1380d511ffffb4ff2be47"
+      "ref": "d6eb60b5ea1efca47401c0be97f456fbe3a55bcd"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `d6eb60b5ea1efca47401c0be97f456fbe3a55bcd`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.