### PR TITLE
Add unit tests for xatt output dimension

### DIFF
--- a/tests/collections/asr/decoding/test_multi_task_decoding.py
+++ b/tests/collections/asr/decoding/test_multi_task_decoding.py
@@ -292,3 +292,38 @@ def test_transformer_aed_greedy_infer_strips_prompt(prompted_inputs, decoder_nm,
     torch.testing.assert_close(
         untrimmed[decoder_input_ids.shape[1] :], best_path
     )  # stripped the prompt from the beggining
+
+def test_beam_xattn_u_dim_matches_prefix_plus_output(
+    prompted_inputs, decoder_nm, nnet, tokenizer
+):
+    decoder_input_ids, encoder_hidden_states, encoder_input_mask = prompted_inputs
+    decoder_input_ids = torch.tensor([[1, 0, 2, 3, 4]], dtype=torch.long)
+    *_, classifier = nnet
+
+    gen = TransformerAEDBeamInfer(
+        decoder_nm,
+        classifier,
+        tokenizer,
+        return_xattn_scores=True,
+    )
+    (packed_result,) = gen(
+        encoder_hidden_states=encoder_hidden_states,
+        encoder_input_mask=encoder_input_mask,
+        decoder_input_ids=decoder_input_ids,
+    )
+
+    prefix_len = decoder_input_ids.shape[1]
+    hyp = packed_result[0]
+
+    assert hyp.xatt_scores is not None
+    assert hyp.y_sequence is not None
+
+    output_len = hyp.y_sequence.shape[0]
+
+    for layer_idx, xatt in enumerate(hyp.xatt_scores):
+        u_dim = xatt.shape[1]
+        expected_u = prefix_len + output_len
+        assert u_dim == expected_u, (
+            f"Layer {layer_idx}: xatt U dim {u_dim} != "
+            f"prefix_len({prefix_len}) + output_len({output_len}) = {expected_u}"
+        )


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

This PR adds unit test for xatt dimension scores.

**Collection**: [Note which collection this PR will affect]

Asr

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [✅] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to https://github.com/NVIDIA-NeMo/NeMo/issues/15419
