### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `7711014...` (2025-06-04)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "7094270c6fa1dbc6b2e99072171e3a559ca36d0f"
+      "ref": "771101474fb1e881a3a62deeca88ecb4f494761c"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `771101474fb1e881a3a62deeca88ecb4f494761c`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.