### PR TITLE
improve canary performance on short audio

### DIFF
--- a/nemo/collections/asr/parts/mixins/transcription.py
+++ b/nemo/collections/asr/parts/mixins/transcription.py
@@ -135,12 +135,12 @@ class TranscriptionTensorDataset(Dataset):
         elif self.pad_direction == 'left':
             pad_left = pad_total
             pad_right = 0
-        else: # right (default)
+        else:  # right (default)
             pad_left = 0
             pad_right = pad_total
         samples = torch.nn.functional.pad(samples, (pad_left, pad_right), mode='constant', value=0.0)
         return samples
-    
+
     def get_item(self, index):
         samples = self.audio_tensors[index]
 


### PR DESCRIPTION
# What does this PR do ?

Fixes: https://github.com/NVIDIA-NeMo/NeMo/issues/15305 

Fix transcription and timestamps prediction for shorter sequences with canary models when using torch tensor/ numpy array as input

**Collection**: ASR

# Changelog

- Add min padding of 1sec when using tensor/array as input
- Pad on both sides (default used in canary models)


# Usage

```python
from nemo.collections.asr.models import EncDecMultiTaskModel
model = EncDecMultiTaskModel.from_pretrained("nvidia/canary-1b-v2")

import librosa
audio, sr = librosa.load('<path to audio>', sr=16000)

hypotheses = model.transcribe(
    audio=audio,
    source_lang='fr', target_lang='fr', timestamps=True,
    batch_size=1,
    return_hypotheses=True,
)
print(hypotheses)
```





# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to  https://github.com/NVIDIA-NeMo/NeMo/issues/15305 
