### PR TITLE
[eval] Suppress TitaNet messages during initialization

### DIFF
--- a/scripts/magpietts/evaluate_generated_audio.py
+++ b/scripts/magpietts/evaluate_generated_audio.py
@@ -107,7 +107,11 @@ def pad_audio_to_min_length(audio_np: np.ndarray, sampling_rate: int, min_second
 @contextmanager
 def nemo_log_level(level):
     """
-    Temporarily sets the logging level for the nemo logger to the specified level.
+    A context manager that temporarily sets the logging level for the NeMo logger 
+    and restores the original level when the context manager is exited.
+
+    Args:
+        level (int): The logging level to set.
     """
     logger = logging.getLogger("nemo_logger")
     original_level = logger.level

--- a/scripts/magpietts/evaluate_generated_audio.py
+++ b/scripts/magpietts/evaluate_generated_audio.py
@@ -16,6 +16,8 @@ import json
 import os
 import pprint
 import string
+import logging
+from contextlib import contextmanager
 
 import numpy as np
 import torch
@@ -102,6 +104,19 @@ def pad_audio_to_min_length(audio_np: np.ndarray, sampling_rate: int, min_second
         audio_np = np.pad(audio_np, (0, padding_needed), mode='constant', constant_values=0)
     return audio_np
 
+@contextmanager
+def nemo_log_level(level):
+    """
+    Temporarily sets the logging level for the nemo logger to the specified level.
+    """
+    logger = logging.getLogger("nemo_logger")
+    original_level = logger.level
+    logger.setLevel(level)
+    try:
+        yield
+    finally:
+        # restore the original level when the context manager is exited (even if an exception was raised)
+        logger.setLevel(original_level)
 
 def extract_embedding(model, extractor, audio_path, device, sv_model_type):
     speech_array, sampling_rate = librosa.load(audio_path, sr=16000)
@@ -149,8 +164,10 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
         speaker_verification_model = nemo_asr.models.EncDecSpeakerLabelModel.from_pretrained(model_name='titanet_large')
         speaker_verification_model = speaker_verification_model.to(device)
         speaker_verification_model.eval()
-
-    speaker_verification_model_alternate = nemo_asr.models.EncDecSpeakerLabelModel.from_pretrained(model_name='titanet_small')
+    with nemo_log_level(logging.ERROR):
+        # The model `titanet_small` prints thousands of lines during initialization, so suppress logs temporarily
+        print("Loading `titanet_small` model...")
+        speaker_verification_model_alternate = nemo_asr.models.EncDecSpeakerLabelModel.from_pretrained(model_name='titanet_small')
     speaker_verification_model_alternate = speaker_verification_model_alternate.to(device)
     speaker_verification_model_alternate.eval()
 


### PR DESCRIPTION
When loading `titanet-small` during evaluation, some 15,000 lines of logs get printed out. This clutters our evaluation logs and makes them harder to analyze.

We now suppress those messages.

Note that `titanet-large` does not have this issue so we don't need to suppress its initialization logs.