### PR TITLE
Inference bugfix: wrong dimension trimmed when saving generated codes for FCD calculation

### DIFF
--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -281,7 +281,8 @@ def run_inference(
                     audio_path = os.path.join(pred_audio_dir, f"predicted_audio_{item_idx}.wav")
                     sf.write(audio_path, predicted_audio_np, model.sample_rate)
                     codes_path = os.path.join(pred_audio_dir, f"predicted_codes_{item_idx}.pt")
-                    torch.save(predicted_codes[idx][:predicted_codes_lens[idx]], codes_path)
+                    predicted_codes_current = predicted_codes[idx, :, :predicted_codes_lens[idx]] # C, T'
+                    torch.save(predicted_codes_current, codes_path)
                     codec_file_paths.append(codes_path)
                     context_audio_path = manifest_records[item_idx].get('context_audio_filepath', None)
                     target_audio_path = manifest_records[item_idx].get('audio_filepath', None)


### PR DESCRIPTION
At inference we save the generated codes for subsequent analysis in the FCD metric. There was a bug where the wrong dimension was being trimmed to the valid code lengths. It should be the time dimension but was the codebook dimension.

This is likely the root cause of the rare FCD errors we saw, with an unexpected codes tensor shape; it would occur when the valid frame length was less than 8, resulting in trimming in the codebook dimension.