### PR TITLE
[MagpieTTS][bugfix] defaults to force_map_dataset=True for validation datast to avoid duplicates by a factor of num_workers.

### DIFF
--- a/examples/tts/conf/magpietts/magpietts_lhotse.yaml
+++ b/examples/tts/conf/magpietts/magpietts_lhotse.yaml
@@ -107,6 +107,7 @@ model:
       quadratic_duration: ${quadratic_duration}
       use_bucketing: false
       force_finite: true
+      force_map_dataset: true
       drop_last: false
       shuffle: false
       num_workers: 2


### PR DESCRIPTION
## Summary

Fix validation dataloader data duplication for Lhotse Shar datasets by adding `force_map_dataset: true` to the MagpieTTS validation config.

## Problem

When using `lhotse_shar` data with `force_map_dataset=False` (the default), the validation dataloader uses an **iterable dataset** path that causes two compounding issues:

1. **No DDP data partitioning** -- The Lhotse sampler is created with `rank=0, world_size=1` ([hardcoded for iterable datasets](https://github.com/NVIDIA/NeMo/blob/bf365d076e/nemo/collections/common/data/lhotse/dataloader.py#L644-L645)), so every GPU independently iterates through the **entire** validation dataset instead of its `1/world_size` share.

2. **Worker-level data duplication** -- Each DataLoader worker gets a full copy of the `IterableDatasetWrapper` and independently iterates all shards. With `num_workers=N`, data is duplicated N× per GPU.

Combined, each GPU processes `num_workers × total_dataset_batches` instead of the correct `total_dataset_batches / world_size`.

This design is intentional for **training** (infinite datasets with `force_finite=False`), where unique per-worker seeds and infinite repetition avoid explicit data splitting. But for **finite validation** (`force_finite=True`), it results in massive redundant computation and metrics computed on duplicated data.

## Empirical Validation

Tested on LibriTTS dev-clean (5,620 records = 176 batches at `batch_size=32`, `num_workers=2`, `quadratic_duration=null`):

| `force_map_dataset` | 8 GPUs | 16 GPUs | Expected |
|---|---|---|---|
| `False` (before) | 352 | 352 | `num_workers × total = 2 × 176 = 352` (GPU-count independent) |
| `True` (after) | 22 | 11 | `total / world_size = 176/8=22, 176/16=11` (proper DDP scaling) |

With `force_map_dataset=True`:
- Validation iterations scale inversely with GPU count (correct DDP behavior)
- No worker duplication (map dataset dispatches work to workers without duplication)
- Reduction factor = `num_workers × world_size` (e.g., 2×8 = **16× fewer iterations** on 8 GPUs)

## Fix

Setting `force_map_dataset: true` in the validation config switches from iterable dataset to map dataset, where:
- The sampler uses the actual `global_rank` and `world_size` to partition data across GPUs
- The DataLoader manages worker dispatch without duplication

This follows the same pattern used in [`speechlm2/data/datamodule.py`](https://github.com/NVIDIA/NeMo/blob/bf365d076e/nemo/collections/speechlm2/data/datamodule.py#L64-L68) for validation/test dataloaders. Unit test at `tests/collections/common/test_lhotse_dataloading.py::test_force_map_dataset` validate the effectiveness.