### PR TITLE
Fix single optional import if ModelOpt not installed

### DIFF
--- a/nemo/collections/llm/modelopt/distill/loss.py
+++ b/nemo/collections/llm/modelopt/distill/loss.py
@@ -30,6 +30,7 @@ mtd, _ = safe_import("modelopt.torch.distill")
 
 if TYPE_CHECKING:
     from megatron.core.transformer.transformer_config import TransformerConfig
+
     DistillationLossBalancer, _ = safe_import_from("modelopt.torch.distill", "DistillationLossBalancer", alt=object)
 
 

--- a/nemo/collections/llm/modelopt/distill/loss.py
+++ b/nemo/collections/llm/modelopt/distill/loss.py
@@ -24,12 +24,13 @@ from torch import Tensor
 from torch.nn.modules.loss import _Loss
 
 from nemo.utils import logging
-from nemo.utils.import_utils import safe_import
+from nemo.utils.import_utils import safe_import, safe_import_from
+
+mtd, _ = safe_import("modelopt.torch.distill")
 
 if TYPE_CHECKING:
     from megatron.core.transformer.transformer_config import TransformerConfig
-
-mtd, _ = safe_import("modelopt.torch.distill")
+    DistillationLossBalancer, _ = safe_import_from("modelopt.torch.distill", "DistillationLossBalancer", alt=object)
 
 
 class BaseLoss(_Loss, metaclass=ABCMeta):
@@ -236,7 +237,7 @@ class LogitsKLLoss(BaseLoss):
         return self.post_forward(loss, tp_reduce=True)
 
 
-class LogitsAndIntermediatesLossBalancer(mtd.DistillationLossBalancer):
+class LogitsAndIntermediatesLossBalancer("DistillationLossBalancer"):
     """
     LossBalancer implementation for Logit and Intermediate losses.
 

--- a/nemo/collections/llm/modelopt/distill/loss.py
+++ b/nemo/collections/llm/modelopt/distill/loss.py
@@ -27,11 +27,10 @@ from nemo.utils import logging
 from nemo.utils.import_utils import safe_import, safe_import_from
 
 mtd, _ = safe_import("modelopt.torch.distill")
+DistillationLossBalancer, _ = safe_import_from("modelopt.torch.distill", "DistillationLossBalancer", alt=object)
 
 if TYPE_CHECKING:
     from megatron.core.transformer.transformer_config import TransformerConfig
-
-    DistillationLossBalancer, _ = safe_import_from("modelopt.torch.distill", "DistillationLossBalancer", alt=object)
 
 
 class BaseLoss(_Loss, metaclass=ABCMeta):
@@ -238,7 +237,7 @@ class LogitsKLLoss(BaseLoss):
         return self.post_forward(loss, tp_reduce=True)
 
 
-class LogitsAndIntermediatesLossBalancer("DistillationLossBalancer"):
+class LogitsAndIntermediatesLossBalancer(DistillationLossBalancer):
     """
     LossBalancer implementation for Logit and Intermediate losses.
 

--- a/nemo/collections/llm/modelopt/distill/utils.py
+++ b/nemo/collections/llm/modelopt/distill/utils.py
@@ -172,8 +172,7 @@ def adjust_distillation_model_for_mcore(model: DistillationModel, distill_cfg: D
     # NOTE: If re-placed, above losses need modifcation as `TransformerConfig` has non-pickleable elements.
     existing_state = mto.ModeloptStateManager(model).state_dict()
     assert len(existing_state) == 1 and existing_state[0][0] == "kd_loss", f"{existing_state=}"
-    # mto.ModeloptStateManager.remove_state(model)
-    delattr(model, mto.ModeloptStateManager._state_key)  # Use above method from modelopt 0.27
+    mto.ModeloptStateManager.remove_state(model)
 
     # Hide teacher during `sharded_state_dict` method.
     def _sharded_state_dict(self, *args, **kwargs) -> "ShardedStateDict":

--- a/scripts/llm/gpt_prune.py
+++ b/scripts/llm/gpt_prune.py
@@ -63,10 +63,6 @@ Example usage to prune depth by dropping specific model layers (1-indexed):
 import argparse
 import os
 
-# Import modelopt first to avoid circular import causing pruning to fail
-# TODO: This can be removed in modelopt 0.27 once modelopt pruning imports nemo inside a function
-import modelopt.torch.prune  # noqa: F401
-
 from nemo.collections import llm
 from nemo.collections.llm.modelopt.prune import PruningConfig
 from nemo.utils import logging


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

One import had an attribute for type checking fail when optional Nvidia Model Optimizer library isn't installed

**Collection**: LLM

# Changelog

- safe import `DistillationLossBalancer` from `modelopt`
- remove some outdated hacks

# Usage

N/A

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
