### PR TITLE
Script to migrate .nemo checkpoints that used torchaudio preprocessor

### DIFF
--- a/scripts/speech_recognition/convert_torchaudio_nemo.py
+++ b/scripts/speech_recognition/convert_torchaudio_nemo.py
@@ -63,7 +63,7 @@ def migrate_state_dict(state_dict: dict) -> tuple[dict, list[tuple[str, str]]]:
         for old_suffix, new_suffix in KEY_MIGRATION.items():
             if key.endswith(old_suffix):
                 new_key = key[: -len(old_suffix)] + new_suffix
-               if "featurizer.fb" in new_suffix:
+                if "featurizer.fb" in new_suffix:
                     state_dict[new_key] = state_dict.pop(key).T.unsqueeze(0)
                 else:
                     state_dict[new_key] = state_dict.pop(key)


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Script to migrate .nemo checkpoints that used torchaudio preprocessor

**Collection**: asr

# Changelog

- Script to migrate .nemo checkpoints that used torchaudio preprocessor

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
