### PR TITLE
fix: correct typos in comments and docstrings

### DIFF
--- a/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
+++ b/nemo/collections/asr/parts/submodules/rnnt_greedy_decoding.py
@@ -982,7 +982,7 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer, WithOptionalCudaGraphs):
                         # If blank was predicted even once, now or in the past,
                         # Force the current predicted label to also be blank
                         # This ensures that blanks propogate across all timesteps
-                        # once they have occured (normally stopping condition of sample level loop).
+                        # once they have occurred (normally stopping condition of sample level loop).
                         for kidx, ki in enumerate(k):
                             if blank_mask[kidx] == 0:
                                 hypotheses[kidx].y_sequence.append(ki)
@@ -1191,7 +1191,7 @@ class GreedyBatchedRNNTInfer(_GreedyRNNTInfer, WithOptionalCudaGraphs):
                         # If blank was predicted even once, now or in the past,
                         # Force the current predicted label to also be blank
                         # This ensures that blanks propogate across all timesteps
-                        # once they have occured (normally stopping condition of sample level loop).
+                        # once they have occurred (normally stopping condition of sample level loop).
                         for kidx, ki in enumerate(k):
                             if blank_mask[kidx] == 0:
                                 hypotheses[kidx].y_sequence.append(ki)
@@ -1408,7 +1408,7 @@ class ExportedModelGreedyBatchedRNNTInfer:
                     # If blank was predicted even once, now or in the past,
                     # Force the current predicted label to also be blank
                     # This ensures that blanks propogate across all timesteps
-                    # once they have occured (normally stopping condition of sample level loop).
+                    # once they have occurred (normally stopping condition of sample level loop).
                     for kidx, ki in enumerate(k):
                         if blank_mask[kidx] == 0:
                             label[kidx].append(ki)
@@ -2168,7 +2168,7 @@ class GreedyBatchedMultiblankRNNTInfer(GreedyBatchedRNNTInfer):
                         # If blank was predicted even once, now or in the past,
                         # Force the current predicted label to also be blank
                         # This ensures that blanks propogate across all timesteps
-                        # once they have occured (normally stopping condition of sample level loop).
+                        # once they have occurred (normally stopping condition of sample level loop).
                         for kidx, ki in enumerate(k):
                             if blank_mask[kidx] == 0:
                                 hypotheses[kidx].y_sequence.append(ki)
@@ -2386,7 +2386,7 @@ class GreedyBatchedMultiblankRNNTInfer(GreedyBatchedRNNTInfer):
                         # If blank was predicted even once, now or in the past,
                         # Force the current predicted label to also be blank
                         # This ensures that blanks propogate across all timesteps
-                        # once they have occured (normally stopping condition of sample level loop).
+                        # once they have occurred (normally stopping condition of sample level loop).
                         for kidx, ki in enumerate(k):
                             if blank_mask[kidx] == 0:
                                 hypotheses[kidx].y_sequence.append(ki)

--- a/nemo/collections/asr/parts/utils/diarization_utils.py
+++ b/nemo/collections/asr/parts/utils/diarization_utils.py
@@ -124,7 +124,7 @@ def init_session_gecko_dict():
 
 def convert_ctm_to_text(ctm_file_path: str) -> Tuple[List[str], str]:
     """
-    Convert ctm file into a list containing transcription (space seperated string) per each speaker.
+    Convert ctm file into a list containing transcription (space separated string) per each speaker.
 
     Args:
         ctm_file_path (str):
@@ -159,7 +159,7 @@ def convert_ctm_to_text(ctm_file_path: str) -> Tuple[List[str], str]:
 
 def convert_word_dict_seq_to_text(word_dict_seq_list: List[Dict[str, float]]) -> Tuple[List[str], str]:
     """
-    Convert word_dict_seq_list into a list containing transcription (space seperated string) per each speaker.
+    Convert word_dict_seq_list into a list containing transcription (space separated string) per each speaker.
 
     Args:
         word_dict_seq_list (list):

--- a/nemo/collections/asr/parts/utils/timestamp_utils.py
+++ b/nemo/collections/asr/parts/utils/timestamp_utils.py
@@ -249,8 +249,8 @@ def get_segment_offsets(
         and not segment_gap_threshold
     ):
         logging.warning(
-            f"Specified segment seperators are not in supported punctuation {supported_punctuation}. "
-            "If the seperators are not punctuation marks, ignore this warning. "
+            f"Specified segment separators are not in supported punctuation {supported_punctuation}. "
+            "If the separators are not punctuation marks, ignore this warning. "
             "Otherwise, specify 'segment_gap_threshold' parameter in decoding config to form segments.",
             mode=logging_mode.ONCE,
         )


### PR DESCRIPTION
Correct minor typos in ASR module comments and docstrings:

- 'occured' → 'occurred' in rnnt_greedy_decoding.py
- 'seperated' → 'separated' in diarization_utils.py  
- 'seperators' → 'separators' in timestamp_utils.py

All changes are in comments and docstrings only, no functional changes.