### PR TITLE
Revert "new changelog-build"

### DIFF
--- a/.github/workflows/changelog-build.yml
+++ b/.github/workflows/changelog-build.yml
@@ -11,11 +11,6 @@ on:
         description: Release branch to build changelog on (e.g. `r2.1.0`)
         type: string
         required: true
-      changelog-main-content:
-        description: Custom changelog content to include before detailed changelogs
-        type: string
-        required: false
-        default: ''
     
 jobs:
   changelog:
@@ -38,8 +33,8 @@ jobs:
           # fromTag: Auto resolved from historical tag order (previous tag compared to current tag)
           # toTag: Current tag reference
           configuration: ".github/workflows/config/changelog-config.json"
-          owner: ${{ github.repository_owner }}
-          repo: ${{ github.event.repository.name }}
+          owner: "NVIDIA"
+          repo: "NeMo"
           ignorePreReleases: "false"
           failOnError: "false"
           fromTag: ${{ inputs.last-release-tag }}
@@ -49,24 +44,12 @@ jobs:
         env: 
           RELEASE_BRANCH: ${{ inputs.release-branch }}
           CHANGELOG: ${{ steps.github_tag.outputs.changelog }}
-          MAIN_CONTENT: ${{ inputs.changelog-main-content }}
         shell: bash -x -e -u -o pipefail {0}
         run: |
           RELEASE_VERSION=${RELEASE_BRANCH#r}
           CHANGELOG=$(echo "$CHANGELOG" | sed '/^[[:blank:]]*#/s/#/###/')
 
-          # Build release notes starting with version header
-          RELEASE_NOTES="## NVIDIA Neural Modules $RELEASE_VERSION"
-
-          # Add custom content if provided
-          if [ -n "$MAIN_CONTENT" ]; then
-            RELEASE_NOTES="$RELEASE_NOTES
-
-          $MAIN_CONTENT"
-          fi
-
-          # Add detailed changelogs section
-          RELEASE_NOTES="$RELEASE_NOTES
+          RELEASE_NOTES="## NVIDIA Neural Modules $RELEASE_VERSION
 
           ### Detailed Changelogs:
 
@@ -79,38 +62,6 @@ jobs:
       - name: Inspect new changelog file
         run: cat CHANGELOG.md
 
-      - name: Create or update label
-        uses: actions/github-script@v6
-        with:
-          script: |
-            const labelName = '${{ inputs.release-branch }}';
-            const labelColor = '0366d6'; // Blue color
-            const labelDescription = `Release ${labelName}`;
-
-            try {
-              // Try to get the label
-              await github.rest.issues.getLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                name: labelName
-              });
-              console.log(`Label '${labelName}' already exists`);
-            } catch (error) {
-              if (error.status === 404) {
-                // Label doesn't exist, create it
-                await github.rest.issues.createLabel({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  name: labelName,
-                  color: labelColor,
-                  description: labelDescription
-                });
-                console.log(`Created label '${labelName}'`);
-              } else {
-                throw error;
-              }
-            }
-
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
@@ -120,4 +71,3 @@ jobs:
           sign-commits: true
           base: main
           branch: bot/chore/update-changelog-into-${{ inputs.release-branch }}
-          labels: ${{ inputs.release-branch }}


### PR DESCRIPTION
This reverts commit 5bd8352af98a65a35707eb4981f67de04ae77a86.

> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
