### PR TITLE
Bump nvidia-modelopt to 0.29.0

### DIFF
--- a/docker/common/install_dep.sh
+++ b/docker/common/install_dep.sh
@@ -301,7 +301,7 @@ extra() {
     "llama-index==0.10.43"                                                                     # incompatible with nvidia-pytriton
     "ctc_segmentation==1.7.1 ; (platform_machine == 'x86_64' and platform_system != 'Darwin')" # requires numpy<2.0.0 to be installed before
     "nemo_run"
-    "nvidia-modelopt[torch]==0.27.1 ; platform_system != 'Darwin'"                             # We want a specific version of nvidia-modelopt
+    "nvidia-modelopt[torch]==0.29.0 ; platform_system != 'Darwin'"                             # We want a specific version of nvidia-modelopt
   )
   if [[ "${NVIDIA_PYTORCH_VERSION}" != "" ]]; then
     DEPS+=(

--- a/requirements/requirements_nlp.txt
+++ b/requirements/requirements_nlp.txt
@@ -12,7 +12,7 @@ matplotlib>=3.3.2
 megatron_core
 nltk>=3.6.5
 numpy<2  # tensorstore has an implicit compiled dependency on numpy<2
-nvidia-modelopt[torch]>=0.23.2,<=0.27.1 ; platform_system != 'Darwin'
+nvidia-modelopt[torch]>=0.25.0,<=0.29.0 ; platform_system != 'Darwin'
 nvidia-resiliency-ext>=0.3.0,<1.0.0; platform_system != 'Darwin'
 opencc
 pangu


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Bump nvidia-modelopt to 0.29.0

**Collection**: [Note which collection this PR will affect]

# Changelog

- Bump nvidia-modelopt to 0.29.0

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Needed for https://github.com/NVIDIA/NeMo/pull/12863
