### PR TITLE
Adapt to use env variable for adapter mixin model loading

### DIFF
--- a/nemo/core/classes/mixins/adapter_mixins.py
+++ b/nemo/core/classes/mixins/adapter_mixins.py
@@ -959,9 +959,9 @@ class AdapterModelPTMixin(AdapterModuleMixin):
                 map_location = 'cpu'
 
         # Load the state dict and extract the internal config.
-        # PyTorch 2.6 changed torch.load() default `weights_only=True`, which
-        # rejects non-tensor objects such as the adapter DictConfig payload.
-        state_dict = torch.load(filepath, map_location=map_location, weights_only=False)
+        # Set the env var TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 before calling this
+        # method when using PyTorch 2.6+. Only do this with trusted checkpoint files.
+        state_dict = torch.load(filepath, map_location=map_location)
         config = state_dict.pop('__cfg__')
 
         # Normalize the name to a list of names (exact match with the state dict)

--- a/tutorials/02_NeMo_Adapters.ipynb
+++ b/tutorials/02_NeMo_Adapters.ipynb
@@ -89,12 +89,18 @@
       },
       "outputs": [],
       "source": [
+        "import os\n",
         "import torch\n",
         "import torch.nn as nn\n",
         "from nemo.core import NeuralModule, ModelPT\n",
         "\n",
         "from hydra.utils import instantiate\n",
-        "from omegaconf import DictConfig, OmegaConf"
+        "from omegaconf import DictConfig, OmegaConf\n",
+        "\n",
+        "# As of PyTorch 2.6, torch.load defaults to weights_only=True. Adapter checkpoints\n",
+        "# contain non-tensor objects (OmegaConf DictConfig), so we must allow full loading.\n",
+        "# Only do this with trusted checkpoint files.\n",
+        "os.environ[\"TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD\"] = \"1\""
       ]
     },
     {
@@ -420,39 +426,44 @@
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "0E2877IlIVoM"
+      },
       "source": [
         "-----\n",
         "You will often not directly with this module, instead of passing the Config Dataclass to the `AdapterModuleMixin` methods. We see an example below - "
-      ],
-      "metadata": {
-        "id": "0E2877IlIVoM"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "8eH6mW792lkY"
+      },
       "source": [
         "## [Optional] Constructing Adapter Components\n",
         "\n",
         "Linear Adapter Modules are not the only type of adapters you can create ! In PyTorch, any torch.nn.Module can be made into an Adapter component.\n",
         "\n",
         "For example, you can potentially convert a pre-existing pytorch module into an adapter component. The below section is **optional**, but is recommended if you wish to create your own adapters.\n"
-      ],
-      "metadata": {
-        "id": "8eH6mW792lkY"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "lgsyaQHI3w5X"
+      },
       "source": [
         "------\n",
         "First, let us start with a simple PyTorch module."
-      ],
-      "metadata": {
-        "id": "lgsyaQHI3w5X"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "wAfA3r0b3fpi"
+      },
+      "outputs": [],
       "source": [
         "class SimpleModule(torch.nn.Module):\n",
         "  def __init__(self, size: int):\n",
@@ -465,41 +476,39 @@
         "  \n",
         "  def forward(self, x):\n",
         "    return self.model(x)"
-      ],
-      "metadata": {
-        "id": "wAfA3r0b3fpi"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "hMKoxc0e5c14"
+      },
       "source": [
         "### Adapter Strategy\n",
         "\n",
         "Adapter modules are, at the end of the day, simply PyTorch modules. Just as PyTorch modules, they take some input tensors, perform some operation and then return some result.\n",
         "\n",
         "There are many ways to integrate adapters - add them as a residual, multiply pointwise, concatenate with the input (at the end or the beginning). The Adapter Strategy class determines how an adapter integrates with its input."
-      ],
-      "metadata": {
-        "id": "hMKoxc0e5c14"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "1DVeRqH65IN8"
+      },
+      "outputs": [],
       "source": [
         "# The earlier LinearAdapter has a simple ResidualAddStrategy\n",
         "# Uncomment below to see the ResidualAddAdapterStrategy definition\n",
         "# help(linear_adapter.adapter_strategy)"
-      ],
-      "metadata": {
-        "id": "1DVeRqH65IN8"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "5mWowiS269h8"
+      },
       "source": [
         "### Creating a custom Adapter Strategy\n",
         "\n",
@@ -510,45 +519,47 @@
         "-----\n",
         "\n",
         "Below, we will create a Multiplication adapter strategy simply as a demonstration."
-      ],
-      "metadata": {
-        "id": "5mWowiS269h8"
-      }
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "from nemo.core.classes.mixins import adapter_mixin_strategies"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "teiTVBMq687x"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "from nemo.core.classes.mixins import adapter_mixin_strategies"
+      ]
     },
     {
       "cell_type": "markdown",
-      "source": [
-        "We will implement a special `forward` method of adapters as follows"
-      ],
       "metadata": {
         "id": "BS2W1a919KDr"
-      }
+      },
+      "source": [
+        "We will implement a special `forward` method of adapters as follows"
+      ]
     },
     {
       "cell_type": "code",
-      "source": [
-        "# Uncomment to see the definition of the AbstractAdapterStrategy\n",
-        "# help(adapter_mixin_strategies.AbstractAdapterStrategy)"
-      ],
+      "execution_count": null,
       "metadata": {
         "id": "G9_bq05P9Izh"
       },
-      "execution_count": null,
-      "outputs": []
+      "outputs": [],
+      "source": [
+        "# Uncomment to see the definition of the AbstractAdapterStrategy\n",
+        "# help(adapter_mixin_strategies.AbstractAdapterStrategy)"
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "T3agPtjA3fst"
+      },
+      "outputs": [],
       "source": [
         "class MultiplicationAdapterStrategy(adapter_mixin_strategies.AbstractAdapterStrategy):\n",
         "\n",
@@ -569,26 +580,26 @@
         "     # Apply scaling factor. Equivalent to f(x) = scale * (x * adapter(x))\n",
         "     result = self.scale * result\n",
         "     return result\n"
-      ],
-      "metadata": {
-        "id": "T3agPtjA3fst"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "ZOS9Z3KVAGH2"
+      },
       "source": [
         "### Design a corresponding dataclass for the Adapter Strategy\n",
         "\n",
         "In order to make usage of this class easier, you should create a Dataclass that can be used to create the strategy easily. We show an example below:"
-      ],
-      "metadata": {
-        "id": "ZOS9Z3KVAGH2"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "MI4oYRYDAeqb"
+      },
+      "outputs": [],
       "source": [
         "from dataclasses import dataclass\n",
         "\n",
@@ -600,28 +611,28 @@
         "    _target_: str = \"{0}.{1}\".format(\n",
         "        MultiplicationAdapterStrategy.__module__, MultiplicationAdapterStrategy.__name__\n",
         "    )  "
-      ],
-      "metadata": {
-        "id": "MI4oYRYDAeqb"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "mZ22m_ZK_ifY"
+      },
       "source": [
         "### Creating a Custom Adapter Component\n",
         "\n",
         "Now that we have both the basic PyTorch module (`SimpleModule`) as well as the Adapter Strategy (`MultiplicationAdapterStrategy`), we can now construct a new adapter component.\n",
         "\n",
         "The prime difference between a basic PyTorch module and an adapter component is the `adapter_strategy` - it defines how an adapter integrates with the original input. "
-      ],
-      "metadata": {
-        "id": "mZ22m_ZK_ifY"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "wCcdXIix__Yq"
+      },
+      "outputs": [],
       "source": [
         "class SimpleModuleAdapter(SimpleModule, adapter_modules.AdapterModuleUtil):\n",
         "\n",
@@ -658,25 +669,25 @@
         "    Make the default adapter strategy of this component be the `MultiplicationAdapterStrategy()`  \n",
         "    \"\"\"\n",
         "    return MultiplicationAdapterStrategyConfig()"
-      ],
-      "metadata": {
-        "id": "wCcdXIix__Yq"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "lYfjhWBtEBYj"
+      },
       "source": [
         "-----\n",
         "Let's quickly test whether the adapter behaves as expected"
-      ],
-      "metadata": {
-        "id": "lYfjhWBtEBYj"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "tVkikcmCEJun"
+      },
+      "outputs": [],
       "source": [
         "simple_adapter = SimpleModuleAdapter(size=5)\n",
         "multiplication_strategy = simple_adapter.adapter_strategy\n",
@@ -686,37 +697,37 @@
         "print(\"Original input :\", x)\n",
         "print(\"Adapter output :\", adapter_x)\n",
         "print(\"Strategy output:\", output)"
-      ],
-      "metadata": {
-        "id": "tVkikcmCEJun"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "mi7WpFgxHmGQ"
+      },
       "source": [
         "We see that the original input passes through the adapter, which results in the original values being returned successfully, and then the adapter strategy multiplies the two values (effectively computing the square of the input).\n",
         "\n",
         "This is a sufficient demonstration of creating custom adapters, and we would normally not perform elementwise multiplication as an adapter strategy. Normally we would prefer the output of the strategy to be equal to the original init, at least at initialization."
-      ],
-      "metadata": {
-        "id": "mi7WpFgxHmGQ"
-      }
+      ]
     },
     {
       "cell_type": "markdown",
+      "metadata": {
+        "id": "OrmCQCX6ImKs"
+      },
       "source": [
         "### Design a corresponding dataclass for the Adapter Component\n",
         "\n",
         "In order to make usage of this Adapter component easier, you should create a Dataclass that can be used to create the component easily. We show an example below:"
-      ],
-      "metadata": {
-        "id": "OrmCQCX6ImKs"
-      }
+      ]
     },
     {
       "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "id": "Ml17OoOVJOwR"
+      },
+      "outputs": [],
       "source": [
         "from typing import Optional\n",
         "\n",
@@ -729,12 +740,7 @@
         "    _target_: str = \"{0}.{1}\".format(\n",
         "        SimpleModuleAdapter.__module__, SimpleModuleAdapter.__name__\n",
         "    )  "
-      ],
-      "metadata": {
-        "id": "Ml17OoOVJOwR"
-      },
-      "execution_count": null,
-      "outputs": []
+      ]
     },
     {
       "cell_type": "markdown",


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fixes an issue with loading adapter ckpts.

Makes adapter checkpoint loading work again on PyTorch 2.6+ without changing checkpoint format.

**Collection**: ASR

# Changelog

- Adding environment variable `TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1` for such cases. 

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
