### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `a48a42f...` (2025-05-14)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "6d628ec7c05c636512c7321da33d55aad9ea498d"
+      "ref": "a48a42fdda6eb0e089fc23575a05517b5b35f007"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `a48a42fdda6eb0e089fc23575a05517b5b35f007`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.