### PR TITLE
EOS detection: check all codebooks

### DIFF
--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -1718,9 +1718,9 @@ class MagpieTTSModel(ModelPT):
 
                 for item_idx in range(all_codes_next_argmax.size(0)):
                     if item_idx not in end_indices:
-                        pred_token = all_codes_next_argmax[item_idx][0].item()
-                        pred_token_multinomial = audio_codes_next[item_idx][0].item()
-                        if (pred_token == self.audio_eos_id) or (pred_token_multinomial == self.audio_eos_id):
+                        eos_in_pred_tokens_argmax = (all_codes_next_argmax[item_idx] == self.audio_eos_id).any().item()
+                        eos_in_pred_tokens_multinomial = (audio_codes_next[item_idx] == self.audio_eos_id).any().item()
+                        if eos_in_pred_tokens_argmax or eos_in_pred_tokens_multinomial:
                             print("End detected for item {} at timestep {}".format(item_idx, idx))
                             end_indices[item_idx] = idx
 


### PR DESCRIPTION
At inference, we previously only looked at the first codebook to check for EOS being generated. This carried the risk of EOS tokens being returned to the user if they occurred only in codebooks other than codebook zero and would therefore not be detected.

I tested on unseen speakers (subset of `libri_dev_clean`) and found no statistically significant performance changes after this change (as expected).