### PR TITLE
ci: Set L2_NeMo_2_Export_Deploy_Query_In_Framework to be optional

### DIFF
--- a/.github/workflows/cicd-main-export-deploy.yml
+++ b/.github/workflows/cicd-main-export-deploy.yml
@@ -73,6 +73,7 @@ jobs:
             runner: self-hosted-azure
           - script: L2_NeMo_2_Export_Deploy_Query_In_Framework
             runner: self-hosted-azure
+            is-optional: true
           - script: L2_ONNX_TRT_LLM_Embedding_Export
             runner: self-hosted-azure
           - script: L2_NeMo_2_Export_TRT_LLM


### PR DESCRIPTION
# What does this PR do ?

Set L2_NeMo_2_Export_Deploy_Query_In_Framework to be optional. It's currently failing on the main branch.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
