### PR TITLE
CI: increase cer to 0.08 from 0.06 to avoid chance to fail.

### DIFF
--- a/tests/functional_tests/L2_TTS_InferEvaluate_Magpietts_MoE_ZeroShot.sh
+++ b/tests/functional_tests/L2_TTS_InferEvaluate_Magpietts_MoE_ZeroShot.sh
@@ -24,5 +24,5 @@ TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 coverage run -a --data-file=/workspace/.cover
     --apply_attention_prior \
     --run_evaluation \
     --clean_up_disk \
-    --cer_target 0.06 \
+    --cer_target 0.08 \
     --ssim_target 0.72


### PR DESCRIPTION
To satisfy the CER <= 0.06 for L2 MoE MagpieTTS CI needs some luck. Increase a little to avoid failure with high prob as suggested by @chtruong814 

sharing one example of failure,
```shell
[NeMo I 2026-02-13 23:18:52 magpietts_inference:116] Metrics appended to: ./mp_moe_zs_0/all_experiment_metrics_with_ci.csv
[NeMo I 2026-02-13 23:18:52 magpietts_inference:358] Cleaning up output directory: ./mp_moe_zs_0
Traceback (most recent call last):
  File "/workspace/examples/tts/magpietts_inference.py", line 672, in <module>
    main()
  File "/workspace/examples/tts/magpietts_inference.py", line 660, in main
    raise ValueError(f"CER {cer:.4f} exceeds target {args.cer_target:.4f}")
ValueError: CER 0.0604 exceeds target 0.0600
Did not finish.
```