### PR TITLE
Disable local gradient checker in performance scripts

### DIFF
--- a/scripts/performance/utils.py
+++ b/scripts/performance/utils.py
@@ -406,6 +406,10 @@ def set_primary_perf_configs(
             recipe.model.config.recompute_num_layers is None
         ), "recompute_num_layers must be None when recompute_modules is provided"
 
+    # Disable local gradient checker at non-debugging mode
+    recipe.trainer.strategy.ddp.check_for_nan_in_grad = False
+    recipe.trainer.strategy.ddp.check_for_large_grads = False
+
     return recipe
 
 


### PR DESCRIPTION
# What does this PR do ?

Disable per-DP rank gradient checking in the performance script, which is only needed for debugging.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Disable per-DP rank NaN and inf checking.

# Usage

- Set by default

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
