### PR TITLE
fix loading of hyb ctc rnnt bpe models when using from pretrained

### DIFF
--- a/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models_prompt.py
+++ b/nemo/collections/asr/models/hybrid_rnnt_ctc_bpe_models_prompt.py
@@ -36,7 +36,7 @@ from nemo.collections.asr.parts.submodules.ctc_decoding import CTCBPEDecoding, C
 from nemo.collections.asr.parts.submodules.rnnt_decoding import RNNTBPEDecoding
 from nemo.collections.asr.parts.utils.rnnt_utils import Hypothesis
 from nemo.collections.common.data.lhotse import get_lhotse_dataloader_from_config
-from nemo.core.classes.common import typecheck
+from nemo.core.classes.common import PretrainedModelInfo, typecheck
 from nemo.core.classes.mixins import AccessMixin
 from nemo.core.neural_types import (
     AcousticEncodedRepresentation,
@@ -46,7 +46,6 @@ from nemo.core.neural_types import (
     NeuralType,
     SpectrogramType,
 )
-from nemo.core.classes.common import PretrainedModelInfo
 from nemo.utils import logging, model_utils
 
 


### PR DESCRIPTION
# What does this PR do ?

Fixes issue when loading hybrid rnnt ctc models with .from_pretrained() method

**Collection**: ASR

# Changelog

- Adds list_available_models() method, to skip initializing the models with prompt based hybrid class

# Usage

```python
import nemo.collections.asr as nemo_asr
model = nemo_asr.models.ASRModel.from_pretrained("stt_en_fastconformer_hybrid_large_streaming_80ms")
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
