### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `42ccbb8...` (2025-05-27)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "1e057005959b75e8bc62f610a335bd03080bc659"
+      "ref": "42ccbb8e107e0fbe354b9de985eb0186099ac454"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `42ccbb8e107e0fbe354b9de985eb0186099ac454`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.