### PR TITLE
Inference bugfix: run inference on all datasets

### DIFF
--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -178,7 +178,10 @@ def run_inference(
         sv_model
     )
     dataset_meta_info = evalset_config.dataset_meta_info
+    ssim_per_dataset = []
+    cer_per_dataset = []
     for dataset in datasets:
+        print(f"Evaluating dataset {dataset}")
         metrics_n_repeated = []
         manifest_records = read_manifest(dataset_meta_info[dataset]['manifest_path'])
         for repeat_idx in range(num_repeats):
@@ -343,13 +346,18 @@ def run_inference(
         
 
         measurements = [m['ssim_pred_context_avg'] for m in metrics_n_repeated]
-        ssim = np.mean(measurements)
+        ssim_current = np.mean(measurements)
+        ssim_per_dataset.append(ssim_current)
         measurements = [m['cer_cumulative'] for m in metrics_n_repeated]
-        cer = np.mean(measurements)
+        cer_current = np.mean(measurements)
+        cer_per_dataset.append(cer_current)
 
-        if clean_up_disk:
-            shutil.rmtree(out_dir)
-        return cer, ssim
+    # Average across datasets
+    ssim = np.mean(ssim_per_dataset)
+    cer = np.mean(cer_per_dataset)
+    if clean_up_disk:
+        shutil.rmtree(out_dir)
+    return cer, ssim
 
 def main():
     parser = argparse.ArgumentParser(description='Experiment Evaluation')


### PR DESCRIPTION
In `run_inference()` we were not actually evaluating on all datasets provided, just the first, since there was a return statement inside the dataset loop.

Instead, move the code that computes SSIM and CER averages and returns them to outside the dataset loop so that all datasets get tested. We return CER and SSIM averaged across all datasets (mean across datasets of means across repeats). These returned values are only used for CER and SSIM thresholds during CI.
