### PR TITLE
Fix BlendableDataset crash when torch.distributed is not initialized (#15465)

### DIFF
--- a/nemo/collections/common/data/blendable_dataset.py
+++ b/nemo/collections/common/data/blendable_dataset.py
@@ -48,16 +48,30 @@ class BlendableDataset(torch.utils.data.Dataset):
         self.dataset_sample_index = np.zeros(self.size, dtype=np.int64)
 
         app_state = AppState()
+
+        # Determine if we are in a distributed environment
+        is_dist = torch.distributed.is_available() and torch.distributed.is_initialized()
+
         try:
-            if app_state.local_rank == 0:
+            # Defensive check for local_rank in AppState
+            local_rank = getattr(app_state, 'local_rank', 0) if is_dist else 0
+
+            if local_rank == 0:
                 compile_helper()
-            torch.distributed.barrier()
+
+            if is_dist:
+                torch.distributed.barrier()
+
+            # pylint: disable=import-outside-toplevel
             from nemo.collections.common.data import helpers
-        except ImportError:
+        except ImportError as exc:
             raise ImportError(
                 'Could not compile megatron dataset C++ helper functions and therefore '
                 'cannot import helpers python file.'
-            )
+            ) from exc
+
+        # Only the main process (rank 0) should handle logging/progress within helpers
+        is_main_process = (torch.distributed.get_rank() == 0) if is_dist else True
 
         helpers.build_blending_indices(
             self.dataset_index,
@@ -65,11 +79,9 @@ class BlendableDataset(torch.utils.data.Dataset):
             weights,
             num_datasets,
             self.size,
-            torch.distributed.get_rank() == 0,
+            is_main_process,
         )
-        logging.info(
-            '> elapsed time for building blendable dataset indices: ' '{:.2f} (sec)'.format(time.time() - start_time)
-        )
+        logging.info(f'> elapsed time for building blendable dataset indices: {time.time() - start_time:.2f} (sec)')
 
     def __len__(self):
         return self.size


### PR DESCRIPTION
# What does this PR do ?

This PR fixes a `ValueError` in `BlendableDataset` that occurs when torch.distributed is available but the process group has not been initialized.
**Collection**: [Common]

# Changelog

- Added torch.distributed.is_initialized() guards before calling barrier() and get_rank() in BlendableDataset.__init__()
- Ensured safe access to AppState.local_rank using getattr to avoid potential AttributeError in non-distributed setups.
- Introduced is_main_process variable for clarity when passing rank-dependent flags.

# Usage

```python
import torch
from nemo.collections.common.data.blendable_dataset import BlendableDataset

# This now works even if torch.distributed.init_process_group() has NOT been called
dataset = BlendableDataset(
    datasets=[ds1, ds2],
    weights=[0.5, 0.5],
    size=100
)
```

# Before your PR is "Ready for review"

**Pre checks**:

- [x] Make sure you read and followed [[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [x] Verified using a minimal standalone script without initializing torch.distributed
- [ ] Did you add or update any necessary documentation?
- [x] Does the PR affect components that are optional to install?
 - [x] Reviewer: Does the PR have correct import guards for all optional libraries?

**PR Type**:

- [ ] New Feature
- [x] Bugfix
- [ ] Documentation

## Who can review?
Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to #15465

---