### PR TITLE
Remove is-optional marker for L2_NeMo_2_EVAL

### DIFF
--- a/.github/workflows/cicd-main-export-deploy.yml
+++ b/.github/workflows/cicd-main-export-deploy.yml
@@ -85,7 +85,6 @@ jobs:
             runner: self-hosted-azure-gpus-1
           - script: L2_NeMo_2_EVAL
             runner: self-hosted-azure-gpus-1
-            is-optional: true
     needs: [unit-tests]
     runs-on: ${{ matrix.runner }}
     name: ${{ matrix.is_optional && 'PLEASEFIXME_' || '' }}${{ matrix.script }}

--- a/tests/functional_tests/L0_Unit_Tests_Eval.sh
+++ b/tests/functional_tests/L0_Unit_Tests_Eval.sh
@@ -13,4 +13,5 @@
 # limitations under the License.
 export HF_DATASETS_OFFLINE=1
 export HF_HOME=/home/TestData/HF_HOME
+export HF_DATASETS_CACHE=${HF_HOME}/datasets
 coverage run -a --data-file=/workspace/.coverage --source=/workspace/nemo -m pytest tests/evaluation/eval_unittest.py -m "not pleasefixme"


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Makes L2_NeMo_2_EVAL a required test and specifies HF_DATASETS_CACHE variable for L0_Unit_Tests_Eval. These changes were accidentally missed in #13658 

**Collection**: llm

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
