### PR TITLE
add claude review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,56 @@
+name: Claude Code Review
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  acknowledge:
+    if: >-
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/claude review')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add eyes reaction to comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'eyes'
+            });
+
+  claude-review:
+    needs: acknowledge
+    uses: NVIDIA-NeMo/FW-CI-templates/.github/workflows/_claude_review.yml@v0.79.0
+    with:
+      prompt: |
+        You are doing a light code review. Keep it concise and actionable.
+
+        Focus ONLY on:
+        - Critical bugs or logic errors
+        - Typos in code, comments, or strings
+        - Missing or insufficient test coverage for changed code
+        - Outdated or inaccurate documentation affected by the changes
+
+        Do NOT comment on:
+        - Style preferences or formatting
+        - Minor naming suggestions
+        - Architectural opinions or refactoring ideas
+        - Performance unless there is a clear, measurable issue
+
+        Provide feedback using inline comments for specific code suggestions.
+        Use top-level comments for general observations.
+
+        It's perfectly acceptable to not have anything to comment on.
+        If you do not have anything to comment on, post "LGTM".
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION

# What does this PR do ?

Adds a GitHub Actions workflow to enable Claude-powered code reviews on pull requests, triggered by commenting `/claude review` on any PR.

**Collection**: All

# Changelog

- Added `.github/workflows/claude-review.yml` workflow that triggers on PR comments.
- Integrated with the reusable `NVIDIA-NeMo/FW-CI-templates/_claude_review.yml` workflow
- Added an acknowledgment step that reacts with 👀 to confirm the review request was received. (new) 

# Usage

- Comment `/claude review` on any pull request to trigger an automated code review by Claude


# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
