### PR TITLE
Fix PEFT resume with `resume_from_path`

### DIFF
--- a/nemo/lightning/io/pl.py
+++ b/nemo/lightning/io/pl.py
@@ -39,7 +39,6 @@ from typing_extensions import Self, override
 from nemo.lightning.ckpt_utils import WEIGHTS_PATH, ckpt_to_dir
 from nemo.lightning.io.capture import IOProtocol
 from nemo.lightning.io.mixin import IOMixin
-from nemo.lightning.resume import AdapterPath
 from nemo.utils import logging
 
 try:
@@ -116,6 +115,8 @@ class TrainerContext(IOMixin, Generic[LightningModuleT]):
 def ckpt_to_weights_subdir(filepath: Union[str, Path], is_saving) -> Path:
     """Given an input checkpoint filepath, clean it using `ckpt_to_dir`
     and then return the weights subdirectory, if it exists."""
+    from nemo.lightning.resume import AdapterPath
+
     filepath = ckpt_to_dir(filepath=filepath)
     base_dir = filepath
     assert not isinstance(base_dir, str)


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fixes PEFT AutoResume if checkpoint is specified with `resume_from_path`.

Currently, in `ckpt_to_weights_subdir()` if the input filepath is an `AdapterPath` (this happens if `resume_from_path` points to a PEFT checkpoint) the following happens:
1. `filepath` copied to `base_dir` ([120](https://github.com/NVIDIA-NeMo/NeMo/compare/maanug/peft-resume-bug?expand=1#diff-8b8117bc8b07d1fa52030c25e6a7c7920aafa31780e2665ec5fe63939c11a622R120))
2. `maybe_base_dir` is set, appending `WEIGHTS_PATH` to `base_dir` which loses `base_model_path` attribute (becomes None), if the input path was an AdapterPath ([123](https://github.com/NVIDIA-NeMo/NeMo/compare/maanug/peft-resume-bug?expand=1#diff-8b8117bc8b07d1fa52030c25e6a7c7920aafa31780e2665ec5fe63939c11a622R123))
3. `maybe_base_dir` is copied to `base_dir` ([125](https://github.com/NVIDIA-NeMo/NeMo/compare/maanug/peft-resume-bug?expand=1#diff-8b8117bc8b07d1fa52030c25e6a7c7920aafa31780e2665ec5fe63939c11a622R125))
4. if `base_dir.base_model_path` is None, [129](https://github.com/NVIDIA-NeMo/NeMo/compare/maanug/peft-resume-bug?expand=1#diff-8b8117bc8b07d1fa52030c25e6a7c7920aafa31780e2665ec5fe63939c11a622R129) breaks

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
