### PR TITLE
Cherry-pick `Update t5.py` (#13082) to `r2.3.0` and `bump mcore to f98b1a0` 

### DIFF
--- a/nemo/collections/llm/t5/model/t5.py
+++ b/nemo/collections/llm/t5/model/t5.py
@@ -170,7 +170,7 @@ class T5Config(TransformerConfig, io.IOMixin):
     bias_dropout_fusion: bool = True
     deallocate_pipeline_outputs: bool = True
     pipeline_model_parallel_split_rank: int = 0
-    num_moe_experts: int = 1
+    num_moe_experts: Optional[int] = None
     recompute_num_layers: int = 1
     distribute_saved_activations: bool = False
     enable_autocast: bool = False

--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "3cdfd613e68e8b734a3b9e28de579daaf81f4503"
+      "ref": "f98b1a008b766d50c23fd3a5798a7ea8cdeb4504"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
# What does this PR do ?

Cherry-pick `Update t5.py` (#13082) to `r2.3.0`

This looks like something we need based on the Mcore cherry-picks to its release branch. Here are tests running against the latest Mcore release branch commit.
https://github.com/NVIDIA/NeMo/actions/runs/15090534032

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
