### PR TITLE
[MagpieTTS] Fix incorrect sort order comment in pareto_rank function

### DIFF
--- a/scripts/magpietts/dpo/create_preference_pairs.py
+++ b/scripts/magpietts/dpo/create_preference_pairs.py
@@ -208,7 +208,7 @@ def pareto_rank(items):
 
         current_rank += 1
 
-    # Now sort the ranked items by (rank asc, cer asc, ssim asc)
+    # Now sort the ranked items by (rank asc, cer asc, ssim desc)
     ranked_items.sort(key=lambda x: (x[0], x[1], -x[2]))
 
     return ranked_items


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fixes an incorrect comment in the `pareto_rank` function that stated SSIM is sorted ascending, when the code actually sorts it descending.

**Collection**: TTS (MagpieTTS)

# Changelog

- Fixed comment on line 211 in `scripts/magpietts/dpo/create_preference_pairs.py`: changed "ssim asc" to "ssim desc" to accurately reflect the sort order (`-x[2]` sorts descending, not ascending).

# Usage

- N/A - This is a comment-only fix with no behavioral changes.

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [X] Did you write any new necessary tests?
  - N/A - comment fix only
- [X] Did you add or update any necessary documentation?
  - N/A - code comment correction
- [X] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - No
- [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [X] Bugfix
- [X] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.
