### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `20304a3...` (2025-05-23)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "8416bff56a06771834be00327e1523aff4b20f88"
+      "ref": "20304a309c1c44b9183c349eb110a5156c2eb84f"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `20304a309c1c44b9183c349eb110a5156c2eb84f`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.