### PR TITLE
Discount FLOPs in dot-product att

### DIFF
--- a/nemo/utils/flops_formulas.py
+++ b/nemo/utils/flops_formulas.py
@@ -62,18 +62,19 @@ class FLOPSConfig:
 
 def gpt3(config: FLOPSConfig):
     """Model FLOPs for GPT3 family"""
-
     vocab_size = LLM_VOCAB_SIZE_MAP["gpt3"]
+    causal_self_attn = True
 
     return (
         24 * config.gbs * config.enc_seq_len * config.hs * config.hs
-        + 4 * config.gbs * config.enc_seq_len * config.enc_seq_len * config.hs
+        + 4 * config.gbs * config.enc_seq_len * config.enc_seq_len * config.hs * (0.5 if causal_self_attn else 1)
     ) * (3 * config.layers) + (6 * config.gbs * config.enc_seq_len * config.hs * vocab_size)
 
 
 def llama2(config: FLOPSConfig):
     """Model FLOPs for llama2 family"""
     vocab_size = LLM_VOCAB_SIZE_MAP["llama2"]
+    causal_self_attn = True
 
     return (
         config.gbs
@@ -85,7 +86,7 @@ def llama2(config: FLOPSConfig):
             12
             + (12 * config.query_groups / config.attention_heads)
             + (18 * config.ffn_hs / config.hs)
-            + (12 * config.enc_seq_len / config.hs)
+            + (12 * config.enc_seq_len / config.hs) * (0.5 if causal_self_attn else 1)
             + (6 * vocab_size / (config.layers * config.hs))
         )
     )
@@ -94,6 +95,7 @@ def llama2(config: FLOPSConfig):
 def llama3(config: FLOPSConfig):
     """Model FLOPs for llama3 family"""
     vocab_size = LLM_VOCAB_SIZE_MAP["llama3"]
+    causal_self_attn = True
 
     return (
         config.gbs
@@ -105,7 +107,7 @@ def llama3(config: FLOPSConfig):
             12
             + (12 * config.query_groups / config.attention_heads)
             + (18 * config.ffn_hs / config.hs)
-            + (12 * config.enc_seq_len / config.hs)
+            + (12 * config.enc_seq_len / config.hs) * (0.5 if causal_self_attn else 1)
             + (6 * vocab_size / (config.layers * config.hs))
         )
     )
@@ -114,6 +116,7 @@ def llama3(config: FLOPSConfig):
 def nemotron(config: FLOPSConfig):
     """Model FLOPs for nemotron family"""
     vocab_size = LLM_VOCAB_SIZE_MAP["nemotron"]
+    causal_self_attn = True
 
     return (
         config.gbs
@@ -125,7 +128,7 @@ def nemotron(config: FLOPSConfig):
             12
             + (12 * config.query_groups / config.attention_heads)
             + (12 * config.ffn_hs / config.hs)
-            + (12 * config.enc_seq_len / config.hs)
+            + (12 * config.enc_seq_len / config.hs) * (0.5 if causal_self_attn else 1)
             + (6 * vocab_size / (config.layers * config.hs))
         )
     )
@@ -134,6 +137,7 @@ def nemotron(config: FLOPSConfig):
 def mixtral(config: FLOPSConfig):
     """Model FLOPs for mixtral family"""
     vocab_size = LLM_VOCAB_SIZE_MAP["mixtral"]
+    causal_self_attn = True
 
     return (
         config.gbs
@@ -145,7 +149,7 @@ def mixtral(config: FLOPSConfig):
             12
             + (12 * config.query_groups / config.attention_heads)
             + (18 * config.moe_router_topk * config.ffn_hs / config.hs)
-            + (12 * config.enc_seq_len / config.hs)
+            + (12 * config.enc_seq_len / config.hs) * (0.5 if causal_self_attn else 1)
             + (6 * vocab_size / (config.layers * config.hs))
         )
     )

--- a/tests/collections/common/test_perf_metrics.py
+++ b/tests/collections/common/test_perf_metrics.py
@@ -93,10 +93,10 @@ def model_config(cfg):
 @pytest.mark.parametrize(
     "cfg, model_name, train_step_time, expected_value",
     [
-        (LLAMA2_CFG_STR, None, 8, 377.53),
-        (LLAMA2_CFG_STR, "llama2", 8, 377.53),
-        (LLAMA2_CFG_STR, None, [8, 8, 8, 8], 377.53),
-        (NEMOTRON_CFG_STR, None, 1.31, 642.73),
+        (LLAMA2_CFG_STR, None, 8, 351.14),
+        (LLAMA2_CFG_STR, "llama2", 8, 351.14),
+        (LLAMA2_CFG_STR, None, [8, 8, 8, 8], 351.14),
+        (NEMOTRON_CFG_STR, None, 1.31, 602.42),
         (
             UNSUPPORTED_MODEL_CFG_STR,
             None,

--- a/tests/utils/test_flops_formulas.py
+++ b/tests/utils/test_flops_formulas.py
@@ -73,6 +73,7 @@ def test_transformer(flops_config):
     expected_flops = 118427811840.0
     assert transformer(flops_config) == expected_flops
 
+
 def test_transformer_no_moe(flops_config):
     flops_config.moe_router_topk = 0
     expected_flops = 96684539904.0

--- a/tests/utils/test_flops_formulas.py
+++ b/tests/utils/test_flops_formulas.py
@@ -35,27 +35,27 @@ def flops_config():
 
 
 def test_gpt3(flops_config):
-    expected_flops = 97240743936
+    expected_flops = 96334774272
     assert gpt3(flops_config) == expected_flops
 
 
 def test_llama2(flops_config):
-    expected_flops = 107659395072.0
+    expected_flops = 106753425408.0
     assert llama2(flops_config) == expected_flops
 
 
 def test_llama3(flops_config):
-    expected_flops = 164433494016.0
+    expected_flops = 163527524352.0
     assert llama3(flops_config) == expected_flops
 
 
 def test_nemotron(flops_config):
-    expected_flops = 218036699136.0
+    expected_flops = 217130729472.0
     assert nemotron(flops_config) == expected_flops
 
 
 def test_mixtral(flops_config):
-    expected_flops = 172889210880.0
+    expected_flops = 171983241216.0
     assert mixtral(flops_config) == expected_flops
 
 


### PR DESCRIPTION
# What does this PR do ?

Discount the number of floating-point operations in dot-product attention for GPT3, LM2, LM3, and Mixtral models.

# Changelog

- Divide the number of floating-point operations in dot-product attention by 2 when `causal_self_attn=True`

# Usage

- Updated the default condition

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
