### PR TITLE
Fix IsADirectoryError when cleaning up unfinished distributed checkpoints

### DIFF
--- a/nemo/utils/callbacks/nemo_model_checkpoint.py
+++ b/nemo/utils/callbacks/nemo_model_checkpoint.py
@@ -693,7 +693,7 @@ class NeMoModelCheckpoint(ModelCheckpoint):
                 if f.is_file()
             }
 
-            checkpoint_filepaths = {f.resolve() for f in checkpoint_dir.rglob("*.ckpt")}
+            checkpoint_filepaths = {f.resolve() for f in checkpoint_dir.rglob("*.ckpt") if f.is_file()}
             for ckpt_filepath in checkpoint_filepaths:
                 possible_marker_path = NeMoModelCheckpoint.format_checkpoint_unfinished_marker_path(ckpt_filepath)
                 if possible_marker_path in existing_marker_filepaths:


### PR DESCRIPTION
## Summary
- `_remove_unfinished_checkpoints()` uses `rglob("*.ckpt")` to find checkpoint files to remove, but this also matches **directories** (distributed/sharded checkpoints like `step=2125.ckpt/`)
- Calling `os.remove()` on a directory raises `IsADirectoryError`, crashing every subsequent training resume attempt
- Add `if f.is_file()` filter so only actual files are collected — directory checkpoints are already handled correctly in the subsequent block using `shutil.rmtree()`
