### PR TITLE
Revert lhotse patch after updating to lhotse 1.32.2

### DIFF
--- a/nemo/collections/common/data/lhotse/__init__.py
+++ b/nemo/collections/common/data/lhotse/__init__.py
@@ -29,14 +29,3 @@ from nemo.collections.common.data.lhotse.text_adapters import (
     SourceTargetTextExample,
     TextExample,
 )
-
-
-# Newer versions of torch.utils.data.Sampler do not have the data_source parameter.
-# lhotse's CutSampler expects to pass data_source to Sampler, so we need to patch
-# Sampler.__init__ to accept it.
-if "data_source" not in inspect.signature(Sampler.__init__).parameters:
-
-    def patched_sampler_init(self, data_source=None):
-        pass
-
-    Sampler.__init__ = patched_sampler_init

--- a/requirements/requirements_asr.txt
+++ b/requirements/requirements_asr.txt
@@ -5,7 +5,7 @@ einops
 jiwer>=3.1.0,<4.0.0
 kaldi-python-io
 kaldialign<=0.9.1
-lhotse>=1.32.0
+lhotse>=1.32.2
 # Align with upstream PyTorch requirements
 librosa>=0.10.1
 marshmallow

--- a/requirements/requirements_audio.txt
+++ b/requirements/requirements_audio.txt
@@ -1,5 +1,5 @@
 einops
-lhotse>=1.31.1
+lhotse>=1.32.2
 librosa>=0.10.0
 matplotlib
 pesq; (platform_machine != 'x86_64' or platform_system != 'Darwin')


### PR DESCRIPTION
# What does this PR do ?

Revert lhotse patch after updating to lhotse 1.32.2

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
