### PR TITLE
Fix ProgressPrinter test phase counter and add regression test

### DIFF
--- a/nemo/lightning/pytorch/callbacks/progress_printer.py
+++ b/nemo/lightning/pytorch/callbacks/progress_printer.py
@@ -218,7 +218,7 @@ class ProgressPrinter(ProgressBar):
             return
         n = int((batch_idx + 1) / get_num_microbatches())
         if self.should_log(n):
-            print(self.test_description + f": iteration {n}/{self.total_validation_steps}")
+            print(self.test_description + f": iteration {n}/{self.total_test_steps}")
 
     def should_log(self, n):
         return n % self.log_interval == 0

--- a/tests/lightning/pytorch/callbacks/test_progress_printer.py
+++ b/tests/lightning/pytorch/callbacks/test_progress_printer.py
@@ -1,0 +1,50 @@
+import torch
+from torch.utils.data import DataLoader, TensorDataset
+from unittest.mock import patch
+
+from lightning.pytorch import LightningModule, Trainer
+
+from nemo.lightning.pytorch.callbacks.progress_printer import ProgressPrinter
+
+
+class DummyTestModel(LightningModule):
+    """
+    Minimal LightningModule for testing ProgressPrinter during test phase.
+    No optimizer or training loop needed.
+    """
+
+    def test_step(self, batch, batch_idx):
+        return {}
+
+    def test_dataloader(self):
+        x = torch.randn(4, 2)
+        y = torch.zeros(4)
+        return DataLoader(TensorDataset(x, y), batch_size=1)
+
+
+def test_progress_printer_test_phase_does_not_crash():
+    """
+    Regression test for:
+    https://github.com/NVIDIA-NeMo/NeMo/issues/15064
+
+    Ensures ProgressPrinter does not reference validation-only state
+    during trainer.test().
+    """
+
+    model = DummyTestModel()
+    callback = ProgressPrinter(log_interval=1)
+
+    trainer = Trainer(
+        accelerator="cpu",
+        devices=1,
+        callbacks=[callback],
+        enable_checkpointing=False,
+        logger=False,
+    )
+
+    # Mock Megatron microbatch logic so the test runs without Megatron strategy
+    with patch(
+        "nemo.lightning.pytorch.callbacks.progress_printer.get_num_microbatches",
+        return_value=1,
+    ):
+        trainer.test(model)


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fixes a bug in the `ProgressPrinter` callback where validation-specific state was incorrectly referenced during the test phase, causing `trainer.test()` to crash when no validation loop had run.

**Collection**: Lightning / PyTorch callbacks

# Changelog

- Fix incorrect usage of `self.total_validation_steps` during the test phase.
- Replace validation-specific counter with `self.total_test_steps` in `on_test_batch_end`.
- Add a CPU-only regression test to ensure `trainer.test()` does not crash when using `ProgressPrinter`.
- Mock Megatron microbatch logic in the test to avoid reliance on Megatron runtime initialization.

# Usage

No changes are required from the user side. The fix is internal and ensures that the `ProgressPrinter` callback works correctly during `trainer.test()`.

```python
from nemo.lightning.pytorch.callbacks import ProgressPrinter
from lightning.pytorch import Trainer

trainer = Trainer(
    callbacks=[ProgressPrinter()],
)

trainer.test(model)
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
-  [X] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
   - [X] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
