### PR TITLE
Align pretrain model load and device handling

### DIFF
--- a/examples/asr/asr_cache_aware_streaming/speech_to_text_multitalker_streaming_infer.py
+++ b/examples/asr/asr_cache_aware_streaming/speech_to_text_multitalker_streaming_infer.py
@@ -41,7 +41,6 @@ class MultitalkerTranscriptionConfig:
 
     # Required configs
     diar_model: Optional[str] = None  # Path to a .nemo file
-    diar_pretrained_name: Optional[str] = None  # Name of a pretrained model
     max_num_of_spks: Optional[int] = 4  # maximum number of speakers
     parallel_speaker_strategy: bool = True  # whether to use parallel speaker strategy
     masked_asr: bool = True  # whether to use masked ASR
@@ -73,7 +72,6 @@ class MultitalkerTranscriptionConfig:
 
     # ASR Configs
     asr_model: Optional[str] = None
-    device: str = 'cuda'
     audio_file: Optional[str] = None
     manifest_file: Optional[str] = None
     att_context_size: Optional[List[int]] = field(default_factory=lambda: [70, 13])
@@ -214,8 +212,8 @@ def main(cfg: MultitalkerTranscriptionConfig) -> Union[MultitalkerTranscriptionC
     if cfg.random_seed:
         pl.seed_everything(cfg.random_seed)
 
-    if cfg.diar_model is None and cfg.diar_pretrained_name is None:
-        raise ValueError("Both cfg.diar_model and cfg.pretrained_name cannot be None!")
+    if cfg.diar_model is None:
+        raise ValueError("cfg.diar_model cannot be None!")
     if cfg.audio_file is None and cfg.manifest_file is None:
         raise ValueError("Both cfg.audio_file and cfg.manifest_file cannot be None!")
 
@@ -246,8 +244,7 @@ def main(cfg: MultitalkerTranscriptionConfig) -> Union[MultitalkerTranscriptionC
     elif cfg.diar_model.endswith(".nemo"):
         diar_model = SortformerEncLabelModel.restore_from(restore_path=cfg.diar_model, map_location=map_location)
     else:
-        raise ValueError("cfg.diar_model must end with.ckpt or.nemo!")
-
+        diar_model = SortformerEncLabelModel.from_pretrained(model_name=cfg.diar_model, map_location=map_location)
     # Model setup for inference
     trainer = pl.Trainer(devices=device, accelerator=accelerator)
     diar_model.set_trainer(trainer)
@@ -297,7 +294,7 @@ def main(cfg: MultitalkerTranscriptionConfig) -> Union[MultitalkerTranscriptionC
     # Initialize to avoid "possibly used before assignment" error
     multispk_asr_streamer = None
 
-    asr_model = asr_model.to(cfg.device)
+    asr_model = asr_model.to(map_location)
     asr_model.eval()
 
     # chunk_size is set automatically for models trained for streaming.


### PR DESCRIPTION
# What does this PR do ?

ux enhancement for example file: speech_to_text_multitalker_streaming_infer.py

# Changelog
- Merge diar_pretrained_name and diar_model arg
- Remove cfg.diar_pretrained_name and cfg.device
- Align asr_model device with diar_model


# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

Tested with nvidia/multitalker-parakeet-streaming-0.6b-v1
