### PR TITLE
Unconstrain protobuf

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -4,7 +4,7 @@ numba==0.61.0
 numpy>=1.22
 onnx>=1.7.0
 # Align with upstream PyTorch requirements
-protobuf==4.24.4
+protobuf>=4.24.4,<5
 python-dateutil
 ruamel.yaml
 scikit-learn


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Unconstrains protobuf 4.x (>=4.24). Previous [PR ](https://github.com/NVIDIA/NeMo/pull/12515) mentioned alignment with pytorch. Pytorch requires >3.12.2. Support for >4.24 allows for support in environments including KServe ([reqs](https://github.com/kserve/kserve/blob/02762855b46efc536f8c92b208c83e96fd22a3fd/python/kserve/pyproject.toml#L45))

# Changelog

- Unconstrain protobuf in requirements.txt

# Usage

- N/A

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
