### PR TITLE
ci: secure release-freeze workflow against command injection

### DIFF
--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -59,9 +59,11 @@ jobs:
           find tutorials -type f -name "*.ipynb" -exec sed -i "s/BRANCH = 'main'/BRANCH = '${{ needs.code-freeze.outputs.release-branch }}'/g" {} +
 
       - name: Pin MCore in Dockerfile
+        env:
+          MCORE_VERSION: ${{ inputs.mcore_version }}
         run: |
           cd ${{ github.run_id }}
-          sed -i 's/^ARG MCORE_TAG=.*$/ARG MCORE_TAG=${{ inputs.mcore_version }}/' docker/Dockerfile.ci
+          sed -i "s/^ARG MCORE_TAG=.*$/ARG MCORE_TAG=$MCORE_VERSION/" docker/Dockerfile.ci
 
       - name: Show status
         run: |


### PR DESCRIPTION
Route inputs.mcore_version through env.MCORE_VERSION before using it in shell command to prevent workflow-dispatch data from being interpreted as shell code.

> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Secures the release freeze workflow by first storing the user-controlled `inputs.mcore_version` in an environment variable before using it in the `Pin MCore in Dockerfile` run step. This removes the command-injection risk inside `.github/workflows/release-freeze.yml` related to CWE-78: Improper Neutralization of Special Elements used in an OS Command.

**Collection**: Release automation

# Changelog

- route `inputs.mcore_version` through `env.MCORE_VERSION` and reference `$MCORE_VERSION` inside `.github/workflows/release-freeze.yml` so workflow-dispatch data can no longer be interpreted as shell code.

# Usage

N/A – workflow automation only.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
