### PR TITLE
[magpietts][lhotse_v2] make model training recipe adapt to the latest v2 datasets.

### DIFF
--- a/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
+++ b/examples/tts/conf/magpietts/magpietts_lhotse_dc_en.yaml
@@ -8,7 +8,6 @@ model:
   use_text_conditioning_encoder: false # If true, distilbert will be used to encode context_text if provided.
   context_duration_min: 5.0
   context_duration_max: 5.0
-  codec_model_name: "21fpsCausalDecoder"
   load_cached_codes_if_available: true
   prior_scaling_factor: 0.5
   prior_end_step: 12_000
@@ -64,6 +63,8 @@ model:
 
     dataset:
       min_duration: 0.2
+      min_context_speaker_similarity: 0.6
+      max_cer: 0.03
       batch_duration : ???  # in seconds. Adjust based on your GPU memory.
       quadratic_duration: ${quadratic_duration}
       use_bucketing: true
@@ -90,6 +91,8 @@ model:
 
     dataset:
       min_duration: 0.2
+      min_context_speaker_similarity: 0.6
+      max_cer: 0.03
       batch_duration: ???   # recommend to use smaller batch_duration for validation dataset than training dataset.
       quadratic_duration: ${quadratic_duration}
       use_bucketing: false

--- a/examples/tts/magpietts.py
+++ b/examples/tts/magpietts.py
@@ -59,7 +59,7 @@ def main(cfg):
         model_cfg = cfg.model
         with open_dict(model_cfg):
             model_cfg.reference_model_ckpt_path = cfg.init_from_ptl_ckpt
-        model = MagpieTTSModelOnlinePO(cfg=cfg.model, trainer=trainer)
+        model = MagpieTTSModelOnlinePO(cfg=model_cfg, trainer=trainer)
     elif mode == 'test':
         model = MagpieTTSModelOfflinePODataGen(cfg=cfg.model, trainer=trainer)
     else:

--- a/examples/tts/magpietts.py
+++ b/examples/tts/magpietts.py
@@ -47,31 +47,49 @@ def main(cfg):
     trainer.callbacks.append(pl.callbacks.LearningRateMonitor(logging_interval='step', log_weight_decay=True))
     exp_manager(trainer, cfg.get("exp_manager", None))
 
-    if cfg.get('mode', 'train') == 'train':
+    mode = cfg.get('mode', 'train')
+    if mode == 'train':
         model = MagpieTTSModel(cfg=cfg.model, trainer=trainer)
-    elif cfg.get('mode', 'train') == 'dpo_train':
+    elif mode == 'dpo_train':
         model_cfg = cfg.model
         with open_dict(model_cfg):
             model_cfg.reference_model_ckpt_path = cfg.init_from_ptl_ckpt
         model = MagpieTTSModelOfflinePO(cfg=model_cfg, trainer=trainer)
-    elif cfg.get('mode', 'train') == 'onlinepo_train':
+    elif mode == 'onlinepo_train':
         model_cfg = cfg.model
         with open_dict(model_cfg):
             model_cfg.reference_model_ckpt_path = cfg.init_from_ptl_ckpt
-        model = MagpieTTSModelOnlinePO(cfg=model_cfg, trainer=trainer)
-    elif cfg.get('mode', 'train') == 'test':
+        model = MagpieTTSModelOnlinePO(cfg=cfg.model, trainer=trainer)
+    elif mode == 'test':
         model = MagpieTTSModelOfflinePODataGen(cfg=cfg.model, trainer=trainer)
     else:
-        raise NotImplementedError(f"Only train, dpo_train and test modes are supported. Got {cfg.mode}")
+        raise NotImplementedError(
+            f"Only train, dpo_train, onlinepo_train and test modes are supported. Got {mode}"
+        )
 
     model.maybe_init_from_pretrained_checkpoint(cfg=cfg)
 
-    if cfg.get('mode', 'train') in ['train', 'dpo_train', 'onlinepo_train']:
-        trainer.fit(model)
-    elif cfg.get('mode', 'train') == 'test':
-        trainer.test(model)
-    else:
-        raise NotImplementedError(f"Only train and test modes are supported. Got {cfg.mode}")
+    try:
+        if mode in ['train', 'dpo_train', 'onlinepo_train']:
+            logging.info("Starting training...")
+            trainer.fit(model)
+        elif mode == 'test':
+            logging.info("Starting testing...")
+            trainer.test(model)
+        else:
+            raise NotImplementedError(f"Only train, dpo_train, onlinepo_train and test modes are supported. Got {mode}")
+        logging.info("Training/testing completed successfully.")
+    finally:
+        # Ensure WandB completes all uploads before Python thread shutdown
+        # Critical when num_workers=0 during debugging - the main process can become
+        # overwhelmed and fail to properly coordinate with WandB's background threads
+        try:
+            import wandb
+            if wandb.run is not None:
+                logging.info("Finishing WandB run to prevent threading shutdown hang...")
+                wandb.finish()
+        except Exception as e:
+            logging.warning(f"Error finishing WandB: {e}")
 
 
 if __name__ == '__main__':

--- a/nemo/collections/common/data/lhotse/sampling.py
+++ b/nemo/collections/common/data/lhotse/sampling.py
@@ -262,6 +262,34 @@ class DurationFilter:
         else:
             return True  # does not apply to text etc.
 
+class CERFilter:
+    """
+    Callable, returns ``True`` if a cut's CER is less than max_cer and ``False`` otherwise.
+    Acts as a pass-through for objects of other type than Cut.
+    """
+
+    def __init__(self, max_cer: float | None) -> None:
+        self.max_cer = ifnone(max_cer, float("inf"))
+
+    def __call__(self, example) -> bool:
+        if isinstance(example, Cut) and example.supervisions[0].has_custom("cer"):
+            return example.supervisions[0].cer <= self.max_cer
+        else:
+            return True
+
+class ContextSpeakerSimilarityFilter:
+    """
+    Callable, returns ``True`` if a cut's context speaker similarity is greater than min_context_speaker_similarity and ``False`` otherwise.
+    Acts as a pass-through for objects of other type than Cut.
+    """
+    def __init__(self, min_context_speaker_similarity: float | None) -> None:
+        self.min_context_speaker_similarity = ifnone(min_context_speaker_similarity, -1)
+
+    def __call__(self, example) -> bool:
+        if isinstance(example, Cut) and example.supervisions[0].has_custom("context_speaker_similarity"):
+            return example.supervisions[0].context_speaker_similarity >= self.min_context_speaker_similarity
+        else:
+            return True
 
 class TokenCountFilter:
     """

--- a/nemo/collections/common/data/lhotse/sampling.py
+++ b/nemo/collections/common/data/lhotse/sampling.py
@@ -272,7 +272,7 @@ class CERFilter:
         self.max_cer = ifnone(max_cer, float("inf"))
 
     def __call__(self, example) -> bool:
-        if isinstance(example, Cut) and example.supervisions[0].has_custom("cer"):
+        if isinstance(example, Cut) and len(example.supervisions) > 0 and example.supervisions[0].has_custom("cer"):
             return example.supervisions[0].cer <= self.max_cer
         else:
             return True
@@ -286,7 +286,7 @@ class ContextSpeakerSimilarityFilter:
         self.min_context_speaker_similarity = ifnone(min_context_speaker_similarity, -1)
 
     def __call__(self, example) -> bool:
-        if isinstance(example, Cut) and example.supervisions[0].has_custom("context_speaker_similarity"):
+        if isinstance(example, Cut) and len(example.supervisions) > 0 and example.supervisions[0].has_custom("context_speaker_similarity"):
             return example.supervisions[0].context_speaker_similarity >= self.min_context_speaker_similarity
         else:
             return True

--- a/nemo/collections/tts/data/text_to_speech_dataset_lhotse.py
+++ b/nemo/collections/tts/data/text_to_speech_dataset_lhotse.py
@@ -317,7 +317,7 @@ class MagpieTTSLhotseDataset(torch.utils.data.Dataset):
                 context_audio_list.append(context_audio)
                 context_audio_len_list.append(context_audio_len)
             else:
-                # We always want to have context_audio_codes if available for multi-encoder model. These are ignored for singlencoder model.
+                # We always want to have context_audio_codes if available for multi-encoder model. These are ignored for single-encoder model.
                 # If context audio is not available, just use a dummy context_audio_codes
                 # (Will be used in text context scenario)
                 # TODO @xueyang: verified that this block should cover below 3 conditions which were handled well.

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -1874,12 +1874,7 @@ class MagpieTTSModel(ModelPT):
             # TODO @xueyang: better to distinguish cfg. self.cfg is the model cfg, while cfg here is train_ds cfg. Also
             #   cfg is a classifier-free guidance.
 
-            # specify target sampling rate the same as codec model's because lhotse config defaults 16_000.
-            if not isinstance(dataset_cfg, DictConfig):
-                dataset_cfg = OmegaConf.create(dataset_cfg)
-            OmegaConf.set_struct(dataset_cfg.dataset, False)
-            dataset_cfg.dataset.update({"sample_rate": self.sample_rate})
-            OmegaConf.set_struct(dataset_cfg.dataset, True)
+            self._update_sample_rate_in_config(dataset_cfg)
 
             self._train_dl = self.get_lhotse_dataloader(dataset_cfg, mode='train')
         else:

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -21,7 +21,7 @@ import wandb
 from hydra.utils import instantiate
 from lightning.pytorch import Trainer
 from lightning.pytorch.loggers import TensorBoardLogger, WandbLogger
-from omegaconf import DictConfig, open_dict
+from omegaconf import DictConfig, OmegaConf, open_dict
 from torch import nn
 from torch.utils.data import get_worker_info
 
@@ -1020,13 +1020,13 @@ class MagpieTTSModel(ModelPT):
     def get_binarized_prior_matrix(self, aligner_attn_soft, audio_lens, text_lens):
         # aligner_attn_soft B, 1, audio_timesteps, text_timesteps
         if self.binarize_attn_method == 'nemo_binarize':
-            logging.info("Binarizing attention using nemo_binarize")
+            logging.debug("Binarizing attention using nemo_binarize")
             binarize_repeat_audio_factor = self.binarize_repeat_audio_factor
             aligner_attn_soft_repeated = aligner_attn_soft.repeat_interleave(binarize_repeat_audio_factor, dim=2) # B, 1, 2*audio_timesteps, text_timesteps
             aligner_attn_hard = binarize_attention_parallel(aligner_attn_soft_repeated, text_lens, audio_lens*binarize_repeat_audio_factor).squeeze(1) # B, 2*audio_timesteps, text_timesteps
             aligner_attn_hard = aligner_attn_hard[:, ::2, :] # B, audio_timesteps, text_timesteps
         elif self.binarize_attn_method == 'argmax':
-            logging.info("Binarizing attention using argmax")
+            logging.debug("Binarizing attention using argmax")
             aligner_attn_hard = torch.argmax(aligner_attn_soft.squeeze(1), dim=-1)
             aligner_attn_hard = torch.nn.functional.one_hot(aligner_attn_hard, num_classes=aligner_attn_soft.size(-1)).float()
         else:
@@ -1265,7 +1265,7 @@ class MagpieTTSModel(ModelPT):
         batch_info_dict = {
             "train/batch_size": batch_size,
             "train/text_token_max_len": text_token_max_len,
-            "train/text_token_total_num_in_batch": text_token_total_num,
+            "train/text_token_total_num_in_batch": text_token_total_num.item(),
             "train/text_token_pad_ratio_percent_in_batch": 100 * (1 - text_token_total_num / (batch_size * text_token_max_len)),
         }
 
@@ -1274,7 +1274,7 @@ class MagpieTTSModel(ModelPT):
             audio_codes_total_num = batch["audio_codes_lens"].sum()
             batch_info_dict.update({
                 "train/audio_codes_max_len": audio_codes_max_len,
-                "train/audio_codes_total_num_in_batch": audio_codes_total_num,
+                "train/audio_codes_total_num_in_batch": audio_codes_total_num.item(),
                 "train/audio_codes_pad_ratio_percent_in_batch": 100 * (1 - audio_codes_total_num / (batch_size * audio_codes_max_len)),
             })
         else:
@@ -1282,7 +1282,7 @@ class MagpieTTSModel(ModelPT):
             audio_samples_total_num = batch["audio_lens"].sum()
             batch_info_dict.update({
                 "train/audio_samples_max_len": audio_samples_max_len,
-                "train/audio_samples_total_num_in_batch": audio_samples_total_num,
+                "train/audio_samples_total_num_in_batch": audio_samples_total_num.item(),
                 "train/audio_samples_pad_ratio_percent_in_batch": 100 * (1 - audio_samples_total_num / (batch_size * audio_samples_max_len)),
             })
 
@@ -1846,7 +1846,6 @@ class MagpieTTSModel(ModelPT):
             sample_rate=self.sample_rate,
             volume_norm=dataset_cfg.volume_norm,
             codec_model_samples_per_frame=self.codec_model_samples_per_frame,
-            codec_model_name=self.cfg.codec_model_name,
             audio_bos_id=self.audio_bos_id,
             audio_eos_id=self.audio_eos_id,
             context_audio_bos_id=self.context_audio_bos_id,
@@ -1874,6 +1873,14 @@ class MagpieTTSModel(ModelPT):
         if dataset_cfg.get("use_lhotse", False):
             # TODO @xueyang: better to distinguish cfg. self.cfg is the model cfg, while cfg here is train_ds cfg. Also
             #   cfg is a classifier-free guidance.
+
+            # specify target sampling rate the same as codec model's because lhotse config defaults 16_000.
+            if not isinstance(dataset_cfg, DictConfig):
+                dataset_cfg = OmegaConf.create(dataset_cfg)
+            OmegaConf.set_struct(dataset_cfg.dataset, False)
+            dataset_cfg.dataset.update({"sample_rate": self.sample_rate})
+            OmegaConf.set_struct(dataset_cfg.dataset, True)
+
             self._train_dl = self.get_lhotse_dataloader(dataset_cfg, mode='train')
         else:
             dataset = self.get_dataset(dataset_cfg, dataset_type='train')
@@ -1898,6 +1905,12 @@ class MagpieTTSModel(ModelPT):
 
     def _setup_test_dataloader(self, dataset_cfg) -> torch.utils.data.DataLoader:
         if dataset_cfg.get("use_lhotse", False):
+            # specify target sampling rate the same as codec model's because lhotse config defaults 16_000.
+            if not isinstance(dataset_cfg, DictConfig):
+                dataset_cfg = OmegaConf.create(dataset_cfg)
+            OmegaConf.set_struct(dataset_cfg.dataset, False)
+            dataset_cfg.dataset.update({"sample_rate": self.sample_rate})
+            OmegaConf.set_struct(dataset_cfg.dataset, True)
             data_loader = self.get_lhotse_dataloader(dataset_cfg, mode='test')
         else:
             dataset = self.get_dataset(dataset_cfg, dataset_type='test')
@@ -1920,11 +1933,11 @@ class MagpieTTSModel(ModelPT):
             )
         return data_loader
 
-    def setup_validation_data(self, cfg):
-        self._validation_dl = self._setup_test_dataloader(cfg)
+    def setup_validation_data(self, dataset_cfg):
+        self._validation_dl = self._setup_test_dataloader(dataset_cfg)
 
-    def setup_test_data(self, cfg):
-        self._test_dl = self._setup_test_dataloader(cfg)
+    def setup_test_data(self, dataset_cfg):
+        self._test_dl = self._setup_test_dataloader(dataset_cfg)
 
     @classmethod
     def list_available_models(cls) -> List[PretrainedModelInfo]:

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -1874,7 +1874,12 @@ class MagpieTTSModel(ModelPT):
             # TODO @xueyang: better to distinguish cfg. self.cfg is the model cfg, while cfg here is train_ds cfg. Also
             #   cfg is a classifier-free guidance.
 
-            self._update_sample_rate_in_config(dataset_cfg)
+            # specify target sampling rate the same as codec model's because lhotse config defaults 16_000.
+            if not isinstance(dataset_cfg, DictConfig):
+                dataset_cfg = OmegaConf.create(dataset_cfg)
+            OmegaConf.set_struct(dataset_cfg.dataset, False)
+            dataset_cfg.dataset.update({"sample_rate": self.sample_rate})
+            OmegaConf.set_struct(dataset_cfg.dataset, True)
 
             self._train_dl = self.get_lhotse_dataloader(dataset_cfg, mode='train')
         else:


### PR DESCRIPTION

- change the codes names in cuts into target_codes and context_codes.
- remove `codec_model_name` in yaml config because we've added the codec name in `input_cfg.yaml` file.
- fixed bugs that `spec_len` has extended with bos and eos resulting in unexpected 2 more tokens. Prioritize `normalized_text` over `text` if available.
- added cuts sampling filters in terms of max CER and min context speaker similarity.
- add `sample_rate` overrides the same as codec model's. Without overrides, the audio will be resampled into 16k by default.
- bugfix: ensure start and duration params equal to `None` in `TemporalArray.load(start, duration)` since the audio codes were extracted based on segmented audio.
- downlevel to `logging.warning` since they were verbosed for every step.
- explicitly call `wandb.finish()` after `trainer.fit` or `trainer.test` complete to avoid hangs when debugging with num_worker=0.
- extract numerical value from tensors.