### PR TITLE
force mcore user cfgs

### DIFF
--- a/nemo/lightning/pytorch/callbacks/megatron_comm_overlap.py
+++ b/nemo/lightning/pytorch/callbacks/megatron_comm_overlap.py
@@ -80,6 +80,8 @@ class MegatronCommOverlapCallback(Callback):
         defer_embedding_wgrad_compute (bool): Overlap wgrads with the pipeline drain bubble for the last pipeline stage
         wgrad_deferral_limit (int): Limit of how many outstanding wgrads may be overlapped with the pipeline drain
                                     bubble
+        force_megatron_user_cfg (bool): Force the use of the Megatron user configs
+                                        CAUTION: Setting to True can have undesirable results
 
     Example:
         >>> callback = MegatronCommOverlapCallback(tp_comm_overlap=True)
@@ -100,7 +102,7 @@ class MegatronCommOverlapCallback(Callback):
         bucket_size: int = None,
         defer_embedding_wgrad_compute: bool = None,
         wgrad_deferral_limit: int = None,
-        force_megatron_user_cfg: bool = False,
+        force_megatron_user_cfg: bool = False,  # CAUTION: Setting to True can have undesirable results
     ):
 
         self.user_comm_overlap_cfg = _CommOverlapConfig(
@@ -121,6 +123,7 @@ class MegatronCommOverlapCallback(Callback):
         self.tp_comm_overlap_cfg = None
         self.tp_comm_bootstrap_backend = None
         self.need_tp_overlap_ub_init = False
+        self.force_megatron_user_cfg = force_megatron_user_cfg
 
     def _get_model_comm_overlap_cfgs(
         self,


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Allow users to forcefully override megatron comm callback cfgs for optimizer

**Collection**: [llm,mm]

# Changelog

```
if data_parallel_size > 1 and not self.force_megatron_user_cfg:
      # use recommended optimal cfg values
      overlap_param_gather = True
```

# Usage

```python
MegatronCommOverlapCallback(
                 overlap_param_gather=False
                 force_megatron_user_cfg=True # WARNING: Use with caution. Setting to True can have undesirable results
         )
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
