### PR TITLE
Remove hardcoded DEBUG log level in gpt_oss to respect global logging configuration

### DIFF
--- a/nemo/collections/llm/gpt/model/gpt_oss.py
+++ b/nemo/collections/llm/gpt/model/gpt_oss.py
@@ -12,10 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import logging
 import math
 import os
-import logging
-
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path


### PR DESCRIPTION
Closes #15116

###Summary
This PR removes the hardcoded `logger.setLevel(logging.DEBUG)` call in
`nemo/collections/llm/gpt/model/gpt_oss.py`.

Hardcoding the DEBUG level at module import time overrides global logging
configuration set by NeMo or the user. This prevents users from controlling the
verbosity of GPT-Oss-related logs.

### Changes
- Removed forced DEBUG logger level.
- Logger now respects global logging settings.
- No behavioral changes beyond allowing global logging configuration to be used.
