### PR TITLE
Disabled post_process when calling MCoreBert + added missing add_lm_h…

### DIFF
--- a/nemo/collections/llm/bert/model/base.py
+++ b/nemo/collections/llm/bert/model/base.py
@@ -317,7 +317,9 @@ class MCoreBertModelWrapperWithPostLNSupport(MCoreBert):
         if self.share_embeddings_and_output_weights:
             output_weight = self.shared_embedding_or_output_weight()
 
-        hidden_states_after_lm_head = self.lm_head(hidden_states=hidden_states) if self.config.add_lm_head else hidden_states
+        hidden_states_after_lm_head = (
+            self.lm_head(hidden_states=hidden_states) if self.config.add_lm_head else hidden_states
+        )
         logits, _ = self.output_layer(hidden_states_after_lm_head, weight=output_weight)
 
         binary_logits = None


### PR DESCRIPTION

# What does this PR do ?

Fixes inconsistencies in MCoreBertModelWrapper which cause a crash using specific BertConfigs. 

**Collection**: NLP

# Changelog

- Disable post_process when calling MCoreBert initializer from the wrapper
- Added missing config.add_lm_head check. 

**Pre checks**:

- [v] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [v] Bugfix
