### PR TITLE
Speedup buffered transducer inference: remove double decoding

### DIFF
--- a/nemo/collections/asr/inference/pipelines/buffered_rnnt_pipeline.py
+++ b/nemo/collections/asr/inference/pipelines/buffered_rnnt_pipeline.py
@@ -583,7 +583,11 @@ class BufferedRNNTPipeline(BasePipeline):
             # decode right context
             _, max_time, feat_dim = encs_dim_last.shape
             device = encs.device
+            # we are indexing `encs_dim_last` with `shift_indices` to get a tensor where right context is at the start
+            # everything after right context is padded with `0` index (first encoder vector)
+            # padding will be ignored by decoder_computer since we pass the lengths
             shift_indices = torch.arange(max_time, device=device, dtype=torch.long)[None, :] + enc_lens_chunk[:, None]
+            # pad with zeros everything beyond needed context
             shift_indices = torch.where(shift_indices < max_time, shift_indices, torch.zeros_like(shift_indices))
             with torch.inference_mode(), torch.no_grad():
                 best_batched_hyps_rc, _, _ = self.decoding_computer(


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Speedup buffered RNN-T/TDT decoding in `asr/inference` by removing double-decoding of the chunk.

Results on LibriSpeech test-other with batch size 128, `nvidia/stt_en_fastconformer_transducer_large` model, default context sizes (1.6-4.8-1.6):

| Approach | WER | RTFx*     |
|----------|-----|----------|
| previous (double-decoding) | 4.55 | 1770     |
| here (with fix)     | 4.55 | **2153** |

\*measured with warmup
RTFx without warmup: 1471 (previous) -> 1619 (here)

**Collection**: [ASR]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```shell
python examples/asr/asr_streaming_inference/asr_streaming_infer.py \
  --config-path=../conf/asr_streaming_inference/ \
  --config-name=buffered_rnnt.yaml \
   asr.model_name=nvidia/stt_en_fastconformer_transducer_large \
   audio_file=ls_test_other.jsonl \
   streaming.batch_size=128 \
   output_filename=ls_test_other_decoded.jsonl
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
