### PR TITLE
fix: improve sequence length handling to fix nan in loss when turning on cudagraph

### DIFF
--- a/nemo/collections/llm/gpt/data/core.py
+++ b/nemo/collections/llm/gpt/data/core.py
@@ -880,8 +880,13 @@ class GPTSFTPackedDataset(GPTSFTDataset):
                 # If padding, use the global max seqlen, so that 'pad_cu_seqlens' is the same
                 # across all batches. This is maintly used compatiblity with megatron's implementation
                 # of cudagraphs, which uses the same cudagraphs over all batches.
-                max_seqlen = [max(p["dataset_max_seqlen"] for p in self.pack_metadata)]
-                max_seqlen = torch.IntTensor(max_seqlen * len(cu_seqlens))
+                dataset_max_seqlen = max(p['dataset_max_seqlen'] for p in self.pack_metadata)
+                min_pack_seq_len = min(p['min_packed_seqlen'] for p in self.pack_metadata)
+                padding_gap = max_length - min_pack_seq_len
+                
+                # Use the larger of the two values to avoid NAN issues with attention kernel
+                safe_max_seqlen = max(dataset_max_seqlen, padding_gap)
+                max_seqlen = torch.IntTensor([safe_max_seqlen] * len(cu_seqlens))
             else:
                 seqlens = cu_seqlens[:, 1:] - cu_seqlens[:, :-1]
                 max_seqlen, _ = seqlens.max(dim=1, keepdim=True)

--- a/nemo/utils/sequence_packing_utils.py
+++ b/nemo/utils/sequence_packing_utils.py
@@ -173,12 +173,14 @@ def create_packing_strategy(
 
     max_seqlen = max(all_seq_lens)
     max_samples_per_bin = max([len(b) for b in assignments])
+    min_packed_seqlen = min(packed_seq_lens)
     packing_metadata = {
         "dataset_max_seqlen": max_seqlen,
         "max_samples_per_bin": max_samples_per_bin,
         "packing_factor": round(packing_factor, 2),
         "packing_efficiency": round(sum(packed_seq_lens) / len(packed_seq_lens) / pack_size * 100, 2),
         "pack_size": pack_size,
+        'min_packed_seqlen': min_packed_seqlen
     }
     logging.debug("Packed sequence lengths:")
     logging.debug(packed_seq_lens)


### PR DESCRIPTION

> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Enhance max_seqlen calculation in nemo.collections.llm.gpt.data.core GPTSFTPackedDataset to prevent NAN issues when turning on cuda graph

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
