### PR TITLE
Stop overwriting MCore FSDP config in MegatronStrategy

### DIFF
--- a/nemo/lightning/pytorch/strategies/megatron_strategy.py
+++ b/nemo/lightning/pytorch/strategies/megatron_strategy.py
@@ -383,18 +383,6 @@ class MegatronStrategy(DDPStrategy, io.IOMixin):
         elif fsdp is not None:
             raise ValueError(f'Invalid DDP type: {fsdp}, please choose from ["megatron", "pytorch"].')
 
-        if ddp == "megatron":
-            self.ddp_config = DistributedDataParallelConfig(check_for_nan_in_grad=True)
-        elif isinstance(ddp, DistributedDataParallelConfig):
-            self.ddp_config = ddp
-        elif ddp == "pytorch":
-            if self._fsdp is not None:
-                raise ValueError("Please set ddp to megatron to use FSDP.")
-            self.ddp_config = None
-            self.no_ddp_communication_hook = False
-        else:
-            raise ValueError(f"Invalid DDP type: {ddp}")
-
         if self.ckpt_load_optimizer and self.ckpt_load_main_params:
             raise ValueError("ckpt_load_optimizer and ckpt_load_main_params cannot be both set to True.")
 


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fixes bug in MCore custom FSDP.

The following code is duplicated in Megatron strategy on lines `346` and `378`:
```
        if ddp == "megatron":
            self.ddp_config = DistributedDataParallelConfig(check_for_nan_in_grad=True)
        elif isinstance(ddp, DistributedDataParallelConfig):
            self.ddp_config = ddp
        elif ddp == "pytorch":
            if self._fsdp is not None:
                raise ValueError("Please set ddp to megatron to use FSDP.")
            self.ddp_config = None
            self.no_ddp_communication_hook = False
        else:
            raise ValueError(f"Invalid DDP type: {ddp}")
```

When megatron fsdp is configured (`fsdp=megatron`), we set `self.ddp_config.use_custom_fsdp` to `true` on line 372. However, this is overwritten immediately due to the duplicated code.
```
        elif fsdp == "megatron":
            self._fsdp = fsdp
            if not self.ddp_config.use_custom_fsdp:
                self.ddp_config.use_custom_fsdp = True
                logging.warning("Setting ddp_config.use_custom_fsdp to True for MCore FSDP.")
            logging.info("FSDP option is set to MCore. Using MCore's Custom FSDP for DP.")
```

**Collection**: [Note which collection this PR will affect]

# Changelog

- Removes duplicated code that overwrites MCore custom FSDP config

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
