### PR TITLE
Docs: use relative path for preprocess_data_for_megatron.py

### DIFF
--- a/docs/source/nlp/nemo_megatron/gpt/gpt_training.rst
+++ b/docs/source/nlp/nemo_megatron/gpt/gpt_training.rst
@@ -76,7 +76,7 @@ The memory map format makes training more efficient, especially with many nodes 
 
 .. code-block:: bash
 
-    python <NeMo_ROOT_FOLDER>/scripts/nlp_language_modeling/preprocess_data_for_megatron.py \
+    python scripts/nlp_language_modeling/preprocess_data_for_megatron.py \
     --input=train_data.jsonl \
     --json-keys=text \
     --tokenizer-library=megatron \
@@ -92,7 +92,7 @@ The memory map format makes training more efficient, especially with many nodes 
 
 .. code-block:: bash
 
-    python <NeMo_ROOT_FOLDER>/scripts/nlp_language_modeling/preprocess_data_for_megatron.py \
+    python scripts/nlp_language_modeling/preprocess_data_for_megatron.py \
     --input=train_data.jsonl \
     --json-keys=text \
     --tokenizer-library=sentencepiece \


### PR DESCRIPTION
This updates GPT training docs to use a relative path:
python scripts/nlp_language_modeling/preprocess_data_for_megatron.py

Fixes #15130