### PR TITLE
[Flux] correct vae_downscale_factor

### DIFF
--- a/nemo/collections/diffusion/models/flux/model.py
+++ b/nemo/collections/diffusion/models/flux/model.py
@@ -489,18 +489,21 @@ class MegatronFluxModel(L.LightningModule, io.IOMixin, io.ConnectorMixin, fn.FNM
         # pylint: disable=C0116
         if isinstance(vae, nn.Module):
             self.vae = vae.eval().cuda()
-            self.vae_scale_factor = 2 ** (len(self.vae.params.ch_mult))
+            self.vae_scale_factor = 2 ** (len(self.vae.params.ch_mult) - 1)
+            self.vae_channels = self.vae.params.z_channels
             for param in self.vae.parameters():
                 param.requires_grad = False
         elif isinstance(vae, AutoEncoderConfig):
             self.vae = AutoEncoder(vae).eval().cuda()
-            self.vae_scale_factor = 2 ** (len(vae.ch_mult))
+            self.vae_scale_factor = 2 ** (len(vae.ch_mult) - 1)
+            self.vae_channels = vae.z_channels
             for param in self.vae.parameters():
                 param.requires_grad = False
         else:
             logging.info("Vae not provided, assuming the image input is precached...")
             self.vae = None
-            self.vae_scale_factor = 16
+            self.vae_scale_factor = 8
+            self.vae_channels = 16
 
     def configure_text_encoders(self, clip, t5):
         # pylint: disable=C0116
@@ -589,9 +592,8 @@ class MegatronFluxModel(L.LightningModule, io.IOMixin, io.ConnectorMixin, fn.FNM
 
         noise_pred = self._unpack_latents(
             noise_pred.transpose(0, 1),
-            int(latents.shape[2] * self.vae_scale_factor // 2),
-            int(latents.shape[3] * self.vae_scale_factor // 2),
-            vae_scale_factor=self.vae_scale_factor,
+            latents.shape[2],
+            latents.shape[3],
         ).transpose(0, 1)
 
         target = noise - latents
@@ -688,17 +690,15 @@ class MegatronFluxModel(L.LightningModule, io.IOMixin, io.ConnectorMixin, fn.FNM
             timesteps,
         )
 
-    def _unpack_latents(self, latents, height, width, vae_scale_factor):
+    def _unpack_latents(self, latents, height, width):
         # pylint: disable=C0116
         batch_size, num_patches, channels = latents.shape
 
-        height = height // vae_scale_factor
-        width = width // vae_scale_factor
-
-        latents = latents.view(batch_size, height, width, channels // 4, 2, 2)
+        # adjust h and w for patching
+        latents = latents.view(batch_size, height // 2, width // 2, channels // 4, 2, 2)
         latents = latents.permute(0, 3, 1, 4, 2, 5)
 
-        latents = latents.reshape(batch_size, channels // (2 * 2), height * 2, width * 2)
+        latents = latents.reshape(batch_size, channels // 4, height, width)
 
         return latents
 


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Correct the vae_scale_factor derivation, which was causing magic numbers to be required furder down

Previously, this was adding one too many downsampling layers. The last layer of the vae encoder does not add a downsampling layer, so we must account for this.
Because of this, unpack_latents was having to do some additional divisions to account for this incorrect factor.

**Collection**: [Note which collection this PR will affect]
- diffusion (flux only)
# Changelog

- Modify the vae_scale_factor calculation from `2 ** (len(vae.ch_mult))` to 2 ** (len(vae.ch_mult) - 1)`
- Simplify unpack_latents as it does not have to correct for this now
- Store vae_channels information, which can be useful.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
