### PR TITLE
fix: Raise exception in nemo.export instead of allowing pickle.loads

### DIFF
--- a/nemo/export/tensorrt_llm.py
+++ b/nemo/export/tensorrt_llm.py
@@ -1667,9 +1667,7 @@ class TensorRTLLM(ITritonDeployable):
             self.p_table = None
 
     def _load_prompt_tables(self):
-        raise Exception(
-            "nemo.export is deprecated. Please use the repo https://github.com/NVIDIA-NeMo/Export-Deploy."
-        )
+        raise Exception("nemo.export is deprecated. Please use the repo https://github.com/NVIDIA-NeMo/Export-Deploy.")
 
     def _get_prompt_embedding_table_ckpt(self, prompt_embeddings_checkpoint_path):
         with TarPath(prompt_embeddings_checkpoint_path) as checkpoint_archive:

--- a/nemo/export/trt_llm/nemo_ckpt_loader/nemo_file.py
+++ b/nemo/export/trt_llm/nemo_ckpt_loader/nemo_file.py
@@ -51,9 +51,7 @@ def load_extra_state_from_bytes(val: Optional[Union[torch.Tensor, BytesIO]]) -> 
     Returns:
         Optional[dict]: Deserialized extra_state, or None if the bytes storage is empty.
     """
-    raise Exception(
-        "nemo.export is deprecated. Please use the repo https://github.com/NVIDIA-NeMo/Export-Deploy."
-    )
+    raise Exception("nemo.export is deprecated. Please use the repo https://github.com/NVIDIA-NeMo/Export-Deploy.")
 
 
 def preprocess_scaling_factors_for_local_export(state_dict: Dict[str, Any]) -> Dict[str, Any]:


### PR DESCRIPTION
# What does this PR do ?

fix: Raise exception in nemo.export instead of allowing pickle.loads.

Export-Deploy has been deprecated in this repo because it has its own repo now, but we need to remove the pickle.loads call here. So we raise an exception for now until we fully remove it.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
