### PR TITLE
Update bitsandbytes dependency to v0.46.0

### DIFF
--- a/requirements/requirements_automodel.txt
+++ b/requirements/requirements_automodel.txt
@@ -1,2 +1,2 @@
-bitsandbytes==0.45.5 ; (platform_machine == 'x86_64' and platform_system != 'Darwin')
+bitsandbytes==0.46.0 ; (platform_machine == 'x86_64' and platform_system != 'Darwin')
 # liger-kernel ; (platform_machine == 'x86_64' and platform_system != 'Darwin')


### PR DESCRIPTION
## What does this PR do ?

Update bitsandbytes dependency to a pypi release containing aarch64 release

## Changelog

- The PyPI release of bitsandbytes v0.45.0 lacks the aarch64 binary wheel.
- Upgrading to v0.46.0 ensures easier installation on aarch64 platforms (see [internal ticket](https://jirasw.nvidia.com/browse/CPERF-2984)).

## Usage

N/A

## Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
  
**PR Type**:

- [X] Dependency Update

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.

## Additional Information

- 0.45.5 doesn't include aarch64 binary wheel https://pypi.org/project/bitsandbytes/0.45.5/#files
