### PR TITLE
chore(🤖): Bump `NVIDIA/Megatron-LM` to `ce8185c...` (2025-09-29)

### DIFF
--- a/requirements/manifest.json
+++ b/requirements/manifest.json
@@ -11,7 +11,7 @@
     },
     "megatron-lm": {
       "repo": "https://github.com/NVIDIA/Megatron-LM",
-      "ref": "b615e731080e83703ff3e93b11d3a9bc5bb281c3"
+      "ref": "ce8185cbbe04f38beb74360e878450f2e8525885"
     },
     "trt-llm": {
       "repo": "https://github.com/NVIDIA/TensorRT-LLM.git",


### PR DESCRIPTION
🚀 PR to bump `NVIDIA/Megatron-LM` in `requirements/manifest.json` to `ce8185cbbe04f38beb74360e878450f2e8525885`.  

📝 Please remember the following to-do's before merge: 
- [ ] Verify the presubmit CI  

🙏 Please merge this PR only if the CI workflow completed successfully.