### PR TITLE
Set L2_NeMo_2_llama3_pretraining_recipe to be optional

### DIFF
--- a/.github/workflows/cicd-main-nemo2.yml
+++ b/.github/workflows/cicd-main-nemo2.yml
@@ -39,6 +39,7 @@ jobs:
             runner: self-hosted-azure
           - script: L2_NeMo_2_llama3_pretraining_recipe
             runner: self-hosted-azure
+            is-optional: true
           # - script: L2_NeMo_2_llama3_pytorch_profiler
           #   runner: self-hosted-azure
           #   timeout: 20


### PR DESCRIPTION
# What does this PR do ?

Set L2_NeMo_2_llama3_pretraining_recipe to be optional

The test is failing for some reason.  Was passing as of Dec 13 but some dependency update seems to be causing this issue. Setting to optional to unblock main branch until I can figure out the issue. 

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
