### PR TITLE
feat: Disable blank Issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

From now on, any Github repo under the Nvidia-NeMo org will use the default Issues system / behavior
(unless overwritten i.e. in this case the individual repo would have a .github/ISSUE_TEMPLATE folder in the repo itself, effectively overriding the default behavior coming from the NVIDIA-NeMo/.github repo [which establishes the default system]).

Default behavior for Issues creation now is :
- There is a Bug Report issue
- There is a Feature Request issue
- Blank issues are NOT allowed to be created