### PR TITLE
[Build] Bump bitsandbytes dependency to 0.45.5 (ubuntu 22.04 compatibility)

### DIFF
--- a/requirements/requirements_automodel.txt
+++ b/requirements/requirements_automodel.txt
@@ -1,2 +1,2 @@
-bitsandbytes==0.45.3 ; (platform_machine == 'x86_64' and platform_system != 'Darwin')
+bitsandbytes==0.45.5 ; (platform_machine == 'x86_64' and platform_system != 'Darwin')
 # liger-kernel ; (platform_machine == 'x86_64' and platform_system != 'Darwin')


### PR DESCRIPTION
## What does this PR do ?

Update `bitsandbytes` to newer version `0.45.5` to avoid the compatibility with Ubuntu 22.04
**Collection**: automodel 

## Changelog

* See discussion in the issue bitsandbytes-foundation/bitsandbytes/issues/1663 and internal #swdl-nemo-framework slack channel
* In summary:
  * `v0.45.3` was using Ubuntu 24.04 which brings `gcc-13` and newer glibcxx dependency
  * `v0.45.4` is missing `libbitsandbytes_cpu.so` and hence one needs to use at least `v0.45.5` to ensure compatibility with Ubuntu 22.04 and use the CPU backend.
* This is required when using nemo/nemo-run on login nodes of cluster where gpus not available and we end-up error like:
```console
python3 -m scripts.performance.llm.pretrain_llama31 -a gcore -p main -t 00:30:00 -l /root/dgx-stage-last-tag/ -i /root/dgx-stage-last-tag//nvidia+nemo+25.02.01.sqsh ...
No CUDA runtime is found, using CUDA_HOME='/usr/local/cuda'
Could not load bitsandbytes native library: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /root/dgx-stage-last-tag/venv/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cpu.so)
Traceback (most recent call last):
  File "/root/dgx-stage-last-tag/venv/lib/python3.10/site-packages/bitsandbytes/cextension.py", line 85, in <module>
    lib = get_native_library()
  File "/root/dgx-stage-last-tag/venv/lib/python3.10/site-packages/bitsandbytes/cextension.py", line 72, in get_native_library
    dll = ct.cdll.LoadLibrary(str(binary_path))
  File "/usr/lib/python3.10/ctypes/__init__.py", line 452, in LoadLibrary
    return self._dlltype(name)
  File "/usr/lib/python3.10/ctypes/__init__.py", line 374, in __init__
    self._handle = _dlopen(self._name, mode)
OSError: /lib/x86_64-linux-gnu/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by /root/dgx-stage-last-tag/venv/lib/python3.10/site-packages/bitsandbytes/libbitsandbytes_cpu.so)
```

## Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
  
**PR Type**:

- [x] Bugfix

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.

## Additional Information

- As far as I see from bitsandbytes release notes, upgrade from 0.45.3 doesn't have any major changes ([1](https://github.com/bitsandbytes-foundation/bitsandbytes/releases/tag/0.45.5), [2](https://github.com/bitsandbytes-foundation/bitsandbytes/releases/tag/0.45.4)).