### PR TITLE
fix: add missing docstring for transcript args in EncDecMultiTaskModel.forward()

### DIFF
--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -744,7 +744,10 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
                 of shape (B, D, T).
             processed_signal_length: Vector of length B, that contains the individual lengths of the
                 processed audio sequences.
-            # TODO: Add support for `transcript` and `transcript_length` in the docstring
+            transcript: Tensor that represents a batch of target transcriptions,
+                of shape [B, T]. Used as decoder input during teacher-forced training.
+            transcript_length: Vector of length B, that contains the individual lengths of the
+                target transcription sequences.
 
         Returns:
             A tuple of 3 elements -


### PR DESCRIPTION
# What does this PR do?

Resolve a TODO in `EncDecMultiTaskModel.forward()` by adding missing docstring entries for the `transcript` and `transcript_length` parameters.

The `forward()` method accepts 6 arguments but only 4 were documented. The TODO comment on line 747 explicitly requested this addition:
`# TODO: Add support for transcript and transcript_length in the docstring`

**Collection**: ASR

# Changelog

- Add docstring for `transcript` and `transcript_length` parameters in `EncDecMultiTaskModel.forward()`
- Remove resolved TODO comment

# Usage

No behavior change — docstring improvement only.

# Before your PR is "Ready for review"

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests? (N/A — docstring only)
- [x] Did you add or update any necessary documentation?

**PR Type**:
- [x] Bugfix
- [x] Documentation