### PR TITLE
Remove artificial block to vortex fp8 TP

### DIFF
--- a/nemo/collections/llm/gpt/model/megatron/hyena/te_compat.py
+++ b/nemo/collections/llm/gpt/model/megatron/hyena/te_compat.py
@@ -16,7 +16,6 @@
 # limitations under the License.
 
 from functools import lru_cache
-from re import L
 
 import transformer_engine.pytorch as te
 from megatron.core.extensions.transformer_engine import TELayerNormColumnParallelLinear, TELinear


### PR DESCRIPTION
# What does this PR do ?

Remove the block on tensor parallelism for the TE variant of the vortex style fp8 layer which should still support TP.

This is a very limited change that will only impact:
**Collection**: llm -> gpt -> hyena

# Changelog

- Remove the init time check against TP usage with the vortex fp8 transformer engine path for the fp8 padded layer.
- Handle the sequence_parallel + TP case in the hyena vortex layer with an appropriate error when padding will not work. 
- Verified that the resulting layer works with TP+SP and produces highly accurate results.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
