### PR TITLE
Allows using other signals (than SIGTERM) with PreemptionPlugin

### DIFF
--- a/nemo/lightning/run/plugins.py
+++ b/nemo/lightning/run/plugins.py
@@ -17,6 +17,7 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, Optional
+import signal 
 
 import nemo_run as run
 import yaml
@@ -58,13 +59,15 @@ class PreemptionPlugin(run.Plugin):
                              stopped before reaching their time limit, reducing waste and
                              promoting fair resource usage. The default value is 60 seconds (1 minute).
                              This is only supported for ``run.SlurmExecutor``.
+        sig (signal.Signals): The signal to listen for. Defaults to signal.SIGTERM.
         callbacks (list[run.Config[Callback]]): A list of callback configurations that the plugin
                                                 will merge with the task's existing callbacks.
                                                 By default, the list includes NeMo's preemption callback.
     """
 
     preempt_time: int = 60
-    callbacks: list[run.Config[Callback]] = field(default_factory=lambda: [run.Config(PreemptionCallback)])
+    sig: signal.Signals = signal.SIGTERM
+    callbacks: list[run.Config[Callback]] = None
 
     def setup(self, task: run.Partial | run.Script, executor: run.Executor):
         """Set up the preemption plugin."""
@@ -77,11 +80,12 @@ class PreemptionPlugin(run.Plugin):
         if isinstance(executor, run.SlurmExecutor):
             # Sends a SIGTERM self.preempt_time seconds before hitting time limit
             logging.info(
-                f"{self.__class__.__name__} will send a SIGTERM {self.preempt_time} seconds before the job's time limit for your Slurm executor."  # pylint: disable=C0301
+                f"{self.__class__.__name__} will send a {self.sig.name} {self.preempt_time} seconds before the job's time limit for your Slurm executor."  # pylint: disable=C0301
             )
-            executor.signal = f"TERM@{self.preempt_time}"
+            executor.signal = f"{self.sig.value}@{self.preempt_time}"
 
-        _merge_callbacks(task, callbacks=self.callbacks)
+        callbacks = self.callbacks or [run.Config(PreemptionCallback, sig=self.sig)]
+        _merge_callbacks(task, callbacks=callbacks)
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Allows to set a different signal to use for the PreemptionPlugin. THis is useful when the default SIGTERM is too aggressive and we'd like to use SIGINT.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Adding `sig` as a argument to PreemptivePlugin.
- Create the PreemptiveCallback with the appropriate signal.


# Usage

```python
PreemptionPlugin(preempt_time=2*60, sig=signal.SIGINT)
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [V] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
