### PR TITLE
Set segment for gb systems when nodes <= 18.

### DIFF
--- a/scripts/performance/executors.py
+++ b/scripts/performance/executors.py
@@ -114,7 +114,7 @@ def slurm_executor(
     if num_gpus_per_node == 4:
         if nodes <= 18:
             segment = nodes
-        else: # nodes > 18
+        else:  # nodes > 18
             for segment_candidate in range(18, 0, -1):
                 if nodes % segment_candidate == 0:
                     segment = segment_candidate


### PR DESCRIPTION
Make segment selection explicit for applicable systems.

Current logic relies on Slurm defaults to do the correct thing. However on at least one internal cluster admins have it configured such that segment unset becomes 'segment=2' with negative performance impact. Better to be explicit.