### PR TITLE
Propagate PERF_ENV_VARS and overrides to SlurmExecutor container_env

### DIFF
--- a/scripts/performance/executors.py
+++ b/scripts/performance/executors.py
@@ -162,6 +162,7 @@ def slurm_executor(
     time_limit: str = "00:30:00",
     container_image: str = "nvcr.io/nvidia/nemo:dev",
     custom_mounts: List[str] = [],
+    container_env: List[str] = [],
     custom_env_vars: Dict[str, str] = {},
     custom_srun_args: List[str] = [],
     hf_token: str = None,
@@ -226,9 +227,6 @@ def slurm_executor(
         PERF_ENV_VARS.update({"HF_TOKEN": hf_token, "TRANSFORMERS_OFFLINE": "0"})
 
     PERF_ENV_VARS |= custom_env_vars
-    # add all environment variables to container environment
-    container_env_args = ["--container-env=" + ",".join(list(PERF_ENV_VARS.keys()))]
-    srun_args.extend(container_env_args)
 
     mounts.extend(custom_mounts)
 
@@ -257,6 +255,8 @@ def slurm_executor(
         template_vars={"pre_cmds": " ; ".join(custom_bash_cmds)},
     )
 
+    all_container_env = list(set(PERF_ENV_VARS) | set(container_env))
+
     executor = run.SlurmExecutor(
         account=account,
         partition=partition,
@@ -265,6 +265,7 @@ def slurm_executor(
         ntasks_per_node=num_gpus_per_node,
         container_image=container_image,
         container_mounts=mounts,
+        container_env=all_container_env,
         env_vars=PERF_ENV_VARS,
         srun_args=srun_args,
         time=time_limit,


### PR DESCRIPTION
Expose the container_env parameter of SlurmExecutor, explicitly set container_env for any environment variable being set. If you're setting performance variables for your run you expect them to be set in the container.

The pyxis/enroot defaults are to set all variables in the user environment in the container environment, except when that variable already exists in the container. Then it won't overwrite it unless '--container-env=VAR' is set.