### PR TITLE
Add TE import guard in qwen2vl vision module

### DIFF
--- a/nemo/collections/vlm/qwen2vl/model/vision.py
+++ b/nemo/collections/vlm/qwen2vl/model/vision.py
@@ -33,6 +33,7 @@ from torch import Tensor
 
 try:
     from megatron.core.extensions.transformer_engine import te_checkpoint
+
     HAVE_TE = True
 except ImportError:
     HAVE_TE = False

--- a/nemo/collections/vlm/qwen2vl/model/vision.py
+++ b/nemo/collections/vlm/qwen2vl/model/vision.py
@@ -19,7 +19,6 @@ import torch.nn.functional as F
 from megatron.core import parallel_state, tensor_parallel
 from megatron.core.config_logger import has_config_logger_enabled, log_config_to_disk
 from megatron.core.enums import Fp8Recipe
-from megatron.core.extensions.transformer_engine import te_checkpoint
 from megatron.core.fp8_utils import get_fp8_context
 from megatron.core.inference.contexts import BaseInferenceContext
 from megatron.core.models.common.vision_module.vision_module import VisionModule
@@ -31,6 +30,12 @@ from megatron.core.transformer.transformer_block import TransformerBlock, Transf
 from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.utils import WrappedTensor, deprecate_inference_params, make_viewless_tensor
 from torch import Tensor
+
+try:
+    from megatron.core.extensions.transformer_engine import te_checkpoint
+    HAVE_TE = True
+except ImportError:
+    HAVE_TE = False
 
 
 class Qwen25VLVisionTransformerBlock(TransformerBlock):


### PR DESCRIPTION
# What does this PR do ?

Add TE import guard in qwen2vl vision module

Otherwise, this requires TE to be installed in a nemo-run environment to launch jobs.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
