### PR TITLE
Add option to construct Llama model with Transformer Engine op fuser

### DIFF
--- a/nemo/collections/llm/gpt/model/base.py
+++ b/nemo/collections/llm/gpt/model/base.py
@@ -153,12 +153,15 @@ def transformer_engine_layer_spec(config: "GPTConfig") -> ModuleSpec:
     """
     from megatron.core.models.gpt import gpt_layer_specs
 
-    return gpt_layer_specs.get_gpt_layer_with_transformer_engine_spec(
-        num_experts=config.num_moe_experts,
-        moe_grouped_gemm=config.moe_grouped_gemm,
-        qk_layernorm=config.qk_layernorm,
-        fp8=bool(config.num_moe_experts and (config.fp8 is not None)),
-    )
+    kwargs = {
+        "num_experts": config.num_moe_experts,
+        "moe_grouped_gemm": config.moe_grouped_gemm,
+        "qk_layernorm": config.qk_layernorm,
+        "fp8": bool(config.num_moe_experts and (config.fp8 is not None)),
+    }
+    if getattr(config, "use_transformer_engine_op_fuser", None) is not None:
+        kwargs["use_te_op_fuser"] = config.use_transformer_engine_op_fuser
+    return gpt_layer_specs.get_gpt_layer_with_transformer_engine_spec(**kwargs)
 
 
 def transformer_engine_full_layer_spec(config: "GPTConfig") -> ModuleSpec:

--- a/nemo/collections/llm/gpt/model/llama.py
+++ b/nemo/collections/llm/gpt/model/llama.py
@@ -79,6 +79,7 @@ class LlamaConfig(GPTConfig):
     persist_layer_norm: bool = True
     bias_dropout_fusion: bool = True
     apply_rope_fusion: bool = True
+    use_transformer_engine_op_fuser: Optional[bool] = None
 
 
 @dataclass


### PR DESCRIPTION
# What does this PR do ?

This PR exposes Megatron-core integration with Transformer Engine's operation fuser. This is an experimental feature.

**Collection**: NLP

# Changelog

- Expose Megatron-core integration with Transformer Engine's operation fuser.

# Usage

```python
from nemo.collections import llm
from nemo.collections.llm.gpt.model import LlamaModel

config = llm.Llama2Config70B(..., use_transformer_engine_op_fuser=True)
model = LlamaModel(config, ...)
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- This option requires a change that has not yet merged into Megatron-LM. However, old version of Megatron-LM will work as long as the option is not explicitly set.