### PR TITLE
ci: make_request in approval test queue appends next url for status checks only

### DIFF
--- a/.github/workflows/cicd-approve-test-queue.yml
+++ b/.github/workflows/cicd-approve-test-queue.yml
@@ -70,7 +70,7 @@ jobs:
                       response = requests.post(url, headers=headers, json=data)
                   response.raise_for_status()
                   response_json = response.json()
-                  if hasattr(response, "links"):
+                  if hasattr(response, "links") and "actions/runs?status" in endpoint:
                       response_json["next"] = response.links.get("next", {}).get("url")
 
                   return response_json


### PR DESCRIPTION
# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

Update make_request in approval test queue to append next url for status checks only

The approval workflow was failing for when a request was made for non-status checks. Other responses from the api such as for the pending-deployments request were returned as a list.

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
