### PR TITLE
[MagpieTTS] set seed and shard_seed=randomized for val dataloader to ensure deterministic multi-GPU eval

### DIFF
--- a/examples/tts/conf/magpietts/magpietts_lhotse.yaml
+++ b/examples/tts/conf/magpietts/magpietts_lhotse.yaml
@@ -108,6 +108,8 @@ model:
       use_bucketing: false
       force_finite: true
       force_map_dataset: true
+      seed: 42
+      shard_seed: "randomized"
       drop_last: false
       shuffle: false
       num_workers: 2

--- a/examples/tts/conf/magpietts/magpietts_lhotse_moe.yaml
+++ b/examples/tts/conf/magpietts/magpietts_lhotse_moe.yaml
@@ -112,6 +112,8 @@ model:
       use_bucketing: false
       force_finite: true
       force_map_dataset: true
+      seed: 42
+      shard_seed: "randomized"
       drop_last: false
       shuffle: false
       num_workers: 2


### PR DESCRIPTION
### Problem
The default `shard_seed: "trng"` for the validation dataloader causes non-deterministic behavior across multi-GPU runs. Even with `force_map_dataset=True`, the Lhotse sampler still uses the TRNG seed to shuffle and distribute batches across GPU ranks. This means:
* Validation batches are distributed differently across GPUs on every run.
* For validation sets (e.g., 22 batches across 4+ GPUs), the uneven remainder batches are assigned to different GPU ranks randomly, introducing subtle per-epoch metric variance.

### Why this fix works
`shard_seed: "randomized"` disables TRNG and instead derives a unique but deterministic sub-seed per GPU rank and CPU worker using the base `seed`. Combined with `force_map_dataset=True`, this guarantees:
1. All 22 (or N) validation batches are loaded into memory upfront.
2. Every GPU rank receives the exact same partition of the validation set on every epoch.
3. Validation metrics are mathematically identical and reproducible across runs and checkpoints.

ref: https://docs.nvidia.com/nemo-framework/user-guide/latest/nemotoolkit/asr/datasets.html#seeds-and-randomness
