### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `7094270...` (2025-05-24)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "a845aa7e12b3a117e24c2352b9e3e60bad2e3a17"
+      "ref": "7094270c6fa1dbc6b2e99072171e3a559ca36d0f"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `7094270c6fa1dbc6b2e99072171e3a559ca36d0f`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.