### PR TITLE
[magpietts] added logging of consumed samples at each training step.

### DIFF
--- a/examples/tts/conf/magpietts/magpietts_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_dc_en.yaml
@@ -165,5 +165,6 @@ exp_manager:
     save_top_k: 5
     save_best_model: true
     always_save_nemo: true
+    filename: '${name}--{${exp_manager.checkpoint_callback_params.monitor}:.4f}-{step}-{epoch}-{consumed_samples:.0f}'
   resume_if_exists: true
   resume_ignore_no_checkpoint: true

--- a/examples/tts/conf/magpietts/magpietts_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_en.yaml
@@ -182,5 +182,6 @@ exp_manager:
     save_top_k: 5
     save_best_model: true
     always_save_nemo: true
+    filename: '${name}--{${exp_manager.checkpoint_callback_params.monitor}:.4f}-{step}-{epoch}-{consumed_samples:.0f}'
   resume_if_exists: true
   resume_ignore_no_checkpoint: true

--- a/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
@@ -182,6 +182,6 @@ exp_manager:
     save_top_k: 5
     save_best_model: true
     always_save_nemo: true
-    filename: '${name}--{${exp_manager.checkpoint_callback_params.monitor}:.4f}-{step}-{epoch}'
+    filename: '${name}--{${exp_manager.checkpoint_callback_params.monitor}:.4f}-{step}-{epoch}-{consumed_samples:.0f}'
   resume_if_exists: true
   resume_ignore_no_checkpoint: true

--- a/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
+++ b/examples/tts/conf/magpietts/magpietts_multilingual_v1.yaml
@@ -226,5 +226,6 @@ exp_manager:
     save_top_k: 5
     save_best_model: true
     always_save_nemo: true
+    filename: '${name}--{${exp_manager.checkpoint_callback_params.monitor}:.4f}-{step}-{epoch}-{consumed_samples:.0f}'
   resume_if_exists: true
   resume_ignore_no_checkpoint: true


### PR DESCRIPTION
The Lhotse dataloader applies dynamic batching based on duration buckets, causing the number of consumed samples at each training step to vary. Tracking the number of consumed samples enables fairer model comparisons than relying solely on training step counts. The Megatron models also tracked consumed samples.

This PR adds sample consumption logs to the wandb UI and appends this information to checkpoint filenames.

**ckpt filename changes**
`MagpieTTS-EN-Lhotse--val_loss=11.7273-step=1350-epoch=26.ckpt -->`
`MagpieTTS-EN-Lhotse--val_loss=11.7273-step=1350-epoch=26-consumed_samples=96466.ckpt`

**wandb UI changes**
![Screenshot 2025-06-05 at 11 52 56 PM](https://github.com/user-attachments/assets/78d324ca-2537-4980-b206-67bea33e52b4)


