### PR TITLE
fix: Use RestrictedUnpickler in nemo.lightning.io.mixin

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -17,7 +17,7 @@
 ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:24.07-py3
 
 FROM ${BASE_IMAGE} as base-image
-ENV PIP_CONSTRAINT="" 
+ENV PIP_CONSTRAINT=""
 ENV TRANSFORMERS_OFFLINE=0
 ENV HYDRA_FULL_ERROR=1
 ENV PYTHONUNBUFFERED=1
@@ -35,7 +35,7 @@ ARG TE_REPO
 ARG TE_TAG
 RUN --mount=type=bind,source=docker/common/install_dep.sh,target=/tmp/NeMo/install_dep.sh \
   --mount=type=bind,source=external/patches,target=/tmp/NeMo/external/patches <<"EOF" bash -ex
-  
+
   bash /tmp/NeMo/install_dep.sh --library te --mode build
   ls -al /tmp/Megatron-LM || true
 EOF
@@ -45,15 +45,15 @@ WORKDIR /tmp/NeMo
 ARG MLM_REPO
 ARG MLM_TAG
 RUN --mount=type=bind,source=docker/common/install_dep.sh,target=/tmp/NeMo/install_dep.sh <<"EOF" bash -ex
-  
+
   bash /tmp/NeMo/install_dep.sh --library mcore --mode build
   ls -al /tmp/Megatron-LM || true
 EOF
 
-FROM base-image 
+FROM base-image
 WORKDIR /tmp/NeMo
 ENV INSTALL_DIR="/opt"
-RUN \  
+RUN \
   --mount=type=bind,from=te-wheel,source=/opt/wheels/te,target=/opt/wheels/te \
   --mount=type=bind,from=mcore-wheel,source=/opt/wheels/mcore,target=/opt/wheels/mcore \
   --mount=type=bind,source=requirements,target=/tmp/NeMo/requirements \
@@ -64,11 +64,11 @@ RUN \
   --mount=type=bind,source=README.md,target=/tmp/NeMo/README.md \
   --mount=type=bind,source=nemo/package_info.py,target=/tmp/NeMo/nemo/package_info.py \
   --mount=type=bind,source=nemo/__init__.py,target=/tmp/NeMo/nemo/__init__.py <<"EOF" bash -ex
-    
+
   bash /tmp/NeMo/install_dep.sh --library te --mode install
   bash /tmp/NeMo/install_dep.sh --library mcore --mode install
   bash /tmp/NeMo/install_dep.sh --library extra --mode install
-  pip install --no-cache-dir ".[all,cu12]"
+  pip install --no-cache-dir ".[all,cu13]"
   rm -rf $NEMO_DIR || true
 EOF
 

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -17,7 +17,7 @@
 ARG BASE_IMAGE=nvcr.io/nvidia/pytorch:24.07-py3
 
 FROM ${BASE_IMAGE} as base-image
-ENV PIP_CONSTRAINT=""
+ENV PIP_CONSTRAINT="" 
 ENV TRANSFORMERS_OFFLINE=0
 ENV HYDRA_FULL_ERROR=1
 ENV PYTHONUNBUFFERED=1
@@ -35,7 +35,7 @@ ARG TE_REPO
 ARG TE_TAG
 RUN --mount=type=bind,source=docker/common/install_dep.sh,target=/tmp/NeMo/install_dep.sh \
   --mount=type=bind,source=external/patches,target=/tmp/NeMo/external/patches <<"EOF" bash -ex
-
+  
   bash /tmp/NeMo/install_dep.sh --library te --mode build
   ls -al /tmp/Megatron-LM || true
 EOF
@@ -45,15 +45,15 @@ WORKDIR /tmp/NeMo
 ARG MLM_REPO
 ARG MLM_TAG
 RUN --mount=type=bind,source=docker/common/install_dep.sh,target=/tmp/NeMo/install_dep.sh <<"EOF" bash -ex
-
+  
   bash /tmp/NeMo/install_dep.sh --library mcore --mode build
   ls -al /tmp/Megatron-LM || true
 EOF
 
-FROM base-image
+FROM base-image 
 WORKDIR /tmp/NeMo
 ENV INSTALL_DIR="/opt"
-RUN \
+RUN \  
   --mount=type=bind,from=te-wheel,source=/opt/wheels/te,target=/opt/wheels/te \
   --mount=type=bind,from=mcore-wheel,source=/opt/wheels/mcore,target=/opt/wheels/mcore \
   --mount=type=bind,source=requirements,target=/tmp/NeMo/requirements \
@@ -64,11 +64,11 @@ RUN \
   --mount=type=bind,source=README.md,target=/tmp/NeMo/README.md \
   --mount=type=bind,source=nemo/package_info.py,target=/tmp/NeMo/nemo/package_info.py \
   --mount=type=bind,source=nemo/__init__.py,target=/tmp/NeMo/nemo/__init__.py <<"EOF" bash -ex
-
+    
   bash /tmp/NeMo/install_dep.sh --library te --mode install
   bash /tmp/NeMo/install_dep.sh --library mcore --mode install
   bash /tmp/NeMo/install_dep.sh --library extra --mode install
-  pip install --no-cache-dir ".[all,cu13]"
+  pip install --no-cache-dir ".[all,cu12]"
   rm -rf $NEMO_DIR || true
 EOF
 

--- a/nemo/lightning/io/mixin.py
+++ b/nemo/lightning/io/mixin.py
@@ -47,13 +47,14 @@ ConnT = TypeVar("ConnT", bound=ModelConnector)
 CkptType = TypeVar("CkptType")
 _enable_ext()
 
-# Modules allowed during pickle deserialization of IO artifacts.
+# Top-level modules allowed during pickle deserialization of IO artifacts.
 # This restricts what can be loaded to prevent arbitrary code execution
+# (see ZDI-CAN-28677).
 _PICKLE_ALLOWED_MODULES = frozenset(
     {
-        "builtins",
         "cloudpickle",
         "collections",
+        "fsspec",
         "copy",
         "dataclasses",
         "enum",
@@ -72,23 +73,33 @@ _PICKLE_ALLOWED_MODULES = frozenset(
     }
 )
 
-# Builtins that must never be deserialized even though the builtins module is allowed.
-_PICKLE_DENIED_BUILTINS = frozenset(
+# Explicitly allowed builtins (safe data types and accessors only).
+_PICKLE_ALLOWED_BUILTINS = frozenset(
     {
-        "eval",
-        "exec",
-        "compile",
-        "globals",
-        "locals",
-        "vars",
-        "__import__",
-        "breakpoint",
-        "exit",
-        "quit",
-        "open",
-        "input",
-        "memoryview",
-        "help",
+        "True",
+        "False",
+        "None",
+        "bool",
+        "bytearray",
+        "bytes",
+        "complex",
+        "dict",
+        "enumerate",
+        "filter",
+        "float",
+        "frozenset",
+        "getattr",
+        "int",
+        "list",
+        "map",
+        "object",
+        "range",
+        "set",
+        "slice",
+        "str",
+        "tuple",
+        "type",
+        "zip",
     }
 )
 
@@ -97,14 +108,18 @@ class RestrictedUnpickler(pickle.Unpickler):
     """Unpickler that only allows known-safe modules to prevent code execution attacks."""
 
     def find_class(self, module: str, name: str) -> type:
+        if module == "builtins":
+            if name not in _PICKLE_ALLOWED_BUILTINS:
+                raise pickle.UnpicklingError(
+                    f"Deserialization of 'builtins.{name}' is not allowed for security reasons."
+                )
+            return super().find_class(module, name)
         top_level = module.split(".")[0]
         if top_level not in _PICKLE_ALLOWED_MODULES:
             raise pickle.UnpicklingError(
                 f"Deserialization of '{module}.{name}' is not allowed. "
                 "Only known NeMo, PyTorch, and related framework classes are permitted."
             )
-        if module == "builtins" and name in _PICKLE_DENIED_BUILTINS:
-            raise pickle.UnpicklingError(f"Deserialization of 'builtins.{name}' is not allowed for security reasons.")
         return super().find_class(module, name)
 
 

--- a/nemo/lightning/io/mixin.py
+++ b/nemo/lightning/io/mixin.py
@@ -49,55 +49,46 @@ _enable_ext()
 
 # Modules allowed during pickle deserialization of IO artifacts.
 # This restricts what can be loaded to prevent arbitrary code execution
-# (see ZDI-CAN-28677).
 _PICKLE_ALLOWED_MODULES = frozenset(
     {
-        "nemo",
-        "megatron",
-        "fiddle",
-        "lightning",
-        "torch",
-        "numpy",
+        "builtins",
         "cloudpickle",
         "collections",
-        "pathlib",
-        "enum",
-        "signal",
-        "functools",
         "copy",
         "dataclasses",
+        "enum",
+        "fiddle",
+        "functools",
+        "lightning",
+        "megatron",
+        "nemo",
+        "numpy",
+        "pathlib",
+        "signal",
+        "torch",
+        "transformers",
         "typing",
         "typing_extensions",
-        "transformers",
     }
 )
 
-_PICKLE_ALLOWED_BUILTINS = frozenset(
+# Builtins that must never be deserialized even though the builtins module is allowed.
+_PICKLE_DENIED_BUILTINS = frozenset(
     {
-        "builtins.True",
-        "builtins.False",
-        "builtins.None",
-        "builtins.int",
-        "builtins.float",
-        "builtins.str",
-        "builtins.bytes",
-        "builtins.bool",
-        "builtins.complex",
-        "builtins.list",
-        "builtins.tuple",
-        "builtins.dict",
-        "builtins.set",
-        "builtins.frozenset",
-        "builtins.slice",
-        "builtins.type",
-        "builtins.range",
-        "builtins.enumerate",
-        "builtins.map",
-        "builtins.filter",
-        "builtins.zip",
-        "builtins.object",
-        "builtins.bytearray",
-        "builtins.getattr",
+        "eval",
+        "exec",
+        "compile",
+        "globals",
+        "locals",
+        "vars",
+        "__import__",
+        "breakpoint",
+        "exit",
+        "quit",
+        "open",
+        "input",
+        "memoryview",
+        "help",
     }
 )
 
@@ -106,16 +97,17 @@ class RestrictedUnpickler(pickle.Unpickler):
     """Unpickler that only allows known-safe modules to prevent code execution attacks."""
 
     def find_class(self, module: str, name: str) -> type:
-        class_path = f"{module}.{name}"
-        if class_path in _PICKLE_ALLOWED_BUILTINS:
-            return super().find_class(module, name)
         top_level = module.split(".")[0]
-        if top_level in _PICKLE_ALLOWED_MODULES:
-            return super().find_class(module, name)
-        raise pickle.UnpicklingError(
-            f"Deserialization of '{class_path}' is not allowed. "
-            "Only known NeMo, PyTorch, and related framework classes are permitted."
-        )
+        if top_level not in _PICKLE_ALLOWED_MODULES:
+            raise pickle.UnpicklingError(
+                f"Deserialization of '{module}.{name}' is not allowed. "
+                "Only known NeMo, PyTorch, and related framework classes are permitted."
+            )
+        if module == "builtins" and name in _PICKLE_DENIED_BUILTINS:
+            raise pickle.UnpicklingError(
+                f"Deserialization of 'builtins.{name}' is not allowed for security reasons."
+            )
+        return super().find_class(module, name)
 
 
 def _safe_pickle_load(f: io.BufferedIOBase) -> Any:

--- a/nemo/lightning/io/mixin.py
+++ b/nemo/lightning/io/mixin.py
@@ -104,9 +104,7 @@ class RestrictedUnpickler(pickle.Unpickler):
                 "Only known NeMo, PyTorch, and related framework classes are permitted."
             )
         if module == "builtins" and name in _PICKLE_DENIED_BUILTINS:
-            raise pickle.UnpicklingError(
-                f"Deserialization of 'builtins.{name}' is not allowed for security reasons."
-            )
+            raise pickle.UnpicklingError(f"Deserialization of 'builtins.{name}' is not allowed for security reasons.")
         return super().find_class(module, name)
 
 

--- a/nemo/lightning/io/mixin.py
+++ b/nemo/lightning/io/mixin.py
@@ -70,46 +70,11 @@ _PICKLE_ALLOWED_MODULES = frozenset(
     }
 )
 
-_PICKLE_ALLOWED_BUILTINS = frozenset(
-    {
-        "True",
-        "False",
-        "None",
-        "bool",
-        "bytearray",
-        "bytes",
-        "complex",
-        "dict",
-        "enumerate",
-        "filter",
-        "float",
-        "frozenset",
-        "getattr",
-        "int",
-        "list",
-        "map",
-        "object",
-        "range",
-        "set",
-        "slice",
-        "str",
-        "tuple",
-        "type",
-        "zip",
-    }
-)
-
 
 class RestrictedUnpickler(pickle.Unpickler):
     """Unpickler that only allows known-safe modules to prevent code execution attacks."""
 
     def find_class(self, module: str, name: str) -> type:
-        if module == "builtins":
-            if name not in _PICKLE_ALLOWED_BUILTINS:
-                raise pickle.UnpicklingError(
-                    f"Deserialization of 'builtins.{name}' is not allowed for security reasons."
-                )
-            return super().find_class(module, name)
         top_level = module.split(".")[0]
         if top_level not in _PICKLE_ALLOWED_MODULES:
             raise pickle.UnpicklingError(

--- a/nemo/lightning/io/mixin.py
+++ b/nemo/lightning/io/mixin.py
@@ -47,9 +47,6 @@ ConnT = TypeVar("ConnT", bound=ModelConnector)
 CkptType = TypeVar("CkptType")
 _enable_ext()
 
-# Top-level modules allowed during pickle deserialization of IO artifacts.
-# This restricts what can be loaded to prevent arbitrary code execution
-# (see ZDI-CAN-28677).
 _PICKLE_ALLOWED_MODULES = frozenset(
     {
         "cloudpickle",
@@ -73,7 +70,6 @@ _PICKLE_ALLOWED_MODULES = frozenset(
     }
 )
 
-# Explicitly allowed builtins (safe data types and accessors only).
 _PICKLE_ALLOWED_BUILTINS = frozenset(
     {
         "True",

--- a/nemo/lightning/io/mixin.py
+++ b/nemo/lightning/io/mixin.py
@@ -15,7 +15,9 @@
 import dataclasses
 import functools
 import inspect
+import io
 import json
+import pickle
 import shutil
 import threading
 import types
@@ -29,7 +31,6 @@ import fiddle as fdl
 import fiddle._src.experimental.dataclasses as fdl_dc
 import lightning.pytorch as pl
 from cloudpickle import dump
-from cloudpickle import load as pickle_load
 from fiddle._src import config as config_lib
 from fiddle._src import partial
 from fiddle._src.experimental import serialization
@@ -45,6 +46,81 @@ from nemo.utils import logging
 ConnT = TypeVar("ConnT", bound=ModelConnector)
 CkptType = TypeVar("CkptType")
 _enable_ext()
+
+# Modules allowed during pickle deserialization of IO artifacts.
+# This restricts what can be loaded to prevent arbitrary code execution
+# (see ZDI-CAN-28677).
+_PICKLE_ALLOWED_MODULES = frozenset(
+    {
+        "nemo",
+        "megatron",
+        "fiddle",
+        "lightning",
+        "torch",
+        "numpy",
+        "cloudpickle",
+        "collections",
+        "pathlib",
+        "enum",
+        "signal",
+        "functools",
+        "copy",
+        "dataclasses",
+        "typing",
+        "typing_extensions",
+        "transformers",
+    }
+)
+
+_PICKLE_ALLOWED_BUILTINS = frozenset(
+    {
+        "builtins.True",
+        "builtins.False",
+        "builtins.None",
+        "builtins.int",
+        "builtins.float",
+        "builtins.str",
+        "builtins.bytes",
+        "builtins.bool",
+        "builtins.complex",
+        "builtins.list",
+        "builtins.tuple",
+        "builtins.dict",
+        "builtins.set",
+        "builtins.frozenset",
+        "builtins.slice",
+        "builtins.type",
+        "builtins.range",
+        "builtins.enumerate",
+        "builtins.map",
+        "builtins.filter",
+        "builtins.zip",
+        "builtins.object",
+        "builtins.bytearray",
+        "builtins.getattr",
+    }
+)
+
+
+class RestrictedUnpickler(pickle.Unpickler):
+    """Unpickler that only allows known-safe modules to prevent code execution attacks."""
+
+    def find_class(self, module: str, name: str) -> type:
+        class_path = f"{module}.{name}"
+        if class_path in _PICKLE_ALLOWED_BUILTINS:
+            return super().find_class(module, name)
+        top_level = module.split(".")[0]
+        if top_level in _PICKLE_ALLOWED_MODULES:
+            return super().find_class(module, name)
+        raise pickle.UnpicklingError(
+            f"Deserialization of '{class_path}' is not allowed. "
+            "Only known NeMo, PyTorch, and related framework classes are permitted."
+        )
+
+
+def _safe_pickle_load(f: io.BufferedIOBase) -> Any:
+    """Load a pickle file using RestrictedUnpickler to block dangerous classes."""
+    return RestrictedUnpickler(f).load()
 
 
 # Thread-local storage for artifacts directory
@@ -637,7 +713,7 @@ def _io_unflatten_object(values, metadata):
     if len(values) == 1:
         pickle_path = values[0]
         with open(Path(output_dir) / pickle_path, "rb") as f:
-            return pickle_load(f)
+            return _safe_pickle_load(f)
 
     return fdl.Config.__unflatten__(values, metadata)
 


### PR DESCRIPTION
# What does this PR do ?

fix: Use RestrictedUnpickler in nemo.lightning.io.mixin

This module is actually already deleted on main branch.  But we aren't planning a release near-term, so let's clean it up in a patch. This uses RestrictedUnpickler to only allow certain objects to be loaded from known paths.

**Collection**: [Note which collection this PR will affect]

# Changelog

- Add specific line by line info of high level changes in this PR.

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
