### PR TITLE
Grok str,int issue PR for main.

### DIFF
--- a/scripts/performance/llm/pretrain_grok1_314b.py
+++ b/scripts/performance/llm/pretrain_grok1_314b.py
@@ -300,10 +300,6 @@ def override_recipe_configs(
 ):
     recipe = pretrain_recipe(performance_mode=True)
 
-    use_fsdp_double_buffer = args.use_fsdp_double_buffer
-    use_user_buffer_registration = args.use_user_buffer_registration
-    use_sharp = args.use_sharp
-
     recipe = set_primary_perf_configs(
         recipe,
         "pre_train",
@@ -322,9 +318,9 @@ def override_recipe_configs(
         etp_size,
         enable_cuda_graphs,
         use_mcore_fsdp,
-        use_fsdp_double_buffer,
-        use_user_buffer_registration,
-        use_sharp,
+        args.use_fsdp_double_buffer,
+        args.use_user_buffer_registration,
+        args.use_sharp,
         recompute_layers,
         activation_offload_layers,
         compute_dtype,


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Made changes to pretrain_grok1.py script. 
Needed to set 
`use_fsdp_double_buffer=args.use_fsdp_double_buffer
  use_user_buffer_registration=args.use_user_buffer_registration
  use_sharp=args.use_sharp
`
to pass to **set_primary_perf_configs** from **helpers.py** script function within **override_recipe_configs** function in **pretrain_grok1_314b.py** script. 

This resolves error:

```
if recompute_layers > 0:
     ^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'str' and 'int'


```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
