### PR TITLE
fix use_feat_cache feature

### DIFF
--- a/nemo/collections/asr/inference/streaming/buffering/cache_feature_bufferer.py
+++ b/nemo/collections/asr/inference/streaming/buffering/cache_feature_bufferer.py
@@ -162,7 +162,8 @@ class BatchedCacheFeatureBufferer:
             if chunk_len > self.feature_buffer_len:
                 raise ValueError(f"feat_chunk ({chunk_len}) longer than buffer ({self.feature_buffer_len})")
 
-            self.feature_buffer[slot_id, :, :-chunk_len].copy_(self.feature_buffer[slot_id, :, chunk_len:])
+            shifted = self.feature_buffer[slot_id, :, chunk_len:].clone()
+            self.feature_buffer[slot_id, :, :-chunk_len].copy_(shifted)
             self.feature_buffer[slot_id, :, -chunk_len:].copy_(feat_chunk[i])
 
     def update(self, frames: list[Frame]) -> tuple[list[Tensor], list[int]]:

--- a/nemo/collections/asr/inference/utils/constants.py
+++ b/nemo/collections/asr/inference/utils/constants.py
@@ -18,7 +18,7 @@ SMALL_EPSILON = 1e-10
 ROUND_PRECISION = 9
 
 # ASR Preprocessing related constants
-LOG_MEL_ZERO = -16.635
+LOG_MEL_ZERO = -16.635532333438686  # log(2^-24), matches preprocessor output for silence
 
 # Punctuation related constants
 POST_WORD_PUNCTUATION = set(".,?")


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

Add a one line overview of what this PR aims to accomplish.

**Collection**: [ASR]

# Changelog                                                                                                                         
         
  - Fix GPU memory corruption in `BatchedCacheFeatureBufferer._update_feature_buffer` caused by overlapping read/write on the same tensor during the feature buffer shift operation. On GPU, tensor.copy_() between overlapping views runs CUDA kernels in parallel, causing  race conditions. Fixed by cloning the source before copying.
  - Fix `LOG_MEL_ZERO` precision from -16.635 to -16.635532333438686 (exact log(2^-24)) to match the preprocessor's actual output for silence signals. 

# WER comparison

model: `nvidia/nemotron-speech-streaming-en-0.6b`
att_context_size: `[70,13]`

### `use_cache=true`

WER% shown as `use_feat_cache=True / use_feat_cache=False`

| chunk (s) | Before (ted) | After (ted) | Before (vox) | After (vox) |
| --- | --- | --- | --- | --- |
| 0.08 | 17.18 / 11.98 | 12.02 / 11.98 | 19.70 / 11.09 | 11.08 / 11.09 |
| 0.16 | 15.93 / 12.05 | 12.04 / 12.05 | 20.17 / 11.09 | 11.09 / 11.09 |
| 0.24 | 13.15 / 12.05 | 12.02 / 12.05 | 13.75 / 11.14 | 11.16 / 11.14 |
| 0.32 | 12.82 / 11.99 | 12.01 / 11.99 | 12.96 / 11.14 | 11.13 / 11.14 |
| 0.40 | 12.29 / 11.98 | 12.01 / 11.98 | 11.77 / 11.13 | 11.10 / 11.13 |
| 0.48 | 12.04 / 11.97 | 11.95 / 11.97 | 11.38 / 11.16 | 11.13 / 11.16 |
| 0.56 | 12.05 / 12.02 | 12.05 / 12.02 | 11.15 / 11.11 | 11.11 / 11.11 |
| 0.64 | 12.04 / 12.05 | 12.04 / 12.05 | 11.23 / 11.28 | 11.23 / 11.28 |
| 0.72 | 12.08 / 12.08 | 12.08 / 12.08 | 11.34 / 11.36 | 11.34 / 11.36 |
| 0.80 | 12.11 / 12.12 | 12.11 / 12.12 | 11.46 / 11.42 | 11.46 / 11.42 |
| 0.88 | 12.27 / 12.19 | 12.27 / 12.19 | 11.51 / 11.54 | 11.51 / 11.54 |
| 0.96 | 12.51 / 12.46 | 12.51 / 12.46 | 11.77 / 11.79 | 11.77 / 11.79 |
| 1.04 | 12.71 / 12.81 | 12.71 / 12.81 | 12.30 / 12.32 | 12.30 / 12.32 |
| 1.12 | 11.97 / 12.01 | 11.97 / 12.01 | 11.13 / 11.16 | 11.13 / 11.16 |

### `use_cache=false`

WER% shown as `use_feat_cache=True / use_feat_cache=False`

| chunk (s) | Before (ted) | After (ted) | Before (vox) | After (vox) |
| --- | --- | --- | --- | --- |
| 0.08 | 51.18 / 16.47 | 16.44 / 16.47 | 66.18 / 14.62 | 14.61 / 14.62 |
| 0.16 | 64.86 / 24.19 | 24.21 / 24.19 | 77.37 / 27.25 | 27.32 / 27.25 |
| 0.24 | 55.38 / 30.63 | 30.64 / 30.63 | 69.92 / 34.96 | 34.75 / 34.96 |
| 0.32 | 45.14 / 33.40 | 33.29 / 33.40 | 43.62 / 36.29 | 36.11 / 36.29 |
| 0.40 | 41.85 / 32.64 | 32.69 / 32.64 | 49.10 / 34.17 | 34.12 / 34.17 |
| 0.48 | 41.66 / 30.17 | 30.20 / 30.17 | 42.97 / 31.13 | 31.03 / 31.13 |
| 0.56 | 42.91 / 27.11 | 27.07 / 27.11 | 44.07 / 27.20 | 27.21 / 27.20 |
| 0.64 | 35.28 / 23.75 | 23.75 / 23.75 | 40.44 / 23.67 | 23.69 / 23.67 |
| 0.72 | 31.09 / 20.27 | 20.35 / 20.27 | 35.40 / 19.65 | 19.67 / 19.65 |
| 0.80 | 25.44 / 17.76 | 17.60 / 17.76 | 29.74 / 16.68 | 16.70 / 16.68 |
| 0.88 | 20.28 / 15.36 | 15.31 / 15.36 | 25.57 / 14.36 | 14.33 / 14.36 |
| 0.96 | 15.95 / 13.60 | 13.65 / 13.60 | 18.46 / 12.59 | 12.52 / 12.59 |
| 1.04 | 13.51 / 12.25 | 12.27 / 12.25 | 14.34 / 11.46 | 11.45 / 11.46 |
| 1.12 | 12.83 / 12.06 | 12.06 / 12.06 | 12.87 / 11.16 | 11.19 / 11.16 |

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [X] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [ ] New Feature
- [X] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
