### PR TITLE
`CLAUDE.md`, PR babysitter, local dev skills + symlinks for Codex/Cursor

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.tool_input.file_path' | { read -r f; case \"$f\" in *.py) ;; *) exit 0;; esac; case \"$f\" in docs/*|external/*|examples/*) exit 0;; nemo/collections/speechlm2/*) ;; nemo/collections/*) exit 0;; esac; black --quiet \"$f\"; isort --quiet \"$f\"; } 2>/dev/null || true",
+            "command": "jq -r '.tool_input.file_path' | { read -r f; f=\"${f#\"$(git rev-parse --show-toplevel)/\"}\"; case \"$f\" in *.py) ;; *) exit 0;; esac; case \"$f\" in docs/*|external/*|examples/*) exit 0;; nemo/collections/speechlm2/*) ;; nemo/collections/*) exit 0;; esac; black --quiet \"$f\"; isort --quiet \"$f\"; } 2>/dev/null || true",
             "timeout": 30
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | { read -r f; case \"$f\" in *.py) ;; *) exit 0;; esac; case \"$f\" in docs/*|external/*|examples/*) exit 0;; nemo/collections/speechlm2/*) ;; nemo/collections/*) exit 0;; esac; black --quiet \"$f\"; isort --quiet \"$f\"; } 2>/dev/null || true",
+            "timeout": 30
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/skills/babysit-pr/SKILL.md
+++ b/.claude/skills/babysit-pr/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: babysit-pr
+description: Get a pull request to green CI. Diagnose and fix CI failures, push fixes, re-trigger CI via the "Run CICD" label, and repeat until all checks pass. Does not post comments — this is a local developer tool.
+---
+
+# babysit-pr
+
+Get a PR's CI to green. Nothing else — no review comments, no PR comments, no status summaries. This skill is run locally by developers in their own sandboxes.
+
+## Inputs
+
+The PR number is the primary input. It may come from:
+- An explicit argument: `/babysit-pr 567`
+- The conversation context: "check on PR #567"
+- A GitHub PR URL pasted into the chat
+
+If no PR number is clear, ask for it before proceeding.
+
+## Workflow
+
+### Step 1 — Get the full picture
+
+```bash
+gh pr view <PR_NUMBER> --repo NVIDIA-NeMo/NeMo
+gh pr checks <PR_NUMBER> --repo NVIDIA-NeMo/NeMo
+gh pr diff <PR_NUMBER> --repo NVIDIA-NeMo/NeMo
+```
+
+Determine the current state:
+
+| State                        | What to do                           |
+|------------------------------|--------------------------------------|
+| CI failing                   | Diagnose and fix (Step 2)            |
+| Merge conflicts              | Resolve (Step 3)                     |
+| Formatting check failing     | Wait — do NOT fix (see below)        |
+| CI green                     | Done, nothing to do                  |
+| CI pending                   | Wait for it to finish, then reassess |
+
+### Checks to ignore
+
+The **"Isort and Black Formatting"** workflow (`reformat_with_isort_and_black` job) auto-pushes formatting fixes. If that check is failing or pending:
+- Do NOT fix formatting yourself — the auto-formatter will push a commit shortly.
+- Wait for it to complete and for the new commit to land before assessing other failures, since the formatting push changes the HEAD SHA and may re-trigger CI.
+
+### Step 2 — Fix CI failures
+
+Check out the PR branch and inspect the failure logs:
+
+```bash
+gh pr checkout <PR_NUMBER> --repo NVIDIA-NeMo/NeMo
+gh run list --repo NVIDIA-NeMo/NeMo --branch <branch-name>
+gh run view <RUN_ID> --repo NVIDIA-NeMo/NeMo --log-failed
+```
+
+Before attempting a fix, check `git log` for recent commits. If you see a previous fix attempt that addressed the same failure and it is still failing, **stop and tell the user** — the issue needs human attention. Do not keep retrying the same fix.
+
+Otherwise, identify the root cause, fix the code, and push:
+
+```bash
+git add <changed files>
+git commit -s -m "<brief summary of fix>"
+git push
+```
+
+### Step 3 — Re-trigger CI
+
+After pushing a fix, add the "Run CICD" label to re-trigger the CI pipeline:
+
+```bash
+gh pr edit <PR_NUMBER> --repo NVIDIA-NeMo/NeMo --add-label "Run CICD"
+```
+
+The "CICD NeMo" workflow is triggered by this label and removes it automatically when done.
+
+Then wait for CI to complete and reassess. Go back to Step 1.
+
+### Step 4 — Resolve merge conflicts
+
+If the PR branch has fallen behind main and has conflicts:
+
+```bash
+git fetch origin main
+git rebase origin/main
+# Resolve conflicts — keep the PR's intent, adopt refactors from main
+git add <resolved files>
+git rebase --continue
+git push --force-with-lease
+```
+
+After rebasing, go back to Step 3 to re-trigger CI.
+
+## Rules
+
+- **Do NOT post comments on the PR.** This is a local tool — communicate with the user directly.
+- **Do NOT address review comments.** The goal is green CI, not review resolution.
+- **Do NOT fix formatting.** The `Isort and Black Formatting` action handles that automatically.
+- **Do NOT retry a failed fix.** If your previous commit didn't resolve the failure, tell the user.
+- **Do NOT create new PRs.** Push to the existing branch only.
+- **Do NOT attempt to merge the PR or push to main.**
+
+## What done looks like
+
+CI is green (or the only remaining failures are pre-existing / flaky and you've told the user about them). That's it.

--- a/.claude/skills/fix-issue/SKILL.md
+++ b/.claude/skills/fix-issue/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: fix-issue
+description: Fix a GitHub issue in NeMo Speech (NVIDIA-NeMo/NeMo). Read the issue, reproduce the bug with a failing test, implement the fix, and verify tests pass. Only opens a PR if the user explicitly asks for it.
+---
+
+# fix-issue
+
+Fix a GitHub issue in NeMo Speech from first principles: understand the bug, prove it with a test, and fix the root cause.
+
+The key discipline is **reproduce first, fix second**. Writing the failing test before touching the source code forces a precise understanding of what broken actually means, which keeps the fix focused and correct.
+
+## Inputs
+
+The issue number is the primary input. It may come from:
+- An explicit argument: `/fix-issue 1234`
+- The conversation context: "fix issue #1234"
+- A GitHub issue URL pasted into the chat
+
+If no issue number is clear, and the description provided is not good enough, ask for more details before proceeding.
+
+## Before starting
+
+Read the issue description carefully. Identify:
+- What is the reported failure (error message, wrong output, crash)?
+- Which collections in `nemo/collections` and components are affected?
+- Are there any repro steps already in the issue? If so, run them first.
+- Is there a linked PR or related issue that gives more context?
+
+## Workflow
+
+1. Read the issue: `gh issue view <ISSUE_NUMBER> --repo NVIDIA-NeMo/NeMo`
+2. Understand the bug — identify the relevant code
+3. Write a minimal reproduction test in `tests/` that demonstrates the failure
+4. Run the test to confirm it fails: `pytest <your_test_file> -v`
+5. Implement the fix in the source code
+6. Run the test again to confirm it now passes
+7. Run the broader test suite for the affected collection to check for regressions:
+   ```bash
+   pytest tests/collections/<collection>/ -m "not pleasefixme" -v --timeout=120
+   ```
+8. Tell the user the fix is ready and what was changed
+
+## Opening a PR
+
+Only create a branch and open a PR if the user explicitly asks for it. When they do:
+
+```bash
+git checkout -b fix/<ISSUE_NUMBER>-<short-description>
+git add <changed files>
+git commit -s -m "Fix <short-description> (closes #<ISSUE_NUMBER>)"
+git push origin fix/<ISSUE_NUMBER>-<short-description>
+gh pr create --repo NVIDIA-NeMo/NeMo \
+  --title "Fix <short-description>" \
+  --body "$(cat <<'EOF'
+# What does this PR do ?
+<one-line overview>
+
+# Changelog
+<line-by-line high-level changes>
+
+# Usage
+<usage example if behavior changed>
+
+Fixes #<ISSUE_NUMBER>
+EOF
+)"
+```
+
+Notes:
+- Add specific files by name — do not use `git add -A` or `git add .`.
+
+## Rules
+
+- **Reproduce first.** Do not attempt a fix without a failing test that demonstrates the bug.
+- **Do NOT open a PR unless the user asks.** The default is local-only: fix the code, verify it works, report back.
+- **Do NOT post comments on the GitHub issue.** Communicate with the user directly.
+- **Do NOT reformat files outside your changes.** The `Isort and Black Formatting` action handles formatting automatically.
+- **Never push to `main` directly.**
+- **Never attempt to merge the PR yourself.**

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: verify
+description: Run style checks and tests on changed files to verify code quality before committing.
+---
+
+Run verification on the current changes:
+
+1. **Find changed files**:
+   ```bash
+   git diff --name-only HEAD
+   ```
+   Also include any files you've been editing in this session.
+
+2. **Style check** on each changed Python file or its parent directory:
+   ```bash
+   python setup.py style --scope <path>
+   ```
+   If issues are found, fix them with `--fix` and report what changed.
+
+3. **Run relevant tests** based on which collection was modified:
+   - `nemo/collections/asr/` → `pytest tests/collections/asr -m "not pleasefixme" -v --timeout=300`
+   - `nemo/collections/tts/` → `pytest tests/collections/tts -m "not pleasefixme" -v --timeout=300`
+   - `nemo/collections/audio/` → `pytest tests/collections/audio -m "not pleasefixme" -v --timeout=300`
+   - `nemo/collections/speechlm2/` → `pytest tests/collections/speechlm2 -m "not pleasefixme" -v --timeout=300`
+   - `nemo/collections/common/` → `pytest tests/collections/common -m "not pleasefixme" -v --timeout=300`
+   - `nemo/core/` → `pytest tests/core -m "not pleasefixme" -v --timeout=300`
+
+4. **Report results**: summarize passes and failures. For failures, show relevant error output and suggest fixes.

--- a/.claude/skills/verify/SKILL.md
+++ b/.claude/skills/verify/SKILL.md
@@ -18,9 +18,9 @@ Run verification on the current changes:
    If issues are found, fix them with `--fix` and report what changed.
 
 3. **Run relevant tests** based on which collection was modified:
-   - `nemo/collections/asr/` → `pytest tests/collections/asr -m "not pleasefixme" -v --timeout=300`
-   - `nemo/collections/tts/` → `pytest tests/collections/tts -m "not pleasefixme" -v --timeout=300`
-   - `nemo/collections/audio/` → `pytest tests/collections/audio -m "not pleasefixme" -v --timeout=300`
+   - `nemo/collections/asr/` → `pytest tests/collections/asr --download -m "not pleasefixme" -v --timeout=300`
+   - `nemo/collections/tts/` → `pytest tests/collections/tts --download -m "not pleasefixme" -v --timeout=300`
+   - `nemo/collections/audio/` → `pytest tests/collections/audio --download -m "not pleasefixme" -v --timeout=300`
    - `nemo/collections/speechlm2/` → `pytest tests/collections/speechlm2 -m "not pleasefixme" -v --timeout=300`
    - `nemo/collections/common/` → `pytest tests/collections/common -m "not pleasefixme" -v --timeout=300`
    - `nemo/core/` → `pytest tests/core -m "not pleasefixme" -v --timeout=300`

--- a/.codex/skills
+++ b/.codex/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.cursor/skills
+++ b/.cursor/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/.github/workflows/claude-babysit-pr.yml
+++ b/.github/workflows/claude-babysit-pr.yml
@@ -1,9 +1,18 @@
-# PR Babysitter — half-autonomous CI fix loop with a human approval gate.
+# PR Babysitter — half-autonomous CI fix loop, speech_team-only.
 #
 # Master switch: the "Has Babysitter" label. Adding it activates, removing
 # it deactivates and cancels any in-flight work.
 #
-# Lifecycle:
+# Authorization model:
+#   - The entire workflow is restricted to the NVIDIA-NeMo/speech_team team.
+#     Every job that mutates state starts with a preflight that verifies the
+#     acting user (label sender / comment author / review author) is an active
+#     speech_team member. Non-members cause the job to post a refusal comment
+#     and revert the triggering label, leaving no misleading state behind.
+#   - The workflow never runs for PRs from forks. Every PR-scoped job
+#     fork-guards on head.repo.full_name == github.repository.
+#
+# Lifecycle (all participants must be speech_team members):
 #   1. "Has Babysitter" added  -> activate posts a takeover comment and adds
 #                                 "Run CICD" to start the pipeline.
 #   2. CI runs (CICD NeMo workflow).
@@ -12,16 +21,15 @@
 #                                 (formatting check skipped — the Isort+Black
 #                                 action auto-pushes its own fixes).
 #   4. investigate-and-propose: Claude investigates root cause, posts a *plan
-#      comment* on the PR, and adds "Agent Plan Awaiting Approval".
-#      **It does NOT push code.**
-#   5. The PR author approves via either:
-#        a) reply on the PR that mentions `@claude` and is affirmative
-#           -> evaluate-comment-approval classifies and, if approve,
-#              swaps "Agent Plan Awaiting Approval" for "Agent Plan Approved".
-#        b) 👍 reaction on Claude's plan comment
-#           -> poll-reaction-approvals (cron every 5 min) does the same swap.
-#   6. "Agent Plan Approved" added -> execute-fix reads the approved plan from
-#      the PR thread, pushes the fix, re-adds "Run CICD", and goes back to #2.
+#      comment* on the PR (tagged with `<!-- babysit-plan -->`), and adds
+#      "Agent Plan Awaiting Approval". It does NOT push code.
+#   5. The PR author (who must also be speech_team) approves by replying with a
+#      comment that mentions `@claude` affirmatively (e.g. `@claude go ahead`).
+#      evaluate-comment-approval classifies the reply via an LLM and, on APPROVE,
+#      swaps "Agent Plan Awaiting Approval" for "Agent Plan Approved".
+#   6. "Agent Plan Approved" added -> execute-fix verifies the sender is
+#      speech_team, verifies a bot-authored plan comment exists, then reads the
+#      plan, pushes the fix, re-adds "Run CICD", and goes back to #2.
 #
 # Termination:
 #   - "Has Babysitter" removed at any time -> deactivate cancels in-progress
@@ -47,8 +55,6 @@ on:
     types: [completed]
   issue_comment:
     types: [created]
-  schedule:
-    - cron: '*/5 * * * *'
 
 permissions:
   contents: write
@@ -63,13 +69,54 @@ jobs:
     if: >-
       github.event_name == 'pull_request' &&
       github.event.action == 'labeled' &&
-      github.event.label.name == 'Has Babysitter'
+      github.event.label.name == 'Has Babysitter' &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     concurrency:
       group: babysit-activate-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
+      # Preflight: only speech_team members may enable the babysitter. If a
+      # non-member adds the label, revert it and explain.
+      - name: Verify label sender is speech_team
+        id: authz
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.ORG_TEAM_READ_TOKEN }}
+          script: |
+            const username = context.payload.sender.login;
+            try {
+              const res = await github.rest.teams.getMembershipForUserInOrg({
+                org: 'NVIDIA-NeMo',
+                team_slug: 'speech_team',
+                username,
+              });
+              if (res.data.state !== 'active') {
+                core.setOutput('authorized', 'false');
+                return;
+              }
+              core.setOutput('authorized', 'true');
+            } catch (e) {
+              core.setOutput('authorized', 'false');
+            }
+
+      - name: Checkout for GH CLI
+        uses: actions/checkout@v6
+
+      - name: Refuse activation from non-speech_team sender
+        if: steps.authz.outputs.authorized != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body \
+            "@${SENDER} the PR Babysitter is restricted to the NVIDIA-NeMo \`speech_team\`. Removing the \`Has Babysitter\` label."
+          gh pr edit "$PR_NUMBER" --remove-label "Has Babysitter"
+          exit 0
+
       - name: Post takeover comment
+        if: steps.authz.outputs.authorized == 'true'
         uses: actions/github-script@v8
         with:
           script: |
@@ -80,10 +127,8 @@ jobs:
               body: "I'll monitor this PR until CI is green. I'll post a plan for any fix and wait for your approval before pushing anything. Ping me by removing 'Has Babysitter' to cancel."
             });
 
-      - name: Checkout for GH CLI
-        uses: actions/checkout@v6
-
       - name: Trigger CI
+        if: steps.authz.outputs.authorized == 'true'
         env:
           GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
@@ -93,12 +138,13 @@ jobs:
 
   authorize-review:
     if: >-
-      (github.event_name == 'pull_request_review_comment' &&
-       contains(github.event.comment.body, '@claude') &&
-       contains(github.event.pull_request.labels.*.name, 'Has Babysitter')) ||
-      (github.event_name == 'pull_request_review' &&
-       contains(github.event.review.body, '@claude') &&
-       contains(github.event.pull_request.labels.*.name, 'Has Babysitter'))
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      ((github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        contains(github.event.pull_request.labels.*.name, 'Has Babysitter')) ||
+       (github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        contains(github.event.pull_request.labels.*.name, 'Has Babysitter')))
     runs-on: ubuntu-latest
     steps:
       - name: Check team membership
@@ -185,16 +231,18 @@ jobs:
             const hasApproved = labels.includes('Agent Plan Approved');
             const failedSha = context.payload.check_run.head_sha;
             const isStale = pr.head.sha !== failedSha;
+            // Fork-guard: the babysitter never runs on PRs from forks.
+            const isFork = pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
             // Propose a new plan only if: babysitter is on, no plan is already
-            // in flight, and the failure isn't stale.
-            const shouldPropose = hasBabysitter && !hasPending && !hasApproved && !isStale;
+            // in flight, the failure isn't stale, and the PR is not from a fork.
+            const shouldPropose = hasBabysitter && !hasPending && !hasApproved && !isStale && !isFork;
             core.setOutput('pr_number', prNumber);
             core.setOutput('should_propose', shouldPropose ? 'true' : 'false');
             core.setOutput('head_ref', pr.head.ref);
             core.setOutput('head_sha', pr.head.sha);
             core.setOutput('author_login', pr.user.login);
             if (!shouldPropose) {
-              core.info(`Skipping investigate-and-propose: babysitter=${hasBabysitter}, pending=${hasPending}, approved=${hasApproved}, stale=${isStale}`);
+              core.info(`Skipping investigate-and-propose: babysitter=${hasBabysitter}, pending=${hasPending}, approved=${hasApproved}, stale=${isStale}, fork=${isFork}`);
             }
 
   investigate-and-propose:
@@ -236,9 +284,9 @@ jobs:
                <your analysis and proposed change>
 
                ---
-               To approve, either **reply with an affirmative comment that mentions `@claude`**
-               (e.g., `@claude go ahead`) or **react 👍 to this comment**. Remove the
-               `Has Babysitter` label to cancel.
+               To approve, **reply with an affirmative comment that mentions `@claude`**
+               (e.g., `@claude go ahead`). Approval is restricted to the PR author.
+               Remove the `Has Babysitter` label to cancel.
 
                <!-- babysit-plan -->
 
@@ -284,9 +332,60 @@ jobs:
       group: babysit-fix-${{ github.event.issue.number }}
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v6
+      # Preflight: the commenter is the PR author (enforced by `if:`) AND must
+      # be an active speech_team member. Also fork-guard by fetching the PR.
+      - name: Verify commenter is speech_team and PR is not a fork
+        id: authz
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.ORG_TEAM_READ_TOKEN }}
+          script: |
+            const prNumber = context.payload.issue.number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const isFork = pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`;
+            if (isFork) {
+              core.info(`PR #${prNumber} is a fork; babysitter does not operate on forks.`);
+              core.setOutput('authorized', 'false');
+              core.setOutput('reason', 'fork');
+              return;
+            }
+            const username = context.payload.comment.user.login;
+            try {
+              const res = await github.rest.teams.getMembershipForUserInOrg({
+                org: 'NVIDIA-NeMo',
+                team_slug: 'speech_team',
+                username,
+              });
+              if (res.data.state !== 'active') {
+                core.setOutput('authorized', 'false');
+                core.setOutput('reason', 'not-speech-team');
+                return;
+              }
+              core.setOutput('authorized', 'true');
+            } catch (e) {
+              core.setOutput('authorized', 'false');
+              core.setOutput('reason', 'not-speech-team');
+            }
+
+      - name: Checkout for GH CLI
+        uses: actions/checkout@v6
+
+      - name: Refuse non-speech_team approval
+        if: steps.authz.outputs.authorized != 'true' && steps.authz.outputs.reason == 'not-speech-team'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          SENDER: ${{ github.event.comment.user.login }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body \
+            "@${SENDER} only NVIDIA-NeMo \`speech_team\` members can approve the babysitter's plan. Ignoring this reply."
 
       - uses: anthropics/claude-code-action@v1
+        if: steps.authz.outputs.authorized == 'true'
         env:
           GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
@@ -319,68 +418,6 @@ jobs:
             5. Do not push any code. Do not edit files in the repository.
           claude_args: "--max-turns 8 --model claude-sonnet-4-6"
 
-  # ---- Approval Path B: 👍 reaction from PR author (scheduled poll) ----
-
-  poll-reaction-approvals:
-    if: github.event_name == 'schedule'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Find PRs with 👍 approval from author
-        id: find
-        uses: actions/github-script@v8
-        with:
-          script: |
-            const { data: issues } = await github.rest.issues.listForRepo({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'open',
-              labels: 'Has Babysitter,Agent Plan Awaiting Approval',
-              per_page: 50,
-            });
-            const approved = [];
-            for (const issue of issues) {
-              if (!issue.pull_request) continue;
-              const prNumber = issue.number;
-              const authorLogin = issue.user.login;
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                per_page: 100,
-              });
-              const planComment = [...comments].reverse().find(c => c.body.includes('<!-- babysit-plan -->'));
-              if (!planComment) {
-                core.info(`PR #${prNumber}: no plan comment`);
-                continue;
-              }
-              const reactions = await github.paginate(github.rest.reactions.listForIssueComment, {
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: planComment.id,
-                per_page: 100,
-              });
-              if (reactions.some(r => r.content === '+1' && r.user.login === authorLogin)) {
-                approved.push(prNumber);
-                core.info(`PR #${prNumber}: +1 from @${authorLogin} detected`);
-              }
-            }
-            core.setOutput('approved_prs', JSON.stringify(approved));
-
-      - name: Checkout for GH CLI
-        if: steps.find.outputs.approved_prs != '[]'
-        uses: actions/checkout@v6
-
-      - name: Swap labels for approved PRs
-        if: steps.find.outputs.approved_prs != '[]'
-        env:
-          GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
-          APPROVED_PRS: ${{ steps.find.outputs.approved_prs }}
-        run: |
-          echo "$APPROVED_PRS" | jq -r '.[]' | while read -r pr; do
-            echo "Approving PR #$pr"
-            gh pr edit "$pr" --remove-label "Agent Plan Awaiting Approval" --add-label "Agent Plan Approved"
-          done
-
   # ---- Execute the approved plan (the only job allowed to push code) ----
 
   execute-fix:
@@ -388,21 +425,92 @@ jobs:
       github.event_name == 'pull_request' &&
       github.event.action == 'labeled' &&
       github.event.label.name == 'Agent Plan Approved' &&
-      contains(github.event.pull_request.labels.*.name, 'Has Babysitter')
+      contains(github.event.pull_request.labels.*.name, 'Has Babysitter') &&
+      github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     concurrency:
       group: babysit-fix-${{ github.event.pull_request.number }}
       cancel-in-progress: true
     steps:
+      # Preflight 1: the sender (who added `Agent Plan Approved`) must be
+      # speech_team. Defense-in-depth against a non-member adding the label.
+      - name: Verify label sender is speech_team
+        id: authz
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.ORG_TEAM_READ_TOKEN }}
+          script: |
+            const username = context.payload.sender.login;
+            try {
+              const res = await github.rest.teams.getMembershipForUserInOrg({
+                org: 'NVIDIA-NeMo',
+                team_slug: 'speech_team',
+                username,
+              });
+              core.setOutput('authorized', res.data.state === 'active' ? 'true' : 'false');
+            } catch (e) {
+              core.setOutput('authorized', 'false');
+            }
+
+      # Preflight 2: there must exist a bot-authored `<!-- babysit-plan -->`
+      # comment on this PR. Prevents execution when someone adds the approved
+      # label manually without an investigator-posted plan.
+      - name: Verify a bot-authored plan comment exists
+        id: plan
+        if: steps.authz.outputs.authorized == 'true'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              per_page: 100,
+            });
+            const planComment = [...comments].reverse().find(c =>
+              c.body.includes('<!-- babysit-plan -->') && c.user && c.user.type === 'Bot'
+            );
+            core.setOutput('found', planComment ? 'true' : 'false');
+
+      - name: Checkout for GH CLI (refusal paths)
+        if: steps.authz.outputs.authorized != 'true' || steps.plan.outputs.found != 'true'
+        uses: actions/checkout@v6
+
+      - name: Refuse execution from non-speech_team sender
+        if: steps.authz.outputs.authorized != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body \
+            "@${SENDER} only NVIDIA-NeMo \`speech_team\` members can approve the babysitter's plan. Removing the \`Agent Plan Approved\` label."
+          gh pr edit "$PR_NUMBER" --remove-label "Agent Plan Approved" || true
+          exit 0
+
+      - name: Refuse execution without a plan comment
+        if: steps.authz.outputs.authorized == 'true' && steps.plan.outputs.found != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --body \
+            "No approved plan found for execution. Remove \`Agent Plan Approved\` and wait for the investigator to post a plan first."
+          gh pr edit "$PR_NUMBER" --remove-label "Agent Plan Approved" || true
+          exit 0
+
       - uses: actions/checkout@v6
+        if: steps.authz.outputs.authorized == 'true' && steps.plan.outputs.found == 'true'
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Record starting SHA
         id: start
+        if: steps.authz.outputs.authorized == 'true' && steps.plan.outputs.found == 'true'
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - uses: anthropics/claude-code-action@v1
+        if: steps.authz.outputs.authorized == 'true' && steps.plan.outputs.found == 'true'
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
@@ -422,6 +530,7 @@ jobs:
           claude_args: "--max-turns 10 --model claude-sonnet-4-6"
 
       - name: Re-trigger CI or stop loop
+        if: steps.authz.outputs.authorized == 'true' && steps.plan.outputs.found == 'true'
         env:
           GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/claude-babysit-pr.yml
+++ b/.github/workflows/claude-babysit-pr.yml
@@ -46,6 +46,9 @@ jobs:
       github.event.action == 'labeled' &&
       github.event.label.name == 'Has Babysitter'
     runs-on: ubuntu-latest
+    concurrency:
+      group: babysit-activate-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     steps:
       - name: Post takeover comment
         uses: actions/github-script@v8
@@ -55,7 +58,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: "I'm taking over this PR. I'll ping the author if I can't figure it out."
+              body: "I'll monitor and fix this PR until the CI is green. I'll ping the author if I can't figure it out."
             });
 
       - name: Checkout for GH CLI

--- a/.github/workflows/claude-babysit-pr.yml
+++ b/.github/workflows/claude-babysit-pr.yml
@@ -1,0 +1,272 @@
+# PR Babysitter — stateful CI fix loop driven by the "Has Babysitter" label.
+#
+# Lifecycle:
+#   1. Someone adds "Has Babysitter" to a PR
+#   2. activate job posts a takeover comment and adds "Run CICD" to start CI
+#   3. CI runs (CICD NeMo workflow)
+#   4. If all checks pass  -> babysitter stays quiet, done
+#      If a check fails    -> check_run event triggers fix-ci-failure
+#      (unless it's black+isort, fixed by another action)
+#   5. Claude inspects ALL failing checks, pushes a fix, then re-adds "Run CICD"
+#      -> back to step 3 (the loop)
+#   6. If Claude cannot fix -> it @-mentions the author and removes "Has Babysitter"
+#      If the job crashes   -> ping-author-on-failure does the same
+#   7. Removing "Has Babysitter" at any time deactivates the babysitter and
+#      cancels any in-progress fix via a shared concurrency group.
+#
+# Additionally, anyone can @claude in a PR review comment on a babysitter-enabled
+# PR to ask questions or request changes (gated by speech_team membership).
+#
+# Required secrets: ANTHROPIC_API_KEY, ORG_TEAM_READ_TOKEN, NEMO_RELABEL_TOKEN
+
+name: Claude Code — PR Babysitter
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  check_run:
+    types: [completed]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  # ---- Activation: one-time setup when "Has Babysitter" is added ----
+
+  activate:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'Has Babysitter'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post takeover comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: "I'm taking over this PR. I'll ping the author if I can't figure it out."
+            });
+
+      - name: Checkout for GH CLI
+        uses: actions/checkout@v6
+
+      - name: Trigger CI
+        env:
+          GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: gh pr edit "$PR_NUMBER" --add-label "Run CICD"
+
+  # ---- Path A: Respond to @claude mentions in PR reviews ----
+
+  authorize-review:
+    if: >-
+      (github.event_name == 'pull_request_review_comment' &&
+       contains(github.event.comment.body, '@claude') &&
+       contains(github.event.pull_request.labels.*.name, 'Has Babysitter')) ||
+      (github.event_name == 'pull_request_review' &&
+       contains(github.event.review.body, '@claude') &&
+       contains(github.event.pull_request.labels.*.name, 'Has Babysitter'))
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check team membership
+        uses: actions/github-script@v8
+        with:
+          github-token: ${{ secrets.ORG_TEAM_READ_TOKEN }}
+          script: |
+            const username =
+              context.payload.comment?.user?.login ||
+              context.payload.review?.user?.login;
+            try {
+              const res = await github.rest.teams.getMembershipForUserInOrg({
+                org: 'NVIDIA-NeMo',
+                team_slug: 'speech_team',
+                username,
+              });
+              if (res.data.state !== 'active') {
+                core.setFailed(`${username} is not an active member of NVIDIA Speech Team`);
+              }
+            } catch (e) {
+              core.setFailed(`${username} is not a member of NVIDIA Speech Team`);
+            }
+
+  acknowledge-review:
+    needs: authorize-review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add eyes reaction
+        uses: actions/github-script@v8
+        with:
+          script: |
+            if (context.payload.comment) {
+              await github.rest.reactions.createForPullRequestReviewComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: context.payload.comment.id,
+                content: 'eyes'
+              });
+            }
+
+  respond-to-review:
+    needs: acknowledge-review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # No prompt — Claude reads the @claude mention and responds in context
+          claude_args: "--max-turns 15 --model claude-sonnet-4-6"
+
+  # ---- Path B: Auto-fix CI failures (the retry loop) ----
+
+  check-label-for-ci:
+    # Skip formatting checks — the "Isort and Black Formatting" action auto-pushes fixes.
+    if: >-
+      github.event_name == 'check_run' &&
+      github.event.check_run.conclusion == 'failure' &&
+      github.event.check_run.pull_requests[0] != null &&
+      !contains(github.event.check_run.name, 'reformat_with_isort_and_black')
+    runs-on: ubuntu-latest
+    outputs:
+      pr_number: ${{ steps.lookup.outputs.pr_number }}
+      has_label: ${{ steps.lookup.outputs.has_label }}
+      head_ref: ${{ steps.lookup.outputs.head_ref }}
+      head_sha: ${{ steps.lookup.outputs.head_sha }}
+      author_login: ${{ steps.lookup.outputs.author_login }}
+    steps:
+      - name: Look up PR and check for Has Babysitter label
+        id: lookup
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const prNumber = context.payload.check_run.pull_requests[0].number;
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            const hasLabel = pr.labels.some(l => l.name === 'Has Babysitter');
+            // Skip stale failures: if the PR head has moved past this check_run's
+            // commit, a fix was already pushed and this failure is outdated.
+            const failedSha = context.payload.check_run.head_sha;
+            const isStale = pr.head.sha !== failedSha;
+            core.setOutput('pr_number', prNumber);
+            core.setOutput('has_label', (hasLabel && !isStale) ? 'true' : 'false');
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('author_login', pr.user.login);
+            if (isStale) {
+              core.info(`Skipping stale failure: check_run SHA ${failedSha} != PR head ${pr.head.sha}`);
+            }
+
+  fix-ci-failure:
+    needs: check-label-for-ci
+    if: needs.check-label-for-ci.outputs.has_label == 'true'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: babysit-fix-${{ needs.check-label-for-ci.outputs.pr_number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.check-label-for-ci.outputs.head_ref }}
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            The CI check "${{ github.event.check_run.name }}" just failed on this PR.
+
+            Instructions:
+            1. Inspect the failure logs for ALL currently failing CI checks on this
+               PR, not just the one named above.
+            2. Check `git log` for recent commits — if you see a previous babysitter
+               fix attempt that addressed the same failure and it is still failing,
+               do NOT retry. Instead, post a comment on the PR mentioning
+               @${{ needs.check-label-for-ci.outputs.author_login }} explaining what
+               you tried and that the issue needs human attention.
+            3. Otherwise, identify the root cause, fix the code, and push to the
+               same branch. Do not create a new PR.
+            4. If you are unable to fix the issue for any reason, post a comment on
+               the PR mentioning @${{ needs.check-label-for-ci.outputs.author_login }}
+               explaining what you found and asking for help.
+          claude_args: "--max-turns 10 --model claude-sonnet-4-6"
+
+      - name: Re-trigger CI or stop loop
+        env:
+          GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
+          PR_NUMBER: ${{ needs.check-label-for-ci.outputs.pr_number }}
+          ORIGINAL_SHA: ${{ needs.check-label-for-ci.outputs.head_sha }}
+        run: |
+          NEW_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q '.headRefOid')
+          if [ "$NEW_SHA" != "$ORIGINAL_SHA" ]; then
+            echo "Fix was pushed (SHA changed), re-triggering CI"
+            gh pr edit "$PR_NUMBER" --add-label "Run CICD"
+          else
+            echo "No fix was pushed (SHA unchanged), removing babysitter label"
+            gh pr edit "$PR_NUMBER" --remove-label "Has Babysitter"
+          fi
+
+  ping-author-on-failure:
+    needs: [check-label-for-ci, fix-ci-failure]
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping PR author
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: parseInt(process.env.PR_NUMBER, 10),
+              body: `I wasn't able to fix the CI failure in \`${process.env.CHECK_NAME}\`. @${process.env.AUTHOR_LOGIN}, could you take a look?`
+            });
+        env:
+          PR_NUMBER: ${{ needs.check-label-for-ci.outputs.pr_number }}
+          CHECK_NAME: ${{ github.event.check_run.name }}
+          AUTHOR_LOGIN: ${{ needs.check-label-for-ci.outputs.author_login }}
+
+      - name: Checkout for GH CLI
+        uses: actions/checkout@v6
+
+      - name: Remove babysitter label to stop the loop
+        env:
+          GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
+          PR_NUMBER: ${{ needs.check-label-for-ci.outputs.pr_number }}
+        run: gh pr edit "$PR_NUMBER" --remove-label "Has Babysitter"
+
+  # ---- Deactivation: cancel in-progress fixes and notify ----
+
+  deactivate:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'unlabeled' &&
+      github.event.label.name == 'Has Babysitter'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: babysit-fix-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Post deactivation comment
+        uses: actions/github-script@v8
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: "Babysitter deactivated for this PR."
+            });

--- a/.github/workflows/claude-babysit-pr.yml
+++ b/.github/workflows/claude-babysit-pr.yml
@@ -1,21 +1,36 @@
-# PR Babysitter — stateful CI fix loop driven by the "Has Babysitter" label.
+# PR Babysitter — half-autonomous CI fix loop with a human approval gate.
+#
+# Master switch: the "Has Babysitter" label. Adding it activates, removing
+# it deactivates and cancels any in-flight work.
 #
 # Lifecycle:
-#   1. Someone adds "Has Babysitter" to a PR
-#   2. activate job posts a takeover comment and adds "Run CICD" to start CI
-#   3. CI runs (CICD NeMo workflow)
-#   4. If all checks pass  -> babysitter stays quiet, done
-#      If a check fails    -> check_run event triggers fix-ci-failure
-#      (unless it's black+isort, fixed by another action)
-#   5. Claude inspects ALL failing checks, pushes a fix, then re-adds "Run CICD"
-#      -> back to step 3 (the loop)
-#   6. If Claude cannot fix -> it @-mentions the author and removes "Has Babysitter"
-#      If the job crashes   -> ping-author-on-failure does the same
-#   7. Removing "Has Babysitter" at any time deactivates the babysitter and
-#      cancels any in-progress fix via a shared concurrency group.
+#   1. "Has Babysitter" added  -> activate posts a takeover comment and adds
+#                                 "Run CICD" to start the pipeline.
+#   2. CI runs (CICD NeMo workflow).
+#   3. If all checks pass      -> babysitter stays silent, done.
+#      If a check fails        -> check_run event triggers investigate-and-propose
+#                                 (formatting check skipped — the Isort+Black
+#                                 action auto-pushes its own fixes).
+#   4. investigate-and-propose: Claude investigates root cause, posts a *plan
+#      comment* on the PR, and adds "Agent Plan Awaiting Approval".
+#      **It does NOT push code.**
+#   5. The PR author approves via either:
+#        a) reply on the PR that mentions `@claude` and is affirmative
+#           -> evaluate-comment-approval classifies and, if approve,
+#              swaps "Agent Plan Awaiting Approval" for "Agent Plan Approved".
+#        b) 👍 reaction on Claude's plan comment
+#           -> poll-reaction-approvals (cron every 5 min) does the same swap.
+#   6. "Agent Plan Approved" added -> execute-fix reads the approved plan from
+#      the PR thread, pushes the fix, re-adds "Run CICD", and goes back to #2.
 #
-# Additionally, anyone can @claude in a PR review comment on a babysitter-enabled
-# PR to ask questions or request changes (gated by speech_team membership).
+# Termination:
+#   - "Has Babysitter" removed at any time -> deactivate cancels in-progress
+#     work via a shared concurrency group and clears plan-state labels.
+#   - Claude can't investigate or can't execute -> ping-author-on-failure pings
+#     the author and clears labels.
+#
+# Additionally, speech_team members can @claude in a PR review comment on a
+# babysitter-enabled PR to ask questions or request changes.
 #
 # Required secrets: ANTHROPIC_API_KEY, ORG_TEAM_READ_TOKEN, NEMO_RELABEL_TOKEN
 
@@ -30,6 +45,10 @@ on:
     types: [submitted]
   check_run:
     types: [completed]
+  issue_comment:
+    types: [created]
+  schedule:
+    - cron: '*/5 * * * *'
 
 permissions:
   contents: write
@@ -58,7 +77,7 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              body: "I'll monitor and fix this PR until the CI is green. I'll ping the author if I can't figure it out."
+              body: "I'll monitor this PR until CI is green. I'll post a plan for any fix and wait for your approval before pushing anything. Ping me by removing 'Has Babysitter' to cancel."
             });
 
       - name: Checkout for GH CLI
@@ -70,7 +89,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: gh pr edit "$PR_NUMBER" --add-label "Run CICD"
 
-  # ---- Path A: Respond to @claude mentions in PR reviews ----
+  # ---- @claude mentions in PR reviews (speech_team only) ----
 
   authorize-review:
     if: >-
@@ -132,7 +151,7 @@ jobs:
           # No prompt — Claude reads the @claude mention and responds in context
           claude_args: "--max-turns 15 --model claude-sonnet-4-6"
 
-  # ---- Path B: Auto-fix CI failures (the retry loop) ----
+  # ---- CI failure: investigate, propose a plan, DO NOT push ----
 
   check-label-for-ci:
     # Skip formatting checks — the "Isort and Black Formatting" action auto-pushes fixes.
@@ -144,12 +163,12 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       pr_number: ${{ steps.lookup.outputs.pr_number }}
-      has_label: ${{ steps.lookup.outputs.has_label }}
+      should_propose: ${{ steps.lookup.outputs.should_propose }}
       head_ref: ${{ steps.lookup.outputs.head_ref }}
       head_sha: ${{ steps.lookup.outputs.head_sha }}
       author_login: ${{ steps.lookup.outputs.author_login }}
     steps:
-      - name: Look up PR and check for Has Babysitter label
+      - name: Look up PR and assess state
         id: lookup
         uses: actions/github-script@v8
         with:
@@ -160,23 +179,27 @@ jobs:
               repo: context.repo.repo,
               pull_number: prNumber,
             });
-            const hasLabel = pr.labels.some(l => l.name === 'Has Babysitter');
-            // Skip stale failures: if the PR head has moved past this check_run's
-            // commit, a fix was already pushed and this failure is outdated.
+            const labels = pr.labels.map(l => l.name);
+            const hasBabysitter = labels.includes('Has Babysitter');
+            const hasPending = labels.includes('Agent Plan Awaiting Approval');
+            const hasApproved = labels.includes('Agent Plan Approved');
             const failedSha = context.payload.check_run.head_sha;
             const isStale = pr.head.sha !== failedSha;
+            // Propose a new plan only if: babysitter is on, no plan is already
+            // in flight, and the failure isn't stale.
+            const shouldPropose = hasBabysitter && !hasPending && !hasApproved && !isStale;
             core.setOutput('pr_number', prNumber);
-            core.setOutput('has_label', (hasLabel && !isStale) ? 'true' : 'false');
+            core.setOutput('should_propose', shouldPropose ? 'true' : 'false');
             core.setOutput('head_ref', pr.head.ref);
             core.setOutput('head_sha', pr.head.sha);
             core.setOutput('author_login', pr.user.login);
-            if (isStale) {
-              core.info(`Skipping stale failure: check_run SHA ${failedSha} != PR head ${pr.head.sha}`);
+            if (!shouldPropose) {
+              core.info(`Skipping investigate-and-propose: babysitter=${hasBabysitter}, pending=${hasPending}, approved=${hasApproved}, stale=${isStale}`);
             }
 
-  fix-ci-failure:
+  investigate-and-propose:
     needs: check-label-for-ci
-    if: needs.check-label-for-ci.outputs.has_label == 'true'
+    if: needs.check-label-for-ci.outputs.should_propose == 'true'
     runs-on: ubuntu-latest
     concurrency:
       group: babysit-fix-${{ needs.check-label-for-ci.outputs.pr_number }}
@@ -190,68 +213,266 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            The CI check "${{ github.event.check_run.name }}" just failed on this PR.
+            The CI check "${{ github.event.check_run.name }}" just failed on
+            PR #${{ needs.check-label-for-ci.outputs.pr_number }}.
+
+            You are in HALF-AUTONOMOUS mode. You MUST NOT edit files, commit,
+            or push code in this job. Investigation and planning only.
 
             Instructions:
-            1. Inspect the failure logs for ALL currently failing CI checks on this
-               PR, not just the one named above.
-            2. Check `git log` for recent commits — if you see a previous babysitter
-               fix attempt that addressed the same failure and it is still failing,
-               do NOT retry. Instead, post a comment on the PR mentioning
-               @${{ needs.check-label-for-ci.outputs.author_login }} explaining what
-               you tried and that the issue needs human attention.
-            3. Otherwise, identify the root cause, fix the code, and push to the
-               same branch. Do not create a new PR.
-            4. If you are unable to fix the issue for any reason, post a comment on
-               the PR mentioning @${{ needs.check-label-for-ci.outputs.author_login }}
-               explaining what you found and asking for help.
+            1. Inspect the failure logs for ALL currently failing CI checks on
+               this PR, not just the one named above.
+            2. Check `git log` for recent commits — if a prior babysitter plan
+               already tried the same approach and it's still failing, call
+               that out in your plan so the author can reconsider.
+            3. Identify the root cause and draft a concrete fix plan covering:
+               - What's broken and why
+               - Which files/lines you'd change
+               - The minimal diff you'd apply
+            4. Post a SINGLE PR comment with this exact structure:
+
+               **CI Fix Plan** — awaiting approval from @${{ needs.check-label-for-ci.outputs.author_login }}
+
+               <your analysis and proposed change>
+
+               ---
+               To approve, either **reply with an affirmative comment that mentions `@claude`**
+               (e.g., `@claude go ahead`) or **react 👍 to this comment**. Remove the
+               `Has Babysitter` label to cancel.
+
+               <!-- babysit-plan -->
+
+               The `<!-- babysit-plan -->` marker MUST be the last line — later
+               jobs use it to find the approved plan.
+            5. If you conclude the issue cannot be fixed from this PR alone,
+               DO NOT include the `<!-- babysit-plan -->` marker. Instead post
+               a comment that mentions @${{ needs.check-label-for-ci.outputs.author_login }}
+               describing what you found and asking for help.
+          claude_args: "--max-turns 10 --model claude-sonnet-4-6"
+
+      - name: Mark plan awaiting approval (or stop if Claude gave up)
+        env:
+          GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
+          PR_NUMBER: ${{ needs.check-label-for-ci.outputs.pr_number }}
+          REPO: ${{ github.repository }}
+        run: |
+          # Detect whether Claude actually posted a plan comment.
+          PLAN_COUNT=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
+            --jq '[.[] | select(.body | contains("<!-- babysit-plan -->"))] | length')
+          if [ "$PLAN_COUNT" -gt 0 ]; then
+            echo "Plan comment posted; adding 'Agent Plan Awaiting Approval'"
+            gh pr edit "$PR_NUMBER" --add-label "Agent Plan Awaiting Approval"
+          else
+            echo "No plan posted; Claude decided it couldn't fix. Disabling babysitter."
+            gh pr edit "$PR_NUMBER" --remove-label "Has Babysitter"
+          fi
+
+  # ---- Approval Path A: affirmative comment from PR author mentioning @claude ----
+
+  evaluate-comment-approval:
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
+      github.event.issue.pull_request != null &&
+      contains(github.event.issue.labels.*.name, 'Has Babysitter') &&
+      contains(github.event.issue.labels.*.name, 'Agent Plan Awaiting Approval') &&
+      github.event.comment.user.type != 'Bot' &&
+      github.event.comment.user.login == github.event.issue.user.login &&
+      contains(github.event.comment.body, '@claude')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: babysit-fix-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: anthropics/claude-code-action@v1
+        env:
+          GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            Decide whether the PR author has approved the fix plan, then act.
+
+            Context:
+            - PR #${{ github.event.issue.number }} has label "Agent Plan Awaiting Approval".
+            - The PR author (@${{ github.event.issue.user.login }}) just posted a reply.
+            - The approved plan is a previous PR comment containing `<!-- babysit-plan -->`.
+
+            Steps:
+            1. Read the latest `<!-- babysit-plan -->` comment on the PR for the plan.
+            2. Read the PR author's reply (use `gh api repos/${{ github.repository }}/issues/comments/${{ github.event.comment.id }}`).
+            3. Classify the reply as exactly one of:
+               - APPROVE: the author clearly agrees to proceed with the plan.
+               - REJECT: the author clearly disagrees or wants changes.
+               - NEITHER: the reply is a question, side remark, or ambiguous.
+            4. Take action:
+               - APPROVE: run exactly
+                 `gh pr edit $PR_NUMBER --remove-label "Agent Plan Awaiting Approval" --add-label "Agent Plan Approved"`
+                 and do nothing else.
+               - REJECT: post a short PR comment acknowledging the rejection
+                 and suggesting they either remove `Has Babysitter` to cancel
+                 or reply with a new direction. Do NOT change labels.
+               - NEITHER: post a short PR comment asking for an explicit
+                 approve/reject. Do NOT change labels.
+            5. Do not push any code. Do not edit files in the repository.
+          claude_args: "--max-turns 8 --model claude-sonnet-4-6"
+
+  # ---- Approval Path B: 👍 reaction from PR author (scheduled poll) ----
+
+  poll-reaction-approvals:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find PRs with 👍 approval from author
+        id: find
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+              labels: 'Has Babysitter,Agent Plan Awaiting Approval',
+              per_page: 50,
+            });
+            const approved = [];
+            for (const issue of issues) {
+              if (!issue.pull_request) continue;
+              const prNumber = issue.number;
+              const authorLogin = issue.user.login;
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                per_page: 100,
+              });
+              const planComment = [...comments].reverse().find(c => c.body.includes('<!-- babysit-plan -->'));
+              if (!planComment) {
+                core.info(`PR #${prNumber}: no plan comment`);
+                continue;
+              }
+              const reactions = await github.paginate(github.rest.reactions.listForIssueComment, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: planComment.id,
+                per_page: 100,
+              });
+              if (reactions.some(r => r.content === '+1' && r.user.login === authorLogin)) {
+                approved.push(prNumber);
+                core.info(`PR #${prNumber}: +1 from @${authorLogin} detected`);
+              }
+            }
+            core.setOutput('approved_prs', JSON.stringify(approved));
+
+      - name: Checkout for GH CLI
+        if: steps.find.outputs.approved_prs != '[]'
+        uses: actions/checkout@v6
+
+      - name: Swap labels for approved PRs
+        if: steps.find.outputs.approved_prs != '[]'
+        env:
+          GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
+          APPROVED_PRS: ${{ steps.find.outputs.approved_prs }}
+        run: |
+          echo "$APPROVED_PRS" | jq -r '.[]' | while read -r pr; do
+            echo "Approving PR #$pr"
+            gh pr edit "$pr" --remove-label "Agent Plan Awaiting Approval" --add-label "Agent Plan Approved"
+          done
+
+  # ---- Execute the approved plan (the only job allowed to push code) ----
+
+  execute-fix:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'Agent Plan Approved' &&
+      contains(github.event.pull_request.labels.*.name, 'Has Babysitter')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: babysit-fix-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Record starting SHA
+        id: start
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          prompt: |
+            The PR author has approved your previously posted fix plan. Execute it now.
+
+            Instructions:
+            1. Read the PR comment thread and find the most recent comment
+               containing the marker `<!-- babysit-plan -->`. That is the
+               approved plan.
+            2. Implement exactly what the plan described. Do not expand scope.
+               Do not refactor code outside the plan.
+            3. Commit with DCO sign-off and push to the same branch.
+            4. If the plan is no longer applicable (e.g., merge conflicts, the
+               code has moved on, the reproduction no longer triggers the bug):
+               post a PR comment mentioning @${{ github.event.pull_request.user.login }}
+               explaining what changed and DO NOT push.
           claude_args: "--max-turns 10 --model claude-sonnet-4-6"
 
       - name: Re-trigger CI or stop loop
         env:
           GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
-          PR_NUMBER: ${{ needs.check-label-for-ci.outputs.pr_number }}
-          ORIGINAL_SHA: ${{ needs.check-label-for-ci.outputs.head_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ORIGINAL_SHA: ${{ steps.start.outputs.sha }}
         run: |
+          # Clear "Agent Plan Approved" so the next iteration can re-use it.
+          gh pr edit "$PR_NUMBER" --remove-label "Agent Plan Approved" || true
           NEW_SHA=$(gh pr view "$PR_NUMBER" --json headRefOid -q '.headRefOid')
           if [ "$NEW_SHA" != "$ORIGINAL_SHA" ]; then
-            echo "Fix was pushed (SHA changed), re-triggering CI"
+            echo "Fix pushed (SHA changed); re-triggering CI"
             gh pr edit "$PR_NUMBER" --add-label "Run CICD"
           else
-            echo "No fix was pushed (SHA unchanged), removing babysitter label"
+            echo "No fix pushed; disabling babysitter"
             gh pr edit "$PR_NUMBER" --remove-label "Has Babysitter"
           fi
 
+  # ---- Safety net: ping author and clear state if investigate-and-propose crashes ----
+
   ping-author-on-failure:
-    needs: [check-label-for-ci, fix-ci-failure]
-    if: failure()
+    needs: [check-label-for-ci, investigate-and-propose]
+    if: failure() && needs.check-label-for-ci.outputs.should_propose == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Ping PR author
         uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ needs.check-label-for-ci.outputs.pr_number }}
+          CHECK_NAME: ${{ github.event.check_run.name }}
+          AUTHOR_LOGIN: ${{ needs.check-label-for-ci.outputs.author_login }}
         with:
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: parseInt(process.env.PR_NUMBER, 10),
-              body: `I wasn't able to fix the CI failure in \`${process.env.CHECK_NAME}\`. @${process.env.AUTHOR_LOGIN}, could you take a look?`
+              body: `I wasn't able to investigate the CI failure in \`${process.env.CHECK_NAME}\`. @${process.env.AUTHOR_LOGIN}, could you take a look?`
             });
-        env:
-          PR_NUMBER: ${{ needs.check-label-for-ci.outputs.pr_number }}
-          CHECK_NAME: ${{ github.event.check_run.name }}
-          AUTHOR_LOGIN: ${{ needs.check-label-for-ci.outputs.author_login }}
 
       - name: Checkout for GH CLI
         uses: actions/checkout@v6
 
-      - name: Remove babysitter label to stop the loop
+      - name: Clear all babysitter labels
         env:
           GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
           PR_NUMBER: ${{ needs.check-label-for-ci.outputs.pr_number }}
-        run: gh pr edit "$PR_NUMBER" --remove-label "Has Babysitter"
+        run: |
+          gh pr edit "$PR_NUMBER" --remove-label "Has Babysitter" || true
+          gh pr edit "$PR_NUMBER" --remove-label "Agent Plan Awaiting Approval" || true
+          gh pr edit "$PR_NUMBER" --remove-label "Agent Plan Approved" || true
 
-  # ---- Deactivation: cancel in-progress fixes and notify ----
+  # ---- Deactivation: cancel in-progress fixes and clear state ----
 
   deactivate:
     if: >-
@@ -273,3 +494,14 @@ jobs:
               issue_number: context.payload.pull_request.number,
               body: "Babysitter deactivated for this PR."
             });
+
+      - name: Checkout for GH CLI
+        uses: actions/checkout@v6
+
+      - name: Clear plan-state labels
+        env:
+          GH_TOKEN: ${{ secrets.NEMO_RELABEL_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          gh pr edit "$PR_NUMBER" --remove-label "Agent Plan Awaiting Approval" || true
+          gh pr edit "$PR_NUMBER" --remove-label "Agent Plan Approved" || true

--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,6 @@ node_modules/
 bot_server.*
 audio_logs/
 eval_results/
+
+# agents
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,97 @@
+# CLAUDE.md / AGENTS.md
+
+This file provides guidance when working with code in this repository.
+
+## Project Overview
+
+NeMo Speech — toolkit for training/deploying speech models (ASR, TTS, Speech LLM). Active collections: `asr`, `tts`, `audio`, `speechlm2`, `common`. No Megatron / Megatron Core / Transformer Engine — parallelism is PyTorch-native (DDP, FSDP2, TP/SP via DTensor).
+
+## Build & Install
+
+```bash
+pip install -e '.[all]'       # Full dev install
+pip install -e '.[asr]'       # ASR only
+pip install -e '.[test]'      # With test deps
+```
+
+Requires Python 3.10+, PyTorch 2.6+.
+
+## Code Style
+
+- **Line length: 119** (not default 88) — consistent across black, isort, flake8
+- Black with `skip_string_normalization = true`
+- isort with `profile = black`
+- Check: `python setup.py style --scope <path>`
+- Fix: `python setup.py style --scope <path> --fix`
+- **Incremental reformatting**: most collections are excluded from black (see `extend-exclude` in pyproject.toml). The files are reformatted when somebody makes changes to avoid a single big reformatting PR. Do not reformat files outside your changes.
+
+## Testing
+
+```bash
+pytest tests/collections/asr -m "not pleasefixme" -v     # ASR tests, skip broken
+pytest tests/collections/tts -m unit -v                  # TTS unit tests
+pytest -k "test_name" tests/                             # Single test by name
+```
+
+Markers: `unit`, `integration`, `system`, `pleasefixme` (broken — skip), `skipduringci`.
+
+## CI & PRs
+
+- NVIDIA developers: feature branches off `main`; community: fork-based workflow
+- CI triggered by adding **"Run CICD"** label to the PR
+- E2E nightly tests: only when really needed. Add both **"Run e2e nightly"** and **"Run CICD"** labels
+- `skip-linting` / `skip-docs` labels bypass those checks
+- Formatting CI auto-commits black/isort fixes back to the PR branch
+
+## Documentation
+
+Sphinx-based docs live in `docs/source/`. Build with:
+
+```bash
+pip install -r requirements/requirements_docs.txt   # one-time setup
+make -C docs clean html                              # full rebuild
+make -C docs html                                    # incremental rebuild
+```
+
+Output goes to `docs/build/html/`. Open `docs/build/html/index.html` to preview locally.
+
+Other useful targets: `make -C docs linkcheck` (verify external links), `make -C docs doctest` (run embedded doctests).
+
+## Training & Inference
+
+Entry-point scripts live under `examples/<collection>/`.
+
+All scripts follow the same Hydra pattern — a `@hydra_runner` decorator points to a YAML config in a nearby `conf/` directory:
+
+```python
+@hydra_runner(config_path="conf", config_name="conformer_ctc_char")
+def main(cfg):
+    trainer = pl.Trainer(**resolve_trainer_cfg(cfg.trainer))
+    exp_manager(trainer, cfg.get("exp_manager", None))
+    model = EncDecCTCModel(cfg=cfg.model, trainer=trainer)
+    trainer.fit(model)
+```
+
+Override any config value from the CLI with Hydra syntax: `python script.py model.optim.lr=1e-4 trainer.max_epochs=50`. Browse configs with `ls examples/<collection>/conf/` to see which models and variants are supported.
+
+## Handy Scripts
+
+Utility scripts live under `scripts/`. Key subdirectories: `speech_recognition/`, `speechlm2/`, `speaker_tasks/`, `tokenizers/`, `dataset_processing/`, `asr_language_modeling/`. Browse with `ls scripts/`.
+
+Four frequently used data/training helpers:
+
+- **`scripts/speech_recognition/estimate_duration_bins.py`** — estimate Lhotse dynamic-bucketing duration bins from a manifest or YAML input config. Usage: `python scripts/speech_recognition/estimate_duration_bins.py <input> -b 30 -n 100000`
+- **`scripts/speech_recognition/oomptimizer.py`** — find the largest batch size per bucket that fits in GPU memory. Usage: `python scripts/speech_recognition/oomptimizer.py --pretrained-name nvidia/canary-1b` or point to a config with `--config-path`.
+- **`scripts/speech_recognition/estimate_data_weights.py`** — compute per-dataset sampling weights from YAML input configs, with optional temperature re-weighting. Usage: `python scripts/speech_recognition/estimate_data_weights.py input.yaml output.yaml -t 0.5`
+- **`scripts/speech_recognition/convert_to_tarred_audio_dataset.py`** — shard audio+manifest into tar files. Usage: `python scripts/speech_recognition/convert_to_tarred_audio_dataset.py --manifest_path=m.json --target_dir=./tar --num_shards=512 --max_duration=60.0`
+
+## Architecture
+
+- **Hydra + OmegaConf** for all config management (YAML configs)
+- **PyTorch Lightning** for training orchestration
+- **Lhotse** (>=1.32.2) for audio data loading
+- Collections are semi-isolated domains sharing `nemo.core` and `nemo.collections.common`
+
+## Subdirectory Instructions
+
+Module-specific instructions can be added as `CLAUDE.md` or `AGENTS.md` files in subdirectories.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ pip install -e '.[asr]'       # ASR only
 pip install -e '.[test]'      # With test deps
 ```
 
-Requires Python 3.10+, PyTorch 2.6+. Works well with  
+Requires Python 3.10+, PyTorch 2.6+.
 
 ## Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ pip install -e '.[asr]'       # ASR only
 pip install -e '.[test]'      # With test deps
 ```
 
-Requires Python 3.10+, PyTorch 2.6+.
+Requires Python 3.10+, PyTorch 2.6+. Works well with  
 
 ## Code Style
 
@@ -42,6 +42,7 @@ Markers: `unit`, `integration`, `system`, `pleasefixme` (broken — skip), `skip
 - E2E nightly tests: only when really needed. Add both **"Run e2e nightly"** and **"Run CICD"** labels
 - `skip-linting` / `skip-docs` labels bypass those checks
 - Formatting CI auto-commits black/isort fixes back to the PR branch
+- CI: GitHub Actions in `.github/workflows/`
 
 ## Documentation
 
@@ -64,11 +65,11 @@ Entry-point scripts live under `examples/<collection>/`.
 All scripts follow the same Hydra pattern — a `@hydra_runner` decorator points to a YAML config in a nearby `conf/` directory:
 
 ```python
-@hydra_runner(config_path="conf", config_name="conformer_ctc_char")
+@hydra_runner(config_path="conf", config_name="fast-conformer_transducer_bpe")
 def main(cfg):
     trainer = pl.Trainer(**resolve_trainer_cfg(cfg.trainer))
     exp_manager(trainer, cfg.get("exp_manager", None))
-    model = EncDecCTCModel(cfg=cfg.model, trainer=trainer)
+    model = EncDecRNNTBPEModel(cfg=cfg.model, trainer=trainer)
     trainer.fit(model)
 ```
 
@@ -95,3 +96,17 @@ Four frequently used data/training helpers:
 ## Subdirectory Instructions
 
 Module-specific instructions can be added as `CLAUDE.md` or `AGENTS.md` files in subdirectories.
+
+## Issue Reproduction
+
+When fixing a bug, always:
+1. First reproduce the issue with a minimal test case
+2. Add the reproduction as a unit test
+3. Then fix the issue
+4. Verify the test passes
+
+## Forbidden Operations
+
+- Never push directly to `main`
+- Never modify `.github/workflows/` without explicit instruction
+- Never delete test files without explicit instruction


### PR DESCRIPTION
> [!IMPORTANT]  
> The `Update branch` button must only be pressed in very rare occassions.
> An outdated branch is never blocking the merge of a PR.
> Please reach out to the automation team before pressing that button.

# What does this PR do ?

* Add CLAUDE.md and symlinks for Codex/Cursor - my first take anyway, provides minimal guidance for NeMo Speech usage and development.
* I symlinked CLAUDE.md -> AGENTS.md and .claude/skills to .codex/skill and .cursor/skills, and checked that the existing skills are correctly discovered by all three harnesses.
* There's also a post-hook for Claude that makes it run linters after every change with the same rules as in repo CI checks (i.e. don't touch files that weren't modified).
* a GitHub Action for babysitting PRs (getting to green CI semi-autonomously) 
* three skills `/verify`, `/babysit-pr` and `/fix-issue` - intended for local development use with a harness if that's preferable to triggering it through GH actions 

PR babysitter GH action logic:

When there is a check failure, and `Has Babysitter` label is set, the agent will debug and post a comment with fix plan, pinging the PR author. The author can respond in a comment or react with a 👍🏻  emoji on the agent's comment. The agent determines the response and if approved, implements the plan. At any time this can be disabled by removing `Has Babysitter` label. The agent uses `Agent Plan Pending Approval` and `Agent Plan Approved` labels on the to manage state, and cleans them up after PR is merged.


**Collection**: [Note which collection this PR will affect]

# Changelog

- Add CLAUDE.md and symlinks for Codex/Cursor

# Usage

- You can potentially add a usage example below

```python
# Add a code snippet demonstrating how to use this 
```

# GitHub Actions CI

The Jenkins CI system has been replaced by GitHub Actions self-hosted runners.

The GitHub Actions CI will run automatically when the "Run CICD" label is added to the PR.
To re-run CI remove and add the label again.
To run CI on an untrusted fork, a NeMo user with write access must first click "Approve and run".

# Before your PR is "Ready for review"

**Pre checks**:

- [ ] Make sure you read and followed [Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md)
- [ ] Did you write any new necessary tests?
- [ ] Did you add or update any necessary documentation?
- [ ] Does the PR affect components that are optional to install? (Ex: Numba, Pynini, Apex etc)
  - [ ] Reviewer: Does the PR have correct import guards for all optional libraries?
  
**PR Type**:

- [x] New Feature
- [ ] Bugfix
- [ ] Documentation

If you haven't finished some of the above items you can still open "Draft" PR.

## Who can review?

Anyone in the community is free to review the PR once the checks have passed.
[Contributor guidelines](https://github.com/NVIDIA/NeMo/blob/main/CONTRIBUTING.md) contains specific people who can review PRs to various areas.

# Additional Information

- Related to # (issue)
- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 