### PR TITLE
Allow exception in hf ckpt load attempt before fallback to standard l…

### DIFF
--- a/nemo/lightning/io/api.py
+++ b/nemo/lightning/io/api.py
@@ -270,7 +270,7 @@ def export_ckpt(
             modelopt_export_kwargs = modelopt_export_kwargs or {}
             # First try to export via ModelOpt route. If rejected, return to the default route
             output = export_hf_checkpoint(path, _output_path, **modelopt_export_kwargs)
-        except:
+        except RuntimeError:
             output = None
         if output is not None:
             return output

--- a/nemo/lightning/io/api.py
+++ b/nemo/lightning/io/api.py
@@ -266,9 +266,12 @@ def export_ckpt(
     _output_path = output_path or Path(path) / target
 
     if target == "hf":
-        modelopt_export_kwargs = modelopt_export_kwargs or {}
-        # First try to export via ModelOpt route. If rejected, return to the default route
-        output = export_hf_checkpoint(path, _output_path, **modelopt_export_kwargs)
+        try:
+            modelopt_export_kwargs = modelopt_export_kwargs or {}
+            # First try to export via ModelOpt route. If rejected, return to the default route
+            output = export_hf_checkpoint(path, _output_path, **modelopt_export_kwargs)
+        except:
+            output = None
         if output is not None:
             return output
 


### PR DESCRIPTION
# What does this PR do ?

The current `export_ckpt` code contains logic that attempts some kind of ModelOpt checkpoint load, and if it fails, then defaults to the usual checkpoint load. The current code assumes that if the ModelOpt checkpoint load fails, a `None` `output` will be the result, but that isn't always the case -- sometimes it fails by throwing an exception. In this case, I just added a try catch block to deal with this.

This solution is not ideal, but and this PR is just to get the discussion started and also to unblock BioNeMo which is currently stuck on this.

**Collection**: All

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
