### PR TITLE
Fix sequence packing loss calculation

### DIFF
--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
@@ -680,7 +680,7 @@ class GPTSFTPackedDataset(GPTSFTDataset):
 
                 # The second eos_id index marks the length of the original unpadded sequence if the sequence is
                 # prepadded for cp_size > 1. Otherwise, there is no extra padding.
-		seqlen_unpadded = eos_idx[0][1] + 1 if eos_idx[0].shape[0] > 1 else len(current_seq)                
+                seqlen_unpadded = eos_idx[0][1] + 1 if eos_idx[0].shape[0] > 1 else len(current_seq)                
                 cu_seqlens_unpadded[-1].append(cu_seqlens_unpadded[-1][-1] + seqlen_unpadded)
 
             # if extra paddings are added in the packed sequence, they can't be counted as

--- a/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
+++ b/nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py
@@ -680,7 +680,7 @@ class GPTSFTPackedDataset(GPTSFTDataset):
 
                 # The second eos_id index marks the length of the original unpadded sequence if the sequence is
                 # prepadded for cp_size > 1. Otherwise, there is no extra padding.
-                seqlen_unpadded = eos_idx[0][0] + 1 if eos_idx[0].any() else len(current_seq)
+		seqlen_unpadded = eos_idx[0][1] + 1 if eos_idx[0].shape[0] > 1 else len(current_seq)                
                 cu_seqlens_unpadded[-1].append(cu_seqlens_unpadded[-1][-1] + seqlen_unpadded)
 
             # if extra paddings are added in the packed sequence, they can't be counted as

--- a/nemo/utils/sequence_packing_utils.py
+++ b/nemo/utils/sequence_packing_utils.py
@@ -232,7 +232,7 @@ def fill_packing_strategy(
                             [
                                 # (x['answer_start_idx'] - 1) because we want to train on the output
                                 # after the last context token
-                                idx >= (x["answer_start_idx"] - 1) and x["input_ids"][idx] != pad_id
+                                idx >= (x["answer_start_idx"] - 1)
                                 for idx in range(len(x["input_ids"]))
                             ]
                             for x in per_seq_data


### PR DESCRIPTION
# What does this PR do ?

Fix sequence packing loss calculation

# Changelog

- Fix sequence packing loss calculation

The current loss calculation with sequence packing for one example with a smaller example is significantly high.

On the dataset side, I created a dataset with a smaller example to reproduce this issue.
```
{"messages": [{"role": "user", "content": "What is 1+2?"}, {"role": "assistant", "content": "The answer is 3."}]}
```
I turned off the data parallelism, used a single batch size, one epoch and max_seq_len of 32. When I ran the fine tuning with the same setup, here are the results:
```
# Without sequence packing
reduced_train_loss=3.660, global_step=0.000, consumed_samples=1.000, train_step_timing in s=1.900, val_loss=3.540
# With sequence packing
reduced_train_loss=5.290, global_step=0.000, consumed_samples=1.000, train_step_timing in s=4.360, val_loss=3.650
```

Even with a smaller example and minimum configuration, the loss difference persists. The below code changes fixes the issue.

For nemo/collections/nlp/data/language_modeling/megatron/gpt_sft_dataset.py, the comment mentions that `The second eos_id index marks the length of the original unpadded sequence`. However, in the code, we are using the first index of eos_id which actually represents the end of turn.

For nemo/utils/sequence_packing_utils.py, we are not considering the pad_id in loss_mask calculation without sequence packing(for example, https://github.com/NVIDIA/NeMo/blob/d0cb20dace8aa0212416c2b43fc3d53026e5c45f/nemo/collections/llm/gpt/data/core.py#L592). So, we should not consider pad_id with sequence packing as well to be consistent.
