### PR TITLE
fix: Remove nemo_class arg in import_hf.py

### DIFF
--- a/scripts/vlm/import_hf.py
+++ b/scripts/vlm/import_hf.py
@@ -45,22 +45,8 @@ if __name__ == '__main__':
         default=None,
         help="Path to save the converted NeMo version Hugging Face checkpoint directory.",
     )
-    parser.add_argument(
-        "--nemo_class",
-        type=str,
-        default=None,
-        help="If input is a local checkpoint path, specify the corresponding NeMo model class (e.g., 'vlm.LlavaModel').",
-    )
     args = parser.parse_args()
 
     model_name_or_path = args.input_name_or_path
-    local_path = Path(model_name_or_path)
-    if local_path.exists():
-        try:
-            model_class = eval(args.nemo_class)
-        except Exception as e:
-            raise ValueError(f"Could not import the specified NeMo class '{args.nemo_class}': {e}")
-    else:
-        model_class = HF_MODEL_ID_TO_NEMO_CLASS[model_name_or_path]
-
+    model_class = HF_MODEL_ID_TO_NEMO_CLASS[model_name_or_path]
     import_ckpt(model_class(), f"hf://{model_name_or_path}", output_path=args.output_path)


### PR DESCRIPTION
# What does this PR do ?

fix: Remove nemo_class arg in import_hf.py

We should not be using eval and an arbitrary nemo_class arg in the import_hf script.  This arg is not used anywhere in the NeMo repo.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
