### PR TITLE
[voice agent][Fix] for non-EOU ASR models

### DIFF
--- a/examples/voice_agent/server/server.py
+++ b/examples/voice_agent/server/server.py
@@ -41,7 +41,7 @@ from nemo.agents.voice_agent.pipecat.processors.frameworks.rtvi import RTVIObser
 from nemo.agents.voice_agent.pipecat.services.nemo.audio_logger import AudioLogger, RTVIAudioLoggerObserver
 from nemo.agents.voice_agent.pipecat.services.nemo.diar import NemoDiarService
 from nemo.agents.voice_agent.pipecat.services.nemo.llm import get_llm_service_from_config
-from nemo.agents.voice_agent.pipecat.services.nemo.stt import ASR_EOU_MODELS, NemoSTTService
+from nemo.agents.voice_agent.pipecat.services.nemo.stt import NemoSTTService
 from nemo.agents.voice_agent.pipecat.services.nemo.tts import get_tts_service_from_config
 from nemo.agents.voice_agent.pipecat.services.nemo.turn_taking import NeMoTurnTakingService
 from nemo.agents.voice_agent.pipecat.transports.network.websocket_server import (


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Previously some additional logic was added to let VAD create user frames for non-EOU ASR models (e.g., `nvidia/nemotron-speech-streaming-en-0.6b`), which will cause the pipeline to send two UserStartedSpeakingFrame/UserStoppedSpeakingFrame, one by VAD and the other by TurnTakingService. 

In this fix, we force to only use TurnTakingService to handle those signals, since the non-EOU ASR models can be treated as an ASR-EOU model with 100% miss rate, which is already handled in the TurnTakingService.

