### PR TITLE
Avoid speaker embedding crash on short signals

### DIFF
--- a/scripts/magpietts/evaluate_generated_audio.py
+++ b/scripts/magpietts/evaluate_generated_audio.py
@@ -18,6 +18,7 @@ import pprint
 import string
 import logging
 from contextlib import contextmanager
+from functools import partial
 
 import numpy as np
 import torch
@@ -252,17 +253,23 @@ def evaluate(manifest_path, audio_dir, generated_audio_dir, language="en", sv_mo
         pred_context_ssim = 0.0
         gt_context_ssim = 0.0
         with torch.no_grad():
-            gt_speaker_embedding = extract_embedding(speaker_verification_model, feature_extractor, gt_audio_filepath, device, sv_model_type)
-            pred_speaker_embedding = extract_embedding(speaker_verification_model, feature_extractor, pred_audio_filepath, device, sv_model_type)
+            extract_embedding_fn = partial(extract_embedding, model=speaker_verification_model, extractor=feature_extractor, device=device, sv_model_type=sv_model_type)
+            extract_embedding_fn_alternate = partial(extract_embedding, model=speaker_verification_model_alternate, extractor=feature_extractor, device=device, sv_model_type=sv_model_type)
+
+            # Ground truth vs predicted
+            gt_speaker_embedding = extract_embedding_fn(audio_path=gt_audio_filepath)
+            pred_speaker_embedding = extract_embedding_fn(audio_path=pred_audio_filepath)
             pred_gt_ssim = torch.nn.functional.cosine_similarity(gt_speaker_embedding, pred_speaker_embedding, dim=0).item()
 
-            gt_speaker_embedding_alternate = speaker_verification_model_alternate.get_embedding(gt_audio_filepath).squeeze()
-            pred_speaker_embedding_alternate = speaker_verification_model_alternate.get_embedding(pred_audio_filepath).squeeze()
+            # Ground truth vs predicted (alternate model)
+            gt_speaker_embedding_alternate = extract_embedding_fn_alternate(audio_path=gt_audio_filepath)
+            pred_speaker_embedding_alternate = extract_embedding_fn_alternate(audio_path=pred_audio_filepath)
             pred_gt_ssim_alternate = torch.nn.functional.cosine_similarity(gt_speaker_embedding_alternate, pred_speaker_embedding_alternate, dim=0).item()
 
             if context_audio_filepath is not None:
-                context_speaker_embedding = extract_embedding(speaker_verification_model, feature_extractor, context_audio_filepath, device, sv_model_type)
-                context_speaker_embedding_alternate = speaker_verification_model_alternate.get_embedding(context_audio_filepath).squeeze()
+                # Predicted vs context
+                context_speaker_embedding = extract_embedding_fn(audio_path=context_audio_filepath)
+                context_speaker_embedding_alternate = extract_embedding_fn_alternate(audio_path=context_audio_filepath)
 
                 pred_context_ssim = torch.nn.functional.cosine_similarity(pred_speaker_embedding, context_speaker_embedding, dim=0).item()
                 gt_context_ssim = torch.nn.functional.cosine_similarity(gt_speaker_embedding, context_speaker_embedding, dim=0).item()


### PR DESCRIPTION
Avoid speaker embedding crash on short signals

The alternate speaker embedding model was not using the extract_embedding()
method, which takes care of padding very short signals (which can
sometimes be generated during evaluation) so that they don't crash
the embedding model. This caused crashes during evaluation.

Fixed it to use extract_embedding() like the default speaker embedding model does.
