### PR TITLE
Fix num_codebooks in Group RVQ

### DIFF
--- a/nemo/collections/tts/modules/encodec_modules.py
+++ b/nemo/collections/tts/modules/encodec_modules.py
@@ -847,6 +847,7 @@ class GroupResidualVectorQuantizer(VectorQuantizerBase):
     def __init__(self, num_codebooks: int, num_groups: int, codebook_dim: int, **kwargs):
         super().__init__()
 
+        self._num_codebooks = num_codebooks
         self.num_groups = num_groups
         self.codebook_dim = codebook_dim
 
@@ -870,7 +871,7 @@ class GroupResidualVectorQuantizer(VectorQuantizerBase):
     @property
     def num_codebooks(self):
         """Returns the number of codebooks."""
-        return self.num_groups
+        return self._num_codebooks
 
     @property
     def codebook_size(self):

--- a/tests/collections/tts/modules/test_audio_codec_modules.py
+++ b/tests/collections/tts/modules/test_audio_codec_modules.py
@@ -240,7 +240,6 @@ class TestResidualVectorQuantizer:
             torch.testing.assert_close(indices_enc, indices_fw, msg=f'example {i}: indices mismatch')
             torch.testing.assert_close(dequantized_dec, dequantized_fw, msg=f'example {i}: dequantized mismatch')
 
-    @pytest.mark.pleasefixme
     @pytest.mark.unit
     @pytest.mark.parametrize('num_groups', [1, 2, 4])
     @pytest.mark.parametrize('num_codebooks', [1, 4])


### PR DESCRIPTION
Previous PR https://github.com/blisc/NeMo/pull/65 incorrectly defined num_codebooks for the GroupRVQ.

In GroupRVQ, there is an embedding of size `codebook_dim` which is split into `num_groups` smaller embeddings. Each of these smaller embeddings then has (num_codebooks / num_groups) recursive RVQ codebooks.