### PR TITLE
Added packed sequence and sequence parallel to qwen2vl

### DIFF
--- a/scripts/vlm/qwen2vl_finetune.py
+++ b/scripts/vlm/qwen2vl_finetune.py
@@ -91,6 +91,7 @@ def main(args):
             tokenizer=tokenizer,
             image_processor=image_processor,
             num_workers=1,
+            packed_sequence=args.use_packed_sequence, 			
         )
     elif args.data_type == "energon":
         from nemo.collections.multimodal.data.energon import EnergonMultiModalDataModule
@@ -288,6 +289,11 @@ if __name__ == "__main__":
     parser.add_argument('--enable_sp', action='store_true', help="enable sequence parallel")
     parser.add_argument(
         "--max_sequence_length", type=int, required=False, default=4096, help="Maximum sequence length"
+    )
+    parser.add_argument(
+        "--use_packed_sequence",
+        action="store_true",
+        help="enable sequence parallel"
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

This PR follow neva implmentation and add packed sequence and sequence parallel to qwen2vl

**Collection**:  `qwen2vl`

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- usage example

```bash
cd /path/to/NeMo

torchrun --nproc_per_node=2 scripts/vlm/qwen2vl_finetune.py \
    --devices=2 --tp_size=2 --pp_size=1 \
    --enable_sp --use_packed_sequence \
    --data_type=qwen2vl \
    --lr 0.00005 \
    --max_sequence_length 8192 \
    --gbs 8 --mbs 2 --max_steps 300 \
    --data_path="/projects/dataset/train.json" \
    --image_folder="/projects/dataset/images" 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

@yaoyu-33 

# Additional Information

- Related to # (issue)
