### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `f98b1a0...` (2025-05-17)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "435bf8d3c4c68fcfa318ac5863fa7a9c22dae147"
+      "ref": "f98b1a008b766d50c23fd3a5798a7ea8cdeb4504"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `f98b1a008b766d50c23fd3a5798a7ea8cdeb4504`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.