### PR TITLE
docs: fix typo and path error in ASR documentation

### DIFF
--- a/docs/source/asr/datasets.rst
+++ b/docs/source/asr/datasets.rst
@@ -534,7 +534,7 @@ An example using an AIS cluster at ``hostname:port`` with a tarred dataset for t
   model.train_ds.manifest_filepath=ais://train_bucket/tarred_audio_manifest.json \
   model.train_ds.tarred_audio_filepaths=ais://train_bucket/audio__OP_0..511_CL_.tar \
   ++model.train_ds.defer_setup=true \
-  mode.validation_ds.manifest_filepath=ais://validation_bucket/validation_manifest.json \
+  model.validation_ds.manifest_filepath=ais://validation_bucket/validation_manifest.json \
   ++model.validation_ds.defer_setup=true
 
 

--- a/docs/source/asr/intro.rst
+++ b/docs/source/asr/intro.rst
@@ -100,7 +100,7 @@ You can also transcribe speech via the command line using the following `script 
 
 .. code-block:: bash
 
-    python <path_to_NeMo>/blob/main/examples/asr/transcribe_speech.py \
+    python <path_to_NeMo>/examples/asr/transcribe_speech.py \
         pretrained_name="stt_en_fastconformer_transducer_large" \
         audio_dir=<path_to_audio_dir> # path to dir containing audio files to transcribe
 


### PR DESCRIPTION
# What does this PR do?

Fix two small documentation errors in ASR docs that could confuse users:

1. **`docs/source/asr/datasets.rst`** (line 537): Fix typo `mode.validation_ds` → `model.validation_ds` in AIS cluster example. Users copy-pasting this command would get a silent config error.
2. **`docs/source/asr/intro.rst`** (line 103): Remove erroneous `/blob/main` from local file path. This was a GitHub URL artifact that doesn't belong in a local CLI command.

**Collection**: ASR

# Changelog

- Fix typo in datasets.rst: `mode.validation_ds` → `model.validation_ds`
- Fix incorrect path in intro.rst: remove `/blob/main` from local path example

# Before your PR is "Ready for review"

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? (N/A — docs only)
- [x] Did you add or update any necessary documentation?

**PR Type**:
- [x] Documentation