### PR TITLE
Fix to Grok pretrain script to resolve: TypeError: '>' not supported …

### DIFF
--- a/nemo/lightning/run/plugins.py
+++ b/nemo/lightning/run/plugins.py
@@ -182,13 +182,13 @@ class NsysPlugin(run.Plugin):
             # NOTE: DO NOT change to f-string, `%q{}` is Slurm placeholder
             launcher.nsys_filename = "profile_%p_%q{SLURM_JOB_ID}_node%q{SLURM_NODEID}_rank%q{SLURM_PROCID}"
             launcher.nsys_extra_args = self.nsys_extra_args or [
-            "--force-overwrite=true",
-            "--capture-range=cudaProfilerApi",
-            "--capture-range-end=stop",
-            "--cuda-graph-trace=node",
-            "--cuda-event-trace=false",
-            "--nvtx-domain-include=NCCL",
-        ]
+                "--force-overwrite=true",
+                "--capture-range=cudaProfilerApi",
+                "--capture-range-end=stop",
+                "--cuda-graph-trace=node",
+                "--cuda-event-trace=false",
+                "--nvtx-domain-include=NCCL",
+            ]
         if self.nsys_gpu_metrics:
             if hasattr(launcher, "nsys_gpu_metrics"):
                 launcher.nsys_gpu_metrics = self.nsys_gpu_metrics

--- a/scripts/performance/llm/pretrain_grok1_314b.py
+++ b/scripts/performance/llm/pretrain_grok1_314b.py
@@ -293,6 +293,9 @@ def override_recipe_configs(
     etp_size: int = None,
     enable_cuda_graphs: bool = False,
     use_mcore_fsdp: bool = False,
+    use_fsdp_double_buffer: Optional[bool] = None,
+    use_user_buffer_registration: bool = False,
+    use_sharp: bool = False,
     recompute_layers: int = 0,
     activation_offload_layers: int = 0,
     compute_dtype: str = None,
@@ -317,6 +320,9 @@ def override_recipe_configs(
         etp_size,
         enable_cuda_graphs,
         use_mcore_fsdp,
+        use_fsdp_double_buffer,
+        use_user_buffer_registration,
+        use_sharp,
         recompute_layers,
         activation_offload_layers,
         compute_dtype,
@@ -376,9 +382,12 @@ if __name__ == "__main__":
         etp_size,
         enable_cuda_graphs,
         use_mcore_fsdp,
+        use_fsdp_double_buffer,
+        use_user_buffer_registration,
+        use_sharp,
         recompute_layers,
         activation_offload_layers,
-    ) = kwargs[:15]
+    ) = kwargs[:18]
 
     recipe = override_recipe_configs(
         args,
@@ -396,6 +405,9 @@ if __name__ == "__main__":
         etp_size,
         enable_cuda_graphs,
         use_mcore_fsdp,
+        use_fsdp_double_buffer,
+        use_user_buffer_registration,
+        use_sharp,
         recompute_layers,
         activation_offload_layers,
         args.compute_dtype,

--- a/scripts/performance/utils.py
+++ b/scripts/performance/utils.py
@@ -167,6 +167,7 @@ def prepare_squad_dataset_experiment(
         "prepare_squad_dataset_exp",
     )
 
+
 def isfile_train_pack_metadata(hf_model_uri: str, data_config: run.Config[SquadDataModule]) -> bool:
     """
     This method is used for fine-tuning. It checks if packed train data for a partiular


### PR DESCRIPTION
…between instances of 'str' and 'int'

> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Made changes to pretrain_grok1.py script. Needed to add variables: use_fsdp_double_buffer_arg,use_user_buffer_registration_arg, use_sharp_arg, to the override_recipe_configs function header because this function calls set_primary_perf_configs function which takes

use_fsdp_double_buffer: Optional[bool] = None,
    use_user_buffer_registration: bool = False,
    use_sharp: bool = False,

as arguments to its function header. Ordering of these variables in calling the function was important as the above 3 variables are set before recompute_layers: int = 0, which was an error that it was complaining about before:

if recompute_layers > 0:
     ^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'str' and 'int'

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
