### PR TITLE
fix: read beam.search_type from config instead of hardcoding 'default'

### DIFF
--- a/nemo/collections/asr/parts/submodules/ctc_decoding.py
+++ b/nemo/collections/asr/parts/submodules/ctc_decoding.py
@@ -318,7 +318,7 @@ class AbstractCTCDecoding(ConfidenceMixin):
             self.decoding = ctc_beam_decoding.BeamCTCInfer(
                 blank_id=blank_id,
                 beam_size=self.cfg.beam.get('beam_size', 1),
-                search_type='default',
+                search_type=self.cfg.beam.get('search_type', 'default'),
                 return_best_hypothesis=self.cfg.beam.get('return_best_hypothesis', True),
                 preserve_alignments=self.preserve_alignments,
                 compute_timestamps=self.compute_timestamps,


### PR DESCRIPTION
> [!IMPORTANT]
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fixes CTC beam decoding configuration by reading `beam.search_type` from the decoding config instead of hardcoding `search_type="default"` when `strategy="beam"` in `AbstractCTCDecoding.__init__`.

This enables intended behavior for LM-aware beam search backends (e.g., `pyctcdecode`) when users set `beam.search_type` and provide `kenlm_path`.

**Collection**: [ASR]

# Changelog

* Update `AbstractCTCDecoding.__init__` to pass:

  * from `search_type="default"`
  * to `search_type=self.cfg.beam.get("search_type", "default")`
* Keeps backward compatibility via the `"default"` fallback when `beam.search_type` is not set.

# Usage

```python
from omegaconf import OmegaConf

ctc_cfg = OmegaConf.create({
    "strategy": "beam",
    "beam": {
        "beam_size": 32,
        "search_type": "pyctcdecode",
        "kenlm_path": "/path/to/lm.arpa",
        "beam_alpha": 0.5,
        "beam_beta": 0.1,
    },
})

model.change_decoding_strategy(decoding_cfg=ctc_cfg, decoder_type="ctc")

# After this fix, the configured search_type is preserved
assert model.ctc_decoding.decoding.search_type == "pyctcdecode"
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

* [x] Make sure you read and followed [[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
* [ ] Did you write any new necessary tests?
* [ ] Did you add or update any necessary documentation?
* [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)

  * [ ] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:

* [ ] New Feature
* [x] Bugfix
* [ ] Documentation

# Additional Information

* Related to #15400

Diff summary:

* `search_type="default"`

- `search_type=self.cfg.beam.get("search_type", "default")`

**Reviewer**: @nithinraok