### PR TITLE
Support recent spike-no-more related additions to Megatron

### DIFF
--- a/nemo/collections/llm/gpt/model/megatron/hyena/hyena_utils.py
+++ b/nemo/collections/llm/gpt/model/megatron/hyena/hyena_utils.py
@@ -430,6 +430,11 @@ def hyena_no_weight_decay_cond(name, param):
     return no_wd
 
 
+def hyena_no_weight_decay_cond_embedding(name, param):
+    """Condition for no weight decay for Hyena embedding parameters."""
+    return hyena_no_weight_decay_cond(name, param) or 'embedding' in name
+
+
 def fftconv_func(u, k, D, dropout_mask, gelu=True, k_rev=None, bidirectional=False):
     """Apply a 1D convolution to the input sequence u using the filter k and the shortcut D."""
     seqlen = u.shape[-1]

--- a/nemo/lightning/fabric/strategies.py
+++ b/nemo/lightning/fabric/strategies.py
@@ -217,6 +217,7 @@ class FabricMegatronStrategy(DDPStrategy):
         no_weight_decay_cond: Optional[Callable] = None,
         scale_lr_cond: Optional[Callable] = None,
         lr_mult: float = 1.0,
+        default_skip_embedding_weight_decay: bool = False,
     ) -> Optimizer:
         """
         Setup the Megatron optimizer.
@@ -232,6 +233,7 @@ class FabricMegatronStrategy(DDPStrategy):
             no_weight_decay_cond=no_weight_decay_cond,
             scale_lr_cond=scale_lr_cond,
             lr_mult=lr_mult,
+            default_skip_embedding_weight_decay=default_skip_embedding_weight_decay,
         )
 
     @override

--- a/nemo/lightning/pytorch/optim/megatron.py
+++ b/nemo/lightning/pytorch/optim/megatron.py
@@ -52,6 +52,7 @@ class MegatronOptimizerModule(OptimizerModule):
         no_weight_decay_cond: Optional[Callable] = None,
         scale_lr_cond: Optional[Callable] = None,
         lr_mult: float = 1.0,
+        default_skip_embedding_weight_decay: bool = False,
     ):
         """Initializes the MegatronOptimizerModule.
 
@@ -61,6 +62,10 @@ class MegatronOptimizerModule(OptimizerModule):
             no_weight_decay_cond (Optional[Callable]): Condition for no weight decay.
             scale_lr_cond (Optional[Callable]): Condition for scaling learning rate.
             lr_mult (float): Learning rate multiplier.
+            default_skip_embedding_weight_decay (bool): Whether to skip weight decay for
+                embedding parameters by default, if no_weight_decay_cond is not provided.
+                This is useful if you do not want embeddings to shrink to zero in training
+                as recommended in https://arxiv.org/abs/2312.16903
         """
 
         super().__init__(lr_scheduler=lr_scheduler)
@@ -68,6 +73,7 @@ class MegatronOptimizerModule(OptimizerModule):
         self.no_weight_decay_cond = no_weight_decay_cond
         self.scale_lr_cond = scale_lr_cond
         self.lr_mult = lr_mult
+        self.default_skip_embedding_weight_decay = default_skip_embedding_weight_decay
 
     def on_fit_start(self, trainer: "pl.Trainer", pl_module: "pl.LightningModule"):
         """We will add the finalize_model_grads function to the model config.
@@ -103,6 +109,7 @@ class MegatronOptimizerModule(OptimizerModule):
             no_weight_decay_cond=self.no_weight_decay_cond,
             scale_lr_cond=self.scale_lr_cond,
             lr_mult=self.lr_mult,
+            default_skip_embedding_weight_decay=self.default_skip_embedding_weight_decay,
         )
 
         return [optimizer]


### PR DESCRIPTION
# What does this PR do ?

Support recent spike-no-more related additions to Megatron, specifically the new option to by default skip weight decay on embedding layers, if requested.

**Collection**: core

# Changelog

- Pass through new option from megatron to skip weight decay on the embedding layer, if desired.
- Default behavior does not change from the current default behavior.

# Usage

- You can potentially add a usage example below

```python
opt = MegatronOptimizerModule(
    ...
    default_skip_embedding_weight_decay=True, # New option supported, defaults to False to mimic old behavior
)
```

**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation
