### PR TITLE
Set segment for gb systems when nodes <= 18

### DIFF
--- a/scripts/performance/executors.py
+++ b/scripts/performance/executors.py
@@ -109,13 +109,16 @@ def slurm_executor(
     PERF_ENV_VARS |= custom_env_vars
     mounts.extend(custom_mounts)
 
-    # add --segment flag to sbatch if job uses GB200 and goes beyond one rack.
+    # add --segment flag to sbatch if job uses GB200.
     segment = None
-    if num_gpus_per_node == 4 and nodes > 18:
-        for segment_candidate in range(18, 0, -1):
-            if nodes % segment_candidate == 0:
-                segment = segment_candidate
-                break
+    if num_gpus_per_node == 4:
+        if nodes <= 18:
+            segment = nodes
+        else:  # nodes > 18
+            for segment_candidate in range(18, 0, -1):
+                if nodes % segment_candidate == 0:
+                    segment = segment_candidate
+                    break
 
     numa_divisor = 2 if gpu.lower() == 'gb200' else 4
     numa_cmd = f"numactl --cpunodebind=$((SLURM_LOCALID/{numa_divisor})) --membind=$((SLURM_LOCALID/{numa_divisor}))"


### PR DESCRIPTION
Make segment selection explicit for applicable systems.

Current logic relies on Slurm defaults to do the correct thing. However on at least one internal cluster admins have it configured such that segment unset becomes 'segment=2' with negative performance impact. Better to be explicit.

Remake of #15062 