### PR TITLE
[eval][bugfix] avoid overidding cross attention maps for multiple repeats

### DIFF
--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -316,7 +316,7 @@ def run_inference(
                 print(f"Time taken for inference: {et-st}", predicted_audio.size())
                 for idx in range(predicted_audio.size(0)):
                     cross_attn_map_image = Image.fromarray(cross_attention_maps[idx])
-                    cross_attn_map_image.save(os.path.join(audio_dir, f"cross_attn_map_{item_idx}.png"))
+                    cross_attn_map_image.save(os.path.join(pred_audio_dir, f"cross_attn_map_{item_idx}.png"))
 
                     predicted_audio_np = predicted_audio[idx].float().detach().cpu().numpy()
                     predicted_audio_np = predicted_audio_np[:predicted_audio_lens[idx]]

--- a/scripts/magpietts/infer_and_evaluate.py
+++ b/scripts/magpietts/infer_and_evaluate.py
@@ -112,6 +112,8 @@ def delete_old_generated_files(output_dir):
         os.remove(f)
     for f in glob.glob(f"{output_dir}/predicted_audio*.wav"):
         os.remove(f)
+    for f in glob.glob(f"{output_dir}/cross_attn_map_*.png"):
+        os.remove(f)
 
 
 def run_inference(


### PR DESCRIPTION
predicted audio files are saved in the dir `parent/audio/repeat_0/predicted_audio_0.wav`, but cross-attention map was overridden by the repeats, and saved in `parent/audio/cross_attn_map_0.png`. Now it is saved in the same dir as predicted audio, `parent/audio/repeat_0/cross_attn_map_0.png`, without overridden.