### PR TITLE
Fix evalset_config path

### DIFF
--- a/scripts/magpietts/evalset_config.py
+++ b/scripts/magpietts/evalset_config.py
@@ -43,7 +43,7 @@ dataset_meta_info = {
         'feature_dir' : '/Data/LibriTTS',
     },
     'libritts_test_clean': {
-        'manifest_path' : '/Data/evaluation_manifests/LibriTTS_test_clean_withContextAudioPaths.json',
+        'manifest_path' : '/Data/evaluation_manifests/LibriTTS_test_clean_withContextAudioPaths.jsonl',
         'audio_dir' : '/Data/LibriTTS',
         'feature_dir' : '/Data/LibriTTS',
     },


### PR DESCRIPTION
Fix a path in `evalset_config.py` to the actual path used in the EOS path (internal only)

Full path name (with prefix) on EOS is:`/lustre/fsw/llmservice_nemo_speechlm/data/TTS/evaluation_manifests/LibriTTS_test_clean_withContextAudioPaths.jsonl`. The last character was missing from evalset_config.py