### PR TITLE
Remove NCCL_NET_GDR_LEVEL and NCCL_NET_GDR_C2C environment variables.

### DIFF
--- a/scripts/performance/executors.py
+++ b/scripts/performance/executors.py
@@ -96,9 +96,7 @@ def slurm_executor(
     if wandb_key is not None:
         PERF_ENV_VARS["WANDB_API_KEY"] = wandb_key
 
-    if gpu.lower() == 'gb200':
-        PERF_ENV_VARS["NCCL_NET_GDR_LEVEL"] = "PHB"  # For NCCL 2.25
-        PERF_ENV_VARS["NCCL_NET_GDR_C2C"] = "1"  # For NCCL 2.26
+
 
     if nemo_home != DEFAULT_NEMO_CACHE_HOME:  # DO NOT change this to 'DEFAULT_NEMO_HOME'/'NEMO_HOME'
         PERF_ENV_VARS["NEMO_HOME"] = nemo_home


### PR DESCRIPTION
These variables were a workaround for NCCL versions older than 2.27.x and are no longer needed in this context.
- Removed setting of these variables from scripts/performance/executors.py
