### PR TITLE
Compatibility between TensorBoard and W&B logging

### DIFF
--- a/nemo/utils/exp_manager.py
+++ b/nemo/utils/exp_manager.py
@@ -219,6 +219,7 @@ class ExpManagerConfig:
     resume_from_checkpoint: Optional[str] = None
     # Logging parameters
     create_tensorboard_logger: Optional[bool] = True
+    tensorboard_resume: Optional[bool] = True
     summary_writer_kwargs: Optional[Dict[Any, Any]] = None
     create_wandb_logger: Optional[bool] = False
     wandb_logger_kwargs: Optional[Dict[Any, Any]] = None
@@ -661,6 +662,7 @@ def exp_manager(trainer: 'lightning.pytorch.Trainer', cfg: Optional[Union[DictCo
             cfg.version,
             cfg.checkpoint_callback_params,
             cfg.create_tensorboard_logger,
+            cfg.tensorboard_resume,
             cfg.summary_writer_kwargs,
             cfg.create_wandb_logger,
             cfg.wandb_logger_kwargs,
@@ -1180,6 +1182,7 @@ def configure_loggers(
     version: str,
     checkpoint_callback_params: dict,
     create_tensorboard_logger: bool,
+    tensorboard_resume: bool,
     summary_writer_kwargs: dict,
     create_wandb_logger: bool,
     wandb_kwargs: dict,
@@ -1208,6 +1211,17 @@ def configure_loggers(
                 "is handled by lightning's "
                 "TensorBoardLogger logger."
             )
+        if tensorboard_resume:
+            assert version is None, "version must be None when tensorboard_resume is True"
+            # force an arbitrary version to ensure all logs are written to the same directory.
+            version = 0
+
+            # alternatively, we could try to find the latest version in the tensorboard directory, e.g.:
+            if False:
+                # find the latest version in the tensorboard directory
+                tb_root_dir = os.path.join(exp_dir, name)
+                versions = [int(d.replace("version_", "")) for d in os.listdir(tb_root_dir) if d.startswith("version_")]
+                version = max(versions) if versions else 0                
         tensorboard_logger = TensorBoardLogger(save_dir=exp_dir, name=name, version=version, **summary_writer_kwargs)
         logger_list.append(tensorboard_logger)
         logging.info("TensorboardLogger has been set up")


### PR DESCRIPTION
We currently don't have a good way for W&B and TensorBoard (TB) to work together because
- if we don't explicitly set `exp_manager.version` then Lightning ends up creating a separate TB directory for each run which results in different-colored plots per run. We don't usually want that, especially when running multiple 4-hour jobs which are really the same experiment.
- if we do set `exp_manager.version=0` it ends up confusing W&B which appears to end up using the provided version as the ID and then all experiments (even ones with different names) end up overwriting each other.

The solution suggested here is to add a config flag named `tensorboard_resume`. If set to true (I suggest to make that the default in the `ExpManagerConfig` class but we don't have to) then the **TB** version will get forced to `0`, resulting in all TB logs getting written to the same directory, but W&B not affected.

We could go fancier and try to detect the most recent TB version but that would mean we have to make assumptions on how Lightning names those, so not sure it's worth it. I gave an example of that under `if False` [here](https://github.com/NVIDIA/NeMo/compare/magpietts_2503...rfejgin:NeMo:magpietts_2503_tensorboard_wandb_compat?expand=1#diff-cacb4d3cf39593d980bcfcd9c7ed4b9a342b9565c5447511758daf1f02e0f60fR1220); but probably better to just leave the version at `0`. 

This is a draft pull request because it's only minimally tested, but I wanted to first run it by you.

@blisc @paarthneekhara: what do you think?
