### PR TITLE
Add gb300 to numa ctl pinning logic.

### DIFF
--- a/scripts/performance/executors.py
+++ b/scripts/performance/executors.py
@@ -248,7 +248,7 @@ def slurm_executor(
                     segment = segment_candidate
                     break
 
-    numa_divisor = 2 if gpu.lower() == 'gb200' else 4
+    numa_divisor = 2 if gpu.lower() in ["gb200", "gb300"] else 4
     numa_cmd = f"numactl --cpunodebind=$((SLURM_LOCALID/{numa_divisor})) --membind=$((SLURM_LOCALID/{numa_divisor}))"
     custom_bash_cmds.append(numa_cmd)
 


### PR DESCRIPTION
Pinning parameters should match gb200. Stop gap until better pinning logic.

Will also apply to previous llmb releases: https://github.com/NVIDIA/dgxc-benchmarking/issues/38 