### PR TITLE
Fix model checkpoint async_save attribute

### DIFF
--- a/nemo/lightning/pytorch/callbacks/model_checkpoint.py
+++ b/nemo/lightning/pytorch/callbacks/model_checkpoint.py
@@ -57,7 +57,6 @@ class ModelCheckpoint(PTLModelCheckpoint):
             model, trainer, and dataloader to allow for reproducibility of experiments.
         save_context_on_train_end: Whether to dump the artifacts on_train_end regardless of whether
             ``always_save_context`` is ``True``.
-        async_save: Whether to enable asynchronous checkpointing.
 
     Attributes:
         UNFINISHED_CHECKPOINT_SUFFIX (str): Suffix for unfinished checkpoint files.
@@ -69,6 +68,7 @@ class ModelCheckpoint(PTLModelCheckpoint):
         best_model_score (float): Score of the best checkpoint.
         best_model_path (str): Path to the best checkpoint.
         kth_best_model_path (str): Path to the kth best checkpoint.
+        async_save: Whether to enable asynchronous checkpointing.
     """
 
     UNFINISHED_CHECKPOINT_SUFFIX = "-unfinished"


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

async_save is an attribute, not an argument. Fixes this:

```
Traceback (most recent call last):
  File "/workdir/main.py", line 210, in <module>
    main()
  File "/workdir/.venv/lib/python3.10/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
  File "/workdir/.venv/lib/python3.10/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
  File "/workdir/.venv/lib/python3.10/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/workdir/.venv/lib/python3.10/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
  File "/workdir/main.py", line 120, in main
    checkpoint_callback = ModelCheckpoint(
  File "/workdir/.venv/lib/python3.10/site-packages/nemo/lightning/pytorch/callbacks/model_checkpoint.py", line 110, in __init__
    super().__init__(
TypeError: ModelCheckpoint.__init__() got an unexpected keyword argument 'async_save'
```

**Collection**: [Note which collection this PR will affect]

# Changelog

- Fix doc of model checkpoint

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [x] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
