### PR TITLE
Extend Slurm exit code override to additional LLM pretrain recipes

### DIFF
--- a/scripts/performance/llm/pretrain_grok1_314b.py
+++ b/scripts/performance/llm/pretrain_grok1_314b.py
@@ -62,6 +62,7 @@ from ..helpers import (
     set_exp_logging_configs,
     set_primary_perf_configs,
 )
+
 # TEMPORARY WORKAROUND - Remove in next release when upstream srun issue is fixed
 from ..slurm_exit_code_override import *  # Monkey-patch for false-positive job failures
 from ..utils import hf_tokenizer

--- a/scripts/performance/llm/pretrain_nemotron4_340b.py
+++ b/scripts/performance/llm/pretrain_nemotron4_340b.py
@@ -38,6 +38,7 @@ from ..helpers import (
     set_exp_logging_configs,
     set_primary_perf_configs,
 )
+
 # TEMPORARY WORKAROUND - Remove in next release when upstream srun issue is fixed
 from ..slurm_exit_code_override import *  # Monkey-patch for false-positive job failures
 from ..utils import get_comm_overlap_callback_idx, hf_tokenizer

--- a/scripts/performance/llm/pretrain_nemotronh_56b.py
+++ b/scripts/performance/llm/pretrain_nemotronh_56b.py
@@ -31,6 +31,7 @@ from ..helpers import (
     set_exp_logging_configs,
     set_primary_perf_configs,
 )
+
 # TEMPORARY WORKAROUND - Remove in next release when upstream srun issue is fixed
 from ..slurm_exit_code_override import *  # Monkey-patch for false-positive job failures
 from ..utils import dump_config_diff_from_base_recipe, hf_tokenizer


### PR DESCRIPTION
Apply the exit code validation to other recipes in our release.
