### PR TITLE
Adds pyxis container writable and no mount home flags

### DIFF
--- a/scripts/performance/executors.py
+++ b/scripts/performance/executors.py
@@ -71,7 +71,7 @@ def slurm_executor(
     custom_bash_cmds = [] if custom_bash_cmds is None else custom_bash_cmds
     err_msgs = []
     mounts = []
-    srun_args = custom_srun_args.copy() + ["--mpi=pmix"]
+    srun_args = custom_srun_args.copy() + ["--mpi=pmix", "--container-writable", "--no-container-mount-home"]
 
     if log_dir != get_nemorun_home():
         err_msgs.append(f"\nRun `export NEMORUN_HOME={log_dir}` in your shell environment and rerun this script.")


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Adds pyxis container writable and no mount home flags.

We've now encountered multiple instances where a customers enroot config does not match our own and the recipes fail. These flags are what we used in previous versions.

# Changelog

- Add `--container-writable` and `--no-container-mount-home` to srun args.

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
- [X] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [X] Bugfix
- [ ] Documentation