### PR TITLE
feat(asr): add optional auxiliary timestamp model restoration for Canary

### DIFF
--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -253,7 +253,10 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
         # Setup encoder adapters (from ASRAdapterModelMixin)
         self.setup_adapters()
 
-        timestamps_asr_model = self.__restore_timestamps_asr_model()
+        if self.cfg.get("restore_timestamps_model", True):
+            timestamps_asr_model = self.__restore_timestamps_asr_model()
+        else:
+            timestamps_asr_model = None
         # Using object.__setattr__ to bypass PyTorch's module registration
         object.__setattr__(self, 'timestamps_asr_model', timestamps_asr_model)
 


### PR DESCRIPTION
# What does this PR do ?

This PR adds an optional `restore_timestamps_model` configuration to `EncDecMultiTaskModel` (Canary). This allows users to disable the automatic restoration of the auxiliary timestamp model (approx. 4GB VRAM) during finetuning/training,

**Collection**: ASR

# Changelog

- Added `restore_timestamps_model` check in `EncDecMultiTaskModel.__init__`.
- Skips loading `timestamps_asr_model` if config flag is False.

# Usage

```yaml
model:
  restore_timestamps_model: False
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [x] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

## Who can review?
@titu1994, @redoctopus, @jbalam-nv, @okuchaiev (ASR Collection)
