### PR TITLE
ASR models knowledge distillation example

### DIFF
--- a/examples/asr/distillation/distill.py
+++ b/examples/asr/distillation/distill.py
@@ -1,24 +1,23 @@
 import logging
-import torch
+
 import lightning.pytorch as pl
+import torch
 from omegaconf import DictConfig, OmegaConf
-
-
 from torch.nn import MSELoss
 
-from nemo.core.config import hydra_runner
-from nemo.core.classes.mixins import AccessMixin
-from nemo.collections.asr.models import ASRModel, EncDecCTCModel
-from nemo.utils.trainer_utils import resolve_trainer_cfg
-from nemo.utils.exp_manager import exp_manager
 from nemo.collections.asr.data.audio_to_text_dali import DALIOutputs
+from nemo.collections.asr.models import ASRModel, EncDecCTCModel
+from nemo.core.classes.mixins import AccessMixin
+from nemo.core.config import hydra_runner
+from nemo.utils.exp_manager import exp_manager
+from nemo.utils.trainer_utils import resolve_trainer_cfg
 
 
 class KDAdapter(torch.nn.Module):
-    """Adapter for knowledge distillation. This module adapts the teacher's features to match the student's features.
-    """
+    """Adapter for knowledge distillation. This module adapts the teacher's features to match the student's features."""
+
     def __init__(self, in_channels, out_channels, kernel_size=1):
-        """ 
+        """
 
         Args:
             in_channels: the number of input channels from the teacher model.
@@ -26,69 +25,60 @@ class KDAdapter(torch.nn.Module):
             kernel_size: the size of the convolution kernel to use for adaptation.
         """
         super().__init__()
-        self.adapter = torch.nn.Conv1d(in_channels=in_channels,
-                                       out_channels=out_channels,
-                                       kernel_size=kernel_size)
+        self.adapter = torch.nn.Conv1d(in_channels=in_channels, out_channels=out_channels, kernel_size=kernel_size)
         self.kd_loss_fn = MSELoss(reduction="mean")
 
     def forward(self, t_feats, s_feats):
         x = t_feats.permute(0, 2, 1)
         x = self.adapter(x)
-        x = torch.nn.functional.interpolate(x, size=s_feats.size(1),
-                          mode='linear',
-                          align_corners=False)
+        x = torch.nn.functional.interpolate(x, size=s_feats.size(1), mode='linear', align_corners=False)
         proj_t = x.permute(0, 2, 1)
         return self.kd_loss_fn(proj_t, s_feats)
 
 
-class KnowledgeDistillationModule(EncDecCTCModel):
+class KnowledgeDistillationCTCModule(EncDecCTCModel):
     def __init__(self, cfg: DictConfig, trainer=None):
-        super(KnowledgeDistillationModule, self).__init__(cfg, trainer)
-        
+        super(KnowledgeDistillationCTCModule, self).__init__(cfg, trainer)
+
         if not hasattr(cfg, "student_model_path"):
-            raise ValueError("Knowledge distillation config file must have `student_model_path`")        
+            raise ValueError("Knowledge distillation config file must have `student_model_path`")
         if not hasattr(cfg, "teacher_model_path"):
             raise ValueError("Knowledge distillation config file must have `teacher_model_path`")
 
-        student_model_path = cfg.student_model_path
+        student_model_path = cfg.get("student_model_path", None)
         if student_model_path is None:
             raise ValueError("`student_model_path` cannot be None")
 
-        student_model = ASRModel.restore_from(
-            student_model_path, strict=cfg.get("init_strict", True)
-        )
+        student_model = ASRModel.restore_from(student_model_path)
 
         # Restore checkpoint into current model
         self.load_state_dict(student_model.state_dict(), strict=False)
         logging.info(f'Student model checkpoint restored from nemo file with path : `{student_model_path}`')
         del student_model
 
-        teacher_model_path = cfg.teacher_model_path
+        teacher_model_path = cfg.get("teacher_model_path", None)
         if teacher_model_path is None:
             raise ValueError("`teacher_model_path` cannot be None")
-        
+
         self.teacher = ASRModel.restore_from(restore_path=teacher_model_path)
         self.teacher.eval()
         if not hasattr(cfg, "kd_pairs"):
             raise ValueError("Knowledge distillation config file must have `kd_pairs`")
-        
+
         # Freeze teacher parameters
         for param in self.teacher.parameters():
             param.requires_grad = False
-        
-        self.kd_pairs = cfg.kd_pairs
+
+        self.kd_pairs = cfg.get("kd_pairs", None)
         if self.kd_pairs is None:
             raise ValueError("`kd_pairs` cannot be None")
-        
-        self.kd_loss_weight = getattr(cfg, "kd_loss_weight", 1.0)
-        
+
+        self.kd_loss_weight = cfg.get("kd_loss_weight", 1.0)
+
         # Dictionaries to store intermediate outputs from hooks
         self.teacher_outputs = {}
         self.student_outputs = {}
-        
-        self.temperature = cfg.get("kd_temperature", 1.0)
-        self.kd_logits_loss_fn = torch.nn.KLDivLoss(reduction="batchmean")
-        
+
         # Register forward hooks for specified layers
         t_modules = dict(self.teacher.named_modules())
         s_modules = dict(self.named_modules())
@@ -101,17 +91,19 @@ class KnowledgeDistillationModule(EncDecCTCModel):
                 raise ValueError(f"Student layer '{s_name}' not found.")
             t_modules[t_name].register_forward_hook(self._get_hook(self.teacher_outputs, t_name))
             s_modules[s_name].register_forward_hook(self._get_hook(self.student_outputs, s_name))
-        
+
         self.adapters = torch.nn.ModuleDict()
         for pair in self.kd_pairs:
             self.adapters[pair["student"].replace(".", "_")] = KDAdapter(pair["t_dim"], pair["s_dim"])
 
     def _get_hook(self, output_dict, name):
         """Returns a hook that stores the layer's output in output_dict."""
+
         def hook(module, input, output):
             output_dict[name] = output
+
         return hook
-    
+
     def training_step(self, batch, batch_nb):
         # Reset access registry
         if AccessMixin.is_access_enabled(self.model_guid):
@@ -136,16 +128,14 @@ class KnowledgeDistillationModule(EncDecCTCModel):
                 t_log_probs, t_encoded_len, t_predictions = self.teacher.forward(
                     input_signal=signal, input_signal_length=signal_len
                 )
-        
+
         # student forward-pass
         if is_dali:
             log_probs, encoded_len, predictions = super().forward(
                 processed_signal=signal, processed_signal_length=signal_len
             )
         else:
-            log_probs, encoded_len, predictions = super().forward(
-                input_signal=signal, input_signal_length=signal_len
-            )
+            log_probs, encoded_len, predictions = super().forward(input_signal=signal, input_signal_length=signal_len)
 
         loss_value = self.loss(
             log_probs=log_probs,
@@ -159,7 +149,7 @@ class KnowledgeDistillationModule(EncDecCTCModel):
             t_feat = self.teacher_outputs[pair["teacher"]]
             s_feat = self.student_outputs[pair["student"]]
             kd_loss += self.adapters[pair["student"].replace(".", "_")](t_feat, s_feat)
-        
+
         kd_loss = kd_loss * self.kd_loss_weight
 
         loss_value = loss_value + kd_loss
@@ -178,12 +168,14 @@ class KnowledgeDistillationModule(EncDecCTCModel):
             AccessMixin.reset_registry(self)
 
         # 7) logging
-        tb_logs.update({
-            "train_loss": loss_value,
-            "kd_loss": kd_loss,
-            "learning_rate": self._optimizer.param_groups[0]["lr"],
-            "global_step": torch.tensor(self.trainer.global_step, dtype=torch.float32),
-        })
+        tb_logs.update(
+            {
+                "train_loss": loss_value,
+                "kd_loss": kd_loss,
+                "learning_rate": self._optimizer.param_groups[0]["lr"],
+                "global_step": torch.tensor(self.trainer.global_step, dtype=torch.float32),
+            }
+        )
         if (batch_nb + 1) % log_every_n == 0:
             self.wer.update(
                 predictions=log_probs,
@@ -197,14 +189,15 @@ class KnowledgeDistillationModule(EncDecCTCModel):
 
         return {"loss": loss_value, "log": tb_logs}
 
+
 @hydra_runner(config_path="conf/asr_distillation", config_name="distill")
 def main(cfg):
     logging.info(f"Hydra config: {OmegaConf.to_yaml(cfg)}")
 
     trainer = pl.Trainer(**resolve_trainer_cfg(cfg.trainer))
     exp_manager(trainer, cfg.get("exp_manager", None))
-    
-    kd_model = KnowledgeDistillationModule(cfg=cfg.model, trainer=trainer)
+
+    kd_model = KnowledgeDistillationCTCModule(cfg=cfg.model, trainer=trainer)
 
     kd_model.setup_training_data(cfg.model.train_ds)
     kd_model.setup_multiple_validation_data(cfg.model.validation_ds)
@@ -212,6 +205,7 @@ def main(cfg):
     kd_model.setup_optimization(cfg.model.optim)
 
     trainer.fit(kd_model)
+
 
 if __name__ == "__main__":
     main()

--- a/examples/asr/distillation/distill.py
+++ b/examples/asr/distillation/distill.py
@@ -1,0 +1,217 @@
+import logging
+import torch
+import lightning.pytorch as pl
+from omegaconf import DictConfig, OmegaConf
+
+
+from torch.nn import MSELoss
+
+from nemo.core.config import hydra_runner
+from nemo.core.classes.mixins import AccessMixin
+from nemo.collections.asr.models import ASRModel, EncDecCTCModel
+from nemo.utils.trainer_utils import resolve_trainer_cfg
+from nemo.utils.exp_manager import exp_manager
+from nemo.collections.asr.data.audio_to_text_dali import DALIOutputs
+
+
+class KDAdapter(torch.nn.Module):
+    """Adapter for knowledge distillation. This module adapts the teacher's features to match the student's features.
+    """
+    def __init__(self, in_channels, out_channels, kernel_size=1):
+        """ 
+
+        Args:
+            in_channels: the number of input channels from the teacher model.
+            out_channels: the number of output channels for the student model.
+            kernel_size: the size of the convolution kernel to use for adaptation.
+        """
+        super().__init__()
+        self.adapter = torch.nn.Conv1d(in_channels=in_channels,
+                                       out_channels=out_channels,
+                                       kernel_size=kernel_size)
+        self.kd_loss_fn = MSELoss(reduction="mean")
+
+    def forward(self, t_feats, s_feats):
+        x = t_feats.permute(0, 2, 1)
+        x = self.adapter(x)
+        x = torch.nn.functional.interpolate(x, size=s_feats.size(1),
+                          mode='linear',
+                          align_corners=False)
+        proj_t = x.permute(0, 2, 1)
+        return self.kd_loss_fn(proj_t, s_feats)
+
+
+class KnowledgeDistillationModule(EncDecCTCModel):
+    def __init__(self, cfg: DictConfig, trainer=None):
+        super(KnowledgeDistillationModule, self).__init__(cfg, trainer)
+        
+        if not hasattr(cfg, "student_model_path"):
+            raise ValueError("Knowledge distillation config file must have `student_model_path`")        
+        if not hasattr(cfg, "teacher_model_path"):
+            raise ValueError("Knowledge distillation config file must have `teacher_model_path`")
+
+        student_model_path = cfg.student_model_path
+        if student_model_path is None:
+            raise ValueError("`student_model_path` cannot be None")
+
+        student_model = ASRModel.restore_from(
+            student_model_path, strict=cfg.get("init_strict", True)
+        )
+
+        # Restore checkpoint into current model
+        self.load_state_dict(student_model.state_dict(), strict=False)
+        logging.info(f'Student model checkpoint restored from nemo file with path : `{student_model_path}`')
+        del student_model
+
+        teacher_model_path = cfg.teacher_model_path
+        if teacher_model_path is None:
+            raise ValueError("`teacher_model_path` cannot be None")
+        
+        self.teacher = ASRModel.restore_from(restore_path=teacher_model_path)
+        self.teacher.eval()
+        if not hasattr(cfg, "kd_pairs"):
+            raise ValueError("Knowledge distillation config file must have `kd_pairs`")
+        
+        # Freeze teacher parameters
+        for param in self.teacher.parameters():
+            param.requires_grad = False
+        
+        self.kd_pairs = cfg.kd_pairs
+        if self.kd_pairs is None:
+            raise ValueError("`kd_pairs` cannot be None")
+        
+        self.kd_loss_weight = getattr(cfg, "kd_loss_weight", 1.0)
+        
+        # Dictionaries to store intermediate outputs from hooks
+        self.teacher_outputs = {}
+        self.student_outputs = {}
+        
+        self.temperature = cfg.get("kd_temperature", 1.0)
+        self.kd_logits_loss_fn = torch.nn.KLDivLoss(reduction="batchmean")
+        
+        # Register forward hooks for specified layers
+        t_modules = dict(self.teacher.named_modules())
+        s_modules = dict(self.named_modules())
+        for pair in self.kd_pairs:
+            t_name = pair["teacher"]
+            s_name = pair["student"]
+            if t_name not in t_modules:
+                raise ValueError(f"Teacher layer '{t_name}' not found.")
+            if s_name not in s_modules:
+                raise ValueError(f"Student layer '{s_name}' not found.")
+            t_modules[t_name].register_forward_hook(self._get_hook(self.teacher_outputs, t_name))
+            s_modules[s_name].register_forward_hook(self._get_hook(self.student_outputs, s_name))
+        
+        self.adapters = torch.nn.ModuleDict()
+        for pair in self.kd_pairs:
+            self.adapters[pair["student"].replace(".", "_")] = KDAdapter(pair["t_dim"], pair["s_dim"])
+
+    def _get_hook(self, output_dict, name):
+        """Returns a hook that stores the layer's output in output_dict."""
+        def hook(module, input, output):
+            output_dict[name] = output
+        return hook
+    
+    def training_step(self, batch, batch_nb):
+        # Reset access registry
+        if AccessMixin.is_access_enabled(self.model_guid):
+            AccessMixin.reset_registry(self)
+        if self.is_interctc_enabled():
+            AccessMixin.set_access_enabled(access_enabled=True, guid=self.model_guid)
+
+        signal, signal_len, transcript, transcript_len = batch
+        is_dali = isinstance(batch, DALIOutputs) and batch.has_processed_signal
+
+        # clear previous hook outputs
+        self.teacher_outputs.clear()
+        self.student_outputs.clear()
+
+        # teacher forward-pass
+        with torch.no_grad():
+            if is_dali:
+                t_log_probs, t_encoded_len, t_predictions = self.teacher.forward(
+                    processed_signal=signal, processed_signal_length=signal_len
+                )
+            else:
+                t_log_probs, t_encoded_len, t_predictions = self.teacher.forward(
+                    input_signal=signal, input_signal_length=signal_len
+                )
+        
+        # student forward-pass
+        if is_dali:
+            log_probs, encoded_len, predictions = super().forward(
+                processed_signal=signal, processed_signal_length=signal_len
+            )
+        else:
+            log_probs, encoded_len, predictions = super().forward(
+                input_signal=signal, input_signal_length=signal_len
+            )
+
+        loss_value = self.loss(
+            log_probs=log_probs,
+            targets=transcript,
+            input_lengths=encoded_len,
+            target_lengths=transcript_len,
+        )
+
+        kd_loss = 0.0
+        for pair in self.kd_pairs:
+            t_feat = self.teacher_outputs[pair["teacher"]]
+            s_feat = self.student_outputs[pair["student"]]
+            kd_loss += self.adapters[pair["student"].replace(".", "_")](t_feat, s_feat)
+        
+        kd_loss = kd_loss * self.kd_loss_weight
+
+        loss_value = loss_value + kd_loss
+
+        loss_value = self.add_auxiliary_losses(loss_value)
+        log_every_n = getattr(self._trainer, "log_every_n_steps", 1)
+        loss_value, tb_logs = self.add_interctc_losses(
+            loss_value,
+            transcript,
+            transcript_len,
+            compute_wer=((batch_nb + 1) % log_every_n == 0),
+        )
+
+        # Reset access registry
+        if AccessMixin.is_access_enabled(self.model_guid):
+            AccessMixin.reset_registry(self)
+
+        # 7) logging
+        tb_logs.update({
+            "train_loss": loss_value,
+            "kd_loss": kd_loss,
+            "learning_rate": self._optimizer.param_groups[0]["lr"],
+            "global_step": torch.tensor(self.trainer.global_step, dtype=torch.float32),
+        })
+        if (batch_nb + 1) % log_every_n == 0:
+            self.wer.update(
+                predictions=log_probs,
+                targets=transcript,
+                targets_lengths=transcript_len,
+                predictions_lengths=encoded_len,
+            )
+            wer, _, _ = self.wer.compute()
+            self.wer.reset()
+            tb_logs["training_batch_wer"] = wer
+
+        return {"loss": loss_value, "log": tb_logs}
+
+@hydra_runner(config_path="conf/asr_distillation", config_name="distill")
+def main(cfg):
+    logging.info(f"Hydra config: {OmegaConf.to_yaml(cfg)}")
+
+    trainer = pl.Trainer(**resolve_trainer_cfg(cfg.trainer))
+    exp_manager(trainer, cfg.get("exp_manager", None))
+    
+    kd_model = KnowledgeDistillationModule(cfg=cfg.model, trainer=trainer)
+
+    kd_model.setup_training_data(cfg.model.train_ds)
+    kd_model.setup_multiple_validation_data(cfg.model.validation_ds)
+
+    kd_model.setup_optimization(cfg.model.optim)
+
+    trainer.fit(kd_model)
+
+if __name__ == "__main__":
+    main()

--- a/examples/asr/distillation/distill.yaml
+++ b/examples/asr/distillation/distill.yaml
@@ -1,0 +1,200 @@
+name: "Conformer-ctc-small-distillation"
+
+model:
+  sample_rate: 16000
+  log_prediction: true # enables logging sample predictions in the output during training
+  ctc_reduction: 'mean_batch'
+  skip_nan_grad: false
+  student_model_path: "stt_en_conformer_ctc_small.nemo"
+  teacher_model_path: "parakeet-ctc-1.1b.nemo"
+
+  kd_pairs:
+    - teacher: encoder.layers.12.norm_out
+      student: encoder.layers.4.norm_out
+      t_dim: 1024
+      s_dim: 176
+    - teacher: encoder.layers.41.norm_out
+      student: encoder.layers.15.norm_out
+      t_dim: 1024
+      s_dim: 176
+
+  train_ds:
+    manifest_filepath: ???
+    sample_rate: 16000
+    batch_size: 32 # you may increase batch_size if your memory allows
+    shuffle: true
+    num_workers: 8
+    pin_memory: true
+    max_duration: 16.7 # it is set for LibriSpeech, you may need to update it for your dataset
+    min_duration: 0.1
+    # tarred datasets
+    is_tarred: false
+    tarred_audio_filepaths: null
+    shuffle_n: 2048
+    # bucketing params
+    bucketing_strategy: "synced_randomized"
+    bucketing_batch_size: null
+
+  validation_ds:
+    manifest_filepath: ???
+    sample_rate: 16000
+    batch_size: 32
+    shuffle: false
+    use_start_end_token: false
+    num_workers: 8
+    pin_memory: true
+
+  test_ds:
+    manifest_filepath: ???
+    sample_rate: 16000
+    batch_size: 32
+    shuffle: false
+    use_start_end_token: false
+    num_workers: 8
+    pin_memory: true
+  
+  char_labels: # use for char based models
+    update_labels: false
+    labels: null # example list config: \[' ', 'a', 'b', 'c'\]
+
+  tokenizer: # use for spe/bpe based tokenizer models
+    dir: ???
+    type: bpe  # Can be either bpe (SentencePiece tokenizer) or wpe (WordPiece tokenizer)
+
+  preprocessor:
+    _target_: nemo.collections.asr.modules.AudioToMelSpectrogramPreprocessor
+    sample_rate: ${model.sample_rate}
+    normalize: "per_feature"
+    window_size: 0.025
+    window_stride: 0.01
+    window: "hann"
+    features: 80
+    n_fft: 512
+    log: true
+    frame_splicing: 1
+    dither: 0.00001
+    pad_to: 0
+    pad_value: 0.0
+
+  spec_augment:
+    _target_: nemo.collections.asr.modules.SpectrogramAugmentation
+    freq_masks: 2 # set to zero to disable it
+    time_masks: 5 # set to zero to disable it
+    freq_width: 27
+    time_width: 0.05
+
+  encoder:
+    _target_: nemo.collections.asr.modules.ConformerEncoder
+    feat_in: ${model.preprocessor.features}
+    feat_out: -1 # you may set it if you need different output size other than the default d_model
+    n_layers: 16
+    d_model: 176
+
+    # Sub-sampling params
+    subsampling: striding # vggnet, striding, stacking or stacking_norm, dw_striding
+    subsampling_factor: 4 # must be power of 2 for striding and vggnet
+    subsampling_conv_channels: -1 # -1 sets it to d_model
+    causal_downsampling: false
+
+    # Feed forward module's params
+    ff_expansion_factor: 4
+
+    # Multi-headed Attention Module's params
+    self_attention_model: rel_pos # rel_pos or abs_pos
+    n_heads: 4 # may need to be lower for smaller d_models
+    # [left, right] specifies the number of steps to be seen from left and right of each step in self-attention
+    att_context_size: [-1, -1] # -1 means unlimited context
+    att_context_style: regular # regular or chunked_limited
+    xscaling: true # scales up the input embeddings by sqrt(d_model)
+    untie_biases: true # unties the biases of the TransformerXL layers
+    pos_emb_max_len: 5000
+
+    # Convolution module's params
+    conv_kernel_size: 31
+    conv_norm_type: 'batch_norm' # batch_norm or layer_norm or groupnormN (N specifies the number of groups)
+    # conv_context_size can be"causal" or a list of two integers while conv_context_size[0]+conv_context_size[1]+1==conv_kernel_size
+    # null means [(kernel_size-1)//2, (kernel_size-1)//2], and 'causal' means [(kernel_size-1), 0]
+    conv_context_size: null
+
+    ### regularization
+    dropout: 0.1 # The dropout used in most of the Conformer Modules
+    dropout_pre_encoder: 0.1 # The dropout used before the encoder
+    dropout_emb: 0.0 # The dropout used for embeddings
+    dropout_att: 0.1 # The dropout for multi-headed attention modules
+
+    # set to non-zero to enable stochastic depth
+    stochastic_depth_drop_prob: 0.0
+    stochastic_depth_mode: linear  # linear or uniform
+    stochastic_depth_start_layer: 1
+
+  decoder:
+    _target_: nemo.collections.asr.modules.ConvASRDecoder
+    feat_in: null
+    num_classes: -1
+    vocabulary: []
+
+  # config for InterCTC loss: https://arxiv.org/abs/2102.03216
+  # specify loss weights and which layers to use for InterCTC
+  # e.g., to reproduce the paper results, set loss_weights: [0.3]
+  # and apply_at_layers: [8] (assuming 18 layers). Note that final
+  # layer loss coefficient is automatically adjusted (to 0.7 in above example)
+  interctc:
+    loss_weights: []
+    apply_at_layers: []
+
+  optim:
+    name: adamw
+    lr: 1e-4
+    # optimizer arguments
+    betas: [0.9, 0.98]
+    weight_decay: 1e-3
+
+    # scheduler setup
+    sched:
+      name: CosineAnnealing
+      # scheduler config override
+      warmup_steps: 5000
+      warmup_ratio: null
+      min_lr: 5e-6
+
+trainer:
+  devices: -1 # number of GPUs, -1 would use all available GPUs
+  num_nodes: 1
+  max_epochs: 5
+  max_steps: -1 # computed at runtime if not set
+  val_check_interval: 1.0 # Set to 0.25 to check 4 times per epoch, or an int for number of iterations
+  accelerator: auto
+  strategy:
+    _target_: lightning.pytorch.strategies.DDPStrategy
+    gradient_as_bucket_view: true
+  accumulate_grad_batches: 1
+  gradient_clip_val: 0.0
+  precision: 32 # 16, 32, or bf16
+  log_every_n_steps: 10  # Interval of logging.
+  enable_progress_bar: True
+  num_sanity_val_steps: 0 # number of steps to perform validation steps for sanity check the validation process before starting the training, setting to 0 disables it
+  check_val_every_n_epoch: 1 # number of evaluations on validation every n epochs
+  sync_batchnorm: true
+  enable_checkpointing: False  # Provided by exp_manager
+  logger: false  # Provided by exp_manager
+  benchmark: false # needs to be false for models with variable-length speech input as it slows down training
+
+
+exp_manager:
+  exp_dir: null
+  name: ${name}
+  create_tensorboard_logger: true
+  create_checkpoint_callback: true
+  checkpoint_callback_params:
+    # in case of multiple validation sets, first one is used
+    monitor: "val_wer"
+    mode: "min"
+    save_top_k: 5
+    always_save_nemo: True # saves the checkpoints as nemo files along with PTL checkpoints
+  resume_if_exists: false
+  resume_ignore_no_checkpoint: false
+
+  create_wandb_logger: false
+  wandb_logger_kwargs:
+    name: null
+    project: null


### PR DESCRIPTION
# What does this PR do ?

In this PR I am adding an example of script for knowledge distillation of EncDecCTCModels which can be adapted for all ASR models, and an example of config file to run knowledge distillation.

**Collection**: ASR

# Changelog

- Created a knowledge distillation module for EncDecCTCModels
- Created a config file scheme for comfortable knowledge distillation, where you can specify between which layers you want to put the loss function and also add an adapter layer between them if teacher and student models features dimensions are not matching on that layers

# Usage

You can simply run the example using this command
```python
python examples/asr/distillation/distill.py --config-path=. --config-name=distill.yaml
```

You need to adapt config file for your models and datasets before running the script
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation


## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.