### PR TITLE
Pin nvidia-lm-eval to 25.5

### DIFF
--- a/requirements/requirements_eval.txt
+++ b/requirements/requirements_eval.txt
@@ -1,1 +1,1 @@
-nvidia-lm-eval==25.6.1
+nvidia-lm-eval==25.5

--- a/requirements/requirements_eval.txt
+++ b/requirements/requirements_eval.txt
@@ -1,1 +1,1 @@
-nvidia-lm-eval
+nvidia-lm-eval==25.6.1


### PR DESCRIPTION
# What does this PR do ?

Pin nvidia-lm-eval to 25.5

The latest verson 25.7.1. has breaking changes. 25.5 is what shipped with the 25.04.02 container. It's pinned to 25.6.1 on the main branch.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Pin nvidia-lm-eval to 25.6.1

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
