### PR TITLE
fix: reduce the excessive test time of test_msdd_diar_inference

### DIFF
--- a/tests/collections/speaker_tasks/test_diar_neural_inference.py
+++ b/tests/collections/speaker_tasks/test_diar_neural_inference.py
@@ -35,8 +35,7 @@ class TestNeuralDiarizerInference:
             ),
         ],
     )
-    @pytest.mark.pleasefixme
-    @pytest.mark.parametrize("num_speakers", [None, 1])
+    @pytest.mark.parametrize("num_speakers", [None])
     @pytest.mark.parametrize("max_num_speakers", [4])
     def test_msdd_diar_inference(self, tmpdir, test_data_dir, device, num_speakers, max_num_speakers):
         """
@@ -47,7 +46,7 @@ class TestNeuralDiarizerInference:
             - Ensures temporary directory is emptied at the end of diarization
             - Sanity check to ensure outputs from diarization are reasonable
         """
-        audio_filenames = ['an22-flrp-b.wav', 'an90-fbbh-b.wav']
+        audio_filenames = ['an90-fbbh-b.wav']
         audio_paths = [os.path.join(test_data_dir, "asr", "train", "an4", "wav", fp) for fp in audio_filenames]
 
         diarizer = NeuralDiarizer.from_pretrained(model_name='diar_msdd_telephonic').to(device)


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Reduces the unit-test time of function `test_msdd_diar_inference`.

**Collection**: [Note which collection this PR will affect]

# Changelog

Removed redundant test repetitions.

# Usage


```python
pytest test_diar_neural_inference.py 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
