### PR TITLE
Update segment.py - add opus to supported formats

### DIFF
--- a/nemo/collections/asr/parts/preprocessing/segment.py
+++ b/nemo/collections/asr/parts/preprocessing/segment.py
@@ -60,6 +60,7 @@ except ModuleNotFoundError:
 
 available_formats = sf.available_formats()
 sf_supported_formats = ["." + i.lower() for i in available_formats.keys()]
+sf_supported_formats = sf_supported_formats.append(".opus")
 
 
 ChannelSelectorType = Union[int, Iterable[int], str]


### PR DESCRIPTION
### PR Description

In the current implementation, `.opus` files are not included in the list of supported audio formats, even though `soundfile` (`sf`) can successfully load them. Additionally, using `pydub` for segment extraction is inefficient for long audio files, as it first loads the entire file into memory before clipping segments.

This PR addresses the issue by adding `.opus` to supported formats.

### Relevant Code

[View on GitHub](https://github.com/NVIDIA-NeMo/NeMo/blob/main/nemo/collections/asr/parts/preprocessing/segment.py#L62)

### Summary of Changes

* Added `.opus` to supported audio formats.
