### PR TITLE
Refactor `FilterbankFeatures` masking to use `make_seq_mask_like` utility

### DIFF
--- a/nemo/collections/asr/parts/preprocessing/features.py
+++ b/nemo/collections/asr/parts/preprocessing/features.py
@@ -486,10 +486,8 @@ class FilterbankFeatures(nn.Module):
             x, _, _ = normalize_batch(x, seq_len, normalize_type=self.normalize)
 
         # mask to zero any values beyond seq_len in batch, pad to multiple of `pad_to` (for efficiency)
-        max_len = x.size(-1)
-        mask = torch.arange(max_len, device=x.device)
-        mask = mask.repeat(x.size(0), 1) >= seq_len.unsqueeze(1)
-        x = x.masked_fill(mask.unsqueeze(1).type(torch.bool).to(device=x.device), self.pad_value)
+        mask: torch.Tensor = make_seq_mask_like(lengths=seq_len, like=x, time_dim=-1, valid_ones=False)
+        x = x.masked_fill(mask, self.pad_value)
         del mask
         pad_to = self.pad_to
         if pad_to == "max":


### PR DESCRIPTION
# What does this PR do ?

> _Don't reinvent the wheel_ 

Refactor `FilterbankFeatures.forward`

**Collection**: [asr]

# Changelog

- Refactor `FilterbankFeatures` masking to use `make_seq_mask_like`

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?
Requesting review from ASR members: @titu1994, @redoctopus, @jbalam-nv, or @okuchaiev

# Additional Information

- `jit.trace`-ing of `FilterbankFeatures` hardcoded to `cuda:0`. Utilizing `make_seq_mask_like` solves this issue.