### PR TITLE
Harden _is_target_allowed by adding runtime class validation on top of prefix checks to prevent unsafe target resolution

### DIFF
--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -82,6 +82,7 @@ ALLOWED_NEMO_SUBMODULE_PREFIXES = [
     "nemo.collections.asr.parts",
     "nemo.collections.audio.parts",
     "nemo.collections.speechlm",
+    "nemo.collections.llm",
     "nemo.lightning",
     "megatron.core",
     "tests.collections.llm.common",


### PR DESCRIPTION

> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Previously, `_is_target_allowed` only checked whether the `_target_` string in a config started with an allowed prefix (e.g., `torch.nn`). This was insufficient, since Python allows nested/indirect module resolution (e.g., `torch.nn.utils.rnn.torch.os.system`), which could be abused to execute arbitrary code at model load time.

In the updated implementation, we:
* Resolve the target at runtime using `hydra.utils.get_class`
* Validate the resolved object to ensure it is a class (not a function)
* Require the class to inherit from known safe bases (torch.nn.Module or nemo.core.ModelPT)
* Reject any target that fails these checks

**Collection**: core

# Changelog

- `_is_target_allowed` function in nemo/core/classes/common.py has been updated


# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
