### PR TITLE
ci: Ensure approval queue fetches all CICD workflows using pagnation

### DIFF
--- a/.github/workflows/cicd-approve-test-queue.yml
+++ b/.github/workflows/cicd-approve-test-queue.yml
@@ -69,17 +69,40 @@ jobs:
                   else:
                       response = requests.post(url, headers=headers, json=data)
                   response.raise_for_status()
-                  return response.json()
+                  response_json = response.json()
+                  if hasattr(response, "links"):
+                      response_json["next"] = response.links.get("next", {}).get("url")
+
+                  return response_json
               except requests.exceptions.RequestException as e:
                   print(f"Error making request to {endpoint}: {str(e)}")
                   if hasattr(e.response, 'text'):
                       print(f"Response: {e.response.text}")
                   return None
 
+
+          def get_workflow_runs(status):
+              """Get all workflow runs for a given status."""
+              all_results = []
+              endpoint = f"actions/runs?status={status}"
+              while endpoint:
+                  response = make_request(endpoint)
+                  if not response:
+                      break
+
+                  all_results.extend(response.get("workflow_runs", []))
+                  endpoint = None
+                  next_url = response.get("next")
+                  if next_url:
+                      endpoint = f"actions/runs?{next_url.split('?')[1]}"
+
+              return all_results
+
+
           # Get current running and queued workflows
           print("Fetching workflow runs...")
-          queued_workflow_runs = make_request("actions/runs?status=queued").get("workflow_runs", [])
-          in_progress_workflow_runs = make_request("actions/runs?status=in_progress").get("workflow_runs", [])
+          queued_workflow_runs = get_workflow_runs("queued")
+          in_progress_workflow_runs = get_workflow_runs("in_progress")
 
           # Count running and queued workflows
           queued_workflows = sum(1 for run in queued_workflow_runs if run["name"] == "CICD NeMo")
@@ -97,7 +120,7 @@ jobs:
 
           # Get waiting CI workflows for test environment
           print("Fetching deployments...")
-          pending_workflows = make_request("actions/runs?status=waiting").get("workflow_runs", [])
+          pending_workflows = get_workflow_runs("waiting")
           pending_workflows = [run for run in pending_workflows if run["name"] == "CICD NeMo"]
 
           # Sort deployments by creation date (oldest first)


### PR DESCRIPTION
# What does this PR do ?

 Ensure approval queue fetches all CICD workflows using pagnation

When there's other workflows being queued, we do not capture the full list of CICD workflows due to pagination.  So the approval bot would add more CICD workflows to process than it should.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
