### PR TITLE
fix(core): patch missing `multistorageclient` behaviour

### DIFF
--- a/nemo/utils/msc_utils.py
+++ b/nemo/utils/msc_utils.py
@@ -58,5 +58,7 @@ def is_multistorageclient_url(path: Union[str, Path]):
 def import_multistorageclient():
     """Import multistorageclient if it is installed."""
     if not HAVE_MSC:
-        raise ValueError('Multi-Storage Client is not installed. Please install it with "pip install multi-storage-client".')
+        raise ValueError(
+            'Multi-Storage Client is not installed. Please install it with "pip install multi-storage-client".'
+        )
     return msc


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?
Loading a nemo model without `multistorageclient` throws an `AttributeError`.
This happens because we try to read the `types.MSC_PROTOCOL` from attribute from `msc` [here](https://github.com/NVIDIA/NeMo/blob/deb10b513e1036c6b40941993b85b9ccc563f178/nemo/utils/msc_utils.py#L43), but since `msc` is set to None instead of the actual `multistorageclient` module [here](https://github.com/NVIDIA/NeMo/blob/deb10b513e1036c6b40941993b85b9ccc563f178/nemo/utils/msc_utils.py#L25), it raises and `AttributeError`. 

This PR fixes issue #13858 by checking for the MSC protocol prefix properly when `multistorageclient` isn't installed.

**Collection**: [Core]

# Changelog
Sets MSC protocol to `"msc://"` so that it can be checked.

# Usage
Fixes crash on ASR model init.

```python
import nemo.collections.asr as nemo_asr
 asr_model = nemo_asr.models.ASRModel.from_pretrained("nvidia/parakeet-rnnt-0.6b")
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] N/A Did you add or update any necessary documentation?
- [ ] N/A Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?
~@titu1994, @redoctopus, @jbalam-nv, or @okuchaiev~
Update:
I notice that this is not an ASR specific issue.
Tagging core maintainers instead: @ericharper, @titu1994, @blisc, or @okuchaiev

# Additional Information
- Related to #13858 
