### PR TITLE
[TTS][Magpietts] Added CFG distillation

### DIFF
--- a/.github/workflows/cicd-main-speech.yml
+++ b/.github/workflows/cicd-main-speech.yml
@@ -192,6 +192,12 @@ jobs:
           - runner: self-hosted-azure
             script: L2_TTS_InferEvaluate_Magpietts_FrameStacking
           - runner: self-hosted-azure
+            script: L2_TTS_Fast_dev_runs_Magpietts_OnlineCFGDistillation
+          - runner: self-hosted-azure
+            script: L2_TTS_Fast_dev_runs_Magpietts_MoE_OnlineCFGDistillation
+          - runner: self-hosted-azure
+            script: L2_TTS_Fast_dev_runs_Magpietts_FrameStacking_OnlineCFGDistillation
+          - runner: self-hosted-azure
             script: L2_TTS_Fast_dev_runs_EasyMagpietts_Qwen
           - runner: self-hosted-azure
             script: L2_TTS_Fast_dev_runs_EasyMagpietts_Nemotron

--- a/examples/tts/magpietts.py
+++ b/examples/tts/magpietts.py
@@ -21,10 +21,18 @@ from nemo.collections.tts.models import (
     MagpieTTSModelOfflinePO,
     MagpieTTSModelOfflinePODataGen,
     MagpieTTSModelOnlinePO,
+    OnlineCFGDistillation,
 )
 from nemo.core.config import hydra_runner
 from nemo.utils import logging
 from nemo.utils.exp_manager import exp_manager
+
+_TRAIN_MODES: list[str] = [
+    "train",
+    "online_cfg_distillation_train",
+    "dpo_train",
+    "onlinepo_train",
+]
 
 
 @hydra_runner(config_path="conf/magpietts", config_name="magpietts_lhotse")
@@ -54,8 +62,12 @@ def main(cfg):
         pl.seed_everything(seed, workers=True)
 
     mode = cfg.get('mode', 'train')
+    train_modes_msg = ", ".join(_TRAIN_MODES)
+
     if mode == 'train':
         model = MagpieTTSModel(cfg=cfg.model, trainer=trainer)
+    elif mode == 'online_cfg_distillation_train':
+        model = OnlineCFGDistillation(cfg=cfg.model, trainer=trainer)
     elif mode == 'dpo_train':
         model_cfg = cfg.model
         with open_dict(model_cfg):
@@ -69,21 +81,19 @@ def main(cfg):
     elif mode == 'test':
         model = MagpieTTSModelOfflinePODataGen(cfg=cfg.model, trainer=trainer)
     else:
-        raise NotImplementedError(f"Only train, dpo_train, onlinepo_train and test modes are supported. Got {mode}")
+        raise NotImplementedError(f"Only {train_modes_msg} and test modes are supported. Got {mode}")
 
     model.maybe_init_from_pretrained_checkpoint(cfg=cfg)
 
     try:
-        if mode in ['train', 'dpo_train', 'onlinepo_train']:
+        if mode in _TRAIN_MODES:
             logging.info("Starting training...")
             trainer.fit(model)
         elif mode == 'test':
             logging.info("Starting testing...")
             trainer.test(model)
         else:
-            raise NotImplementedError(
-                f"Only train, dpo_train, onlinepo_train and test modes are supported. Got {mode}"
-            )
+            raise NotImplementedError(f"Only {train_modes_msg} and test modes are supported. Got {mode}")
         logging.info("Training/testing completed successfully.")
     finally:
         # Ensure WandB completes all uploads before Python thread shutdown

--- a/nemo/collections/tts/losses/magpietts_cfg_distillation.py
+++ b/nemo/collections/tts/losses/magpietts_cfg_distillation.py
@@ -1,0 +1,309 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Losses used in CFG distillation of the MagpieTTS model.
+"""
+
+from typing import Generator, Optional
+
+import torch
+from torch import Tensor, nn
+
+from nemo.core.classes import Loss, typecheck
+from nemo.core.neural_types import LabelsType, LogitsType, LossType, MaskType, NeuralType
+
+__all__ = [
+    "KLDivergenceLoss",
+    "CodesCrossEntropyLoss",
+    "NRMSELogitsLoss",
+]
+
+
+def _iter_slices(
+    num_codebooks: int,
+    num_tokens_per_codebook: int,
+    frame_stacking_factor: int,
+    mask: Tensor,
+) -> Generator[tuple[int, int, int, int, Tensor, Tensor], None, None]:
+    for fs_index in range(frame_stacking_factor):
+        slice_mask = mask[:, fs_index::frame_stacking_factor].float()
+        slice_len = slice_mask.sum(dim=-1).clamp_min(1)
+        offset = num_codebooks * fs_index * num_tokens_per_codebook
+
+        for codebook in range(num_codebooks):
+            start = offset + codebook * num_tokens_per_codebook
+            end = start + num_tokens_per_codebook
+
+            yield fs_index, codebook, start, end, slice_mask, slice_len
+
+
+class KLDivergenceLoss(Loss):
+    """The Kullback-Leibler divergence loss."""
+
+    @property
+    def input_types(self) -> dict[str, NeuralType]:
+        """Define definitions of module input ports.
+
+        Returns:
+            dict[str, NeuralType]: A dictionary describing expected input tensors.
+        """
+        return {
+            "student_logits": NeuralType(("B", "T", "D"), LogitsType()),
+            "teacher_logits": NeuralType(("B", "T", "D"), LogitsType()),
+            "mask": NeuralType(("B", "T"), MaskType()),
+            "sample_weights": NeuralType(tuple("B"), MaskType(), optional=True),
+        }
+
+    @property
+    def output_types(self) -> dict[str, NeuralType]:
+        """Define definitions of module output ports.
+
+        Returns:
+            dict[str, NeuralType]: A dictionary describing expected output tensors.
+        """
+        return {"loss": NeuralType(elements_type=LossType())}
+
+    def __init__(
+        self,
+        num_codebooks: int,
+        num_tokens_per_codebook: int,
+        frame_stacking_factor: int,
+    ) -> None:
+        super().__init__()
+        self.num_codebooks = num_codebooks
+        self.num_tokens_per_codebook = num_tokens_per_codebook
+        self.frame_stacking_factor = frame_stacking_factor
+        self.criterion = nn.KLDivLoss(reduction="none", log_target=False)
+
+    @typecheck()
+    def forward(
+        self,
+        student_logits: Tensor,
+        teacher_logits: Tensor,
+        mask: Tensor,
+        sample_weights: Optional[Tensor] = None,
+    ) -> Tensor:
+        """Compute the Kullback-Leibler divergence loss between student and teacher logits.
+
+        Args:
+            student_logits (Tensor): Student logits of shape `(B, T', D)`, where `B` is batch size,
+                `T'` is the frame-stacked sequence length, and `D` is the concatenated logit dimension
+                across all codebooks and frame-stacking positions.
+            teacher_logits (Tensor): Teacher logits of shape `(B, T', D)`.
+            mask (Tensor): Binary mask of shape `(B, T)` over the unstacked time dimension. For each
+                frame-stacking position, the corresponding stacked-time mask is obtained by slicing.
+            sample_weights (Optional[Tensor]): Optional per-sample weighting factors of shape `(B,)`.
+                If provided, these weights scale the per-sample loss contribution before averaging.
+                If `None`, all samples contribute equally.
+
+        Returns:
+            Tensor: Scalar tensor representing the averaged masked KL divergence loss.
+        """
+        loss = 0.0
+        student_log_probs = student_logits.log_softmax(dim=-1)
+        teacher_probs = teacher_logits.softmax(dim=-1)
+
+        for _, _, start, end, slice_mask, slice_len in _iter_slices(
+            self.num_codebooks,
+            self.num_tokens_per_codebook,
+            self.frame_stacking_factor,
+            mask,
+        ):
+            teacher_probs_slice = teacher_probs[:, :, start:end]
+            student_log_probs_slice = student_log_probs[:, :, start:end]
+            slice_loss = self.criterion(input=student_log_probs_slice, target=teacher_probs_slice)
+            slice_loss = slice_loss.sum(dim=-1)
+            slice_loss = (slice_loss * slice_mask).sum(dim=-1) / slice_len
+            loss = loss + slice_loss
+
+        loss = loss / (self.num_codebooks * self.frame_stacking_factor)
+
+        if sample_weights is not None:
+            loss = loss * sample_weights
+
+        return loss.mean()
+
+
+class CodesCrossEntropyLoss(Loss):
+    """Cross-entropy loss that supports time masks."""
+
+    @property
+    def input_types(self) -> dict[str, NeuralType]:
+        """Define definitions of module input ports.
+
+        Returns:
+            dict[str, NeuralType]: A dictionary describing expected input tensors.
+        """
+        return {
+            "predicted_logits": NeuralType(("B", "T", "D"), LogitsType()),
+            "target_codes": NeuralType(("B", "C", "T"), LabelsType()),
+            "mask": NeuralType(("B", "T"), MaskType()),
+            "sample_weights": NeuralType(tuple("B"), MaskType(), optional=True),
+        }
+
+    @property
+    def output_types(self) -> dict[str, NeuralType]:
+        """Define definitions of module output ports.
+
+        Returns:
+            dict[str, NeuralType]: A dictionary describing expected output tensors.
+        """
+        return {"loss": NeuralType(elements_type=LossType())}
+
+    def __init__(
+        self,
+        num_codebooks: int,
+        num_tokens_per_codebook: int,
+        frame_stacking_factor: int,
+    ) -> None:
+        super().__init__()
+        self.num_codebooks = num_codebooks
+        self.num_tokens_per_codebook = num_tokens_per_codebook
+        self.frame_stacking_factor = frame_stacking_factor
+        self.criterion = nn.CrossEntropyLoss(reduction="none")
+
+    @typecheck()
+    def forward(
+        self,
+        predicted_logits: Tensor,
+        target_codes: Tensor,
+        mask: Tensor,
+        sample_weights: Optional[Tensor] = None,
+    ) -> Tensor:
+        """Compute cross-entropy loss for discretized code sequences with frame stacking and time masking.
+
+        Args:
+            predicted_logits (Tensor): Predicted logits of shape `(B, T', D)`, where `B` is batch size,
+                `T'` is the frame-stacked sequence length, and `D` is the concatenated logit dimension
+                across all codebooks and frame-stacking positions.
+            target_codes (Tensor): Target code indices of shape `(B, C, T)`, where `C` is the number
+                of codebooks and `T` is the unstacked time dimension.
+            mask (Tensor): Binary mask of shape `(B, T)` over the unstacked time dimension.
+            sample_weights (Optional[Tensor]): Optional per-sample weighting factors of shape `(B,)`.
+                If provided, these weights scale the per-sample loss contribution before averaging.
+                If `None`, all samples contribute equally.
+
+        Returns:
+            Tensor: Scalar tensor representing the averaged masked cross-entropy loss.
+        """
+        loss = 0.0
+
+        for fs_index, codebook, start, end, slice_mask, slice_len in _iter_slices(
+            self.num_codebooks,
+            self.num_tokens_per_codebook,
+            self.frame_stacking_factor,
+            mask,
+        ):
+            target_slice = target_codes[:, codebook, fs_index :: self.frame_stacking_factor]
+            logits_slice = predicted_logits[:, :, start:end].permute(0, 2, 1)
+            slice_loss = self.criterion(input=logits_slice, target=target_slice)
+            slice_loss = (slice_loss * slice_mask).sum(dim=-1) / slice_len
+            loss = loss + slice_loss
+
+        loss = loss / (self.num_codebooks * self.frame_stacking_factor)
+
+        if sample_weights is not None:
+            loss = loss * sample_weights
+
+        return loss.mean()
+
+
+class NRMSELogitsLoss(Loss):
+    """Normalized Root Mean Square Error (NRMSE) loss applied to raw logits."""
+
+    @property
+    def input_types(self) -> dict[str, NeuralType]:
+        """Define definitions of module input ports.
+
+        Returns:
+            dict[str, NeuralType]: A dictionary describing expected input tensors.
+        """
+        return {
+            "student_logits": NeuralType(("B", "T", "D"), LogitsType()),
+            "teacher_logits": NeuralType(("B", "T", "D"), LogitsType()),
+            "mask": NeuralType(("B", "T"), MaskType()),
+            "sample_weights": NeuralType(tuple("B"), MaskType(), optional=True),
+        }
+
+    @property
+    def output_types(self) -> dict[str, NeuralType]:
+        """Define definitions of module output ports.
+
+        Returns:
+            dict[str, NeuralType]: A dictionary describing expected output tensors.
+        """
+        return {"loss": NeuralType(elements_type=LossType())}
+
+    def __init__(
+        self,
+        num_codebooks: int,
+        num_tokens_per_codebook: int,
+        frame_stacking_factor: int,
+    ) -> None:
+        super().__init__()
+        self.num_codebooks = num_codebooks
+        self.num_tokens_per_codebook = num_tokens_per_codebook
+        self.frame_stacking_factor = frame_stacking_factor
+        self.eps = 1e-8
+        self.criterion = nn.MSELoss(reduction="none")
+
+    @typecheck()
+    def forward(
+        self,
+        student_logits: Tensor,
+        teacher_logits: Tensor,
+        mask: Tensor,
+        sample_weights: Optional[Tensor] = None,
+    ) -> Tensor:
+        """Compute the normalized RMSE loss between student and teacher logits.
+
+        Args:
+            student_logits (Tensor): Student logits of shape `(B, T', D)`, where `B` is batch size,
+                `T'` is the frame-stacked sequence length, and `D` is the concatenated logit dimension
+                across all codebooks and frame-stacking positions.
+            teacher_logits (Tensor): Teacher logits of shape `(B, T', D)`.
+            mask (Tensor): Binary mask of shape `(B, T)` over the unstacked time dimension.
+            sample_weights (Optional[Tensor]): Optional per-sample weighting factors of shape `(B,)`.
+                If provided, these weights scale the per-sample loss contribution before averaging.
+                If `None`, all samples contribute equally.
+
+        Returns:
+            Tensor: Scalar tensor representing the averaged masked normalized RMSE loss.
+        """
+        inf_mask = torch.isinf(teacher_logits) | torch.isinf(student_logits)
+        teacher_logits = teacher_logits.masked_fill(inf_mask, 0.0)
+        student_logits = student_logits.masked_fill(inf_mask, 0.0)
+        loss = 0.0
+
+        for _, _, start, end, slice_mask, slice_len in _iter_slices(
+            self.num_codebooks,
+            self.num_tokens_per_codebook,
+            self.frame_stacking_factor,
+            mask,
+        ):
+            student_logits_slice = student_logits[:, :, start:end]
+            teacher_logits_slice = teacher_logits[:, :, start:end]
+            slice_loss = self.criterion(input=student_logits_slice, target=teacher_logits_slice)
+            slice_loss = torch.sqrt(slice_loss.mean(dim=-1))
+            norm = teacher_logits_slice.std(dim=-1).clamp_min(self.eps)
+            slice_loss = slice_loss / norm
+            slice_loss = (slice_loss * slice_mask).sum(dim=-1) / slice_len
+            loss = loss + slice_loss
+
+        loss = loss / (self.num_codebooks * self.frame_stacking_factor)
+
+        if sample_weights is not None:
+            loss = loss * sample_weights
+
+        return loss.mean()

--- a/nemo/collections/tts/models/__init__.py
+++ b/nemo/collections/tts/models/__init__.py
@@ -21,6 +21,7 @@ from nemo.collections.tts.models.fastpitch import FastPitchModel
 from nemo.collections.tts.models.fastpitch_ssl import FastPitchModel_SSL
 from nemo.collections.tts.models.hifigan import HifiGanModel
 from nemo.collections.tts.models.magpietts import InferBatchOutput, MagpieTTSModel
+from nemo.collections.tts.models.magpietts_cfg_distillation import OnlineCFGDistillation
 from nemo.collections.tts.models.magpietts_preference_optimization import (
     MagpieTTSModelOfflinePO,
     MagpieTTSModelOfflinePODataGen,
@@ -37,6 +38,7 @@ __all__ = [
     "HifiGanModel",
     "InferBatchOutput",
     "MagpieTTSModel",
+    "OnlineCFGDistillation",
     "EasyMagpieTTSModel",
     "EasyMagpieTTSInferenceModel",
     "EasyMagpieTTSModelOnlinePO",

--- a/nemo/collections/tts/models/magpietts.py
+++ b/nemo/collections/tts/models/magpietts.py
@@ -1068,6 +1068,7 @@ class MagpieTTSModel(ModelPT):
             'eval_speaker_verification_model',
             'whisper_model',
             'squim_objective_model',
+            '_teacher_model',
         ]
         # Skip context_encoder if checkpoint has baked embedding (weights won't be in checkpoint)
         if has_baked_embedding_in_ckpt:

--- a/nemo/collections/tts/models/magpietts_cfg_distillation.py
+++ b/nemo/collections/tts/models/magpietts_cfg_distillation.py
@@ -1,0 +1,883 @@
+# Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Adapted MagpieTTSModel class for classifier-free guidance distillation.
+"""
+import copy
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+import torch
+from lightning.pytorch import Trainer
+from lightning.pytorch.utilities import rank_zero_only
+from omegaconf import DictConfig, OmegaConf, open_dict
+from torch import Tensor
+
+from nemo.collections.tts.losses.magpietts_cfg_distillation import (
+    CodesCrossEntropyLoss,
+    KLDivergenceLoss,
+    NRMSELogitsLoss,
+)
+from nemo.collections.tts.models.magpietts import ContextTensorsOutput, MagpieTTSModel
+from nemo.collections.tts.modules.magpietts_modules import EOSDetectionMethod, remove_embedded_eos_token
+from nemo.collections.tts.parts.utils.helpers import get_mask_from_lengths
+from nemo.lightning.callback_group import CallbackGroup
+from nemo.utils import logging
+
+__all__ = ["OnlineCFGDistillation"]
+
+_STATE_DICT_EXCLUDE_NAMES: set[str] = {
+    "_codec_model",
+    "_teacher_model",
+}
+
+
+@dataclass
+class _DefaultParams:
+
+    # Maximum number of decoding steps during audio rollout generation.
+    max_decoder_steps: int = 430
+    # Sampling temperature during rollout generation.
+    rollout_temperature: float = 0.7
+    # Top-k sampling limit for token selection.
+    rollout_topk: int = 80
+    # Whether to use key-value cache during rollout inference.
+    use_kv_cache_during_rollout: bool = True
+    # Classifier-free guidance (CFG) scale used during distillation.
+    distillation_cfg_scale: float = 2.5
+    # Temperature used for softening logits during distillation (1.0 means no change).
+    distillation_temperature: float = 1.0
+    # Weight coefficient in the combined entropy-divergence distillation loss.
+    alpha: float = 0.3
+    # Weight coefficient for the NRMSE component in the distillation loss.
+    beta: float = 2.0
+    # Fraction of the ground-truth sequence length used as a cutoff for early rollout truncation.
+    truncation_threshold: Optional[float] = 1.25
+    # Weight assigned to truncated samples when computing the loss (used to down-weight truncated rollouts).
+    truncation_weight: Optional[float] = 0.1
+    # Weight coefficient for the MoE loss component.
+    moe_loss_weight: float = 1.0
+
+
+_DEFAULT_PARAMS = _DefaultParams()
+
+
+def _validate_configuration(cfg: DictConfig) -> None:
+    if not hasattr(cfg, "prior_scaling_factor"):
+        raise ValueError("Missing required parameter `prior_scaling_factor` in configuration.")
+
+    if cfg.get("prior_scaling_factor") is not None:
+        raise ValueError(
+            "Attention priors are not applied during distillation. "
+            "Please set `prior_scaling_factor = None` in the configuration."
+        )
+
+    if hasattr(cfg, "distillation_temperature") and cfg.get("distillation_temperature") <= 0:
+        raise ValueError(
+            "`distillation_temperature` must be greater than 0. "
+            "Typical values for distillation are in the range [1.0, 4.0]."
+        )
+
+    if hasattr(cfg, "alpha") and not (0 <= cfg.get("alpha") <= 1):
+        raise ValueError(
+            "`alpha` must be in the range [0, 1]. "
+            "It controls the weighting between KL-divergence and cross-entropy losses."
+        )
+
+    if hasattr(cfg, "beta") and cfg.get("beta") < 0:
+        raise ValueError("`beta` must be non-negative. It scales the contribution of the NRMSE loss component.")
+
+    if (
+        hasattr(cfg, "truncation_threshold")
+        and cfg.get("truncation_threshold") is not None
+        and cfg.get("truncation_threshold") < 1.0
+    ):
+        raise ValueError(
+            "`truncation_threshold` must be >= 1.0 or `None`. "
+            "Values below 1.0 would truncate sequences shorter than the ground truth."
+        )
+
+    if (
+        hasattr(cfg, "truncation_weight")
+        and cfg.get("truncation_weight") is not None
+        and cfg.get("truncation_weight") < 0
+    ):
+        raise ValueError(
+            "`truncation_weight` must be non-negative or `None`. "
+            "It defines the relative weighting for truncated samples in the loss."
+        )
+
+
+def _get_teacher_model(cfg: DictConfig) -> MagpieTTSModel:
+    model_path = Path(cfg.teacher_model_path)
+    teacher_model_cfg = copy.deepcopy(cfg)
+
+    with open_dict(teacher_model_cfg):
+        teacher_model_cfg.train_ds = None
+        teacher_model_cfg.validation_ds = None
+
+    if model_path.suffix == ".ckpt":
+        teacher_model = MagpieTTSModel(cfg=teacher_model_cfg)
+        ckpt = torch.load(model_path.as_posix(), map_location="cpu")
+        state_dict = ckpt["state_dict"] if "state_dict" in ckpt else ckpt
+        teacher_model.load_state_dict(state_dict)
+
+    elif model_path.suffix == ".nemo":
+        teacher_model = MagpieTTSModel.restore_from(
+            restore_path=model_path.as_posix(),
+            override_config_path=teacher_model_cfg,
+            map_location="cpu",
+            strict=cfg.get("init_strict", True),
+        )
+    else:
+        raise ValueError(f"Unsupported teacher model format: {model_path.suffix}")
+
+    teacher_model.freeze()
+    teacher_model.eval()
+    teacher_model._no_state_dict = True
+
+    return teacher_model
+
+
+def _prepare_forward_inputs(
+    model: MagpieTTSModel,
+    context_tensors: ContextTensorsOutput,
+    audio_codes_embedded: Tensor,
+    audio_codes_mask: Tensor,
+) -> dict[str, Tensor | None]:
+    additional_decoder_input = context_tensors.additional_decoder_input
+    additional_decoder_mask = context_tensors.additional_decoder_mask
+    attn_prior = [None, None] if model.model_type == "multi_encoder_context_tts" else None
+
+    if additional_decoder_input is not None:
+        dec_input_embedded = torch.cat([additional_decoder_input, audio_codes_embedded], dim=1)
+        dec_input_mask = torch.cat([additional_decoder_mask, audio_codes_mask], dim=1)
+    else:
+        dec_input_embedded = audio_codes_embedded
+        dec_input_mask = audio_codes_mask
+
+    return {
+        "dec_input_embedded": dec_input_embedded,
+        "dec_input_mask": dec_input_mask,
+        "cond": context_tensors.cond,
+        "cond_mask": context_tensors.cond_mask,
+        "attn_prior": attn_prior,
+        "multi_encoder_mapping": context_tensors.multi_encoder_mapping,
+    }
+
+
+def _process_moe_routing_info(
+    moe_routing_info: Optional[list[dict]],
+    dec_input_mask: Tensor,
+) -> dict[str, Tensor]:
+    all_router_logits, all_router_probs, all_expert_indices = [], [], []
+
+    for layer_routing_info in moe_routing_info:
+        all_router_logits.append(layer_routing_info["router_logits"])
+        all_router_probs.append(layer_routing_info["router_probs"])
+        all_expert_indices.append(layer_routing_info["expert_indices"])
+
+    stacked_logits = torch.stack(all_router_logits, dim=0)
+    stacked_probs = torch.stack(all_router_probs, dim=0)
+    num_layers, _, seq_len, num_experts = stacked_logits.size()
+
+    merged_logits = stacked_logits.view(-1, seq_len, num_experts)
+    merged_probs = stacked_probs.view(-1, seq_len, num_experts)
+    merged_mask = dec_input_mask.unsqueeze(0).repeat(num_layers, 1, 1).view(-1, seq_len)
+
+    return {
+        "router_logits": merged_logits,
+        "router_probs": merged_probs,
+        "x_mask": merged_mask,
+    }
+
+
+def _process_batch_student(
+    model: MagpieTTSModel,
+    batch: dict[str, Tensor | list],
+) -> tuple[Tensor, Optional[dict[str, Tensor]]]:
+    """Perform a teacher-forced forward decoding pass for a MagpieTTS student model.
+
+    This method runs a standard forward pass without classifier-free guidance (CFG).
+    It prepares decoder inputs from the provided audio code sequence, removes the
+    terminal EOS token, and computes logits for all positions after the decoder context
+    prefix. If the model uses a Mixture-of-Experts (MoE) decoder, aggregated routing
+    information is also processed and returned.
+
+    Args:
+        model (MagpieTTSModel): Student model instance used for the forward pass.
+        batch (dict[str, Tensor | list]): Input batch containing audio token codes,
+            audio code lengths, and contextual tensors required for decoding.
+            The audio code sequence is expected to already include the special tokens
+            required by the decoder input convention.
+
+    Returns:
+        tuple[Tensor, Optional[dict[str, Tensor]]]:
+            - **logits (Tensor)**: Logits tensor of shape `(B, T', D)`, where `B` is
+              batch size, `T'` is the frame-stacked decoder sequence length after
+              removing the decoder context prefix, and `D` is the concatenated logit
+              dimension across codebooks and frame-stacking positions.
+            - **moe_routing_data (Optional[dict[str, Tensor]])**: Aggregated Mixture-of-Experts
+              routing data, or `None` if MoE is disabled or routing information is unavailable.
+    """
+    context_tensors = model.prepare_context_tensors(batch)
+    audio_codes = batch["audio_codes"]
+    audio_codes_lens = batch["audio_codes_lens"]
+    dec_context_size = context_tensors.dec_context_size
+    moe_routing_data = None
+
+    audio_codes_embedded_all, audio_codes_lens_all = model.embed_audio_tokens(
+        audio_tokens=audio_codes,
+        audio_tokens_lens=audio_codes_lens,
+    )
+    audio_codes_embedded, audio_codes_lens_ = remove_embedded_eos_token(
+        embedded=audio_codes_embedded_all,
+        embedded_len=audio_codes_lens_all,
+    )
+    audio_codes_mask = get_mask_from_lengths(audio_codes_lens_)
+    inputs = _prepare_forward_inputs(model, context_tensors, audio_codes_embedded, audio_codes_mask)
+    logits, _, _, moe_routing_info = model.forward(**inputs)
+    logits = logits[:, dec_context_size:, :]
+
+    if model.use_moe and moe_routing_info is not None:
+        moe_routing_data = _process_moe_routing_info(
+            moe_routing_info=moe_routing_info,
+            dec_input_mask=inputs["dec_input_mask"],
+        )
+    return logits, moe_routing_data
+
+
+def _infer_batch_teacher(
+    model: MagpieTTSModel,
+    batch: dict[str, Tensor | list],
+    max_decoder_steps: int = 500,
+    temperature: float = 0.7,
+    topk: int = 80,
+    cfg_scale: int = 2.5,
+    truncation_threshold: Optional[float] = None,
+    truncation_weight: Optional[float] = None,
+    use_kv_cache: bool = False,
+    eos_detection_method: str = "argmax_or_multinomial_any",
+    min_generated_frames: int = 4,
+) -> tuple[Tensor, Tensor, Tensor, Optional[Tensor]]:
+    """Perform autoregressive batch inference for a MagpieTTS teacher model.
+
+    This method generates audio token rollouts conditioned on text and context inputs.
+    It performs autoregressive decoding with classifier-free guidance (CFG) by combining
+    conditional and unconditional logits using the specified guidance scale. The function
+    also supports optional truncation-based early stopping and per-sample weighting for
+    downstream distillation losses.
+
+    Generation is performed in units of stacked frames. When frame stacking is enabled,
+    each decoder step predicts a full stacked block of audio codes. If EOS is detected
+    inside a stacked block, the entire block is retained in the rollout. This behavior
+    is intentional: distillation is performed over complete generated stacked steps rather
+    than truncating at the exact EOS frame inside the final block.
+
+    Args:
+        model (MagpieTTSModel): The teacher model instance used for autoregressive generation.
+        batch (dict[str, Tensor | list]): Input batch containing text tokens, audio code lengths,
+            and additional contextual tensors required for decoding.
+        max_decoder_steps (int, optional): Maximum number of generated audio frames in the
+            unstacked time domain. Defaults to 500.
+        temperature (float, optional): Sampling temperature controlling randomness during token
+            generation. Defaults to 0.7.
+        topk (int, optional): Top-k sampling limit. Only the k most probable tokens are considered
+            at each decoding step. Defaults to 80.
+        cfg_scale (float, optional): Classifier-free guidance scale factor controlling the strength
+            of conditioning. Higher values increase adherence to conditioning. Defaults to 2.5.
+        truncation_threshold (Optional[float], optional): Fraction of ground-truth length used as
+            a cutoff for early truncation. If set, generation stops once this threshold is reached.
+            Defaults to None.
+        truncation_weight (Optional[float], optional): Weight assigned to truncated samples for
+            downstream loss computation. Defaults to None.
+        use_kv_cache (bool, optional): Whether to enable key-value caching during inference.
+            Defaults to False.
+        eos_detection_method (str, optional): End-of-sequence detection strategy. Must be one of
+            the supported `EOSDetectionMethod` values. Defaults to `"argmax_or_multinomial_any"`.
+        min_generated_frames (int, optional): Minimum number of generated frames before EOS detection
+            is allowed. Prevents premature termination. Defaults to 4.
+
+    Returns:
+        tuple[Tensor, Tensor, Tensor, Optional[Tensor]]:
+            - **predicted_codes (Tensor)**: Generated discrete audio codes of shape `(B, C, T)`,
+              where `T` is in the unstacked time domain.
+            - **predicted_codes_logits (Tensor)**: Decoder logits collected per stacked decoding step,
+              shape `(B, T', D)`, where `T'` is the frame-stacked sequence length.
+            - **predicted_codes_lens (Tensor)**: Predicted rollout lengths per batch item in the
+              unstacked time domain, shape `(B,)`.
+            - **sample_weights (Optional[Tensor])**: Optional per-sample weighting factors, shape `(B,)`.
+    """
+    model.decoder.reset_cache(use_cache=use_kv_cache)
+    eos_detection_method = EOSDetectionMethod(eos_detection_method)
+    context_tensors = model.prepare_context_tensors(batch)
+    text = context_tensors.text
+    bs = text.size(0)
+    device = text.device
+    fs_factor = model.frame_stacking_factor
+    dims = (bs, model.num_audio_codebooks, fs_factor)
+    audio_codes_input = torch.full(dims, model.audio_bos_id, device=device).long()
+    audio_codes_lens = torch.full((bs,), fs_factor, device=device).long()
+    truncation_count = 0
+
+    if truncation_weight is None:
+        sample_weights = None
+    else:
+        sample_weights = torch.ones(bs, dtype=torch.float, device=device)
+
+    if truncation_threshold is not None:
+        truncation_thresholds = truncation_threshold * batch["audio_codes_lens"].clone()
+        truncation_thresholds = torch.round(truncation_thresholds).long()
+
+    dummy_cond, dummy_cond_mask, dummy_additional_decoder_input, dummy_addition_dec_mask, _ = (
+        model.prepare_dummy_cond_for_cfg(
+            context_tensors.cond,
+            context_tensors.cond_mask,
+            context_tensors.additional_decoder_input,
+            context_tensors.additional_decoder_mask,
+        )
+    )
+    predicted_codes_logits = []
+    predictions = []
+    # Stores the start of the final retained stacked block.
+    end_indices = {}
+    attn_prior = [None, None] if model.model_type == "multi_encoder_context_tts" else None
+
+    with torch.no_grad():
+        for idx in range(max_decoder_steps // fs_factor):
+            audio_codes_embedded, audio_codes_embedded_lens = model.embed_audio_tokens(
+                audio_tokens=audio_codes_input, audio_tokens_lens=audio_codes_lens
+            )
+            audio_codes_mask = get_mask_from_lengths(audio_codes_embedded_lens)
+
+            if context_tensors.additional_decoder_input is not None:
+                _audio_codes_embedded = torch.cat(
+                    [context_tensors.additional_decoder_input, audio_codes_embedded], dim=1
+                )
+                _audio_codes_mask = torch.cat([context_tensors.additional_decoder_mask, audio_codes_mask], dim=1)
+            else:
+                _audio_codes_embedded = audio_codes_embedded
+                _audio_codes_mask = audio_codes_mask
+
+            cfg_audio_codes_embedded = torch.cat([_audio_codes_embedded, _audio_codes_embedded], dim=0)
+            cfg_audio_codes_mask = torch.cat([_audio_codes_mask, _audio_codes_mask], dim=0)
+            cfg_cond = torch.cat([context_tensors.cond, dummy_cond], dim=0)
+            cfg_cond_mask = torch.cat([context_tensors.cond_mask, dummy_cond_mask], dim=0)
+
+            if dummy_additional_decoder_input is not None:
+                index = dummy_additional_decoder_input.size(1)
+                cfg_audio_codes_embedded[bs:, :index] = dummy_additional_decoder_input
+                cfg_audio_codes_mask[bs:, :index] = dummy_addition_dec_mask
+
+            combined_logits, _, _, _ = model.forward(
+                dec_input_embedded=cfg_audio_codes_embedded,
+                dec_input_mask=cfg_audio_codes_mask,
+                cond=cfg_cond,
+                cond_mask=cfg_cond_mask,
+                attn_prior=attn_prior,
+                multi_encoder_mapping=context_tensors.multi_encoder_mapping,
+            )
+            cond_logits = combined_logits[:bs]
+            uncond_logits = combined_logits[bs:]
+            all_code_logits = (1 - cfg_scale) * uncond_logits + cfg_scale * cond_logits
+            forbid_audio_eos = idx * fs_factor < min_generated_frames
+            all_code_logits_t = all_code_logits[:, -1, :]
+            predicted_codes_logits.append(all_code_logits_t.unsqueeze(1))
+
+            audio_codes_next = model.sample_codes_from_logits(
+                all_code_logits_t,
+                temperature=temperature,
+                topk=topk,
+                forbid_audio_eos=forbid_audio_eos,
+            )
+            all_codes_next_argmax = model.sample_codes_from_logits(
+                all_code_logits_t,
+                temperature=0.01,
+                topk=1,
+                forbid_audio_eos=forbid_audio_eos,
+            )
+
+            for item_idx in range(bs):
+                if item_idx in end_indices:
+                    continue
+
+                global_index = idx * fs_factor
+
+                if truncation_threshold is not None and global_index >= truncation_thresholds[item_idx].item():
+                    end_indices[item_idx] = global_index
+                    truncation_count += 1
+
+                    if truncation_weight is not None:
+                        sample_weights[item_idx] = truncation_weight
+
+                    print(f"Item {item_idx} truncated at decoder timestep: {idx}")
+
+                else:
+                    end_frame_index = model.detect_eos(
+                        audio_codes_multinomial=audio_codes_next[item_idx],
+                        audio_codes_argmax=all_codes_next_argmax[item_idx],
+                        eos_detection_method=eos_detection_method,
+                    )
+                    if end_frame_index != float("inf"):
+                        # Intentionally retain the full stacked block containing EOS.
+                        end_indices[item_idx] = global_index
+                        print(f"End detected for item {item_idx} at decoder timestep: {idx}")
+
+            predictions.append(audio_codes_next)
+            audio_codes_input = torch.cat([audio_codes_input, audio_codes_next], dim=-1)
+            audio_codes_lens = audio_codes_lens + fs_factor
+
+            if len(end_indices) == bs and len(predictions) >= 4:
+                msg = "All ends reached"
+                if truncation_threshold is not None:
+                    msg += f", truncated samples: {truncation_count}"
+                print(msg)
+                break
+
+        predicted_codes = torch.cat(predictions, dim=-1)
+        predicted_codes_logits = torch.cat(predicted_codes_logits, dim=1)
+
+        max_step = predicted_codes.size(-1)
+        predicted_lens = [end_indices[idx] + fs_factor if idx in end_indices else max_step for idx in range(bs)]
+        predicted_codes_lens = torch.tensor(predicted_lens, device=text.device).long()
+
+        max_len = predicted_codes_lens.max()
+        max_stacked_len = max_len // fs_factor
+        predicted_codes = predicted_codes[:, :, :max_len]
+        predicted_codes_logits = predicted_codes_logits[:, :max_stacked_len, :]
+
+    model.decoder.reset_cache(use_cache=False)
+    torch.cuda.empty_cache()
+
+    return predicted_codes, predicted_codes_logits, predicted_codes_lens, sample_weights
+
+
+def _collect_validation_outputs(
+    outputs: list[dict[str, Tensor]] | list[list[dict[str, Tensor]]],
+    key: str,
+) -> Optional[Tensor]:
+    values = []
+
+    def _add(items: list[dict[str, Tensor]]) -> None:
+        for item in items:
+            val = item.get(key)
+            if val is not None:
+                values.append(val)
+
+    if outputs and isinstance(outputs[0], list):
+        for items in outputs:
+            _add(items)
+    else:
+        _add(outputs)
+
+    if not values:
+        return None
+
+    return torch.stack(values).mean()
+
+
+class OnlineCFGDistillation(MagpieTTSModel):
+    """Implements online classifier-free guidance (CFG) distillation for MagpieTTS."""
+
+    def __init__(
+        self,
+        cfg: DictConfig,
+        trainer: "Trainer" = None,
+    ) -> None:
+        _validate_configuration(cfg)
+        super().__init__(cfg, trainer)
+        self._init_extra_attributes()
+
+        if self.alpha != 1.0:
+            self._kl_criterion = KLDivergenceLoss(
+                num_codebooks=self.num_audio_codebooks,
+                num_tokens_per_codebook=self.num_all_tokens_per_codebook,
+                frame_stacking_factor=self.frame_stacking_factor,
+            )
+        if self.alpha != 0.0:
+            self._ce_criterion = CodesCrossEntropyLoss(
+                num_codebooks=self.num_audio_codebooks,
+                num_tokens_per_codebook=self.num_all_tokens_per_codebook,
+                frame_stacking_factor=self.frame_stacking_factor,
+            )
+        if self.beta != 0.0:
+            self._nrmse_criterion = NRMSELogitsLoss(
+                num_codebooks=self.num_audio_codebooks,
+                num_tokens_per_codebook=self.num_all_tokens_per_codebook,
+                frame_stacking_factor=self.frame_stacking_factor,
+            )
+        self._teacher_model: Optional[MagpieTTSModel] = None
+
+    def _load_teacher_model(self) -> None:
+        if self._teacher_model is None:
+            print("Loading teacher model from checkpoint.")
+            self._teacher_model = _get_teacher_model(self.cfg).to(self.device)
+            print("Teacher model loaded and frozen.")
+
+    def on_fit_start(self) -> None:
+        """See the ModelPT class docstring."""
+        super().on_fit_start()
+        self._load_teacher_model()
+
+    @rank_zero_only
+    def maybe_init_from_pretrained_checkpoint(
+        self,
+        cfg: OmegaConf,
+        map_location: str = "cpu",
+    ) -> None:
+        """See the ModelPT class docstring."""
+        args = ["init_from_nemo_model", "init_from_ptl_ckpt"]
+        arg_matches = [(1 if arg in cfg and cfg[arg] is not None else 0) for arg in args]
+
+        if sum(arg_matches) == 0:
+            return
+
+        if sum(arg_matches) > 1:
+            raise ValueError(
+                f"Cannot pass more than one model initialization arguments to config!\n"
+                f"Found : {[args[idx] for idx, arg_present in enumerate(arg_matches) if arg_present]}"
+            )
+
+        CallbackGroup.get_instance().on_load_checkpoint_start()
+
+        if "init_from_nemo_model" in cfg and cfg.init_from_nemo_model is not None:
+            model_path = cfg.init_from_nemo_model
+            restore_cfg = copy.deepcopy(self.cfg)
+
+            with open_dict(restore_cfg):
+                restore_cfg.train_ds = None
+                restore_cfg.validation_ds = None
+
+            if isinstance(model_path, str):
+                restored_model = MagpieTTSModel.restore_from(
+                    restore_path=model_path,
+                    override_config_path=restore_cfg,
+                    map_location=map_location,
+                    strict=cfg.get("init_strict", True),
+                )
+                self.load_state_dict(restored_model.state_dict(), strict=False)
+                logging.info(f'Model checkpoint restored from nemo file with path : `{model_path}`')
+                del restored_model
+            else:
+                raise TypeError("Invalid type: init_from_nemo_model is not a string!")
+
+        elif "init_from_ptl_ckpt" in cfg and cfg.init_from_ptl_ckpt is not None:
+            with open_dict(cfg):
+                if isinstance(cfg.init_from_ptl_ckpt, str):
+                    ckpt_path = cfg.get("init_from_ptl_ckpt")
+                    ckpt = torch.load(ckpt_path, map_location=map_location)
+                    state_dict = ckpt["state_dict"] if "state_dict" in ckpt else ckpt
+                    self.load_state_dict(state_dict, strict=False)
+                    logging.info(
+                        f'Model checkpoint restored from pytorch lightning checkpoint with path : `{ckpt_path}`'
+                    )
+                    del ckpt
+                else:
+                    raise TypeError("Invalid type: init_from_ptl_ckpt is not a string!")
+
+        CallbackGroup.get_instance().on_load_checkpoint_end()
+
+    def _init_extra_attributes(self) -> None:
+        defaults = vars(_DEFAULT_PARAMS)
+        for k, v in defaults.items():
+            setattr(self, k, self.cfg.get(k, v))
+
+    def state_dict(
+        self,
+        destination: Optional[dict[str, Any]] = None,
+        prefix: str = "",
+        keep_vars: bool = False,
+    ) -> dict[str, Any]:
+        """See the MagpieTTSModel class docstring."""
+        state_dict = super().state_dict(destination, prefix, keep_vars)
+
+        for key in list(state_dict.keys()):
+            if any(substring in key for substring in _STATE_DICT_EXCLUDE_NAMES):
+                del state_dict[key]
+
+        return state_dict
+
+    def _add_batch_audio_codes(
+        self,
+        batch: dict[str, Tensor | list],
+    ) -> dict[str, Tensor | list]:
+        if "audio_codes" in batch:
+            return batch
+
+        audio_codes, audio_codes_lens = self._codec_helper.audio_to_codes(
+            audio=batch["audio"],
+            audio_len=batch["audio_lens"],
+            sample_rate=batch.get("sample_rate"),
+        )
+        if self._codec_converter:
+            audio_codes = self._codec_converter.convert_original_to_new(
+                audio_tokens=audio_codes, audio_lens=audio_codes_lens
+            )
+        batch["audio_codes"] = audio_codes
+        batch["audio_codes_lens"] = audio_codes_lens
+        return batch
+
+    def _update_batch(
+        self,
+        batch: dict[str, Tensor | list],
+        rollout_codes: Tensor,
+        rollout_lens: Tensor,
+    ) -> dict[str, Tensor | list]:
+        rollout_codes = torch.nn.functional.pad(
+            input=rollout_codes,
+            pad=(self.frame_stacking_factor, 0),
+            value=self.audio_bos_id,
+        )
+        batch["audio_codes"] = rollout_codes
+        batch["audio_codes_lens"] = rollout_lens + self.frame_stacking_factor
+        return batch
+
+    def _compute_loss(
+        self,
+        teacher_codes: Tensor,
+        teacher_logits: Tensor,
+        student_logits: Tensor,
+        mask: Tensor,
+        sample_weights: Optional[Tensor],
+        moe_routing_data: Optional[dict[str, Tensor]],
+    ) -> dict[str, Tensor]:
+        output: dict[str, Tensor] = {}
+
+        if self.alpha != 1.0:
+            kl_loss = self._kl_criterion(
+                student_logits=student_logits,
+                teacher_logits=teacher_logits,
+                mask=mask,
+                sample_weights=sample_weights,
+            )
+            if self.distillation_temperature != 1.0:
+                kl_loss = kl_loss * (self.distillation_temperature**2)
+
+            output["kl_loss"] = kl_loss
+
+        if self.alpha != 0.0:
+            ce_loss = self._ce_criterion(
+                predicted_logits=student_logits,
+                target_codes=teacher_codes,
+                mask=mask,
+                sample_weights=sample_weights,
+            )
+            output["ce_loss"] = ce_loss
+
+        loss = (1 - self.alpha) * output.get("kl_loss", 0.0) + self.alpha * output.get("ce_loss", 0.0)
+
+        if self.beta > 0.0:
+            nrmse_loss = self._nrmse_criterion(
+                student_logits=student_logits,
+                teacher_logits=teacher_logits,
+                mask=mask,
+                sample_weights=sample_weights,
+            )
+            output["nrmse_loss"] = nrmse_loss
+            loss = loss + self.beta * nrmse_loss
+
+        if moe_routing_data is not None:
+            _, _, moe_loss = self.moe_auxiliary_loss(**moe_routing_data)
+            output["moe_loss"] = moe_loss
+            loss = loss + self.moe_loss_weight * moe_loss
+
+        output["loss"] = loss
+
+        return output
+
+    def _process_batch_distillation(
+        self,
+        batch: dict[str, Tensor | list],
+        mode: str = "train",
+    ) -> dict[str, Tensor]:
+        """Perform a knowledge distillation step between teacher and student models.
+
+        This method orchestrates the end-to-end distillation process:
+        1. The teacher model generates rollouts.
+        2. The student model performs a teacher-forced forward pass on those rollouts.
+        3. Multiple loss components are computed, including KL divergence, cross-entropy,
+        normalized RMSE (NRMSE), and optionally Mixture-of-Experts (MoE) auxiliary loss.
+        4. The total loss is formed from the active loss terms, controlled by the
+        coefficients `alpha`, `beta`, and `moe_loss_weight`.
+
+        Args:
+            batch (dict[str, Tensor | list]): Input batch containing text tokens, conditioning
+                features, and any additional fields required for teacher inference and student
+                loss computation.
+            mode (str, optional): Execution mode, either `"train"` or `"validation"`.
+                In `"train"` mode, truncation and sample weighting may be applied to improve
+                efficiency. Defaults to `"train"`.
+
+        Returns:
+            dict[str, Tensor]: Dictionary containing computed loss components and auxiliary values:
+                - **loss (Tensor)**: Total weighted distillation loss combining all active components.
+                - **kl_loss (Tensor, optional)**: KL divergence between student and teacher logits.
+                Included when `alpha != 1.0`.
+                - **ce_loss (Tensor, optional)**: Cross-entropy loss between student predictions and
+                teacher-generated discrete audio codes. Included when `alpha != 0.0`.
+                - **nrmse_loss (Tensor, optional)**: Normalized RMSE loss between student and teacher
+                logits. Included when `beta > 0.0`.
+                - **moe_loss (Tensor, optional)**: Auxiliary Mixture-of-Experts routing loss.
+                Included when MoE routing data is available.
+        """
+        batch = self._add_batch_audio_codes(batch)
+
+        rollout_codes, rollout_logits, rollout_lens, sample_weights = _infer_batch_teacher(
+            model=self._teacher_model,
+            batch=batch,
+            max_decoder_steps=self.max_decoder_steps,
+            temperature=self.rollout_temperature,
+            topk=self.rollout_topk,
+            cfg_scale=self.distillation_cfg_scale,
+            truncation_threshold=self.truncation_threshold if mode == "train" else None,
+            truncation_weight=self.truncation_weight if mode == "train" else None,
+            use_kv_cache=self.use_kv_cache_during_rollout,
+        )
+
+        batch = self._update_batch(batch, rollout_codes, rollout_lens)
+        student_logits, moe_routing_data = _process_batch_student(model=self, batch=batch)
+        mask = get_mask_from_lengths(rollout_lens)
+
+        if self.distillation_temperature != 1.0:
+            student_logits = student_logits / self.distillation_temperature
+            rollout_logits = rollout_logits / self.distillation_temperature
+
+        output = self._compute_loss(
+            teacher_codes=rollout_codes,
+            teacher_logits=rollout_logits,
+            student_logits=student_logits,
+            mask=mask,
+            sample_weights=sample_weights,
+            moe_routing_data=moe_routing_data,
+        )
+        return output
+
+    def training_step(
+        self,
+        batch: dict[str, Tensor | list],
+        batch_idx: int,
+    ) -> Tensor:
+        """Execute a single training step for the model.
+
+        Args:
+            batch (dict): Input batch containing text, conditioning, and audio codes.
+            batch_idx (int): Index of the current batch within the epoch.
+
+        Returns:
+            Tensor: Scalar tensor representing the total training loss for this step.
+        """
+        outputs = self._process_batch_distillation(batch, mode="train")
+        bs = batch["audio_codes"].size(0)
+        loss = outputs["loss"]
+
+        self.log(
+            name="train/loss",
+            value=loss,
+            prog_bar=True,
+            sync_dist=True,
+            batch_size=bs,
+            on_step=True,
+            on_epoch=True,
+        )
+        for key in ["kl_loss", "ce_loss", "nrmse_loss", "moe_loss"]:
+            if key in outputs:
+                self.log(
+                    name=f"train/{key}",
+                    value=outputs[key],
+                    prog_bar=True,
+                    sync_dist=True,
+                    batch_size=bs,
+                    on_step=True,
+                    on_epoch=True,
+                )
+        return loss
+
+    def validation_step(
+        self,
+        batch: dict[str, Tensor | list],
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> dict[str, Tensor]:
+        """Execute a single validation step for the model.
+
+            Args:
+                batch (dict): Validation batch containing required model inputs.
+                batch_idx (int): Index of the current validation batch.
+                dataloader_idx (int): Index of the dataloader (0 for single dataloader).
+
+        Returns:
+            dict[str, Tensor]: Dictionary containing validation loss values returned by
+                `_process_batch_distillation()`. Always includes `"loss"` and may also
+                include `"kl_loss"`, `"ce_loss"`, `"nrmse_loss"`, and `"moe_loss"`.
+        """
+        val_output = self._process_batch_distillation(batch, mode="validation")
+        self.validation_step_outputs[dataloader_idx].append(val_output)
+        return val_output
+
+    def _on_validation_epoch_end_logging(
+        self,
+        val_outputs: list[dict[str, Tensor]] | list[list[dict[str, Tensor]]],
+        prefix: str,
+        aggregated: bool = False,
+    ) -> None:
+        val_loss = _collect_validation_outputs(val_outputs, key="loss")
+
+        if val_loss is not None:
+            self.log(
+                name=f"{prefix}/loss",
+                value=val_loss,
+                prog_bar=aggregated,
+                sync_dist=True,
+            )
+            if aggregated:
+                self.log(
+                    name="val_loss",
+                    value=val_loss,
+                    prog_bar=False,
+                    sync_dist=True,
+                    on_step=False,
+                    on_epoch=True,
+                    logger=False,
+                    enable_graph=False,
+                )
+
+        for key in ["kl_loss", "ce_loss", "nrmse_loss", "moe_loss"]:
+            value = _collect_validation_outputs(val_outputs, key)
+            if value is not None:
+                self.log(
+                    name=f"{prefix}/{key}",
+                    value=value,
+                    prog_bar=aggregated,
+                    sync_dist=True,
+                )
+
+    def on_validation_epoch_end(self) -> None:
+        """Aggregate and log validation metrics at the end of an epoch.
+
+        Computes mean losses across all validation steps and logs them for both progress
+        bar and external monitoring systems. Clears cached outputs to free memory.
+        """
+        self._on_validation_epoch_end_logging(self.validation_step_outputs, prefix="val", aggregated=True)
+
+        if len(self.validation_step_outputs) > 1:
+            for dataloader_idx, val_outputs in enumerate(self.validation_step_outputs):
+                if not val_outputs:
+                    continue
+
+                prefix = self.get_validation_dataloader_prefix(dataloader_idx)
+                self._on_validation_epoch_end_logging(val_outputs, prefix=f"val-{prefix}")
+
+        for val_outputs in self.validation_step_outputs:
+            val_outputs.clear()

--- a/tests/functional_tests/L2_TTS_Fast_dev_runs_Magpietts_FrameStacking_OnlineCFGDistillation.sh
+++ b/tests/functional_tests/L2_TTS_Fast_dev_runs_Magpietts_FrameStacking_OnlineCFGDistillation.sh
@@ -1,0 +1,89 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+HF_HUB_OFFLINE=1 TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 coverage run -a --data-file=/workspace/.coverage --source=/workspace/nemo examples/tts/magpietts.py \
+    --config-name magpietts \
+    name="MagpieTTS-FrameStacking-OnlineCFGDistillation" \
+    +mode="online_cfg_distillation_train" \
+    +init_from_ptl_ckpt="/home/TestData/tts/2602_FrameStacking4x/frame-stacking-4x-english-nanocodec.ckpt" \
+    +model.teacher_model_path="/home/TestData/tts/2602_FrameStacking4x/frame-stacking-4x-english-nanocodec.ckpt" \
+    model.codecmodel_path="/home/TestData/tts/21fps_causal_codecmodel.nemo" \
+    +model.frame_stacking_factor=4 \
+    model.alignment_loss_scale=0.0 \
+    model.use_text_conditioning_encoder=false \
+    model.prior_scaling_factor=null \
+    model.local_transformer_type="autoregressive" \
+    model.local_transformer_n_layers=4 \
+    model.local_transformer_n_heads=12 \
+    model.local_transformer_hidden_dim=768 \
+    +model.text_tokenizers.spanish_phoneme._target_=nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers.IPATokenizer \
+    +model.text_tokenizers.spanish_phoneme.locale=es-ES \
+    +model.text_tokenizers.spanish_phoneme.punct=true \
+    +model.text_tokenizers.spanish_phoneme.apostrophe=true \
+    +model.text_tokenizers.spanish_phoneme.pad_with_space=true \
+    +model.text_tokenizers.spanish_phoneme.g2p._target_=nemo.collections.tts.g2p.models.i18n_ipa.IpaG2p \
+    +model.text_tokenizers.spanish_phoneme.g2p.locale=es-ES \
+    +model.text_tokenizers.spanish_phoneme.g2p.phoneme_dict="scripts/tts_dataset_files/es_ES/es_ES_nv230301.dict" \
+    +model.text_tokenizers.spanish_phoneme.g2p.phoneme_probability=0.8 \
+    +model.text_tokenizers.spanish_phoneme.g2p.use_chars=true \
+    +model.text_tokenizers.spanish_phoneme.g2p.use_stresses=true \
+    +model.text_tokenizers.german_phoneme._target_=nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers.IPATokenizer \
+    +model.text_tokenizers.german_phoneme.locale=de-DE \
+    +model.text_tokenizers.german_phoneme.punct=true \
+    +model.text_tokenizers.german_phoneme.apostrophe=true \
+    +model.text_tokenizers.german_phoneme.pad_with_space=true \
+    +model.text_tokenizers.german_phoneme.g2p._target_=nemo.collections.tts.g2p.models.i18n_ipa.IpaG2p \
+    +model.text_tokenizers.german_phoneme.g2p.locale=de-DE \
+    +model.text_tokenizers.german_phoneme.g2p.phoneme_dict="scripts/tts_dataset_files/de/de_nv230119.dict" \
+    +model.text_tokenizers.german_phoneme.g2p.phoneme_probability=0.8 \
+    +model.text_tokenizers.german_phoneme.g2p.use_chars=true \
+    +model.text_tokenizers.german_phoneme.g2p.use_stresses=true \
+    +model.text_tokenizers.german_phoneme.g2p.grapheme_case="mixed" \
+    +model.text_tokenizers.german_phoneme.g2p.grapheme_prefix="'#'" \
+    +model.text_tokenizers.mandarin_phoneme._target_=nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers.ChinesePhonemesTokenizer \
+    +model.text_tokenizers.mandarin_phoneme.punct=true \
+    +model.text_tokenizers.mandarin_phoneme.apostrophe=true \
+    +model.text_tokenizers.mandarin_phoneme.pad_with_space=true \
+    +model.text_tokenizers.mandarin_phoneme.g2p._target_=nemo.collections.tts.g2p.models.zh_cn_pinyin.ChineseG2p \
+    +model.text_tokenizers.mandarin_phoneme.g2p.phoneme_dict="scripts/tts_dataset_files/zh/36finals/ipa_dict_nv23.05.txt" \
+    +model.text_tokenizers.mandarin_phoneme.g2p.word_segmenter="jieba" \
+    +model.text_tokenizers.mandarin_phoneme.g2p.phoneme_prefix="" \
+    +model.text_tokenizers.mandarin_phoneme.g2p.phoneme_case="lower" \
+    +model.text_tokenizers.mandarin_phoneme.g2p.tone_prefix="'#'" \
+    +model.text_tokenizers.mandarin_phoneme.g2p.ascii_letter_prefix="" \
+    +model.text_tokenizers.mandarin_phoneme.g2p.ascii_letter_case="upper" \
+    +model.text_tokenizers.french_chartokenizer._target_=AutoTokenizer \
+    +model.text_tokenizers.french_chartokenizer.pretrained_model="google/byt5-small" \
+    +model.text_tokenizers.hindi_phoneme._target_=AutoTokenizer \
+    +model.text_tokenizers.hindi_phoneme.pretrained_model="google/byt5-small" \
+    +model.text_tokenizers.italian_phoneme._target_=AutoTokenizer \
+    +model.text_tokenizers.italian_phoneme.pretrained_model="google/byt5-small" \
+    +model.text_tokenizers.vietnamese_phoneme._target_=AutoTokenizer \
+    +model.text_tokenizers.vietnamese_phoneme.pretrained_model="google/byt5-small" \
+    +train_ds_meta.an4.manifest_path="/home/TestData/an4_dataset/an4_train_context_v1.json" \
+    +train_ds_meta.an4.audio_dir="/" \
+    +train_ds_meta.an4.tokenizer_names="[english_phoneme]" \
+    +train_ds_meta.an4.feature_dir=null \
+    +val_ds_meta.an4.manifest_path="/home/TestData/an4_dataset/an4_val_context_v1.json" \
+    +val_ds_meta.an4.audio_dir="/" \
+    +val_ds_meta.an4.tokenizer_names="[english_phoneme]" \
+    +val_ds_meta.an4.feature_dir=null \
+    trainer.devices="[0]" \
+    max_epochs=1 \
+    batch_size=4 \
+    +trainer.limit_train_batches=1 \
+    +trainer.limit_val_batches=1 \
+    trainer.strategy=auto \
+    model.train_ds.dataloader_params.num_workers=0 \
+    model.validation_ds.dataloader_params.num_workers=0 \
+    ~trainer.check_val_every_n_epoch

--- a/tests/functional_tests/L2_TTS_Fast_dev_runs_Magpietts_MoE_OnlineCFGDistillation.sh
+++ b/tests/functional_tests/L2_TTS_Fast_dev_runs_Magpietts_MoE_OnlineCFGDistillation.sh
@@ -1,0 +1,50 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+HF_HUB_OFFLINE=1 TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 coverage run -a --data-file=/workspace/.coverage --source=/workspace/nemo examples/tts/magpietts.py \
+    --config-name magpietts \
+    name="MagpieTTS-MoE-OnlineCFGDistillation" \
+    +mode="online_cfg_distillation_train" \
+    +init_from_nemo_model="/home/TestData/tts/2602_MoE/moe16_sinkhorn_top1_valLoss5.0469_step2625132_epoch524.nemo" \
+    +model.teacher_model_path="/home/TestData/tts/2602_MoE/moe16_sinkhorn_top1_valLoss5.0469_step2625132_epoch524.nemo" \
+    model.codecmodel_path="/home/TestData/tts/21fps_causal_codecmodel.nemo" \
+    +model.use_moe=true \
+    +model.decoder.use_moe=true \
+    model.prior_scaling_factor=null \
+    +train_ds_meta.an4.manifest_path="/home/TestData/an4_dataset/an4_train_context_v1.json" \
+    +train_ds_meta.an4.audio_dir="/" \
+    +train_ds_meta.an4.tokenizer_names="[english_phoneme]" \
+    +train_ds_meta.an4.feature_dir=null \
+    +val_ds_meta.an4.manifest_path="/home/TestData/an4_dataset/an4_val_context_v1.json" \
+    +val_ds_meta.an4.audio_dir="/" \
+    +val_ds_meta.an4.tokenizer_names="[english_phoneme]" \
+    +val_ds_meta.an4.feature_dir=null \
+    trainer.devices="[0]" \
+    max_epochs=1 \
+    batch_size=4 \
+    +trainer.limit_train_batches=1 \
+    +trainer.limit_val_batches=1 \
+    trainer.strategy=auto \
+    model.train_ds.dataloader_params.num_workers=0 \
+    model.validation_ds.dataloader_params.num_workers=0 \
+    ~trainer.check_val_every_n_epoch \
+    +model.router_load_balancing_loss_coeff=0.0 \
+    +model.router_z_loss_coeff=0.001 \
+    model.decoder.d_ffn=3072 \
+    +model.decoder.num_experts=16 \
+    +model.decoder.top_k_experts=1 \
+    +model.decoder.routing_strategy="sinkhorn" \
+    +model.decoder.router_jitter_noise=0.0 \
+    model.local_transformer_type="none" \
+    model.encoder.is_causal=false \
+    model.model_type="decoder_context_tts"

--- a/tests/functional_tests/L2_TTS_Fast_dev_runs_Magpietts_OnlineCFGDistillation.sh
+++ b/tests/functional_tests/L2_TTS_Fast_dev_runs_Magpietts_OnlineCFGDistillation.sh
@@ -1,0 +1,95 @@
+# Copyright (c) 2026, NVIDIA CORPORATION.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+HF_HUB_OFFLINE=1 TORCH_FORCE_NO_WEIGHTS_ONLY_LOAD=1 coverage run -a --data-file=/workspace/.coverage --source=/workspace/nemo examples/tts/magpietts.py \
+    --config-name magpietts \
+    name="MagpieTTS-OnlineCFGDistillation" \
+    +mode="online_cfg_distillation_train" \
+    +init_from_nemo_model="/home/TestData/tts/2602_MagpieTTS/feb26_Magpie-TTS-ML-V1--val_cer_gt\=0.3258-step\=1000.nemo" \
+    +model.teacher_model_path="/home/TestData/tts/2602_MagpieTTS/feb26_Magpie-TTS-ML-V1--val_cer_gt\=0.3258-step\=1000.nemo" \
+    model.codecmodel_path="/home/TestData/tts/21fps_causal_codecmodel.nemo" \
+    model.prior_scaling_factor=null \
+    model.local_transformer_type="autoregressive" \
+    model.local_transformer_n_layers=1 \
+    model.local_transformer_n_heads=1 \
+    model.local_transformer_hidden_dim=256 \
+    +train_ds_meta.an4.manifest_path="/home/TestData/an4_dataset/an4_train_context_v1.json" \
+    +train_ds_meta.an4.audio_dir="/" \
+    +train_ds_meta.an4.tokenizer_names="[english_phoneme]" \
+    +train_ds_meta.an4.feature_dir=null \
+    +val_ds_meta.an4.manifest_path="/home/TestData/an4_dataset/an4_val_context_v1.json" \
+    +val_ds_meta.an4.audio_dir="/" \
+    +val_ds_meta.an4.tokenizer_names="[english_phoneme]" \
+    +val_ds_meta.an4.feature_dir=null \
+    +model.text_tokenizers.spanish_phoneme._target_=nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers.IPATokenizer \
+    +model.text_tokenizers.spanish_phoneme.locale=es-ES \
+    +model.text_tokenizers.spanish_phoneme.punct=true \
+    +model.text_tokenizers.spanish_phoneme.apostrophe=true \
+    +model.text_tokenizers.spanish_phoneme.pad_with_space=true \
+    +model.text_tokenizers.spanish_phoneme.g2p._target_=nemo.collections.tts.g2p.models.i18n_ipa.IpaG2p \
+    +model.text_tokenizers.spanish_phoneme.g2p.locale=es-ES \
+    +model.text_tokenizers.spanish_phoneme.g2p.phoneme_dict="scripts/tts_dataset_files/es_ES/es_ES_nv230301.dict" \
+    +model.text_tokenizers.spanish_phoneme.g2p.phoneme_probability=0.8 \
+    +model.text_tokenizers.spanish_phoneme.g2p.use_chars=true \
+    +model.text_tokenizers.spanish_phoneme.g2p.use_stresses=true \
+    +model.text_tokenizers.german_phoneme._target_=nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers.IPATokenizer \
+    +model.text_tokenizers.german_phoneme.locale=de-DE \
+    +model.text_tokenizers.german_phoneme.punct=true \
+    +model.text_tokenizers.german_phoneme.apostrophe=true \
+    +model.text_tokenizers.german_phoneme.pad_with_space=true \
+    +model.text_tokenizers.german_phoneme.g2p._target_=nemo.collections.tts.g2p.models.i18n_ipa.IpaG2p \
+    +model.text_tokenizers.german_phoneme.g2p.locale=de-DE \
+    +model.text_tokenizers.german_phoneme.g2p.phoneme_dict="scripts/tts_dataset_files/de/de_nv230119.dict" \
+    +model.text_tokenizers.german_phoneme.g2p.phoneme_probability=0.8 \
+    +model.text_tokenizers.german_phoneme.g2p.use_chars=true \
+    +model.text_tokenizers.german_phoneme.g2p.use_stresses=true \
+    +model.text_tokenizers.german_phoneme.g2p.grapheme_case="mixed" \
+    +model.text_tokenizers.german_phoneme.g2p.grapheme_prefix="'#'" \
+    +model.text_tokenizers.mandarin_phoneme._target_=nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers.ChinesePhonemesTokenizer \
+    +model.text_tokenizers.mandarin_phoneme.punct=true \
+    +model.text_tokenizers.mandarin_phoneme.apostrophe=true \
+    +model.text_tokenizers.mandarin_phoneme.pad_with_space=true \
+    +model.text_tokenizers.mandarin_phoneme.g2p._target_=nemo.collections.tts.g2p.models.zh_cn_pinyin.ChineseG2p \
+    +model.text_tokenizers.mandarin_phoneme.g2p.phoneme_dict="scripts/tts_dataset_files/zh/36finals/ipa_dict_nv23.05.txt" \
+    +model.text_tokenizers.mandarin_phoneme.g2p.word_segmenter="jieba" \
+    +model.text_tokenizers.mandarin_phoneme.g2p.phoneme_prefix="" \
+    +model.text_tokenizers.mandarin_phoneme.g2p.phoneme_case="lower" \
+    +model.text_tokenizers.mandarin_phoneme.g2p.tone_prefix="'#'" \
+    +model.text_tokenizers.mandarin_phoneme.g2p.ascii_letter_prefix="" \
+    +model.text_tokenizers.mandarin_phoneme.g2p.ascii_letter_case="upper" \
+    +model.text_tokenizers.japanese_phoneme._target_=nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers.JapanesePhonemeTokenizer \
+    +model.text_tokenizers.japanese_phoneme.punct=true \
+    +model.text_tokenizers.japanese_phoneme.apostrophe=false \
+    +model.text_tokenizers.japanese_phoneme.pad_with_space=true \
+    +model.text_tokenizers.japanese_phoneme.g2p._target_=nemo.collections.tts.g2p.models.ja_jp_ipa.JapaneseKatakanaAccentG2p \
+    +model.text_tokenizers.japanese_phoneme.g2p.ascii_letter_prefix="" \
+    +model.text_tokenizers.japanese_phoneme.g2p.ascii_letter_case="upper" \
+    +model.text_tokenizers.french_chartokenizer._target_=AutoTokenizer \
+    +model.text_tokenizers.french_chartokenizer.pretrained_model="google/byt5-small" \
+    +model.text_tokenizers.hindi_chartokenizer._target_=nemo.collections.common.tokenizers.text_to_speech.tts_tokenizers.HindiCharsTokenizer \
+    +model.text_tokenizers.hindi_chartokenizer.punct=true \
+    +model.text_tokenizers.hindi_chartokenizer.apostrophe=true \
+    +model.text_tokenizers.hindi_chartokenizer.pad_with_space=true \
+    +model.text_tokenizers.italian_phoneme._target_=AutoTokenizer \
+    +model.text_tokenizers.italian_phoneme.pretrained_model="google/byt5-small" \
+    +model.text_tokenizers.vietnamese_phoneme._target_=AutoTokenizer \
+    +model.text_tokenizers.vietnamese_phoneme.pretrained_model="google/byt5-small" \
+    trainer.devices="[0]" \
+    max_epochs=1 \
+    batch_size=4 \
+    +trainer.limit_train_batches=1 \
+    +trainer.limit_val_batches=1 \
+    trainer.strategy=auto \
+    model.train_ds.dataloader_params.num_workers=0 \
+    model.validation_ds.dataloader_params.num_workers=0 \
+    ~trainer.check_val_every_n_epoch


### PR DESCRIPTION
# Summary
This PR adds support for online classifier-free guidance (CFG) distillation for MagpieTTS.

# What’s included
- Added a new `OnlineCFGDistillation` model that extends `MagpieTTSModel` for online CFG distillation training.
- Added MagpieTTS distillation loss implementations, including KL-divergence, cross-entropy, and normalized RMSE losses.
- Added a new training mode, `online_cfg_distillation_train`, to `examples/tts/magpietts.py`.

# Training flow
- Teacher model is loaded from checkpoint and frozen.
- Teacher performs autoregressive CFG rollout generation.
- Generated rollout is fed into the student in teacher-forced mode.
- The student is optimized using a weighted combination of KL-divergence, cross-entropy, normalized RMSE, and optional MoE loss.
