### PR TITLE
fix: support for tensors/numpy being passed to transcribe() of Canary v2

### DIFF
--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -1048,7 +1048,9 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
         )
         merge_to_be_done = trcfg.enable_chunking and len(hypotheses) > 1
         if trcfg.enable_chunking:
-            assert isinstance(batch, PromptedAudioToTextMiniBatch), "Chunking is only supported with Canary dataloaders"
+            assert isinstance(
+                batch, PromptedAudioToTextMiniBatch
+            ), "Chunking is only supported with Canary dataloaders"
 
         del enc_states, enc_mask, decoder_input_ids
 

--- a/nemo/collections/asr/parts/mixins/transcription.py
+++ b/nemo/collections/asr/parts/mixins/transcription.py
@@ -358,8 +358,10 @@ class TranscriptionMixin(ABC):
                     dataloader = audio
                 assert isinstance(dataloader, DataLoader), "`dataloader` must be of type DataLoader at this point."
 
-                if (isinstance(audio, list) and isinstance(audio[0], (np.ndarray, torch.Tensor))) or isinstance(audio, (np.ndarray, torch.Tensor)):
-                    transcribe_cfg.enable_chunking = False # Can't chunk tensors (don't know cuts)
+                if (isinstance(audio, list) and isinstance(audio[0], (np.ndarray, torch.Tensor))) or isinstance(
+                    audio, (np.ndarray, torch.Tensor)
+                ):
+                    transcribe_cfg.enable_chunking = False  # Can't chunk tensors (don't know cuts)
 
                 if hasattr(transcribe_cfg, 'verbose'):
                     verbose = transcribe_cfg.verbose


### PR DESCRIPTION
# What does this PR do ?

This PR fixes that tensors/numpy can't be passed to transcribe() if timestamps==True

# Changelog

- This PR matches the batch format of audio tensors against the expected data loader format.
- It also disables chunking if audio tensors are passed, because the tensors don't contain cutting info and need to be cut by the caller.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [NA] Did you write any new necessary tests?
- [NA] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

@titu1994, @redoctopus, @jbalam-nv, or @okuchaiev

# Additional Information

- Fixes #14877 
