### PR TITLE
fix: correct typo 'occured' to 'occurred' in error messages

### DIFF
--- a/nemo/core/classes/common.py
+++ b/nemo/core/classes/common.py
@@ -360,7 +360,7 @@ class Typing(ABC):
 
                     if type_shape is not None and len(value_shape) != len(type_shape):
                         raise TypeError(
-                            f"Input shape mismatch occured for {name} in module {self.__class__.__name__} : \n"
+                            f"Input shape mismatch occurred for {name} in module {self.__class__.__name__} : \n"
                             f"Input shape expected = {metadata.base_types[key].axes} | \n"
                             f"Input shape found : {value_shape}"
                         )
@@ -447,7 +447,7 @@ class Typing(ABC):
 
                     if type_shape is not None and len(value_shape) != len(type_shape):
                         raise TypeError(
-                            f"Output shape mismatch occured for {name} in module {self.__class__.__name__} : \n"
+                            f"Output shape mismatch occurred for {name} in module {self.__class__.__name__} : \n"
                             f"Output shape expected = {type_shape} | \n"
                             f"Output shape found : {value_shape}"
                         )
@@ -535,7 +535,7 @@ class Typing(ABC):
 
             if type_shape is not None and len(value_shape) != len(type_shape):
                 raise TypeError(
-                    f"Input shape mismatch occured for {name} in module {self.__class__.__name__} : \n"
+                    f"Input shape mismatch occurred for {name} in module {self.__class__.__name__} : \n"
                     f"Input shape expected = {type_shape} | \n"
                     f"Input shape found : {value_shape}"
                 )
@@ -578,7 +578,7 @@ class Typing(ABC):
 
             if type_shape is not None and len(value_shape) != len(type_shape):
                 raise TypeError(
-                    f"Output shape mismatch occured for {name} in module {self.__class__.__name__} : \n"
+                    f"Output shape mismatch occurred for {name} in module {self.__class__.__name__} : \n"
                     f"Output shape expected = {type_shape} | \n"
                     f"Output shape found : {value_shape}"
                 )


### PR DESCRIPTION
Fixed typo 'occured' → 'occurred' in error messages in nemo/core/classes/common.py.