### PR TITLE
Remove typing annotation breaking earlier python versions in speechlm2

### DIFF
--- a/nemo/collections/speechlm2/modules/ear_tts_vae_codec.py
+++ b/nemo/collections/speechlm2/modules/ear_tts_vae_codec.py
@@ -16,7 +16,7 @@ import functools
 import math
 from collections.abc import Callable
 from contextlib import contextmanager
-from typing import Any, Concatenate
+from typing import Any
 
 import librosa
 import torch
@@ -111,7 +111,7 @@ def spectrogram(
     n_fft: int,
     hop_length: int,
     win_length: int,
-    window_fn: Callable[Concatenate[int, ...], Tensor] = torch.hann_window,
+    window_fn: Callable = torch.hann_window,
 ) -> Tensor:
     """
     Computes the Short-Time Fourier Transform (STFT) of a waveform with manual padding.
@@ -167,7 +167,7 @@ def spec_to_wav(
     n_fft: int,
     hop_length: int,
     win_length: int,
-    window_fn: Callable[Concatenate[int, ...], Tensor] = torch.hann_window,
+    window_fn: Callable = torch.hann_window,
     constrain_value_range: bool = False,
 ) -> Tensor:
     """
@@ -255,7 +255,7 @@ def spectrogram_mag(
     n_fft: int,
     hop_length: int,
     win_length: int,
-    window_fn: Callable[Concatenate[int, ...], Tensor] = torch.hann_window,
+    window_fn: Callable = torch.hann_window,
     power: float = 1.0,
 ) -> Tensor:
     """
@@ -355,7 +355,7 @@ def mel_spectrogram(
     n_mels: int,
     f_min: float,
     f_max: float | None = None,
-    window_fn: Callable[Concatenate[int, ...], Tensor] = torch.hann_window,
+    window_fn: Callable = torch.hann_window,
     power: float = 1.0,
     log_scale: str | None = "natural",
 ) -> Tensor:


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fixes the following:

```
Traceback (most recent call last):
  File "/home/user/app/app.py", line 8, in <module>
    from nemo.collections.speechlm2 import SALM
  File "/usr/local/lib/python3.10/site-packages/nemo/collections/speechlm2/__init__.py", line 15, in <module>
    from .models import SALM, DuplexEARTTS, DuplexS2SModel, DuplexS2SSpeechDecoderModel, SALMWithAsrDecoder
  File "/usr/local/lib/python3.10/site-packages/nemo/collections/speechlm2/models/__init__.py", line 14, in <module>
    from .duplex_ear_tts import DuplexEARTTS
  File "/usr/local/lib/python3.10/site-packages/nemo/collections/speechlm2/models/duplex_ear_tts.py", line 42, in <module>
    from nemo.collections.speechlm2.modules.ear_tts_vae_codec import RVQVAEModel
  File "/usr/local/lib/python3.10/site-packages/nemo/collections/speechlm2/modules/ear_tts_vae_codec.py", line 114, in <module>
    window_fn: Callable[Concatenate[int, ...], Tensor] = torch.hann_window,
  File "/usr/local/lib/python3.10/typing.py", line 312, in inner
    return func(*args, **kwds)
  File "/usr/local/lib/python3.10/typing.py", line 403, in __getitem__
    return self._getitem(self, parameters)
  File "/usr/local/lib/python3.10/typing.py", line 599, in Concatenate
    raise TypeError("The last parameter to Concatenate should be a "
TypeError: The last parameter to Concatenate should be a ParamSpec variable.
```

**Collection**: speechlm2

# Changelog

- Remove typing annotation breaking earlier python versions in speechlm2

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
