### PR TITLE
Changing the tokenizer from Scout to Maverick in the pretrain LLAMA4 …

### DIFF
--- a/scripts/performance/llm/pretrain_llama4_e128.py
+++ b/scripts/performance/llm/pretrain_llama4_e128.py
@@ -72,7 +72,7 @@ def override_recipe_configs(
     )
 
     # data module configs
-    recipe.data.tokenizer = hf_tokenizer('meta-llama/Llama-4-Scout-17B-16E-Instruct')
+    recipe.data.tokenizer = hf_tokenizer('meta-llama/Llama-4-Maverick-17B-128E-Instruct')
 
     # compute dtype configs
     if args.compute_dtype.lower() == "fp8":


### PR DESCRIPTION
Making the change to the tokenizer from Scout to Maverick. It was verified that both have the same vocab size. 
```
from transformers import AutoTokenizer

# Scout
tokenizer_scout = AutoTokenizer.from_pretrained("meta-llama/Llama-4-Scout-17B-16E-Instruct")
print("Scout's Vocab Size:",tokenizer_scout.vocab_size)

# Maverick
tokenizer_maverick = AutoTokenizer.from_pretrained("meta-llama/Llama-4-Maverick-17B-128E-Instruct")
print("Maverick's Vocab Size:",tokenizer_maverick.vocab_size)
```
```
Scout's Vocab Size: 200000
Maverick's Vocab Size: 200000
```
