### PR TITLE
Fix multitask transcribe override_config timestamps handling

### DIFF
--- a/nemo/collections/asr/models/aed_multitask_models.py
+++ b/nemo/collections/asr/models/aed_multitask_models.py
@@ -569,7 +569,8 @@ class EncDecMultiTaskModel(ASRModel, ExportableEncDecModel, ASRBPEMixin, ASRModu
                     f"but got {type(override_config)}"
                 )
             trcfg = override_config
-            trcfg.timestamps = timestamps
+            if timestamps is not None:
+                trcfg.timestamps = timestamps
 
         if trcfg.enable_chunking:
             # Check if only one audio is provided with string

--- a/tests/collections/asr/mixins/test_transcription.py
+++ b/tests/collections/asr/mixins/test_transcription.py
@@ -579,3 +579,30 @@ class TestTranscriptionMixin:
 
         # Reset the decoding strategy to original
         canary_1b_v2.change_decoding_strategy(orig_decoding_config)
+
+    @pytest.mark.with_downloads()
+    @pytest.mark.unit
+    def test_transcribe_override_config_preserves_timestamps(self, audio_files, canary_1b_v2):
+        canary_1b_v2.eval()
+        audio1, audio2 = audio_files
+
+        config = MultiTaskTranscriptionConfig(
+            batch_size=4,
+            return_hypotheses=True,
+            num_workers=0,
+            verbose=False,
+            prompt={'source_lang': 'en', 'target_lang': 'en'},
+            enable_chunking=False,
+            timestamps=True,
+        )
+
+        output = canary_1b_v2.transcribe([audio1, audio2], override_config=config)
+
+        assert len(output) == 2
+        assert isinstance(output[0], Hypothesis)
+        assert isinstance(output[1], Hypothesis)
+
+        assert output[0].timestamp is not None
+        assert output[1].timestamp is not None
+        assert 'word' in output[0].timestamp
+        assert 'word' in output[1].timestamp


### PR DESCRIPTION

One of the checks appears to be failing due to the workflow not being able to find the PR head commit from the fork:

- Unable to locate commit sha: 3bfbcb676de9224c1a3404dbc2a27f7d756c8dd5
- Unable to find merge base
- Suggestion in logs mentions setting actions/checkout `repository` to `${{ github.event.pull_request.head.repo.full_name }}` for forked PRs

This looks like a workflow checkout/diff issue rather than a code issue on this PR.

> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Fixes an issue where `EncDecMultiTaskModel.transcribe()` overwrites the `timestamps` value provided through `override_config` when the `timestamps` parameter is left as its default (`None`). The fix ensures that timestamps defined in `MultiTaskTranscriptionConfig` are preserved unless the `timestamps` parameter is explicitly provided.

**Collection**: ASR

# Changelog

- Fixed logic in `EncDecMultiTaskModel.transcribe()` to prevent `override_config.timestamps` from being overwritten by the default `timestamps=None` parameter.
- Added a conditional guard so that timestamps are only overridden when explicitly provided.
- Added a regression test to ensure timestamps set via `MultiTaskTranscriptionConfig` are preserved when using `override_config`.

# Usage

Example demonstrating usage of `override_config` with timestamps preserved.

```python
from nemo.collections.asr.models import ASRModel
from nemo.collections.asr.models.aed_multitask_models import MultiTaskTranscriptionConfig

model = ASRModel.restore_from("model.nemo")

config = MultiTaskTranscriptionConfig(
    batch_size=4,
    return_hypotheses=True,
    timestamps=True,
)

outputs = model.transcribe(["audio.wav"], override_config=config)

print(outputs[0].timestamp)
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to #8596
