### PR TITLE
ci: upgrade GitHub Actions for Node.js 24 compatibility

### DIFF
--- a/.github/actions/test-template/action.yml
+++ b/.github/actions/test-template/action.yml
@@ -83,7 +83,7 @@ runs:
         echo "id=$(uuidgen)" >> "$GITHUB_OUTPUT"
 
     - name: Checkout NeMo
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       env:
         DIR: ${{ github.run_id }}
       with:
@@ -213,7 +213,7 @@ runs:
         docker exec -t nemo_container_${{ github.run_id }}_${{ inputs.runner }} coverage report -i
 
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       if: ${{ steps.check.outputs.coverage_report != 'none' }}
       with:
         name: ${{ steps.check.outputs.coverage_report }}

--- a/.github/workflows/_build_container.yml
+++ b/.github/workflows/_build_container.yml
@@ -23,7 +23,7 @@ jobs:
       cache-from: ${{ steps.cache_from.outputs.LAST_PRS }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Parse manifest.json
         id: manifest

--- a/.github/workflows/_bump_mcore_tag.yml
+++ b/.github/workflows/_bump_mcore_tag.yml
@@ -18,7 +18,7 @@ jobs:
   update-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           ref: ${{ inputs.nemo-target-branch }}
 

--- a/.github/workflows/cicd-approve-test-queue.yml
+++ b/.github/workflows/cicd-approve-test-queue.yml
@@ -25,10 +25,10 @@ jobs:
     environment: main
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/cicd-main-speech.yml
+++ b/.github/workflows/cicd-main-speech.yml
@@ -64,7 +64,7 @@ jobs:
     name: ${{ matrix.script }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}
       - name: main
@@ -206,7 +206,7 @@ jobs:
     name: ${{ matrix.is-optional && 'PLEASEFIXME_' || '' }}${{ matrix.script }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}
       - name: main
@@ -470,7 +470,7 @@ jobs:
     name: ${{ matrix.script }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}
       - name: main

--- a/.github/workflows/cicd-main-unit-tests.yml
+++ b/.github/workflows/cicd-main-unit-tests.yml
@@ -34,7 +34,7 @@ jobs:
     name: ${{ matrix.script }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}
       - name: main
@@ -65,7 +65,7 @@ jobs:
     name: ${{ matrix.script }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}
       - name: main
@@ -91,7 +91,7 @@ jobs:
     name: ${{ matrix.script }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}
       - name: main

--- a/.github/workflows/cicd-main.yml
+++ b/.github/workflows/cicd-main.yml
@@ -48,7 +48,7 @@ jobs:
       HAS_LABEL: ${{ github.event.label.name == 'Run CICD' }}
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -171,7 +171,7 @@ jobs:
           echo "id=$(uuidgen)" >> "$GITHUB_OUTPUT"
 
       - name: Checkout NeMo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}/${{steps.uuid.outputs.id }}/NeMo
 
@@ -212,7 +212,7 @@ jobs:
       && !cancelled()
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}
 
@@ -274,7 +274,7 @@ jobs:
     permissions: write-all
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get workflow result
         id: result
@@ -301,7 +301,7 @@ jobs:
           echo "code=$RESULT" | tee -a $GITHUB_OUTPUT
 
       - name: Checkout for GH CLI
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Remove label if not cancelled
         if: |
@@ -359,10 +359,10 @@ jobs:
         flag: [unit-test, e2e]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download coverage reports of current branch
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: coverage-${{ matrix.flag }}-*
 
@@ -387,7 +387,7 @@ jobs:
           flags: ${{ matrix.flag }}
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: coverage-${{ matrix.flag }}-aggregated
           path: |

--- a/.github/workflows/cicd-relabel-bot.yml
+++ b/.github/workflows/cicd-relabel-bot.yml
@@ -17,7 +17,7 @@ jobs:
     permissions: write-all
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Check if PR was already labeled with `Run CICD`
         id: pre-flight

--- a/.github/workflows/claude-answer.yml
+++ b/.github/workflows/claude-answer.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check team membership
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.ORG_TEAM_READ_TOKEN }}
           script: |
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add eyes reaction to comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -54,7 +54,7 @@ jobs:
     needs: acknowledge
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: anthropics/claude-code-action@v1
         with:
           prompt: |

--- a/.github/workflows/claude-fix.yml
+++ b/.github/workflows/claude-fix.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check team membership
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.ORG_TEAM_READ_TOKEN }}
           script: |
@@ -41,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add eyes reaction to comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.reactions.createForIssueComment({
@@ -55,7 +55,7 @@ jobs:
     needs: acknowledge
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: anthropics/claude-code-action@v1
         id: claude
         with:
@@ -93,7 +93,7 @@ jobs:
 
       - name: Label PR with agent-contribution
         if: steps.claude.outputs.branch_name
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             const prs = await github.rest.pulls.list({

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Add eyes reaction to comment
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             await github.rest.reactions.createForIssueComment({

--- a/.github/workflows/code-formatting.yml
+++ b/.github/workflows/code-formatting.yml
@@ -27,7 +27,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # setup repository and ref for PRs, see
           # https://github.com/EndBug/add-and-commit?tab=readme-ov-file#working-with-prs
@@ -45,7 +45,7 @@ jobs:
             **.py
 
       - name: Setup Python env
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.10"
 

--- a/.github/workflows/code-init-file-checker.yml
+++ b/.github/workflows/code-init-file-checker.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/code-linting.yml
+++ b/.github/workflows/code-linting.yml
@@ -17,7 +17,7 @@ jobs:
       DOMAIN: ${{ matrix.domain }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Select filter
         id: filter

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/install-test.yml
+++ b/.github/workflows/install-test.yml
@@ -21,7 +21,7 @@ jobs:
         installer: ["pip-install", "nemo-install"]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Check disk space before cleanup
         run: df -h
@@ -39,7 +39,7 @@ jobs:
       - name: Check disk space after cleanup
         run: df -h
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "${{ matrix.python }}"
 
@@ -80,7 +80,7 @@ jobs:
         installer: ["pip-install", "nemo-install"]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Check disk space before cleanup
         run: df -h
@@ -102,7 +102,7 @@ jobs:
         run: df -h
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -137,7 +137,7 @@ jobs:
         python: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Check disk space before cleanup
         run: df -h
@@ -159,7 +159,7 @@ jobs:
         run: df -h
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -186,7 +186,7 @@ jobs:
         installer: ["pip-install", "nemo-install"]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Check disk space before cleanup
         run: df -h
@@ -208,7 +208,7 @@ jobs:
         run: df -h
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -243,7 +243,7 @@ jobs:
         python: ["3.10", "3.11", "3.12"]
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
 
       - name: Check disk space before cleanup
         run: df -h
@@ -265,7 +265,7 @@ jobs:
         run: df -h
 
       - name: Install Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 

--- a/.github/workflows/release-freeze.yml
+++ b/.github/workflows/release-freeze.yml
@@ -45,7 +45,7 @@ jobs:
     environment: main
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: ${{ github.run_id }}
           token: ${{ secrets.PAT }}

--- a/.github/workflows/secrets-detector.yml
+++ b/.github/workflows/secrets-detector.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.NEMO_REFORMAT_TOKEN }}

--- a/.github/workflows/update-buildcache.yml
+++ b/.github/workflows/update-buildcache.yml
@@ -34,7 +34,7 @@ jobs:
       cache-from: ${{ steps.cache_from.outputs.LAST_PRS }}
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Parse manifest.json
         id: manifest


### PR DESCRIPTION
## Summary

Upgrades all GitHub Actions to versions compatible with the Node.js 24 runtime, which GitHub is rolling out as the new runner default.

**Action upgrades:**
- `actions/checkout`: any version → `v6`
- `actions/upload-artifact`: any version → `v6`
- `actions/download-artifact`: any version → `v7`
- `actions/github-script`: any version → `v8`
- `actions/setup-python`: any version → `v6`

Mirrors: https://github.com/NVIDIA/Megatron-LM/commit/1d5e68b0749f0fc075250fae4e36081d972379a8

## Test plan
- [ ] Verify CI pipelines pass after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)