### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `435bf8d...` (2025-05-15)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "a48a42fdda6eb0e089fc23575a05517b5b35f007"
+      "ref": "435bf8d3c4c68fcfa318ac5863fa7a9c22dae147"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `435bf8d3c4c68fcfa318ac5863fa7a9c22dae147`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.