### PR TITLE
Safely import optional python packages

### DIFF
--- a/nemo/collections/llm/modelopt/speculative/model_transform.py
+++ b/nemo/collections/llm/modelopt/speculative/model_transform.py
@@ -16,17 +16,19 @@ import torch.nn as nn
 
 from nemo.collections.llm import GPTModel
 from nemo.utils import logging
-from nemo.utils.import_utils import safe_import
+from nemo.utils.import_utils import safe_import, UnavailableError
 from nemo.utils.model_utils import unwrap_model
 
 mto, HAVE_MODELOPT = safe_import("modelopt.torch.opt")
 mtsp, _ = safe_import("modelopt.torch.speculative")
 
-
-ALGORITHMS = {
-    "eagle3": mtsp.EAGLE3_DEFAULT_CFG,
-    # more TBD
-}
+try:
+    ALGORITHMS = {
+        "eagle3": mtsp.EAGLE3_DEFAULT_CFG,
+        # more TBD
+    }
+except UnavailableError:
+    ALGORITHMS = {}
 
 
 def apply_speculative_decoding(model: nn.Module, algorithm: str = "eagle3") -> nn.Module:

--- a/nemo/collections/llm/modelopt/speculative/model_transform.py
+++ b/nemo/collections/llm/modelopt/speculative/model_transform.py
@@ -16,7 +16,7 @@ import torch.nn as nn
 
 from nemo.collections.llm import GPTModel
 from nemo.utils import logging
-from nemo.utils.import_utils import safe_import, UnavailableError
+from nemo.utils.import_utils import UnavailableError, safe_import
 from nemo.utils.model_utils import unwrap_model
 
 mto, HAVE_MODELOPT = safe_import("modelopt.torch.opt")

--- a/nemo/lightning/nemo_logger.py
+++ b/nemo/lightning/nemo_logger.py
@@ -22,12 +22,14 @@ import lightning.fabric as fl
 import lightning.pytorch as pl
 from lightning.pytorch.callbacks.model_checkpoint import ModelCheckpoint as PTLModelCheckpoint
 from lightning.pytorch.loggers import Logger, TensorBoardLogger, WandbLogger
-from nvidia_resiliency_ext.ptl_resiliency.local_checkpoint_callback import LocalCheckpointCallback
 
 from nemo.lightning.io.mixin import IOMixin
 from nemo.lightning.pytorch.callbacks import ModelCheckpoint
 from nemo.utils import logging
 from nemo.utils.app_state import AppState
+from nemo.utils.import_utils import safe_import
+
+LocalCheckpointCallback, HAVE_RES = safe_import('nvidia_resiliency_ext.ptl_resiliency.local_checkpoint_callback')
 
 
 @dataclass


### PR DESCRIPTION
# What does this PR do ?

This update safely imports optional Python packages which are incompatible with Windows and MacOS. This allows nemo_toolkit to be installable and usable on Windows and MacOS, especially in conjunction with NeMo-Run.

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [x] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation