### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `64cb6bd...` (2025-06-17)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "771101474fb1e881a3a62deeca88ecb4f494761c"
+      "ref": "64cb6bd7a155c4e742514ed1024407fb97d0a367"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `64cb6bd7a155c4e742514ed1024407fb97d0a367`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.