### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `1e05700...` (2025-05-26)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "8416bff56a06771834be00327e1523aff4b20f88"
+      "ref": "1e057005959b75e8bc62f610a335bd03080bc659"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `1e057005959b75e8bc62f610a335bd03080bc659`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.