### PR TITLE
Remove NCCL_NET_GDR_LEVEL and NCCL_NET_GDR_C2C environment variables.

### DIFF
--- a/scripts/performance/executors.py
+++ b/scripts/performance/executors.py
@@ -216,8 +216,6 @@ def slurm_executor(
     if wandb_key is not None:
         PERF_ENV_VARS["WANDB_API_KEY"] = wandb_key
 
-
-
     if nemo_home != DEFAULT_NEMO_CACHE_HOME:  # DO NOT change this to 'DEFAULT_NEMO_HOME'/'NEMO_HOME'
         PERF_ENV_VARS["NEMO_HOME"] = nemo_home
         mounts.extend([f"{nemo_home}:{nemo_home}"])

--- a/scripts/performance/llm/finetune_llama3_70b.py
+++ b/scripts/performance/llm/finetune_llama3_70b.py
@@ -202,8 +202,6 @@ if __name__ == "__main__":
         )
         plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
 
-
-
         if args.enable_nsys:
             plugins.append(
                 NsysPlugin(

--- a/scripts/performance/llm/finetune_llama4_e128.py
+++ b/scripts/performance/llm/finetune_llama4_e128.py
@@ -187,8 +187,6 @@ if __name__ == "__main__":
         )
         plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
 
-
-
         if args.enable_nsys:
             plugins.append(
                 NsysPlugin(

--- a/scripts/performance/llm/pretrain_deepseek_v3.py
+++ b/scripts/performance/llm/pretrain_deepseek_v3.py
@@ -246,8 +246,6 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     custom_env_vars = {}
 
-
-
     if args.enable_nsys:
         plugins.append(
             NsysPlugin(

--- a/scripts/performance/llm/pretrain_grok1_314b.py
+++ b/scripts/performance/llm/pretrain_grok1_314b.py
@@ -423,8 +423,6 @@ if __name__ == "__main__":
 
     env_vars = args.custom_env_vars
 
-
-
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
 
     if args.enable_nsys:

--- a/scripts/performance/llm/pretrain_llama31_405b.py
+++ b/scripts/performance/llm/pretrain_llama31_405b.py
@@ -226,8 +226,6 @@ if __name__ == "__main__":
     else:
         env_vars = {}
 
-
-
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     if args.enable_memory_profile:
         assert args.memory_profile_out_path is not None

--- a/scripts/performance/llm/pretrain_llama3_70b.py
+++ b/scripts/performance/llm/pretrain_llama3_70b.py
@@ -197,8 +197,6 @@ if __name__ == "__main__":
     else:
         env_vars = {}
 
-
-
     executor = slurm_executor(
         args.gpu.lower(),
         args.account,

--- a/scripts/performance/llm/pretrain_llama3_8b.py
+++ b/scripts/performance/llm/pretrain_llama3_8b.py
@@ -165,8 +165,6 @@ if __name__ == "__main__":
     else:
         env_vars = {}
 
-
-
     executor = slurm_executor(
         args.gpu.lower(),
         args.account,

--- a/scripts/performance/llm/pretrain_llama4_e128.py
+++ b/scripts/performance/llm/pretrain_llama4_e128.py
@@ -157,7 +157,6 @@ if __name__ == "__main__":
     plugins = [build_perf_env_plugin(args, pp_size=pp_size)]
     custom_env_vars = {}
 
-
     if args.enable_nsys:
         plugins.append(
             NsysPlugin(

--- a/scripts/performance/llm/pretrain_nemotron4_15b.py
+++ b/scripts/performance/llm/pretrain_nemotron4_15b.py
@@ -164,7 +164,6 @@ if __name__ == "__main__":
 
     env_vars = {}
 
-
     if args.cluster_type == "runai":
         pvcs = []
         for item in args.custom_mounts:

--- a/scripts/performance/llm/pretrain_nemotron4_340b.py
+++ b/scripts/performance/llm/pretrain_nemotron4_340b.py
@@ -183,8 +183,6 @@ if __name__ == "__main__":
 
     env_vars = {}
 
-
-
     executor = slurm_executor(
         args.gpu.lower(),
         args.account,

--- a/scripts/performance/llm/pretrain_nemotronh_56b.py
+++ b/scripts/performance/llm/pretrain_nemotronh_56b.py
@@ -156,8 +156,6 @@ if __name__ == "__main__":
 
     custom_env_vars = {}
 
-
-
     if args.enable_nsys:
         plugins.append(
             NsysPlugin(


### PR DESCRIPTION
These variables were a workaround for NCCL versions older than 2.27.x and are no longer needed in this context.
- Removed setting of these variables from scripts/performance/executors.py
- Removed setting of these variables from various LLM pretrain/finetune scripts in scripts/performance/llm
