### PR TITLE
Randomized shard slicing for tarred data

### DIFF
--- a/nemo/collections/common/data/lhotse/cutset.py
+++ b/nemo/collections/common/data/lhotse/cutset.py
@@ -203,6 +203,7 @@ def read_dataset_config(config) -> tuple[CutSet, bool]:
         "skip_missing_manifest_entries": config.get("skip_missing_manifest_entries", False),
         "force_map_dataset": config.get("force_map_dataset", False),
         "force_iterable_dataset": config.get("force_iterable_dataset", False),
+        "slice_length": config.get("slice_length", None),
     }
     cuts, is_tarred = parse_and_combine_datasets(config.input_cfg, propagate_attrs=propagate_attrs)
     return cuts, is_tarred
@@ -241,7 +242,7 @@ def read_txt_paths(config: DictConfig) -> tuple[CutSet, bool]:
         )
     )
     if not config.get("force_finite", False):
-        cuts = cuts.repeat()
+        cuts = cuts.repeat(preserve_id=True)
     return cuts, True
 
 
@@ -261,7 +262,7 @@ def read_txt_pair_paths(config: DictConfig) -> tuple[CutSet, bool]:
         )
     )
     if not config.get("force_finite", False):
-        cuts = cuts.repeat()
+        cuts = cuts.repeat(preserve_id=True)
     return cuts, True
 
 
@@ -277,7 +278,7 @@ def read_nemo_sft_jsonl(config: DictConfig) -> tuple[CutSet, bool]:
         )
     )
     if not config.get("force_finite", False):
-        cuts = cuts.repeat()
+        cuts = cuts.repeat(preserve_id=True)
     return cuts, True
 
 
@@ -296,7 +297,7 @@ def read_multimodal_conversation_jsonl(config: DictConfig) -> tuple[CutSet, bool
         )
     )
     if not config.get("force_finite", False):
-        cuts = cuts.repeat()
+        cuts = cuts.repeat(preserve_id=True)
     return cuts, True
 
 
@@ -315,7 +316,7 @@ def read_share_gpt_as_conversation(config) -> tuple[CutSet, bool]:
         )
     )
     if not config.get("force_finite", False):
-        cuts = cuts.repeat()
+        cuts = cuts.repeat(preserve_id=True)
     return cuts, True
 
 
@@ -425,10 +426,13 @@ def read_lhotse_manifest(config) -> tuple[CutSet, bool]:
         if isinstance(config.shar_path, (str, Path)):
             logging.info(f"Initializing Lhotse Shar CutSet (tarred) from a single data source: '{config.shar_path}'")
             cuts = CutSet.from_shar(
-                **_resolve_shar_inputs(config.shar_path, metadata_only), shuffle_shards=True, seed=shard_seed
+                **_resolve_shar_inputs(config.shar_path, metadata_only),
+                shuffle_shards=True,
+                seed=shard_seed,
+                slice_length=config.get("slice_length", None),
             )
             if not metadata_only and not force_finite:
-                cuts = cuts.repeat()
+                cuts = cuts.repeat(preserve_id=True)
         elif isinstance(config.shar_path, Sequence):
             # Multiple datasets in Lhotse Shar format: we will dynamically multiplex them
             # with probability approximately proportional to their size
@@ -442,7 +446,10 @@ def read_lhotse_manifest(config) -> tuple[CutSet, bool]:
                 if isinstance(item, (str, Path)):
                     path = item
                     cs = CutSet.from_shar(
-                        **_resolve_shar_inputs(path, metadata_only), shuffle_shards=True, seed=shard_seed
+                        **_resolve_shar_inputs(path, metadata_only),
+                        shuffle_shards=True,
+                        seed=shard_seed,
+                        slice_length=config.get("slice_length", None),
                     )
                     weight = len(cs)
                 else:
@@ -454,7 +461,10 @@ def read_lhotse_manifest(config) -> tuple[CutSet, bool]:
                     )
                     path, weight = item
                     cs = CutSet.from_shar(
-                        **_resolve_shar_inputs(path, metadata_only), shuffle_shards=True, seed=shard_seed
+                        **_resolve_shar_inputs(path, metadata_only),
+                        shuffle_shards=True,
+                        seed=shard_seed,
+                        slice_length=config.get("slice_length", None),
                     )
                 logging.info(f"- {path=} {weight=}")
                 cutsets.append(cs)
@@ -475,9 +485,14 @@ def read_lhotse_manifest(config) -> tuple[CutSet, bool]:
             )
             if metadata_only:
                 fields = {"cuts": fields["cuts"]}
-            cuts = CutSet.from_shar(fields=fields, shuffle_shards=True, seed=shard_seed)
+            cuts = CutSet.from_shar(
+                fields=fields,
+                shuffle_shards=True,
+                seed=shard_seed,
+                slice_length=config.get("slice_length", None),
+            )
             if not metadata_only and not force_finite:
-                cuts = cuts.repeat()
+                cuts = cuts.repeat(preserve_id=True)
         else:
             raise RuntimeError(
                 f"Unexpected value for key 'shar_path'. We support string, list of strings, "
@@ -711,11 +726,12 @@ def read_nemo_manifest(config) -> tuple[CutSet, bool]:
                     config.manifest_filepath,
                     tar_paths=config.tarred_audio_filepaths,
                     skip_missing_manifest_entries=config.get("skip_missing_manifest_entries", False),
+                    slice_length=config.get("slice_length", None),
                     **common_kwargs,
                 )
             )
             if not force_finite:
-                cuts = cuts.repeat()
+                cuts = cuts.repeat(preserve_id=True)
         else:
             cuts = CutSet(LazyNeMoIterator(config.manifest_filepath, **notar_kwargs, **common_kwargs))
     else:
@@ -755,6 +771,7 @@ def read_nemo_manifest(config) -> tuple[CutSet, bool]:
                     manifest_path=manifest_path,
                     tar_paths=tar_path,
                     skip_missing_manifest_entries=config.get("skip_missing_manifest_entries", False),
+                    slice_length=config.get("slice_length", None),
                     **common_kwargs,
                 )
             else:
@@ -813,7 +830,7 @@ def mux(
         cuts = CutSet.infinite_mux(*cutsets, weights=weights, seed=seed, max_open_streams=max_open_streams)
     else:
         if not force_finite:
-            cutsets = [cs.repeat() for cs in cutsets]
+            cutsets = [cs.repeat(preserve_id=True) for cs in cutsets]
         if len(cutsets) == 1:
             # CutSet.mux must take more than one CutSet.
             cuts = cutsets[0]

--- a/nemo/collections/common/data/lhotse/dataloader.py
+++ b/nemo/collections/common/data/lhotse/dataloader.py
@@ -203,6 +203,14 @@ class LhotseDataLoadingConfig:
     # * use map dataset for non-tarred audio data (we might change this in the future)
     force_map_dataset: bool = False
     force_iterable_dataset: bool = False
+    # Force the dataloader to slice each data source.
+    # This may improve sampling randomness for large-scale runs with many dataset sources and large shards
+    # at the cost of some IO redundancy.
+    # The slicing is achieved with a randomly-selected offset K used to skip the first K examples,
+    # and reading them consecutively for ``slice_length`` iterations.
+    # The first K examples will actually be read and then discarded, incurring the IO cost, due to
+    # our support of object stores and gzipped files that generally don't have indexes of byte offsets per line.
+    slice_length: Optional[int] = None
 
 
 def determine_use_iterable_dataset(use_iterable_dataset: bool, config: DictConfig) -> bool:

--- a/tests/collections/common/test_lhotse_dataloading.py
+++ b/tests/collections/common/test_lhotse_dataloading.py
@@ -225,7 +225,7 @@ def nemo_tarred_manifest_subset_path(nemo_tarred_manifest_path: Tuple[str, str])
     from lhotse.shar.writers import JsonlShardWriter
 
     json_p, tar_p = nemo_tarred_manifest_path
-    json_dir = json_p.parent / "shard_manifests"
+    json_dir = json_p.parent / "shard_manifests_subset"
     json_dir.mkdir(exist_ok=True)
     all_items = list(load_jsonl(json_p))
     tarr_0_data = all_items[:5]
@@ -2592,3 +2592,130 @@ def test_dataloader_from_data_input_cfg_yaml_path_with_skipme(cutset_shar_path, 
     skipme_s = [cut.custom.get('_skipme', 0) for batch in batches for cut in batch]
 
     assert not any(skipme_s)
+
+
+def test_dataloader_lhotse_shar_nemo_tarred_slice_length(
+    nemo_tarred_manifest_path_multi: tuple[str, str], cutset_shar_path: Path
+):
+    json_mft, tar_mft = nemo_tarred_manifest_path_multi
+    config = OmegaConf.create(
+        {
+            "input_cfg": [
+                {
+                    # 2 shards, 5 utterances each
+                    "type": "nemo_tarred",
+                    "manifest_filepath": json_mft,
+                    "tarred_audio_filepaths": tar_mft,
+                    "tags": {"origin": "nemo_tarred"},
+                },
+                {
+                    # 2 shards, 5 utterances each
+                    "type": "lhotse_shar",
+                    "shar_path": cutset_shar_path,
+                    "tags": {"origin": "lhotse_shar"},
+                },
+            ],
+            "slice_length": 2,
+            "shuffle": True,
+            "num_workers": 0,
+            "seed": 0,
+            "shard_seed": 0,
+            "batch_size": 4,
+            "force_finite": True,
+        }
+    )
+
+    dl = get_lhotse_dataloader_from_config(config=config, global_rank=0, world_size=1, dataset=Identity())
+
+    batches = [b for b in dl]
+    assert len(batches) == 2
+
+    # We expect to sample a total of 8 examples (4 shards, 2 examples each), in 2 batches of size 4 each,
+    # half of it coming from nemo tarred dataset, and the other half from lhotse shar dataset.
+    origin_tags = Counter()
+    origin_shards = Counter()
+    for b in batches:
+        assert len(b) == 4
+        for cut in b:
+            origin_tags[cut.origin] += 1
+            if cut.origin == "lhotse_shar":
+                origin_shard = cut.shard_origin
+            else:
+                origin_shard = cut.manifest_origin
+            origin_shard = Path(origin_shard).name
+            origin_shards[origin_shard] += 1
+    assert origin_tags["lhotse_shar"] == 4
+    assert origin_tags["nemo_tarred"] == 4
+    assert origin_shards["cuts.000000.jsonl.gz"] == 2
+    assert origin_shards["cuts.000001.jsonl.gz"] == 2
+    assert origin_shards["manifest_0.jsonl"] == 2
+    assert origin_shards["manifest_1.jsonl"] == 2
+
+
+def test_dataloader_lhotse_shar_slice_length_multi_epoch_different_sample(cutset_shar_path: Path):
+    config = OmegaConf.create(
+        {
+            "input_cfg": [
+                {
+                    # 2 shards, 5 utterances each
+                    "type": "lhotse_shar",
+                    "shar_path": cutset_shar_path,
+                    "tags": {"origin": "lhotse_shar"},
+                },
+            ],
+            "slice_length": 2,
+            "shuffle": False,  # shuffle is disabled, but the slice offset still must be random!
+            "num_workers": 0,
+            "seed": 0,
+            "shard_seed": 0,
+            "batch_size": 2,
+        }
+    )
+
+    dl = get_lhotse_dataloader_from_config(config=config, global_rank=0, world_size=1, dataset=Identity())
+
+    # 2 batches == 1 epoch => 4 batches == 2 epochs
+    batches = [b for b in islice(dl, 4)]
+    assert len(batches) == 4
+    epoch0_ids = [cut.id for b in batches[:2] for cut in b]
+    epoch1_ids = [cut.id for b in batches[2:] for cut in b]
+    print(epoch0_ids)
+    print(epoch1_ids)
+    assert epoch0_ids != epoch1_ids
+
+
+def test_dataloader_nemo_tarred_slice_length_multi_epoch_different_sample(
+    nemo_tarred_manifest_path_multi: tuple[str, str],
+):
+    json_mft, tar_mft = nemo_tarred_manifest_path_multi
+    config = OmegaConf.create(
+        {
+            "input_cfg": [
+                {
+                    # 2 shards, 5 utterances each
+                    "type": "nemo_tarred",
+                    "manifest_filepath": json_mft,
+                    "tarred_audio_filepaths": tar_mft,
+                    "tags": {"origin": "nemo_tarred"},
+                },
+            ],
+            "slice_length": 2,
+            "shuffle": False,  # shuffle is disabled, but the slice offset still must be random!
+            "num_workers": 0,
+            "seed": 0,
+            "shard_seed": 0,
+            "batch_size": 2,
+        }
+    )
+
+    dl = get_lhotse_dataloader_from_config(config=config, global_rank=0, world_size=1, dataset=Identity())
+
+    # 2 batches == 1 epoch => 4 batches == 2 epochs
+    batches = [b for b in islice(dl, 4)]
+    assert len(batches) == 4
+
+    epoch0_ids = [cut.id for b in batches[:2] for cut in b]
+    epoch1_ids = [cut.id for b in batches[2:] for cut in b]
+    print(epoch0_ids)
+    print(epoch1_ids)
+    assert epoch0_ids != epoch1_ids


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Adds a ``slice_length`` option to Lhotse dataloader. 
It affects datasets in Lhotse Shar and NeMo webdataset format.

When set (to an int), instead of reading the entire shard, the reader will randomly choose an offset between `[0, len(shard) - slice_length)` to read consecutive ``slice_length`` examples, and will return early. 
We don't attempt to do this efficiently at this time due to many supported storage backends - the skipped examples between 0 and chosen offset will be just read and discarded.

This only needs to be enabled in very specific scenarios where all of the following are true:
* the run time of your training job is strictly bounded (e.g. 2 hours), and you train the model by running multiple consecutive jobs
* your entire data cannot be iterated over within the run time of a single training job (e.g. you only iterate 20% of data per training run)
* you have many (e.g., 100+) different datasets blended via mux
* your data sampler is stateless, i.e. you don't save/load state between training jobs, but randomize the RNG instead
* some of the datasets have really small weight (e.g., 0.001 or less)
* each dataset is tarred and sharded
* the shard size is relatively large (e.g., 5k examples per shard)

In such a scenario, you might have ended up never seeing a part of your data throughout the entire training with multiple jobs, because the sampler would never be able to reach the examples located at the tail of some/all shards. If changing any of the above is not practical, this is a "last-resort" type of workaround to still be able to iterate over the entire data in the expectation.

Requires latest (unreleased right now) Lhotse with the following PR merged: https://github.com/lhotse-speech/lhotse/pull/1505

**Collection**: Speech (ASR, TTS, SpeechLM2)

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
