### PR TITLE
Changes to grok to alleviate error: TypeError: '>' not supported betw…

### DIFF
--- a/scripts/performance/llm/pretrain_grok1_314b.py
+++ b/scripts/performance/llm/pretrain_grok1_314b.py
@@ -293,6 +293,9 @@ def override_recipe_configs(
     etp_size: int = None,
     enable_cuda_graphs: bool = False,
     use_mcore_fsdp: bool = False,
+    use_fsdp_double_buffer: Optional[bool] = None,
+    use_user_buffer_registration: bool = False,
+    use_sharp: bool = False,
     recompute_layers: int = 0,
     activation_offload_layers: int = 0,
     compute_dtype: str = None,
@@ -317,6 +320,9 @@ def override_recipe_configs(
         etp_size,
         enable_cuda_graphs,
         use_mcore_fsdp,
+        use_fsdp_double_buffer,
+        use_user_buffer_registration,
+        use_sharp,
         recompute_layers,
         activation_offload_layers,
         compute_dtype,
@@ -380,6 +386,11 @@ if __name__ == "__main__":
         activation_offload_layers,
     ) = kwargs[:15]
 
+    use_fsdp_double_buffer_arg = False
+    use_user_buffer_registration_arg = False
+    use_sharp_arg = None
+
+
     recipe = override_recipe_configs(
         args,
         num_nodes,
@@ -396,6 +407,9 @@ if __name__ == "__main__":
         etp_size,
         enable_cuda_graphs,
         use_mcore_fsdp,
+        use_fsdp_double_buffer_arg,
+        use_user_buffer_registration_arg,
+        use_sharp_arg,
         recompute_layers,
         activation_offload_layers,
         args.compute_dtype,

--- a/scripts/performance/llm/pretrain_grok1_314b.py
+++ b/scripts/performance/llm/pretrain_grok1_314b.py
@@ -390,7 +390,6 @@ if __name__ == "__main__":
     use_user_buffer_registration_arg = False
     use_sharp_arg = None
 
-
     recipe = override_recipe_configs(
         args,
         num_nodes,

--- a/scripts/performance/llm/pretrain_grok1_314b.py
+++ b/scripts/performance/llm/pretrain_grok1_314b.py
@@ -382,13 +382,13 @@ if __name__ == "__main__":
         etp_size,
         enable_cuda_graphs,
         use_mcore_fsdp,
+        use_fsdp_double_buffer,
+        use_user_buffer_registration,
+        use_sharp,
         recompute_layers,
         activation_offload_layers,
-    ) = kwargs[:15]
+    ) = kwargs[:18]
 
-    use_fsdp_double_buffer_arg = False
-    use_user_buffer_registration_arg = False
-    use_sharp_arg = None
 
     recipe = override_recipe_configs(
         args,
@@ -406,9 +406,9 @@ if __name__ == "__main__":
         etp_size,
         enable_cuda_graphs,
         use_mcore_fsdp,
-        use_fsdp_double_buffer_arg,
-        use_user_buffer_registration_arg,
-        use_sharp_arg,
+        use_fsdp_double_buffer,
+        use_user_buffer_registration,
+        use_sharp,
         recompute_layers,
         activation_offload_layers,
         args.compute_dtype,

--- a/scripts/performance/llm/pretrain_grok1_314b.py
+++ b/scripts/performance/llm/pretrain_grok1_314b.py
@@ -389,7 +389,6 @@ if __name__ == "__main__":
         activation_offload_layers,
     ) = kwargs[:18]
 
-
     recipe = override_recipe_configs(
         args,
         num_nodes,

--- a/scripts/performance/llm/pretrain_grok1_314b.py
+++ b/scripts/performance/llm/pretrain_grok1_314b.py
@@ -293,15 +293,17 @@ def override_recipe_configs(
     etp_size: int = None,
     enable_cuda_graphs: bool = False,
     use_mcore_fsdp: bool = False,
-    use_fsdp_double_buffer: Optional[bool] = None,
-    use_user_buffer_registration: bool = False,
-    use_sharp: bool = False,
     recompute_layers: int = 0,
     activation_offload_layers: int = 0,
     compute_dtype: str = None,
     fp8_recipe: str = None,
 ):
     recipe = pretrain_recipe(performance_mode=True)
+
+    use_fsdp_double_buffer=args.use_fsdp_double_buffer
+    use_user_buffer_registration=args.use_user_buffer_registration
+    use_sharp=args.use_sharp
+
     recipe = set_primary_perf_configs(
         recipe,
         "pre_train",
@@ -382,12 +384,9 @@ if __name__ == "__main__":
         etp_size,
         enable_cuda_graphs,
         use_mcore_fsdp,
-        use_fsdp_double_buffer,
-        use_user_buffer_registration,
-        use_sharp,
         recompute_layers,
         activation_offload_layers,
-    ) = kwargs[:18]
+    ) = kwargs[:15]
 
     recipe = override_recipe_configs(
         args,
@@ -405,9 +404,6 @@ if __name__ == "__main__":
         etp_size,
         enable_cuda_graphs,
         use_mcore_fsdp,
-        use_fsdp_double_buffer,
-        use_user_buffer_registration,
-        use_sharp,
         recompute_layers,
         activation_offload_layers,
         args.compute_dtype,

--- a/scripts/performance/llm/pretrain_grok1_314b.py
+++ b/scripts/performance/llm/pretrain_grok1_314b.py
@@ -300,9 +300,9 @@ def override_recipe_configs(
 ):
     recipe = pretrain_recipe(performance_mode=True)
 
-    use_fsdp_double_buffer=args.use_fsdp_double_buffer
-    use_user_buffer_registration=args.use_user_buffer_registration
-    use_sharp=args.use_sharp
+    use_fsdp_double_buffer = args.use_fsdp_double_buffer
+    use_user_buffer_registration = args.use_user_buffer_registration
+    use_sharp = args.use_sharp
 
     recipe = set_primary_perf_configs(
         recipe,

--- a/scripts/performance/llm/pretrain_grok1_314b.py
+++ b/scripts/performance/llm/pretrain_grok1_314b.py
@@ -300,10 +300,6 @@ def override_recipe_configs(
 ):
     recipe = pretrain_recipe(performance_mode=True)
 
-    use_fsdp_double_buffer = args.use_fsdp_double_buffer
-    use_user_buffer_registration = args.use_user_buffer_registration
-    use_sharp = args.use_sharp
-
     recipe = set_primary_perf_configs(
         recipe,
         "pre_train",
@@ -322,9 +318,9 @@ def override_recipe_configs(
         etp_size,
         enable_cuda_graphs,
         use_mcore_fsdp,
-        use_fsdp_double_buffer,
-        use_user_buffer_registration,
-        use_sharp,
+        args.use_fsdp_double_buffer,
+        args.use_user_buffer_registration,
+        args.use_sharp,
         recompute_layers,
         activation_offload_layers,
         compute_dtype,


### PR DESCRIPTION
…een instances of 'str' and 'int'

> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Made changes to pretrain_grok1.py script. Needed to add variables: **use_fsdp_double_buffer_arg,use_user_buffer_registration_arg, use_sharp_arg, to the override_recipe_configs function** header because this function calls set_primary_perf_configs function which takes

```
use_fsdp_double_buffer: Optional[bool] = None,
    use_user_buffer_registration: bool = False,
    use_sharp: bool = False,

```
as arguments to its function header. Ordering of these variables in calling the function was important as the above 3 variables are set before recompute_layers: int = 0, which was an error that it was complaining about before:


```
if recompute_layers > 0:
     ^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'str' and 'int'
```


# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
