### PR TITLE
[documentation] Add correct `pyroomacoustics` version to speech data simulator README

### DIFF
--- a/tools/speech_data_simulator/README.md
+++ b/tools/speech_data_simulator/README.md
@@ -55,7 +55,7 @@ Note that only one of gpuRIR or pyroomacoustics is required for RIR simulation.
 ```bash
 pip install cmake
 pip install https://github.com/DavidDiazGuerra/gpuRIR/zipball/master
-pip install pyroomacoustics
+pip install pyroomacoustics==0.7.7
 ```
 
 Parameters


### PR DESCRIPTION
# What does this PR do ?

This PR adds correct `pyroomacoustics` version to the speech data simulator `README`

**Collection**: `asr`
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [x] Documentation

# Additional Information

`DirectivityPattern` imported in `nemo/collections/asr/data/data_simulation.py` as been dropped from `pyroomacoustics`, starting in `0.8.0` version.