### PR TITLE
Add option to suppress import checks in `Dockerfile.speech`

### DIFF
--- a/docker/Dockerfile.speech
+++ b/docker/Dockerfile.speech
@@ -28,6 +28,8 @@ ARG REQUIRE_TORCHAUDIO=false
 ARG REQUIRE_K2=false
 # ais cli: not required by default, install only if required
 ARG REQUIRE_AIS_CLI=false
+# check imports: if flag is false, ignore result
+ARG REQUIRE_CHECK_IMPORTS=true
 
 # Ensure apt-get won't prompt for selecting options
 ENV DEBIAN_FRONTEND=noninteractive
@@ -162,11 +164,18 @@ RUN --mount=from=nemo-src,target=/tmp/nemo,rw cd /tmp/nemo && pip install ".[all
 # NB: adjusting LD_LIBRARY_PATH (only here, should not be persistent!) is a temporary hack
 # to avoid failure if CUDA is unavailable (`docker build` does not expose GPUs)
 # The error is raised in NeMo Core, and the main reason is reinstalled Transformer-Engine;
-RUN export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${CUDA_HOME}/compat/lib.real && \
+RUN CHECK_MSG=$(export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${CUDA_HOME}/compat/lib.real && \
   python -c "import nemo.collections.asr as nemo_asr" && \
   python -c "import nemo.collections.nlp as nemo_nlp" && \
   python -c "import nemo.collections.tts as nemo_tts" && \
-  python -c "import nemo_text_processing.text_normalization as text_normalization"
+  python -c "import nemo_text_processing.text_normalization as text_normalization"); CHECK_CODE=$?; \
+  echo ${CHECK_MSG}; \
+  if [ ${CHECK_CODE} -ne 0 ]; then \
+  echo "Import check failed"; \
+  if [ "${REQUIRE_CHECK_IMPORTS}" = true ]; then \
+  exit ${CHECK_CODE}; \
+  else echo "Skipping unsuccessful import check"; fi \
+  else echo "Import check success"; fi
 
 
 # copy scripts/examples/tests into container for end user


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Add `REQUIRE_CHECK_IMPORTS` argument to `Dockerfile.speech` to suppress imports.
**Reason**: transformer-engine requires GPU to be exposed when importing NeMo. Since there are multiple issues related to building docker containers on Gitlab (e.g., see https://gitlab.com/gitlab-org/gitlab-runner/-/issues/36830), `REQUIRE_CHECK_IMPORTS` flag added to suppress these checks.
**By default nothing changed:** import checks are required by default.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
