### PR TITLE
FCD Metric: error handling when provided with codes of unexpected shape

### DIFF
--- a/nemo/collections/tts/modules/fcd_metric.py
+++ b/nemo/collections/tts/modules/fcd_metric.py
@@ -172,6 +172,10 @@ class FrechetCodecDistance(Metric):
             logging.warning(f"\nFCD metric received an empty batch of codes - skipping update\n")
             return
 
+        if codes.shape[1] != self.model.codec.num_codebooks:
+            logging.warning(f"\nFCD metric received a batch of codes of shape {codes.shape}, but the model has {self.model.codec.num_codebooks} codebooks - skipping update\n")
+            return
+        
         # Dequantize the codes to a continuous representation
         embeddings = self.model.codes_to_embedding(
             codes, codes_len

--- a/tests/collections/tts/modules/test_fcd_metric.py
+++ b/tests/collections/tts/modules/test_fcd_metric.py
@@ -110,3 +110,14 @@ class TestFrechetCodecDistance:
         codes_len = T * torch.ones(B, device=device)
         # if it crashes PyTest will report it
         metric.update(codes, codes_len, is_real=True)
+
+    @pytest.mark.unit
+    def test_codebooks_mismatch_update(self, metric, device, codec):
+        """Test that the FCD metric doesn't crash when provided with incorrect number ofcodebooks."""
+        B = 2
+        C = codec.num_codebooks - 1  # intentionally missing one codebook
+        T = 10
+        codes = torch.ones(B, C, T, device=device)
+        codes_len = T * torch.ones(B, device=device, dtype=torch.long)
+        # if it crashes PyTest will report it
+        metric.update(codes, codes_len, is_real=True)


### PR DESCRIPTION
We have observed very rare cases that the codes provided to the FCD metric by the inference script have an unexpected shape, e.g. 6 codebooks instead of 8. We need to debug the upstream cause of this, but the FCD shouldn't crash either.

We now log a warning if the above situation is detected. Also added a test to check FCD doesn't crash in this case.