### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `8416bff...` (2025-05-15)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "d6eb60b5ea1efca47401c0be97f456fbe3a55bcd"
+      "ref": "8416bff56a06771834be00327e1523aff4b20f88"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `8416bff56a06771834be00327e1523aff4b20f88`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.